### PR TITLE
fix(qa): decouple bundle worker rollback from app tag

### DIFF
--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -121,24 +121,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: bash ops/stage0/verify_ghcr_manifest.sh "$INPUT_TAG" "$INPUT_OVERRIDE"
 
-      - name: Checkout target-tag QA host artifacts
-        uses: actions/checkout@v6
-        with:
-          ref: v${{ inputs.tag }}
-          path: qa-host-runtime
-          fetch-depth: 1
-
-      - name: Verify target-tag QA host artifacts
-        id: qa_host_artifacts
-        run: |
-          set -euo pipefail
-          test "$(git -C qa-host-runtime describe --tags --exact-match)" = "v${INPUT_TAG}"
-          test -f qa-host-runtime/deploy/aws/stage0/tokenkey-qa-maintenance.sh
-          test -f qa-host-runtime/deploy/aws/stage0/tokenkey-qa-boundary.sh
-          SHA="$(git -C qa-host-runtime rev-parse HEAD)"
-          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
-          echo "QA host artifacts resolved from v${INPUT_TAG}@${SHA}"
-
       - name: Blue/green migration safety gate
         # The target app can apply migrations while the old app is still serving
         # existing requests on the same prod DB. Advisory locks serialize
@@ -262,12 +244,14 @@ jobs:
           set -euo pipefail
           STACK_ERROR="$(mktemp)"
           trap 'rm -f "$STACK_ERROR"' EXIT
+          EXISTING_WORKER_IMAGE=""
           if STACK_JSON="$(aws cloudformation describe-stacks --stack-name "$QA_STACK_NAME" --output json 2>"$STACK_ERROR")"; then
             OPS_RECOVERY_PRINCIPAL_ARN="$(jq -r '.Stacks[0].Parameters[]? | select(.ParameterKey == "OpsRecoveryPrincipalArn") | .ParameterValue' <<<"$STACK_JSON")"
             if [ -z "$OPS_RECOVERY_PRINCIPAL_ARN" ] || [ "$OPS_RECOVERY_PRINCIPAL_ARN" = None ]; then
               echo "::error::existing QA stack has no OpsRecoveryPrincipalArn parameter"
               exit 1
             fi
+            EXISTING_WORKER_IMAGE="$(jq -r '.Stacks[0].Parameters[]? | select(.ParameterKey == "BundleWorkerImage") | .ParameterValue' <<<"$STACK_JSON")"
           else
             describe_rc=$?
             STACK_ERROR_TEXT="$(<"$STACK_ERROR")"
@@ -283,8 +267,34 @@ jobs:
               exit "$describe_rc"
             fi
           fi
+          RESOLUTION="$(python3 ops/qa/resolve_qa_bundle_worker_image.py \
+            --target-tag "$INPUT_TAG" --existing-image "$EXISTING_WORKER_IMAGE")"
+          MODE="$(jq -er '.mode' <<<"$RESOLUTION")"
+          RESOLVED_WORKER_IMAGE="$(jq -er '.resolved_worker_image' <<<"$RESOLUTION")"
           echo "qa_stack_name=$QA_STACK_NAME" >> "$GITHUB_OUTPUT"
           echo "ops_recovery_principal_arn=$OPS_RECOVERY_PRINCIPAL_ARN" >> "$GITHUB_OUTPUT"
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+          echo "resolved_worker_image=$RESOLVED_WORKER_IMAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout target-tag QA host artifacts
+        if: steps.qa_infra.outputs.mode == 'phase3'
+        uses: actions/checkout@v6
+        with:
+          ref: v${{ inputs.tag }}
+          path: qa-host-runtime
+          fetch-depth: 1
+
+      - name: Verify target-tag QA host artifacts
+        if: steps.qa_infra.outputs.mode == 'phase3'
+        id: qa_host_artifacts
+        run: |
+          set -euo pipefail
+          test "$(git -C qa-host-runtime describe --tags --exact-match)" = "v${INPUT_TAG}"
+          test -f qa-host-runtime/deploy/aws/stage0/tokenkey-qa-maintenance.sh
+          test -f qa-host-runtime/deploy/aws/stage0/tokenkey-qa-boundary.sh
+          SHA="$(git -C qa-host-runtime rev-parse HEAD)"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "QA host artifacts resolved from v${INPUT_TAG}@${SHA}"
 
       - name: Deploy QA Bundle infrastructure
         env:
@@ -294,7 +304,7 @@ jobs:
           QA_RAW_ARCHIVE_VPC_ID: ${{ steps.instance.outputs.vpc_id }}
           QA_RAW_ARCHIVE_ROUTE_TABLE_IDS: ${{ steps.instance.outputs.route_table_id }}
           QA_BUNDLE_WORKER_PUBLIC_SUBNET_IDS: ${{ steps.instance.outputs.subnet_id }}
-          QA_BUNDLE_WORKER_IMAGE: ghcr.io/youxuanxue/sub2api:${{ env.INPUT_TAG }}
+          QA_BUNDLE_WORKER_IMAGE: ${{ steps.qa_infra.outputs.resolved_worker_image }}
           QA_BUNDLE_WORKER_DESIRED_COUNT: "1"
           QA_BUNDLE_BROWSER_ALLOWED_ORIGIN: ${{ steps.instance.outputs.browser_origin }}
           QA_CLOUDFORMATION_SERVICE_ROLE_ARN: ${{ steps.instance.outputs.qa_cfn_service_role_arn }}
@@ -305,7 +315,7 @@ jobs:
         id: qa_bundle
         env:
           QA_RAW_ARCHIVE_STACK: ${{ steps.qa_infra.outputs.qa_stack_name }}
-          QA_BUNDLE_WORKER_IMAGE: ghcr.io/youxuanxue/sub2api:${{ env.INPUT_TAG }}
+          QA_BUNDLE_WORKER_IMAGE: ${{ steps.qa_infra.outputs.resolved_worker_image }}
           QA_BUNDLE_WORKER_DESIRED_COUNT: "1"
         run: bash ops/qa/verify_qa_bundle_infra.sh
 
@@ -334,6 +344,7 @@ jobs:
         run: bash ops/stage0/external_health.sh "$API_URL"
 
       - name: Sync QA maintenance host runner
+        if: steps.qa_infra.outputs.mode == 'phase3'
         env:
           INSTANCE_ID: ${{ steps.instance.outputs.id }}
           QA_MAINTENANCE_TIMER_STATE: enabled
@@ -343,6 +354,7 @@ jobs:
         run: bash ops/stage0/sync-qa-maintenance-timer-via-ssm.sh "$INSTANCE_ID" "deploy-stage0 qa-maintenance host artifact"
 
       - name: Sync QA boundary host runner and restore durable owner
+        if: steps.qa_infra.outputs.mode == 'phase3'
         env:
           INSTANCE_ID: ${{ steps.instance.outputs.id }}
           QA_BOUNDARY_TIMER_STATE: auto
@@ -352,10 +364,16 @@ jobs:
         run: bash ops/stage0/sync-qa-boundary-timer-via-ssm.sh "$INSTANCE_ID" "deploy-stage0 qa-boundary host artifact"
 
       - name: Post-deploy QA Bundle canary
+        if: steps.qa_infra.outputs.mode == 'phase3'
         env:
           INSTANCE_ID: ${{ steps.instance.outputs.id }}
           STAGE0_SSM_OUTPUT_DIR: .qa-bundle-canary
         run: bash ops/stage0/run-qa-bundle-canary-via-ssm.sh "$INSTANCE_ID" "deploy-stage0 qa-bundle canary"
+
+      - name: Report legacy QA rollback degradation
+        if: steps.qa_infra.outputs.mode == 'legacy_rollback'
+        run: |
+          echo "::warning::QA Phase 3 degraded: the app was rolled back to legacy mode; existing Worker and host runners were preserved, Bundle canary was skipped, and archive-gated DROP may pause until a Phase 3 app is restored."
 
       - name: Audit pricing registry runtime (read-only)
         # Price publication is owned only by pricing-registry-publish.yml after a
@@ -460,17 +478,25 @@ jobs:
           STACK_NAME: ${{ steps.stack.outputs.name }}
           CMD_ID: ${{ steps.ssm.outputs.command_id }}
           INPUT_TAG: ${{ inputs.tag }}
+          QA_MODE: ${{ steps.qa_infra.outputs.mode }}
+          QA_WORKER_IMAGE: ${{ steps.qa_infra.outputs.resolved_worker_image }}
         run: |
           {
             echo "## deploy-stage0"
             echo "- environment: \`prod\`"
-            echo "- tag: \`$INPUT_TAG\`"
+            echo "- app image: \`ghcr.io/youxuanxue/sub2api:$INPUT_TAG\`"
+            echo "- QA mode: \`${QA_MODE:-not-resolved}\`"
+            echo "- QA Bundle Worker image: \`${QA_WORKER_IMAGE:-not-resolved}\`"
             echo "- stack: \`$STACK_NAME\`"
             echo "- instance: \`$INSTANCE_ID\`"
             echo "- api: $API_URL"
             echo "- ssm command id: \`${CMD_ID:-none}\`"
             echo
-            echo "Rollback: re-dispatch this workflow with the previous tag."
+            if [ "$QA_MODE" = legacy_rollback ]; then
+              echo "**QA Phase 3 degraded:** legacy rollback changed only the app image; the existing compatible Worker and host runners were retained, Bundle canary was skipped, and archive-gated DROP may pause."
+              echo
+            fi
+            echo "Rollback: re-dispatch with a previous app tag. The QA resolver never downgrades the Bundle Worker; legacy mode also preserves the Phase 3 host runners."
             echo
             echo '```bash'
             echo "gh workflow run deploy-stage0.yml -f tag=<previous>"

--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -259,7 +259,9 @@ jobs:
 
       - name: Discover existing QA Bundle Worker (read-only)
         id: qa_worker_discovery
-        continue-on-error: true
+        # Phase 3 bootstrap legitimately has no existing Bundle stack; legacy mode
+        # still fails closed when the resolver receives no verified image.
+        continue-on-error: true  # preflight-allow: swallow
         env:
           QA_RAW_ARCHIVE_STACK: ${{ vars.QA_RAW_ARCHIVE_STACK || 'tokenkey-prod-qa-raw-archive' }}
           QA_BUNDLE_VERIFY_MODE: discovery

--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -8,15 +8,16 @@ on:
   workflow_dispatch:
     inputs:
       operation:
-        description: "deploy changes the active prod image; smoke-only only runs canonical prod acceptance probes."
+        description: "deploy changes prod; smoke-only probes the API; qa-infra-check verifies QA OIDC/IAM readiness without mutation."
         required: true
         type: choice
         options:
           - deploy
           - smoke-only
+          - qa-infra-check
         default: deploy
       tag:
-        description: "Released image tag without leading v (e.g. 1.6.0). In smoke-only mode this is an audit label; no image is changed."
+        description: "Released image tag without leading v (e.g. 1.6.0). In smoke-only and qa-infra-check modes this is an audit label; no image is changed."
         required: true
         type: string
       simple_release_override:
@@ -229,29 +230,59 @@ jobs:
           echo "qa_cfn_service_role_arn=$SERVICE_ROLE_ARN" >> "$GITHUB_OUTPUT"
           echo "deploying ${INPUT_TAG} to instance=$ID api=$API_URL (env=prod stack=$STACK_NAME)"
 
+      - name: Checkout target-tag QA contract and host artifacts
+        uses: actions/checkout@v6
+        with:
+          ref: v${{ inputs.tag }}
+          path: qa-target-release
+          fetch-depth: 1
+
+      - name: Verify target-tag QA release tree
+        id: qa_target
+        run: |
+          set -euo pipefail
+          test "$(git -C qa-target-release describe --tags --exact-match)" = "v${INPUT_TAG}"
+          SHA="$(git -C qa-target-release rev-parse HEAD)"
+          ROLLOUT=qa-target-release/ops/qa/deploy_rollout.yaml
+          if [ ! -f "$ROLLOUT" ]; then
+            ROLLOUT="$(mktemp)"
+            printf 'prod:\n  user_export:\n    marker: legacy_release\n' > "$ROLLOUT"
+          fi
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "rollout=${ROLLOUT}" >> "$GITHUB_OUTPUT"
+
       - name: Configure QA infrastructure credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.QA_INFRA_OIDC_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Discover existing QA Bundle Worker (read-only)
+        id: qa_worker_discovery
+        continue-on-error: true
+        env:
+          QA_RAW_ARCHIVE_STACK: ${{ vars.QA_RAW_ARCHIVE_STACK || 'tokenkey-prod-qa-raw-archive' }}
+          QA_BUNDLE_VERIFY_MODE: discovery
+          QA_BUNDLE_WORKER_DESIRED_COUNT: "1"
+        run: bash ops/qa/verify_qa_bundle_infra.sh
+
       - name: Resolve QA infrastructure deploy inputs
         id: qa_infra
         env:
           QA_STACK_NAME: ${{ vars.QA_RAW_ARCHIVE_STACK || 'tokenkey-prod-qa-raw-archive' }}
           CONFIGURED_OPS_RECOVERY_PRINCIPAL_ARN: ${{ vars.QA_OPS_RECOVERY_PRINCIPAL_ARN }}
+          VERIFIED_EXISTING_WORKER_IMAGE: ${{ steps.qa_worker_discovery.outputs.worker_image }}
+          TARGET_ROLLOUT: ${{ steps.qa_target.outputs.rollout }}
         run: |
           set -euo pipefail
           STACK_ERROR="$(mktemp)"
           trap 'rm -f "$STACK_ERROR"' EXIT
-          EXISTING_WORKER_IMAGE=""
           if STACK_JSON="$(aws cloudformation describe-stacks --stack-name "$QA_STACK_NAME" --output json 2>"$STACK_ERROR")"; then
             OPS_RECOVERY_PRINCIPAL_ARN="$(jq -r '.Stacks[0].Parameters[]? | select(.ParameterKey == "OpsRecoveryPrincipalArn") | .ParameterValue' <<<"$STACK_JSON")"
             if [ -z "$OPS_RECOVERY_PRINCIPAL_ARN" ] || [ "$OPS_RECOVERY_PRINCIPAL_ARN" = None ]; then
               echo "::error::existing QA stack has no OpsRecoveryPrincipalArn parameter"
               exit 1
             fi
-            EXISTING_WORKER_IMAGE="$(jq -r '.Stacks[0].Parameters[]? | select(.ParameterKey == "BundleWorkerImage") | .ParameterValue' <<<"$STACK_JSON")"
           else
             describe_rc=$?
             STACK_ERROR_TEXT="$(<"$STACK_ERROR")"
@@ -268,33 +299,51 @@ jobs:
             fi
           fi
           RESOLUTION="$(python3 ops/qa/resolve_qa_bundle_worker_image.py \
-            --target-tag "$INPUT_TAG" --existing-image "$EXISTING_WORKER_IMAGE")"
+            --target-tag "$INPUT_TAG" --target-rollout "$TARGET_ROLLOUT" \
+            --verified-existing-image "$VERIFIED_EXISTING_WORKER_IMAGE")"
           MODE="$(jq -er '.mode' <<<"$RESOLUTION")"
           RESOLVED_WORKER_IMAGE="$(jq -er '.resolved_worker_image' <<<"$RESOLUTION")"
           echo "qa_stack_name=$QA_STACK_NAME" >> "$GITHUB_OUTPUT"
           echo "ops_recovery_principal_arn=$OPS_RECOVERY_PRINCIPAL_ARN" >> "$GITHUB_OUTPUT"
-          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
-          echo "resolved_worker_image=$RESOLVED_WORKER_IMAGE" >> "$GITHUB_OUTPUT"
+          jq -r 'to_entries[] | "\(.key)=\(.value)"' <<<"$RESOLUTION" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout target-tag QA host artifacts
+      - name: Verify target-tag Phase 3 host artifacts
         if: steps.qa_infra.outputs.mode == 'phase3'
-        uses: actions/checkout@v6
-        with:
-          ref: v${{ inputs.tag }}
-          path: qa-host-runtime
-          fetch-depth: 1
-
-      - name: Verify target-tag QA host artifacts
-        if: steps.qa_infra.outputs.mode == 'phase3'
-        id: qa_host_artifacts
         run: |
           set -euo pipefail
-          test "$(git -C qa-host-runtime describe --tags --exact-match)" = "v${INPUT_TAG}"
-          test -f qa-host-runtime/deploy/aws/stage0/tokenkey-qa-maintenance.sh
-          test -f qa-host-runtime/deploy/aws/stage0/tokenkey-qa-boundary.sh
-          SHA="$(git -C qa-host-runtime rev-parse HEAD)"
-          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
-          echo "QA host artifacts resolved from v${INPUT_TAG}@${SHA}"
+          test -f qa-target-release/deploy/aws/stage0/tokenkey-qa-maintenance.sh
+          test -f qa-target-release/deploy/aws/stage0/tokenkey-qa-boundary.sh
+
+      - name: Configure Stage0 credentials for legacy host safety
+        if: steps.qa_infra.outputs.mode == 'legacy_rollback'
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.OIDC_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Converge current QA maintenance runner before legacy app rollback
+        if: steps.qa_infra.outputs.mode == 'legacy_rollback'
+        env:
+          INSTANCE_ID: ${{ steps.instance.outputs.id }}
+          QA_MAINTENANCE_TIMER_STATE: enabled
+          QA_HOST_ARTIFACT_SHA: ${{ github.sha }}
+          STAGE0_SSM_OUTPUT_DIR: .qa-maintenance-legacy-safety
+        run: bash ops/stage0/sync-qa-maintenance-timer-via-ssm.sh "$INSTANCE_ID" "deploy-stage0 legacy safety maintenance"
+
+      - name: Disable QA boundary before legacy app rollback
+        if: steps.qa_infra.outputs.mode == 'legacy_rollback'
+        env:
+          INSTANCE_ID: ${{ steps.instance.outputs.id }}
+          QA_BOUNDARY_TIMER_STATE: disabled
+          QA_HOST_ARTIFACT_SHA: ${{ github.sha }}
+          STAGE0_SSM_OUTPUT_DIR: .qa-boundary-legacy-safety
+        run: bash ops/stage0/sync-qa-boundary-timer-via-ssm.sh "$INSTANCE_ID" "deploy-stage0 legacy safety boundary"
+
+      - name: Restore QA infrastructure credentials before mutation
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.QA_INFRA_OIDC_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Deploy QA Bundle infrastructure
         env:
@@ -317,6 +366,7 @@ jobs:
           QA_RAW_ARCHIVE_STACK: ${{ steps.qa_infra.outputs.qa_stack_name }}
           QA_BUNDLE_WORKER_IMAGE: ${{ steps.qa_infra.outputs.resolved_worker_image }}
           QA_BUNDLE_WORKER_DESIRED_COUNT: "1"
+          QA_BUNDLE_VERIFY_MODE: expected
         run: bash ops/qa/verify_qa_bundle_infra.sh
 
       - name: Restore Stage0 deployment credentials via OIDC
@@ -348,8 +398,8 @@ jobs:
         env:
           INSTANCE_ID: ${{ steps.instance.outputs.id }}
           QA_MAINTENANCE_TIMER_STATE: enabled
-          QA_HOST_ARTIFACT_ROOT: qa-host-runtime
-          QA_HOST_ARTIFACT_SHA: ${{ steps.qa_host_artifacts.outputs.sha }}
+          QA_HOST_ARTIFACT_ROOT: qa-target-release
+          QA_HOST_ARTIFACT_SHA: ${{ steps.qa_target.outputs.sha }}
           STAGE0_SSM_OUTPUT_DIR: .qa-maintenance-sync
         run: bash ops/stage0/sync-qa-maintenance-timer-via-ssm.sh "$INSTANCE_ID" "deploy-stage0 qa-maintenance host artifact"
 
@@ -358,13 +408,13 @@ jobs:
         env:
           INSTANCE_ID: ${{ steps.instance.outputs.id }}
           QA_BOUNDARY_TIMER_STATE: auto
-          QA_HOST_ARTIFACT_ROOT: qa-host-runtime
-          QA_HOST_ARTIFACT_SHA: ${{ steps.qa_host_artifacts.outputs.sha }}
+          QA_HOST_ARTIFACT_ROOT: qa-target-release
+          QA_HOST_ARTIFACT_SHA: ${{ steps.qa_target.outputs.sha }}
           STAGE0_SSM_OUTPUT_DIR: .qa-boundary-sync
         run: bash ops/stage0/sync-qa-boundary-timer-via-ssm.sh "$INSTANCE_ID" "deploy-stage0 qa-boundary host artifact"
 
       - name: Post-deploy QA Bundle canary
-        if: steps.qa_infra.outputs.mode == 'phase3'
+        if: steps.qa_infra.outputs.run_canary == 'true'
         env:
           INSTANCE_ID: ${{ steps.instance.outputs.id }}
           STAGE0_SSM_OUTPUT_DIR: .qa-bundle-canary
@@ -373,7 +423,7 @@ jobs:
       - name: Report legacy QA rollback degradation
         if: steps.qa_infra.outputs.mode == 'legacy_rollback'
         run: |
-          echo "::warning::QA Phase 3 degraded: the app was rolled back to legacy mode; existing Worker and host runners were preserved, Bundle canary was skipped, and archive-gated DROP may pause until a Phase 3 app is restored."
+          echo "::warning::QA Phase 3 degraded: the app was rolled back to legacy mode; the verified Worker was preserved, current maintenance was enabled, boundary was forced disabled, Bundle canary was skipped, and DROP is paused until a Phase 3 app is restored."
 
       - name: Audit pricing registry runtime (read-only)
         # Price publication is owned only by pricing-registry-publish.yml after a
@@ -480,6 +530,8 @@ jobs:
           INPUT_TAG: ${{ inputs.tag }}
           QA_MODE: ${{ steps.qa_infra.outputs.mode }}
           QA_WORKER_IMAGE: ${{ steps.qa_infra.outputs.resolved_worker_image }}
+          QA_WORKER_SOURCE: ${{ steps.qa_infra.outputs.worker_source }}
+          QA_HOST_RUNTIME_MODE: ${{ steps.qa_infra.outputs.host_runtime_mode }}
         run: |
           {
             echo "## deploy-stage0"
@@ -487,20 +539,127 @@ jobs:
             echo "- app image: \`ghcr.io/youxuanxue/sub2api:$INPUT_TAG\`"
             echo "- QA mode: \`${QA_MODE:-not-resolved}\`"
             echo "- QA Bundle Worker image: \`${QA_WORKER_IMAGE:-not-resolved}\`"
+            echo "- QA Bundle Worker source: \`${QA_WORKER_SOURCE:-not-resolved}\`"
+            echo "- QA host runtime mode: \`${QA_HOST_RUNTIME_MODE:-not-resolved}\`"
             echo "- stack: \`$STACK_NAME\`"
             echo "- instance: \`$INSTANCE_ID\`"
             echo "- api: $API_URL"
             echo "- ssm command id: \`${CMD_ID:-none}\`"
             echo
             if [ "$QA_MODE" = legacy_rollback ]; then
-              echo "**QA Phase 3 degraded:** legacy rollback changed only the app image; the existing compatible Worker and host runners were retained, Bundle canary was skipped, and archive-gated DROP may pause."
+              echo "**QA Phase 3 degraded:** legacy rollback preserved the verified Worker, converged current maintenance, forced boundary disabled, skipped Bundle canary, and paused DROP."
               echo
             fi
-            echo "Rollback: re-dispatch with a previous app tag. The QA resolver never downgrades the Bundle Worker; legacy mode also preserves the Phase 3 host runners."
+            echo "Rollback: re-dispatch with a previous app tag. Legacy mode requires a verified live Worker, installs the current safe host runners, and pauses DROP until Phase 3 is restored."
             echo
             echo '```bash'
             echo "gh workflow run deploy-stage0.yml -f tag=<previous>"
             echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  qa-infra-check:
+    if: inputs.operation == 'qa-infra-check'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: prod
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
+      QA_INFRA_OIDC_ROLE_ARN: ${{ vars.QA_INFRA_OIDC_ROLE_ARN }}
+      CICD_OIDC_STACK_NAME: ${{ vars.CICD_OIDC_STACK_NAME || 'tokenkey-cicd-oidc' }}
+      QA_STACK_NAME: ${{ vars.QA_RAW_ARCHIVE_STACK || 'tokenkey-prod-qa-raw-archive' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Validate QA infrastructure check inputs
+        run: |
+          set -euo pipefail
+          test -n "${OIDC_ROLE_ARN:-}" || { echo "::error::AWS_OIDC_ROLE_ARN is unset"; exit 1; }
+          test -n "${QA_INFRA_OIDC_ROLE_ARN:-}" || { echo "::error::QA_INFRA_OIDC_ROLE_ARN is unset"; exit 1; }
+
+      - name: Configure Stage0 read credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.OIDC_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Verify QA role outputs and configured variable
+        id: qa_roles
+        run: |
+          set -euo pipefail
+          OUTPUTS="$(aws cloudformation describe-stacks --stack-name "$CICD_OIDC_STACK_NAME" --query 'Stacks[0].Outputs' --output json)"
+          DEPLOYMENT_ROLE="$(jq -r '.[] | select(.OutputKey == "QAInfraDeploymentRoleArn") | .OutputValue' <<<"$OUTPUTS")"
+          SERVICE_ROLE="$(jq -r '.[] | select(.OutputKey == "QAInfraCloudFormationServiceRoleArn") | .OutputValue' <<<"$OUTPUTS")"
+          for value in "$DEPLOYMENT_ROLE" "$SERVICE_ROLE"; do
+            test -n "$value" && test "$value" != None || { echo "::error::QA OIDC stack outputs are incomplete"; exit 1; }
+          done
+          test "$QA_INFRA_OIDC_ROLE_ARN" = "$DEPLOYMENT_ROLE" || {
+            echo "::error::QA_INFRA_OIDC_ROLE_ARN does not match QAInfraDeploymentRoleArn"
+            exit 1
+          }
+          echo "deployment_role=$DEPLOYMENT_ROLE" >> "$GITHUB_OUTPUT"
+          echo "service_role=$SERVICE_ROLE" >> "$GITHUB_OUTPUT"
+
+      - name: Assume QA deployment role
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ steps.qa_roles.outputs.deployment_role }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Verify QA role access and stack service role
+        id: qa_access
+        env:
+          EXPECTED_SERVICE_ROLE: ${{ steps.qa_roles.outputs.service_role }}
+        run: |
+          set -euo pipefail
+          CALLER_ARN="$(aws sts get-caller-identity --query Arn --output text)"
+          STACK="$(aws cloudformation describe-stacks --stack-name "$QA_STACK_NAME" --output json)"
+          STATUS="$(jq -r '.Stacks[0].StackStatus' <<<"$STACK")"
+          ROLE_ARN="$(jq -r '.Stacks[0].RoleARN // empty' <<<"$STACK")"
+          BUNDLE_IMAGE="$(jq -r '.Stacks[0].Parameters[]? | select(.ParameterKey == "BundleWorkerImage") | .ParameterValue' <<<"$STACK")"
+          OUTPUT_KEYS="$(jq -c '[.Stacks[0].Outputs[]?.OutputKey]' <<<"$STACK")"
+          [[ "$STATUS" =~ _COMPLETE$ ]] || { echo "::error::QA stack is not complete: $STATUS"; exit 1; }
+          LEGACY_REQUIRED_OUTPUTS='["QaRawArchiveBucketName","QaRawArchiveRecoveryRoleArn"]'
+          if ! jq -e --argjson required "$LEGACY_REQUIRED_OUTPUTS" '($required - .) | length == 0' <<<"$OUTPUT_KEYS" >/dev/null; then
+            echo "::error::QA stack does not match the recognized raw-archive contract"
+            exit 1
+          fi
+          if [ -n "$BUNDLE_IMAGE" ] && [ "$BUNDLE_IMAGE" != None ]; then
+            test "$ROLE_ARN" = "$EXPECTED_SERVICE_ROLE" || {
+              echo "::error::Bundle-era QA stack is not bound to the expected CloudFormation service role"
+              exit 1
+            }
+            READINESS=bundle_ready
+          else
+            test -z "$ROLE_ARN" || test "$ROLE_ARN" = "$EXPECTED_SERVICE_ROLE" || {
+              echo "::error::legacy QA stack has an unexpected CloudFormation service role"
+              exit 1
+            }
+            READINESS=legacy_bootstrap_ready
+          fi
+          echo "caller_arn=$CALLER_ARN" >> "$GITHUB_OUTPUT"
+          echo "stack_status=$STATUS" >> "$GITHUB_OUTPUT"
+          echo "readiness=$READINESS" >> "$GITHUB_OUTPUT"
+
+      - name: Job summary
+        env:
+          CALLER_ARN: ${{ steps.qa_access.outputs.caller_arn }}
+          STACK_STATUS: ${{ steps.qa_access.outputs.stack_status }}
+          READINESS: ${{ steps.qa_access.outputs.readiness }}
+        run: |
+          {
+            echo "## QA infrastructure OIDC check"
+            echo "- deployment role: \`${{ steps.qa_roles.outputs.deployment_role }}\`"
+            echo "- service role: \`${{ steps.qa_roles.outputs.service_role }}\`"
+            echo "- assumed caller: \`${CALLER_ARN}\`"
+            echo "- QA stack: \`${QA_STACK_NAME}\` (${STACK_STATUS})"
+            echo "- readiness: \`${READINESS}\`"
+            echo "- safety: read-only; no change set, SSM command, host sync, canary, or app mutation"
           } >> "$GITHUB_STEP_SUMMARY"
 
   smoke-only:

--- a/.github/workflows/ops-daily-diagnostics.yml
+++ b/.github/workflows/ops-daily-diagnostics.yml
@@ -358,7 +358,7 @@ jobs:
               add_finding "qa_phase2_live_health" "warning" "warning" "QA Phase 2 live probe warning ($TARGET_ID)" "$PHASE2_WARNING" "qa-phase2-live-warning|$TARGET_ID|$PHASE2_WARNING"
             done < <(printf '%s' "$PHASE2_VERDICT" | jq -r '.warnings[]?')
 
-            if QA_BUNDLE_INFRA="$(bash ops/qa/verify_qa_bundle_infra.sh 2>>"$STDERR")"; then
+            if QA_BUNDLE_INFRA="$(QA_BUNDLE_VERIFY_MODE=discovery bash ops/qa/verify_qa_bundle_infra.sh 2>>"$STDERR")"; then
               printf 'qa_bundle_infra: %s\n' "$QA_BUNDLE_INFRA" >> "$STDOUT"
               add_finding "qa_bundle_infra" "ok" "info" "QA Bundle infrastructure passed ($TARGET_ID)" "Stack, bucket, queues, ECS capacity, DLQ, and worker image are ready." "qa-bundle-infra|$TARGET_ID"
             else

--- a/.testing/user-stories/stories/US-044-qa-lifecycle-single-owner-and-export-contract.md
+++ b/.testing/user-stories/stories/US-044-qa-lifecycle-single-owner-and-export-contract.md
@@ -21,6 +21,7 @@
 6. rollout 将 repository readiness 与 `single_owner_not_activated` observed state 分开记录。
 7. single-owner activation 在锁内拒绝最近 24 个已完成小时及当前到未来 72 小时的 catalog 缺口和非精确 UTC-hour bounds；
    首次 Bundle 部署所需 IAM bootstrap 有唯一运维入口且 app image 切换前 fail closed。
+8. app rollback 与 Bundle Worker/host runners 解耦：兼容 Worker 只前进，legacy app 保留 Phase 3 控制面、跳过不兼容 canary 并明确报告 degraded；首次 legacy bootstrap 在任何 mutation 前失败。
 
 ## Linked Tests
 
@@ -41,6 +42,10 @@
 - `backend/internal/observability/qa/bundle/publisher_test.go`::`TestBuildExportZipReadsOnlyCommittedBundlePages`
 - `deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py`::`Stage0QABundleContractTest.test_qa_cloudformation_service_role_covers_managed_resource_lifecycles`
 - `deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py`::`Stage0QABundleContractTest.test_qa_bundle_verifier_roles_have_scoped_bucket_readback`
+- `ops/qa/test_resolve_qa_bundle_worker_image.py`::`ResolveQABundleWorkerImageTest.test_phase3_app_rollback_does_not_downgrade_worker`
+- `ops/qa/test_resolve_qa_bundle_worker_image.py`::`ResolveQABundleWorkerImageTest.test_legacy_app_rollback_preserves_compatible_worker`
+- `ops/stage0/test_deploy_stage0_workflow.py`::`DeployStage0WorkflowTest.test_legacy_rollback_preserves_phase3_control_plane_and_reports_degraded`
+- `ops/stage0/test_deploy_stage0_workflow.py`::`DeployStage0WorkflowTest.test_legacy_bootstrap_without_compatible_worker_fails_before_mutation`
 - `frontend/e2e/qa-bundle.e2e.ts`::`QA Bundle list, detail, watermark and ZIP export stay on Bundle/S3 paths`
 - `frontend/e2e/qa-bundle.e2e.ts`::`QA Bundle entitlement denial removes the entry and never starts a job`
 - `frontend/e2e/qa-bundle.e2e.ts`::`temporary unavailability is recoverable from the visible retry action`
@@ -50,6 +55,7 @@
 ```bash
 cd backend && go test -tags=unit ./internal/handler ./internal/observability/qa
 cd .. && python3 scripts/checks/qa-lifecycle-ssot.py
+python3 -m unittest ops.qa.test_resolve_qa_bundle_worker_image ops.stage0.test_deploy_stage0_workflow
 cd frontend && pnpm exec playwright test e2e/qa-bundle.e2e.ts --project=chromium
 ```
 

--- a/.testing/user-stories/stories/US-044-qa-lifecycle-single-owner-and-export-contract.md
+++ b/.testing/user-stories/stories/US-044-qa-lifecycle-single-owner-and-export-contract.md
@@ -21,7 +21,7 @@
 6. rollout 将 repository readiness 与 `single_owner_not_activated` observed state 分开记录。
 7. single-owner activation 在锁内拒绝最近 24 个已完成小时及当前到未来 72 小时的 catalog 缺口和非精确 UTC-hour bounds；
    首次 Bundle 部署所需 IAM bootstrap 有唯一运维入口且 app image 切换前 fail closed。
-8. app rollback 与 Bundle Worker/host runners 解耦：兼容 Worker 只前进，legacy app 保留 Phase 3 控制面、跳过不兼容 canary 并明确报告 degraded；首次 legacy bootstrap 在任何 mutation 前失败。
+8. app rollback 与 Bundle Worker/host runners 解耦：目标 release tree 显式声明 Bundle runtime contract；legacy app 只保留 fully verified live Worker，在 app mutation 前收敛当前 maintenance 并禁用 boundary，跳过 canary、暂停 DROP、明确报告 degraded；无 verified Worker 则在任何 mutation 前失败。
 
 ## Linked Tests
 
@@ -42,10 +42,12 @@
 - `backend/internal/observability/qa/bundle/publisher_test.go`::`TestBuildExportZipReadsOnlyCommittedBundlePages`
 - `deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py`::`Stage0QABundleContractTest.test_qa_cloudformation_service_role_covers_managed_resource_lifecycles`
 - `deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py`::`Stage0QABundleContractTest.test_qa_bundle_verifier_roles_have_scoped_bucket_readback`
-- `ops/qa/test_resolve_qa_bundle_worker_image.py`::`ResolveQABundleWorkerImageTest.test_phase3_app_rollback_does_not_downgrade_worker`
-- `ops/qa/test_resolve_qa_bundle_worker_image.py`::`ResolveQABundleWorkerImageTest.test_legacy_app_rollback_preserves_compatible_worker`
-- `ops/stage0/test_deploy_stage0_workflow.py`::`DeployStage0WorkflowTest.test_legacy_rollback_preserves_phase3_control_plane_and_reports_degraded`
-- `ops/stage0/test_deploy_stage0_workflow.py`::`DeployStage0WorkflowTest.test_legacy_bootstrap_without_compatible_worker_fails_before_mutation`
+- `ops/qa/test_resolve_qa_bundle_worker_image.py`::`ResolveQABundleWorkerImageTest.test_phase3_contract_uses_target_release_image`
+- `ops/qa/test_resolve_qa_bundle_worker_image.py`::`ResolveQABundleWorkerImageTest.test_missing_contract_is_legacy_and_preserves_verified_tag`
+- `ops/qa/test_resolve_qa_bundle_worker_image.py`::`ResolveQABundleWorkerImageTest.test_legacy_without_verified_worker_fails_closed`
+- `ops/stage0/test_deploy_stage0_workflow.py`::`DeployStage0WorkflowTest.test_legacy_worker_discovery_precedes_resolution_and_all_mutation`
+- `ops/stage0/test_deploy_stage0_workflow.py`::`DeployStage0WorkflowTest.test_legacy_rollback_converges_safe_control_plane_before_app_mutation`
+- `ops/stage0/test_deploy_stage0_workflow.py`::`DeployStage0WorkflowTest.test_qa_infra_check_is_read_only_and_verifies_oidc_binding`
 - `frontend/e2e/qa-bundle.e2e.ts`::`QA Bundle list, detail, watermark and ZIP export stay on Bundle/S3 paths`
 - `frontend/e2e/qa-bundle.e2e.ts`::`QA Bundle entitlement denial removes the entry and never starts a job`
 - `frontend/e2e/qa-bundle.e2e.ts`::`temporary unavailability is recoverable from the visible retry action`

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -688,7 +688,10 @@ bash ops/stage0/load_smoke_github_env.sh --check prod
 Required reviewers；否则 prod deploy 会在无人把关的情况下继续执行（GitHub 首次引用
 Environment 时会自动创建无门禁的同名 Env）。
 QA Bundle 的 dedicated OIDC role、CloudFormation service role 和 GitHub variable bootstrap 只在
-`ops/qa/README.md` 维护；不要在本部署手册复制第二套值。
+`ops/qa/README.md` 维护；不要在本部署手册复制第二套值。bootstrap 后 dispatch
+`deploy-stage0.yml` 的 `operation=qa-infra-check` 做只读验收；它真实 assume dedicated role，
+并检查 recognized legacy raw-archive stack 或 Bundle-era service-role binding，不创建 change set、
+不发 SSM、不改 app/Worker/host。
 
 回滚也走 dispatch：
 

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -696,6 +696,8 @@ QA Bundle 的 dedicated OIDC role、CloudFormation service role 和 GitHub varia
 gh workflow run deploy-stage0.yml -f tag=<上一版本>
 ```
 
+这只把输入解释为 app tag；QA Worker 与 host runners 不随 legacy app 一起降级。具体模式、失败边界和 degraded 验收只以 `ops/qa/README.md` 链接的 QA SSOT 为准。
+
 ### 生产升级 SOP（备用：纯手工 SSM）
 
 > 当 `deploy-stage0.yml` 被禁用、或调试 workflow 本身时使用。两段是 1:1 等价的。

--- a/deploy/aws/cloudformation/cicd-oidc.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc.yaml
@@ -174,7 +174,8 @@ Resources:
                 Effect: Allow
                 Action:
                   - ecs:DescribeServices
-                  - ecs:DescribeTaskDefinition
+                  - ecs:DescribeTasks
+                  - ecs:ListTasks
                   - sqs:GetQueueAttributes
                 Resource: "*"
               - Sid: ReadQaBundleBucketState
@@ -397,7 +398,8 @@ Resources:
                 Effect: Allow
                 Action:
                   - ecs:DescribeServices
-                  - ecs:DescribeTaskDefinition
+                  - ecs:DescribeTasks
+                  - ecs:ListTasks
                   - sqs:GetQueueAttributes
                 Resource: "*"
               - Sid: ReadQaBundleBucketState

--- a/deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py
+++ b/deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py
@@ -194,6 +194,28 @@ class Stage0QABundleContractTest(unittest.TestCase):
                 self.assertEqual(set(statement["Action"]), expected_actions)
                 self.assertEqual(statement["Resource"], expected_resource)
 
+    def test_qa_verifier_roles_can_read_running_worker_tasks(self) -> None:
+        oidc = _load_oidc_template()
+        expected = {
+            "ecs:DescribeServices",
+            "ecs:DescribeTasks",
+            "ecs:ListTasks",
+            "sqs:GetQueueAttributes",
+        }
+        for role_name, sid in (
+            ("ClusteringRole", "ReadQaBundleRuntimeForDiagnostics"),
+            ("QAInfraDeploymentRole", "VerifyQaBundleRuntime"),
+        ):
+            with self.subTest(role_name=role_name):
+                policies = oidc["Resources"][role_name]["Properties"]["Policies"]
+                statement = next(
+                    statement
+                    for policy in policies
+                    for statement in policy["PolicyDocument"]["Statement"]
+                    if isinstance(statement, dict) and statement.get("Sid") == sid
+                )
+                self.assertEqual(set(statement["Action"]), expected)
+
     def assert_worker_contract(self, template: dict) -> None:
         parameters = template["Parameters"]
         self.assertEqual(parameters["BundleWorkerDesiredCount"]["Default"], 1)

--- a/docs/approved/deploy-stage0-workflow.md
+++ b/docs/approved/deploy-stage0-workflow.md
@@ -82,13 +82,14 @@ Inputs:
 
 | Name | Type | Default | Notes |
 |---|---|---|---|
-| `operation` | choice | `deploy` | `deploy` runs the existing image switch and acceptance path; `smoke-only` runs canonical acceptance probes without host mutation |
-| `tag` | string | required | image tag without leading `v`; must match `^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+|-beta\.[0-9]+)?$`; in `smoke-only` it is an audit label only |
+| `operation` | choice | `deploy` | `deploy` runs the image switch and acceptance path; `smoke-only` runs canonical API acceptance probes; `qa-infra-check` validates the dedicated QA OIDC/IAM path and stack binding without mutation |
+| `tag` | string | required | image tag without leading `v`; must match `^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+|-beta\.[0-9]+)?$`; in read-only modes it is an audit label only |
 | `simple_release_override` | bool | `false` | deploy-only; flip only when the target host is amd64 (default-deny against the §9.1 Graviton trap) |
 
-Both jobs bind GitHub Environment **`prod`**. Only the `deploy` job receives
-`id-token: write` and `packages: read`; `smoke-only` receives `contents: read`
-only and therefore cannot obtain AWS credentials.
+All jobs bind GitHub Environment **`prod`**. The `deploy` job receives
+`id-token: write` and `packages: read`; `qa-infra-check` receives only
+`contents: read` plus `id-token: write` so it can prove both OIDC role assumptions;
+`smoke-only` receives `contents: read` only and cannot obtain AWS credentials.
 
 Steps:
 
@@ -165,14 +166,23 @@ Steps:
    `claude-sonnet-4-6`), `TK_SMOKE_GEMINI_MODELS` (default empty; native
    Gemini Google One pool retired 2026-07-04), `TK_SMOKE_OPENAI_OAUTH_MODELS`
    (default `gpt-5.4`).
-11. **Job summary** — write the deployed tag, the SSM command id, and a
-   one-liner re-dispatch command for rollback. No auto-rollback (would
-   mask transient failures).
+11. **Job summary** — write app and QA Worker images, Worker source, rollout
+   mode, host runtime mode, the SSM command id, and a one-line app rollback
+   dispatch. Legacy rollback is explicitly degraded: it requires a fully
+   verified live Worker, converges the current maintenance runner, disables
+   boundary before app mutation, skips canary, and pauses DROP until a
+   Phase 3 app is restored. No auto-rollback (would mask transient failures).
+12. **Read-only QA infrastructure acceptance** — `operation=qa-infra-check`
+   validates both IAM stack outputs, exact `QA_INFRA_OIDC_ROLE_ARN` binding,
+   real deployment-role assumption, recognized raw-archive stack identity,
+   and Bundle-era CloudFormation service-role binding. It contains no change
+   set, SSM, host sync, canary, or image mutation.
 
 Concurrency `group: deploy-stage0-prod`, `cancel-in-progress: false` is shared
-by both operations. Workflow-level permission is `contents: read`; the `deploy`
-job adds `id-token: write` and `packages: read`, while `smoke-only` remains
-read-only. No job receives `contents: write`.
+by all operations. Workflow-level permission is `contents: read`; the `deploy`
+job adds `id-token: write` and `packages: read`, `qa-infra-check` adds only
+`id-token: write`, and `smoke-only` keeps the workflow default. No job receives
+`contents: write`.
 
 ## 5. Required pre-deploy operator setup
 

--- a/docs/approved/deploy-stage0-workflow.md
+++ b/docs/approved/deploy-stage0-workflow.md
@@ -223,7 +223,9 @@ To stay focused on prod deploy automation and nothing else:
   upgrades **`prod` only**; smoke probes target that stack's `ApiUrl`.
 - **No post-cutover auto-rollback** — before Caddy reload, failures leave the
   old color untouched and serving; after Caddy reload, re-dispatch the workflow
-  with the previous tag so the rollback goes through the same health/smoke path.
+  with the previous app tag so the rollback goes through the same health/smoke
+  path. QA Worker/host-runner rollback is a separate lifecycle governed only by
+  `docs/approved/design-prod-qa-24h-s3-lifecycle.md` section 18.2.
 - **No CFN `ImageTag` parameter mutation** — drift between the CFN
   parameter and runtime `TOKENKEY_IMAGE` remains the accepted trade-off
   documented in `deploy/aws/README.md` §升级 / 发版.
@@ -245,6 +247,8 @@ If the workflow misbehaves after merge:
   `/var/lib/tokenkey/active-color`, per-color image env keys, and a blue/green
   `tokenkey.service`. To disable the workflow without rolling the host layout
   back, re-dispatch the previous known-good tag through the same workflow.
+  This is an app-image rollback; its QA control-plane behavior remains governed
+  by the QA lifecycle SSOT linked above.
 
 ## 8. Acceptance criteria
 

--- a/docs/approved/design-prod-qa-24h-s3-lifecycle.md
+++ b/docs/approved/design-prod-qa-24h-s3-lifecycle.md
@@ -1,9 +1,9 @@
 ---
 title: Prod-only QA S3 用户面与小时归档生命周期
 status: approved
-approved_by: "user (conversation approvals, 2026-08-05 through 2026-08-15; S3-only user surface, capture-sealed archive-gated hourly DROP, fail-closed single maintenance owner, no automatic emergency deletion)"
+approved_by: "user (conversation approvals, 2026-08-05 through 2026-08-17; S3-only user surface, capture-sealed archive-gated hourly DROP, fail-closed single maintenance owner, no automatic emergency deletion, and PR #1688 Bundle bootstrap/app rollback contract)"
 approved_at: 2026-08-05
-last_reviewed: 2026-08-16
+last_reviewed: 2026-08-17
 created: 2026-08-05
 authors: [agent]
 risk: high
@@ -534,9 +534,9 @@ PR 3 的代码发布不自动激活 DROP；生产激活仍需独立高风险批�
 
 任何步骤失败都停止推进，不通过手工触发 timer、DDL 或线上写入来伪造验证。
 
-### 18.2 首次 Bundle 发布与 app rollback 契约（待本 PR 人工确认）
+### 18.2 首次 Bundle 发布与 app rollback 契约
 
-> 本节是 PR #1688 的高风险修订，尚未扩展本文 frontmatter 中既有的审批范围；合并前必须经人工确认。
+> 本节是 PR #1688 的高风险修订，由用户于 2026-08-17 明确批准；该批准不授权部署、生产 IAM/GitHub variable 变更、host timer 同步或 single-owner activation。
 
 Bundle 基础设施 bootstrap 与普通 app 发布分属两个权限边界。首次 Bundle-aware prod deploy 前必须同时满足：
 

--- a/docs/approved/design-prod-qa-24h-s3-lifecycle.md
+++ b/docs/approved/design-prod-qa-24h-s3-lifecycle.md
@@ -1,9 +1,9 @@
 ---
 title: Prod-only QA S3 用户面与小时归档生命周期
 status: approved
-approved_by: "user (conversation approvals, 2026-08-05 through 2026-08-15; S3-only user surface, capture-sealed archive-gated hourly DROP, fail-closed single maintenance owner, no automatic emergency deletion)"
+approved_by: "user (conversation approvals, 2026-08-05 through 2026-08-17; S3-only user surface, capture-sealed archive-gated hourly DROP, fail-closed single maintenance owner, decoupled app/Bundle Worker rollback, no automatic emergency deletion)"
 approved_at: 2026-08-05
-last_reviewed: 2026-08-16
+last_reviewed: 2026-08-17
 created: 2026-08-05
 authors: [agent]
 risk: high
@@ -533,6 +533,43 @@ PR 3 的代码发布不自动激活 DROP；生产激活仍需独立高风险批�
 7. rollout 才能把 repository/observed state 更新为 target verified。
 
 任何步骤失败都停止推进，不通过手工触发 timer、DDL 或线上写入来伪造验证。
+
+### 18.2 首次 Bundle 发布与 app rollback 契约
+
+Bundle 基础设施 bootstrap 与普通 app 发布分属两个权限边界。首次 Bundle-aware prod deploy 前必须同时满足：
+
+- `tokenkey-cicd-oidc` 输出 `QAInfraDeploymentRoleArn` 与
+  `QAInfraCloudFormationServiceRoleArn`；
+- `prod` Environment variable `QA_INFRA_OIDC_ROLE_ARN` 精确等于
+  `QAInfraDeploymentRoleArn`；
+- deployment role 只信任 `repo:youxuanxue/sub2api:environment:prod` 的 GitHub OIDC subject，
+  CloudFormation service role 只信任 `cloudformation.amazonaws.com`，且 live policy 与当前模板一致；
+- bootstrap 后按 `ops/qa/README.md` 只读核对上述事实，普通 deploy 继续由现有 workflow 前置门禁验证 outputs、
+  variable、role assumption 与 CloudFormation 权限，不新增第二套 bootstrap workflow。旧 raw-archive stack 暂无
+  Bundle outputs 不是 blocker，首次 deploy 可以在 app image 切换前更新它；OIDC outputs、IAM trust/policy 或
+  GitHub variable 缺失则必须在任何 QA stack/app mutation 前失败。
+
+app image 与 Bundle Worker image 是两个发布生命周期，不能再用同一个 tag 隐式绑定。首个支持
+`--qa-bundle-worker` 的 release 是 `1.8.156`；这一版本下限与 CLI 的持续存在由 resolver 测试、现有 Worker
+测试和 QA sentinel 共同守卫，不新增 per-release capability marker。prod deploy 只调用一个确定性 resolver，
+由它输出 `mode` 与唯一 `resolved_worker_image`：
+
+1. 目标 app tag 不低于 `1.8.156` 时，`mode=phase3`；Worker image 只允许从现有兼容版本前进到目标版本，
+   不得因 app rollback 降级。首次建栈使用目标 release image；
+2. 目标 app tag 低于 `1.8.156` 时，`mode=legacy_rollback`；必须已有不低于该下限的
+   `BundleWorkerImage`，并原样保留；
+3. 首次建栈既没有现有兼容 Worker，又请求 legacy app tag 时，必须在 CloudFormation mutation 前失败；
+4. 无法证明现有 image 为本仓库不可变兼容 release 时，不得把它当作 rollback fallback；
+5. infra deploy 与 readiness verifier 必须消费同一个 `resolved_worker_image`，并在 summary 同时报告 app image、
+   Worker image 与 mode，禁止再声称任意 previous tag 都会同时成为可运行 Worker。
+
+回滚到 Phase 3 之前的 app 只用于恢复 gateway 服务，不撤销已经建立的 Bundle 基础设施，也不把 Worker
+降级到不支持其命令的 binary。`mode=phase3` 才 checkout/sync target-tag host runners 并执行 post-deploy
+Bundle canary；`mode=legacy_rollback` 必须原样保留已经部署的 Phase 3 maintenance/boundary runners，避免旧
+runner 恢复退役状态机或第二删除 owner，同时因旧 app 不支持 canary 命令而明确跳过 canary。此时 workflow
+warning 与 summary 必须标记 `QA Phase 3 degraded`；旧 app 最多让后续 archive-gated DROP 暂停，不能改变 durable
+activation receipt 或恢复 boundary owner。恢复 gateway 后应尽快发布兼容 Phase 3 的 app，而不是把旧 tag
+当作长期 QA 运行目标。
 
 ## 19. 迁移完成后的唯一运行图
 

--- a/docs/approved/design-prod-qa-24h-s3-lifecycle.md
+++ b/docs/approved/design-prod-qa-24h-s3-lifecycle.md
@@ -1,9 +1,9 @@
 ---
 title: Prod-only QA S3 用户面与小时归档生命周期
 status: approved
-approved_by: "user (conversation approvals, 2026-08-05 through 2026-08-17; S3-only user surface, capture-sealed archive-gated hourly DROP, fail-closed single maintenance owner, decoupled app/Bundle Worker rollback, no automatic emergency deletion)"
+approved_by: "user (conversation approvals, 2026-08-05 through 2026-08-15; S3-only user surface, capture-sealed archive-gated hourly DROP, fail-closed single maintenance owner, no automatic emergency deletion)"
 approved_at: 2026-08-05
-last_reviewed: 2026-08-17
+last_reviewed: 2026-08-16
 created: 2026-08-05
 authors: [agent]
 risk: high
@@ -534,7 +534,9 @@ PR 3 的代码发布不自动激活 DROP；生产激活仍需独立高风险批�
 
 任何步骤失败都停止推进，不通过手工触发 timer、DDL 或线上写入来伪造验证。
 
-### 18.2 首次 Bundle 发布与 app rollback 契约
+### 18.2 首次 Bundle 发布与 app rollback 契约（待本 PR 人工确认）
+
+> 本节是 PR #1688 的高风险修订，尚未扩展本文 frontmatter 中既有的审批范围；合并前必须经人工确认。
 
 Bundle 基础设施 bootstrap 与普通 app 发布分属两个权限边界。首次 Bundle-aware prod deploy 前必须同时满足：
 
@@ -549,27 +551,26 @@ Bundle 基础设施 bootstrap 与普通 app 发布分属两个权限边界。首
   Bundle outputs 不是 blocker，首次 deploy 可以在 app image 切换前更新它；OIDC outputs、IAM trust/policy 或
   GitHub variable 缺失则必须在任何 QA stack/app mutation 前失败。
 
-app image 与 Bundle Worker image 是两个发布生命周期，不能再用同一个 tag 隐式绑定。首个支持
-`--qa-bundle-worker` 的 release 是 `1.8.156`；这一版本下限与 CLI 的持续存在由 resolver 测试、现有 Worker
-测试和 QA sentinel 共同守卫，不新增 per-release capability marker。prod deploy 只调用一个确定性 resolver，
-由它输出 `mode` 与唯一 `resolved_worker_image`：
+app image 与 Bundle Worker image 是两个发布生命周期，不能再用同一个 tag 隐式绑定。能力由目标 release
+tree 的 `ops/qa/deploy_rollout.yaml` 显式声明 `bundle_runtime_contract: phase3_v1`，不得根据尚未发布的 semver
+下限猜测。prod deploy 只调用一个确定性 resolver，由它输出 `mode`、唯一 `resolved_worker_image`、
+`worker_source`、`run_canary` 与 `host_runtime_mode`：
 
-1. 目标 app tag 不低于 `1.8.156` 时，`mode=phase3`；Worker image 只允许从现有兼容版本前进到目标版本，
-   不得因 app rollback 降级。首次建栈使用目标 release image；
-2. 目标 app tag 低于 `1.8.156` 时，`mode=legacy_rollback`；必须已有不低于该下限的
-   `BundleWorkerImage`，并原样保留；
-3. 首次建栈既没有现有兼容 Worker，又请求 legacy app tag 时，必须在 CloudFormation mutation 前失败；
-4. 无法证明现有 image 为本仓库不可变兼容 release 时，不得把它当作 rollback fallback；
-5. infra deploy 与 readiness verifier 必须消费同一个 `resolved_worker_image`，并在 summary 同时报告 app image、
-   Worker image 与 mode，禁止再声称任意 previous tag 都会同时成为可运行 Worker。
+1. 目标 release tree 声明受支持 contract 时，`mode=phase3`，Worker 使用同一目标 release image；
+2. contract 缺失时，`mode=legacy_rollback`，只接受完整 read-only readiness verifier 已证明正在运行的本仓库
+   immutable release tag/digest；未知或 malformed contract 一律 fail closed；
+3. 没有 verified live Worker 的 legacy rollback 必须在 CloudFormation/app mutation 前失败；
+4. discovery 必须先验证 stack complete、CORS、AES256、lifecycle、queue/DLQ、ECS capacity 与实际 task image
+   精确等于 stack parameter，不能把 parameter 本身当成运行证明；
+5. infra deploy 与 post-update verifier 必须消费同一个 `resolved_worker_image`，并在 summary 同时报告 app image、
+   Worker image/source、mode 与 host runtime mode。
 
 回滚到 Phase 3 之前的 app 只用于恢复 gateway 服务，不撤销已经建立的 Bundle 基础设施，也不把 Worker
-降级到不支持其命令的 binary。`mode=phase3` 才 checkout/sync target-tag host runners 并执行 post-deploy
-Bundle canary；`mode=legacy_rollback` 必须原样保留已经部署的 Phase 3 maintenance/boundary runners，避免旧
-runner 恢复退役状态机或第二删除 owner，同时因旧 app 不支持 canary 命令而明确跳过 canary。此时 workflow
-warning 与 summary 必须标记 `QA Phase 3 degraded`；旧 app 最多让后续 archive-gated DROP 暂停，不能改变 durable
-activation receipt 或恢复 boundary owner。恢复 gateway 后应尽快发布兼容 Phase 3 的 app，而不是把旧 tag
-当作长期 QA 运行目标。
+降级到不支持其命令的 binary。`mode=phase3` checkout/sync target-tag host runners 并执行 post-deploy Bundle
+canary；`mode=legacy_rollback` 在 app switch 前用当前 release tree 的 Phase 3 runners 收敛 host：maintenance
+enabled，boundary disabled/inactive；不得安装 legacy target runner，也不得保留未经证明的 live runner 状态。
+此模式跳过 canary，标记 `QA Phase 3 degraded`，archive 可继续而 DROP 明确暂停；durable activation receipt 不变，
+恢复 compatible Phase 3 app 后才以 boundary `auto` 恢复唯一 owner。
 
 ## 19. 迁移完成后的唯一运行图
 

--- a/frontend/src/views/admin/__tests__/SettingsView.spec.ts
+++ b/frontend/src/views/admin/__tests__/SettingsView.spec.ts
@@ -196,8 +196,6 @@ vi.mock("vue-i18n", async () => {
     "admin.settings.paymentVisibleMethods.sourceRequiredError": "{title} 已启用，请先选择支付来源。",
     "admin.settings.payment.configGuide": "查看支付配置说明",
     "admin.settings.payment.findProvider": "查看支持的支付方式",
-    "admin.settings.upstreamBillingProbe.title": "上游倍率自动探测",
-    "admin.settings.upstreamBillingProbe.saved": "上游倍率自动探测设置已保存",
     "admin.settings.openaiExperimentalScheduler.title": "OpenAI 实验调度策略",
     "admin.settings.openaiExperimentalScheduler.description": "默认关闭。开启后仅影响本网关在 OpenAI 账号间的实验性调度选择逻辑，不代表上游 OpenAI 官方能力。",
     "admin.settings.openaiExperimentalScheduler.lowRatePriorityTitle": "低倍率优先",
@@ -539,6 +537,7 @@ function mountView() {
     global: {
       stubs: {
         AppLayout: AppLayoutStub,
+        RouterLink: true,
         Select: SelectStub,
         Toggle: ToggleStub,
         Icon: true,
@@ -1245,6 +1244,7 @@ describe("admin SettingsView payment visible method controls", () => {
       global: {
         stubs: {
           AppLayout: AppLayoutStub,
+          RouterLink: true,
           Select: SelectStub,
           Toggle: ToggleStub,
           Icon: true,
@@ -1491,6 +1491,7 @@ describe("admin SettingsView payment visible method controls", () => {
       global: {
         stubs: {
           AppLayout: AppLayoutStub,
+          RouterLink: true,
           Select: SelectStub,
           Toggle: ToggleStub,
           Icon: true,

--- a/ops/observability/test_ops_daily_diagnostics_workflow.py
+++ b/ops/observability/test_ops_daily_diagnostics_workflow.py
@@ -171,7 +171,10 @@ class OpsDailyDiagnosticsWorkflowTest(unittest.TestCase):
 
     def test_qa_bundle_infra_and_real_canary_are_wired_for_prod(self) -> None:
         text = workflow_text()
-        self.assertIn("verify_qa_bundle_infra.sh", text)
+        self.assertIn(
+            "QA_BUNDLE_VERIFY_MODE=discovery bash ops/qa/verify_qa_bundle_infra.sh",
+            text,
+        )
         self.assertIn("run-qa-bundle-canary-via-ssm.sh", text)
         self.assertIn("qa-bundle-infra|$TARGET_ID", text)
         self.assertIn("qa-bundle-canary|$TARGET_ID", text)

--- a/ops/qa/README.md
+++ b/ops/qa/README.md
@@ -21,11 +21,12 @@ This is the single operator entry for the IAM and GitHub configuration required 
 2. Set GitHub Actions variable `QA_INFRA_OIDC_ROLE_ARN` to stack output `QAInfraDeploymentRoleArn`. Keep `CICD_OIDC_STACK_NAME=tokenkey-cicd-oidc` unless the stack uses a non-default name.
 3. Set `QA_OPS_RECOVERY_PRINCIPAL_ARN` to the approved IAM user or role that may assume the raw-archive recovery role. It is required to create the QA stack; later deploys recover the durable value from the stack parameter.
 4. Optional non-default stack names use `QA_RAW_ARCHIVE_STACK`. The deploy workflow resolves all remaining VPC, subnet, route-table, app-role, image, and browser-origin inputs from the target Stage0 stack and release tag.
-5. Dispatching `deploy-stage0.yml` then deploys and verifies Bundle infrastructure before changing the prod app image. The verifier reads back the exact bucket CORS origin, AES256 encryption, job-surface lifecycle, running Fargate task/image, and queue/DLQ state; any missing or drifting prerequisite fails closed before the app mutation.
+5. Dispatch `deploy-stage0.yml` with `operation=qa-infra-check` to verify both OIDC outputs, exact variable binding, real deployment-role assumption, QA stack read access, and the Bundle-era CloudFormation service-role binding without mutation. Only a stack exposing the canonical raw-archive outputs is recognized; a matching legacy pre-Bundle stack reports `legacy_bootstrap_ready`, while an unrelated/malformed stack or Bundle-era service-role drift fails.
+6. Normal deploy then verifies Bundle infrastructure before changing the prod app image. Legacy rollback first runs the verifier in explicit discovery mode and accepts only its actual Worker image; post-update verification requires the resolved image explicitly.
 
 `QA_INFRA_OIDC_ROLE_ARN`, `QA_OPS_RECOVERY_PRINCIPAL_ARN`, `CICD_OIDC_STACK_NAME`, and `QA_RAW_ARCHIVE_STACK` are GitHub Actions variables, not secrets. No AWS long-lived credentials are added to GitHub.
 
-App rollback does not imply QA control-plane rollback. The deploy workflow resolves the Bundle Worker image independently; legacy app rollback preserves the compatible Worker and Phase 3 host runners, skips the unsupported Bundle canary, and reports a degraded state. The complete resolver and recovery contract has one normative source: `docs/approved/design-prod-qa-24h-s3-lifecycle.md` section 18.2.
+App rollback does not imply QA control-plane rollback. The target release tree explicitly declares `bundle_runtime_contract: phase3_v1`. Legacy app rollback preserves only a fully verified live Worker, converges the current Phase 3 maintenance runner, forces boundary disabled/inactive before the app switch, skips canary, pauses DROP, and reports a degraded state. The complete resolver and recovery contract has one normative source: `docs/approved/design-prod-qa-24h-s3-lifecycle.md` section 18.2.
 
 ## State and checks
 

--- a/ops/qa/README.md
+++ b/ops/qa/README.md
@@ -25,6 +25,8 @@ This is the single operator entry for the IAM and GitHub configuration required 
 
 `QA_INFRA_OIDC_ROLE_ARN`, `QA_OPS_RECOVERY_PRINCIPAL_ARN`, `CICD_OIDC_STACK_NAME`, and `QA_RAW_ARCHIVE_STACK` are GitHub Actions variables, not secrets. No AWS long-lived credentials are added to GitHub.
 
+App rollback does not imply QA control-plane rollback. The deploy workflow resolves the Bundle Worker image independently; legacy app rollback preserves the compatible Worker and Phase 3 host runners, skips the unsupported Bundle canary, and reports a degraded state. The complete resolver and recovery contract has one normative source: `docs/approved/design-prod-qa-24h-s3-lifecycle.md` section 18.2.
+
 ## State and checks
 
 The repository may be `single_owner_ready` while observed live state remains `single_owner_not_activated`. Editing rollout metadata never proves deployment.
@@ -32,6 +34,7 @@ The repository may be `single_owner_ready` while observed live state remains `si
 ```bash
 python3 scripts/checks/qa-lifecycle-ssot.py --self-test
 python3 scripts/checks/qa-lifecycle-ssot.py
+python3 -m unittest ops.qa.test_resolve_qa_bundle_worker_image ops.stage0.test_deploy_stage0_workflow
 python3 -m unittest ops.qa.test_qa_phase_ops
 cd backend && go test -tags=unit ./internal/observability/qa/lifecycle ./cmd/server
 ```

--- a/ops/qa/deploy_rollout.yaml
+++ b/ops/qa/deploy_rollout.yaml
@@ -65,6 +65,7 @@ prod:
     database_job_registry: retired
     bundle_infra_repository_state: ready
     bundle_infra_observed_state: not_verified
+    bundle_runtime_contract: phase3_v1
     bundle_worker_desired_count: 1
     bundle_readiness_verifier: ops/qa/verify_qa_bundle_infra.sh
     bundle_canary: ops/stage0/run-qa-bundle-canary-via-ssm.sh

--- a/ops/qa/resolve_qa_bundle_worker_image.py
+++ b/ops/qa/resolve_qa_bundle_worker_image.py
@@ -1,91 +1,100 @@
 #!/usr/bin/env python3
-"""Resolve the QA Bundle Worker image independently from the app rollback tag."""
+"""Resolve QA Bundle rollout from an explicit release-tree capability contract."""
 from __future__ import annotations
 
 import argparse
 import json
 import re
 import sys
-from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
 
 
 IMAGE_REPOSITORY = "ghcr.io/youxuanxue/sub2api"
-PHASE3_MINIMUM_TAG = "1.8.156"
+SUPPORTED_RUNTIME_CONTRACT = "phase3_v1"
 TAG_PATTERN = re.compile(
-    r"^(?P<major>0|[1-9][0-9]*)\."
-    r"(?P<minor>0|[1-9][0-9]*)\."
-    r"(?P<patch>0|[1-9][0-9]*)"
-    r"(?:-(?P<stage>beta|rc)\.(?P<number>0|[1-9][0-9]*))?$"
+    r"^(?:0|[1-9][0-9]*)\."
+    r"(?:0|[1-9][0-9]*)\."
+    r"(?:0|[1-9][0-9]*)"
+    r"(?:-(?:beta|rc)\.(?:0|[1-9][0-9]*))?$"
 )
+DIGEST_PATTERN = re.compile(r"^sha256:[a-f0-9]{64}$")
 
 
-@dataclass(frozen=True, order=True)
-class Version:
-    major: int
-    minor: int
-    patch: int
-    stage_rank: int
-    stage_number: int
-
-
-def parse_tag(tag: str) -> Version | None:
-    match = TAG_PATTERN.fullmatch(tag)
-    if match is None:
+def release_contract(path: Path) -> str | None:
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+        user_export = payload["prod"]["user_export"]
+    except (OSError, KeyError, TypeError, yaml.YAMLError) as exc:
+        raise ValueError(f"target rollout manifest is invalid: {exc}") from exc
+    if not isinstance(user_export, dict):
+        raise ValueError("target rollout manifest prod.user_export must be a mapping")
+    contract = user_export.get("bundle_runtime_contract")
+    if contract is None:
         return None
-    stage = match.group("stage")
-    stage_rank = {"beta": 0, "rc": 1, None: 2}[stage]
-    return Version(
-        int(match.group("major")),
-        int(match.group("minor")),
-        int(match.group("patch")),
-        stage_rank,
-        int(match.group("number") or 0),
-    )
+    if contract != SUPPORTED_RUNTIME_CONTRACT:
+        raise ValueError(f"unsupported target Bundle runtime contract: {contract!r}")
+    return contract
 
 
-def existing_release(image: str) -> tuple[Version, str] | None:
-    prefix = f"{IMAGE_REPOSITORY}:"
-    if not image.startswith(prefix):
-        return None
-    tag = image.removeprefix(prefix)
-    version = parse_tag(tag)
-    if version is None:
-        return None
-    return version, image
+def verified_worker_image(image: str) -> str | None:
+    tag_prefix = f"{IMAGE_REPOSITORY}:"
+    digest_prefix = f"{IMAGE_REPOSITORY}@"
+    if image.startswith(tag_prefix):
+        tag = image.removeprefix(tag_prefix)
+        return image if TAG_PATTERN.fullmatch(tag) else None
+    if image.startswith(digest_prefix):
+        digest = image.removeprefix(digest_prefix)
+        return image if DIGEST_PATTERN.fullmatch(digest) else None
+    return None
 
 
-def resolve(target_tag: str, existing_image: str) -> dict[str, str]:
-    target = parse_tag(target_tag)
-    if target is None:
+def resolve(
+    target_tag: str,
+    target_rollout: Path,
+    verified_existing_image: str,
+) -> dict[str, str | bool]:
+    if TAG_PATTERN.fullmatch(target_tag) is None:
+        raise ValueError("target tag must match X.Y.Z (optionally -rc.N or -beta.N)")
+
+    contract = release_contract(target_rollout)
+    if contract == SUPPORTED_RUNTIME_CONTRACT:
+        return {
+            "mode": "phase3",
+            "resolved_worker_image": f"{IMAGE_REPOSITORY}:{target_tag}",
+            "worker_source": "target_release",
+            "run_canary": True,
+            "host_runtime_mode": "target_release",
+        }
+
+    existing = verified_worker_image(verified_existing_image)
+    if existing is None:
         raise ValueError(
-            "target tag must match X.Y.Z (optionally -rc.N or -beta.N)"
+            "legacy rollback requires a fully verified immutable QA Bundle Worker "
+            f"image from {IMAGE_REPOSITORY}"
         )
-
-    minimum = parse_tag(PHASE3_MINIMUM_TAG)
-    assert minimum is not None
-    current = existing_release(existing_image)
-
-    if target >= minimum:
-        target_image = f"{IMAGE_REPOSITORY}:{target_tag}"
-        if current is not None and current[0] >= minimum and current[0] > target:
-            target_image = current[1]
-        return {"mode": "phase3", "resolved_worker_image": target_image}
-
-    if current is None or current[0] < minimum:
-        raise ValueError(
-            "legacy rollback requires an existing compatible QA Bundle Worker "
-            f"image from {IMAGE_REPOSITORY} at or above {PHASE3_MINIMUM_TAG}"
-        )
-    return {"mode": "legacy_rollback", "resolved_worker_image": current[1]}
+    return {
+        "mode": "legacy_rollback",
+        "resolved_worker_image": existing,
+        "worker_source": "verified_live_worker",
+        "run_canary": False,
+        "host_runtime_mode": "current_safe_degraded",
+    }
 
 
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--target-tag", required=True)
-    parser.add_argument("--existing-image", default="")
+    parser.add_argument("--target-rollout", type=Path, required=True)
+    parser.add_argument("--verified-existing-image", default="")
     args = parser.parse_args()
     try:
-        result = resolve(args.target_tag, args.existing_image)
+        result = resolve(
+            args.target_tag,
+            args.target_rollout,
+            args.verified_existing_image,
+        )
     except ValueError as exc:
         print(f"resolve QA Bundle Worker image: {exc}", file=sys.stderr)
         return 1

--- a/ops/qa/resolve_qa_bundle_worker_image.py
+++ b/ops/qa/resolve_qa_bundle_worker_image.py
@@ -25,9 +25,13 @@ DIGEST_PATTERN = re.compile(r"^sha256:[a-f0-9]{64}$")
 def release_contract(path: Path) -> str | None:
     try:
         payload = yaml.safe_load(path.read_text(encoding="utf-8"))
-        user_export = payload["prod"]["user_export"]
-    except (OSError, KeyError, TypeError, yaml.YAMLError) as exc:
+    except (OSError, yaml.YAMLError) as exc:
         raise ValueError(f"target rollout manifest is invalid: {exc}") from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("prod"), dict):
+        raise ValueError("target rollout manifest prod must be a mapping")
+    user_export = payload["prod"].get("user_export")
+    if user_export is None:
+        return None
     if not isinstance(user_export, dict):
         raise ValueError("target rollout manifest prod.user_export must be a mapping")
     contract = user_export.get("bundle_runtime_contract")

--- a/ops/qa/resolve_qa_bundle_worker_image.py
+++ b/ops/qa/resolve_qa_bundle_worker_image.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Resolve the QA Bundle Worker image independently from the app rollback tag."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+
+
+IMAGE_REPOSITORY = "ghcr.io/youxuanxue/sub2api"
+PHASE3_MINIMUM_TAG = "1.8.156"
+TAG_PATTERN = re.compile(
+    r"^(?P<major>0|[1-9][0-9]*)\."
+    r"(?P<minor>0|[1-9][0-9]*)\."
+    r"(?P<patch>0|[1-9][0-9]*)"
+    r"(?:-(?P<stage>beta|rc)\.(?P<number>0|[1-9][0-9]*))?$"
+)
+
+
+@dataclass(frozen=True, order=True)
+class Version:
+    major: int
+    minor: int
+    patch: int
+    stage_rank: int
+    stage_number: int
+
+
+def parse_tag(tag: str) -> Version | None:
+    match = TAG_PATTERN.fullmatch(tag)
+    if match is None:
+        return None
+    stage = match.group("stage")
+    stage_rank = {"beta": 0, "rc": 1, None: 2}[stage]
+    return Version(
+        int(match.group("major")),
+        int(match.group("minor")),
+        int(match.group("patch")),
+        stage_rank,
+        int(match.group("number") or 0),
+    )
+
+
+def existing_release(image: str) -> tuple[Version, str] | None:
+    prefix = f"{IMAGE_REPOSITORY}:"
+    if not image.startswith(prefix):
+        return None
+    tag = image.removeprefix(prefix)
+    version = parse_tag(tag)
+    if version is None:
+        return None
+    return version, image
+
+
+def resolve(target_tag: str, existing_image: str) -> dict[str, str]:
+    target = parse_tag(target_tag)
+    if target is None:
+        raise ValueError(
+            "target tag must match X.Y.Z (optionally -rc.N or -beta.N)"
+        )
+
+    minimum = parse_tag(PHASE3_MINIMUM_TAG)
+    assert minimum is not None
+    current = existing_release(existing_image)
+
+    if target >= minimum:
+        target_image = f"{IMAGE_REPOSITORY}:{target_tag}"
+        if current is not None and current[0] >= minimum and current[0] > target:
+            target_image = current[1]
+        return {"mode": "phase3", "resolved_worker_image": target_image}
+
+    if current is None or current[0] < minimum:
+        raise ValueError(
+            "legacy rollback requires an existing compatible QA Bundle Worker "
+            f"image from {IMAGE_REPOSITORY} at or above {PHASE3_MINIMUM_TAG}"
+        )
+    return {"mode": "legacy_rollback", "resolved_worker_image": current[1]}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--target-tag", required=True)
+    parser.add_argument("--existing-image", default="")
+    args = parser.parse_args()
+    try:
+        result = resolve(args.target_tag, args.existing_image)
+    except ValueError as exc:
+        print(f"resolve QA Bundle Worker image: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, separators=(",", ":"), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/qa/test_qa_phase_ops.py
+++ b/ops/qa/test_qa_phase_ops.py
@@ -1012,13 +1012,19 @@ JSON
     printf '%s\n' '{"Rules":[{"ID":"expire-qa-bundle-job-surfaces","Status":"Enabled","Filter":{"Prefix":"user-qa/qa-bundles/v1/jobs/"},"Expiration":{"Days":2}}]}'
     ;;
   *"sqs get-queue-attributes"*"https://sqs/dlq"*)
-    printf '{"Attributes":{"QueueArn":"arn:dlq","ApproximateNumberOfMessages":"%s"}}\n' "${DLQ_DEPTH:-0}"
+    printf '{"Attributes":{"QueueArn":"arn:dlq","SqsManagedSseEnabled":"%s","ApproximateNumberOfMessages":"%s"}}\n' "${DLQ_SSE_ENABLED:-true}" "${DLQ_DEPTH:-0}"
     ;;
   *"sqs get-queue-attributes"*"https://sqs/queue"*)
-    printf '%s\n' '{"Attributes":{"QueueArn":"arn:queue","ApproximateNumberOfMessages":"0","ApproximateNumberOfMessagesNotVisible":"0"}}'
+    jq -cn --arg dlq "${REDRIVE_DLQ_ARN:-arn:dlq}" --arg sse "${QUEUE_SSE_ENABLED:-true}" '{Attributes:{QueueArn:"arn:queue",RedrivePolicy:({deadLetterTargetArn:$dlq,maxReceiveCount:"3"}|tojson),SqsManagedSseEnabled:$sse,ApproximateNumberOfMessages:"0",ApproximateNumberOfMessagesNotVisible:"0"}}'
     ;;
   *"ecs describe-services"*)
-    printf '%s\n' '{"failures":[],"services":[{"status":"ACTIVE","desiredCount":1,"runningCount":1,"taskDefinition":"arn:task:1"}]}'
+    printf '%s\n' '{"failures":[],"services":[{"status":"ACTIVE","desiredCount":1,"runningCount":1,"taskDefinition":"arn:task-def:1"}]}'
+    ;;
+  *"ecs list-tasks"*)
+    printf '%s\n' '{"taskArns":["arn:task/1"]}'
+    ;;
+  *"ecs describe-tasks"*)
+    printf '{"failures":[],"tasks":[{"taskArn":"arn:task/1","lastStatus":"RUNNING","taskDefinitionArn":"%s","containers":[{"name":"qa-bundle-worker","image":"%s"}]}]}\n' "${RUNNING_TASK_DEFINITION:-arn:task-def:1}" "${RUNNING_TASK_IMAGE:-ghcr.io/youxuanxue/sub2api:1.8.156}"
     ;;
   *"ecs describe-task-definition"*)
     printf '%s\n' '{"taskDefinition":{"containerDefinitions":[{"name":"qa-bundle-worker","image":"ghcr.io/youxuanxue/sub2api:1.8.156"}]}}'
@@ -1064,7 +1070,8 @@ esac
                 "s3api get-bucket-lifecycle-configuration",
                 "sqs get-queue-attributes",
                 "ecs describe-services",
-                "ecs describe-task-definition",
+                "ecs list-tasks",
+                "ecs describe-tasks",
             ):
                 self.assertIn(expected, observed)
 
@@ -1126,6 +1133,39 @@ esac
             )
             self.assertNotEqual(unhealthy.returncode, 0)
             self.assertIn("QA Bundle DLQ is not empty: 2", unhealthy.stderr)
+
+            stale_task = subprocess.run(
+                ["bash", str(script)],
+                env={
+                    **base_env,
+                    "RUNNING_TASK_IMAGE": "ghcr.io/youxuanxue/sub2api:1.8.155",
+                },
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(stale_task.returncode, 0)
+            self.assertIn("running task contract drift", stale_task.stderr)
+
+            redrive_drift = subprocess.run(
+                ["bash", str(script)],
+                env={**base_env, "REDRIVE_DLQ_ARN": "arn:wrong-dlq"},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(redrive_drift.returncode, 0)
+            self.assertIn("QA Bundle queue redrive drift", redrive_drift.stderr)
+
+            queue_sse_drift = subprocess.run(
+                ["bash", str(script)],
+                env={**base_env, "QUEUE_SSE_ENABLED": "false"},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(queue_sse_drift.returncode, 0)
+            self.assertIn("QA Bundle queue encryption drift", queue_sse_drift.stderr)
 
     def test_qa_bundle_canary_ssm_wrapper_requires_canonical_receipt(self) -> None:
         script = ROOT / "ops/stage0/run-qa-bundle-canary-via-ssm.sh"

--- a/ops/qa/test_qa_phase_ops.py
+++ b/ops/qa/test_qa_phase_ops.py
@@ -58,6 +58,7 @@ class TestQAPhaseOps(unittest.TestCase):
         self.assertEqual(user_export["phase3_worker_observed_state"], "transitional_in_prod")
         self.assertEqual(user_export["job_registry"], "immutable_s3_spec")
         self.assertEqual(user_export["database_job_registry"], "retired")
+        self.assertEqual(user_export["bundle_runtime_contract"], "phase3_v1")
         self.assertEqual(user_export["bundle_worker_desired_count"], 1)
 
     def test_maintenance_is_the_only_target_lifecycle_owner(self) -> None:
@@ -1032,6 +1033,7 @@ esac
                 "PATH": f"{fake_bin}:/usr/bin:/bin",
                 "AWS_CALLS": str(calls),
                 "GITHUB_OUTPUT": str(root / "github-output"),
+                "QA_BUNDLE_VERIFY_MODE": "expected",
                 "QA_BUNDLE_WORKER_IMAGE": "ghcr.io/youxuanxue/sub2api:1.8.156",
                 "QA_BUNDLE_WORKER_DESIRED_COUNT": "1",
             }
@@ -1047,7 +1049,11 @@ esac
             self.assertEqual(receipt["browser_origin"], "https://tokenkey.dev")
             self.assertEqual(
                 (root / "github-output").read_text(encoding="utf-8").splitlines(),
-                ["bucket=qa-bucket", "queue_url=https://sqs/queue"],
+                [
+                    "bucket=qa-bucket",
+                    "queue_url=https://sqs/queue",
+                    "worker_image=ghcr.io/youxuanxue/sub2api:1.8.156",
+                ],
             )
             observed = calls.read_text(encoding="utf-8")
             for expected in (
@@ -1061,6 +1067,45 @@ esac
                 "ecs describe-task-definition",
             ):
                 self.assertIn(expected, observed)
+
+            discovery_output = root / "github-output-discovery"
+            discovery = subprocess.run(
+                ["bash", str(script)],
+                env={
+                    key: value
+                    for key, value in base_env.items()
+                    if key != "QA_BUNDLE_WORKER_IMAGE"
+                }
+                | {
+                    "QA_BUNDLE_VERIFY_MODE": "discovery",
+                    "GITHUB_OUTPUT": str(discovery_output),
+                },
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(discovery.returncode, 0, discovery.stderr)
+            self.assertIn(
+                "worker_image=ghcr.io/youxuanxue/sub2api:1.8.156",
+                discovery_output.read_text(encoding="utf-8").splitlines(),
+            )
+
+            missing_expected = subprocess.run(
+                ["bash", str(script)],
+                env={
+                    key: value
+                    for key, value in base_env.items()
+                    if key != "QA_BUNDLE_WORKER_IMAGE"
+                },
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(missing_expected.returncode, 0)
+            self.assertIn(
+                "QA_BUNDLE_WORKER_IMAGE is required in expected mode",
+                missing_expected.stderr,
+            )
 
             cors_drift = subprocess.run(
                 ["bash", str(script)],

--- a/ops/qa/test_resolve_qa_bundle_worker_image.py
+++ b/ops/qa/test_resolve_qa_bundle_worker_image.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Contract tests for the QA Bundle Worker release resolver."""
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+RESOLVER = REPO_ROOT / "ops" / "qa" / "resolve_qa_bundle_worker_image.py"
+IMAGE_REPOSITORY = "ghcr.io/youxuanxue/sub2api"
+
+
+def resolve(target_tag: str, existing_image: str = "") -> subprocess.CompletedProcess[str]:
+    command = ["python3", str(RESOLVER), "--target-tag", target_tag]
+    if existing_image:
+        command.extend(("--existing-image", existing_image))
+    return subprocess.run(command, capture_output=True, text=True, check=False)
+
+
+class ResolveQABundleWorkerImageTest(unittest.TestCase):
+    def assert_resolution(
+        self,
+        target_tag: str,
+        existing_image: str,
+        *,
+        mode: str,
+        image: str,
+    ) -> None:
+        proc = resolve(target_tag, existing_image)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertEqual(
+            json.loads(proc.stdout),
+            {"mode": mode, "resolved_worker_image": image},
+        )
+
+    def test_first_phase3_release_bootstraps_worker_from_target(self) -> None:
+        self.assert_resolution(
+            "1.8.156",
+            "",
+            mode="phase3",
+            image=f"{IMAGE_REPOSITORY}:1.8.156",
+        )
+
+    def test_phase3_upgrade_advances_worker_to_target(self) -> None:
+        self.assert_resolution(
+            "1.8.158",
+            f"{IMAGE_REPOSITORY}:1.8.156",
+            mode="phase3",
+            image=f"{IMAGE_REPOSITORY}:1.8.158",
+        )
+
+    def test_phase3_target_replaces_an_unproven_existing_image(self) -> None:
+        self.assert_resolution(
+            "1.8.157",
+            "ghcr.io/example/sub2api:9.9.9",
+            mode="phase3",
+            image=f"{IMAGE_REPOSITORY}:1.8.157",
+        )
+
+    def test_phase3_app_rollback_does_not_downgrade_worker(self) -> None:
+        self.assert_resolution(
+            "1.8.157",
+            f"{IMAGE_REPOSITORY}:1.8.158",
+            mode="phase3",
+            image=f"{IMAGE_REPOSITORY}:1.8.158",
+        )
+
+    def test_prerelease_ordering_uses_the_same_monotonic_rule(self) -> None:
+        self.assert_resolution(
+            "1.8.157-rc.2",
+            f"{IMAGE_REPOSITORY}:1.8.157-beta.3",
+            mode="phase3",
+            image=f"{IMAGE_REPOSITORY}:1.8.157-rc.2",
+        )
+        self.assert_resolution(
+            "1.8.157-rc.2",
+            f"{IMAGE_REPOSITORY}:1.8.157-rc.3",
+            mode="phase3",
+            image=f"{IMAGE_REPOSITORY}:1.8.157-rc.3",
+        )
+
+    def test_phase3_release_candidate_is_still_legacy_until_the_compatibility_floor(self) -> None:
+        self.assert_resolution(
+            "1.8.156-rc.1",
+            f"{IMAGE_REPOSITORY}:1.8.156",
+            mode="legacy_rollback",
+            image=f"{IMAGE_REPOSITORY}:1.8.156",
+        )
+
+    def test_legacy_app_rollback_preserves_compatible_worker(self) -> None:
+        self.assert_resolution(
+            "1.8.155",
+            f"{IMAGE_REPOSITORY}:1.8.156",
+            mode="legacy_rollback",
+            image=f"{IMAGE_REPOSITORY}:1.8.156",
+        )
+
+    def test_legacy_app_without_existing_worker_fails_closed(self) -> None:
+        proc = resolve("1.8.155")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("requires an existing compatible QA Bundle Worker", proc.stderr)
+
+    def test_legacy_app_rejects_pre_phase3_existing_worker(self) -> None:
+        proc = resolve("1.8.155", f"{IMAGE_REPOSITORY}:1.8.155")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("requires an existing compatible QA Bundle Worker", proc.stderr)
+
+    def test_legacy_app_rejects_foreign_or_unversioned_existing_image(self) -> None:
+        for image in (
+            "ghcr.io/example/sub2api:1.8.156",
+            f"{IMAGE_REPOSITORY}:latest",
+            f"{IMAGE_REPOSITORY}@sha256:{'a' * 64}",
+        ):
+            with self.subTest(image=image):
+                proc = resolve("1.8.155", image)
+                self.assertNotEqual(proc.returncode, 0)
+                self.assertIn("requires an existing compatible QA Bundle Worker", proc.stderr)
+
+    def test_invalid_target_tag_is_rejected(self) -> None:
+        for target in ("v1.8.156", "1.8", "1.8.156-preview.1"):
+            with self.subTest(target=target):
+                proc = resolve(target)
+                self.assertNotEqual(proc.returncode, 0)
+                self.assertIn("target tag must match", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/qa/test_resolve_qa_bundle_worker_image.py
+++ b/ops/qa/test_resolve_qa_bundle_worker_image.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import pathlib
 import subprocess
+import tempfile
 import unittest
 
 
@@ -13,10 +14,33 @@ RESOLVER = REPO_ROOT / "ops" / "qa" / "resolve_qa_bundle_worker_image.py"
 IMAGE_REPOSITORY = "ghcr.io/youxuanxue/sub2api"
 
 
-def resolve(target_tag: str, existing_image: str = "") -> subprocess.CompletedProcess[str]:
-    command = ["python3", str(RESOLVER), "--target-tag", target_tag]
+def rollout_manifest(root: pathlib.Path, contract: object = ...,) -> pathlib.Path:
+    path = root / "deploy_rollout.yaml"
+    if contract is ...:
+        user_export = "    bundle_runtime_contract: phase3_v1\n"
+    elif contract is None:
+        user_export = ""
+    else:
+        user_export = f"    bundle_runtime_contract: {contract}\n"
+    path.write_text(f"prod:\n  user_export:\n{user_export}    marker: true\n")
+    return path
+
+
+def resolve(
+    target_tag: str,
+    target_rollout: pathlib.Path,
+    existing_image: str = "",
+) -> subprocess.CompletedProcess[str]:
+    command = [
+        "python3",
+        str(RESOLVER),
+        "--target-tag",
+        target_tag,
+        "--target-rollout",
+        str(target_rollout),
+    ]
     if existing_image:
-        command.extend(("--existing-image", existing_image))
+        command.extend(("--verified-existing-image", existing_image))
     return subprocess.run(command, capture_output=True, text=True, check=False)
 
 
@@ -24,107 +48,115 @@ class ResolveQABundleWorkerImageTest(unittest.TestCase):
     def assert_resolution(
         self,
         target_tag: str,
+        target_rollout: pathlib.Path,
         existing_image: str,
         *,
         mode: str,
         image: str,
+        worker_source: str,
+        run_canary: bool,
+        host_runtime_mode: str,
     ) -> None:
-        proc = resolve(target_tag, existing_image)
+        proc = resolve(target_tag, target_rollout, existing_image)
         self.assertEqual(proc.returncode, 0, msg=proc.stderr)
         self.assertEqual(
             json.loads(proc.stdout),
-            {"mode": mode, "resolved_worker_image": image},
+            {
+                "mode": mode,
+                "resolved_worker_image": image,
+                "worker_source": worker_source,
+                "run_canary": run_canary,
+                "host_runtime_mode": host_runtime_mode,
+            },
         )
 
-    def test_first_phase3_release_bootstraps_worker_from_target(self) -> None:
-        self.assert_resolution(
-            "1.8.156",
-            "",
-            mode="phase3",
-            image=f"{IMAGE_REPOSITORY}:1.8.156",
-        )
+    def test_phase3_contract_uses_target_release_image(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = rollout_manifest(pathlib.Path(temp_dir))
+            self.assert_resolution(
+                "1.8.200",
+                manifest,
+                f"{IMAGE_REPOSITORY}:1.8.999",
+                mode="phase3",
+                image=f"{IMAGE_REPOSITORY}:1.8.200",
+                worker_source="target_release",
+                run_canary=True,
+                host_runtime_mode="target_release",
+            )
 
-    def test_phase3_upgrade_advances_worker_to_target(self) -> None:
-        self.assert_resolution(
-            "1.8.158",
-            f"{IMAGE_REPOSITORY}:1.8.156",
-            mode="phase3",
-            image=f"{IMAGE_REPOSITORY}:1.8.158",
-        )
+    def test_missing_contract_is_legacy_and_preserves_verified_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = rollout_manifest(pathlib.Path(temp_dir), None)
+            image = f"{IMAGE_REPOSITORY}:1.8.200"
+            self.assert_resolution(
+                "1.8.155",
+                manifest,
+                image,
+                mode="legacy_rollback",
+                image=image,
+                worker_source="verified_live_worker",
+                run_canary=False,
+                host_runtime_mode="current_safe_degraded",
+            )
 
-    def test_phase3_target_replaces_an_unproven_existing_image(self) -> None:
-        self.assert_resolution(
-            "1.8.157",
-            "ghcr.io/example/sub2api:9.9.9",
-            mode="phase3",
-            image=f"{IMAGE_REPOSITORY}:1.8.157",
-        )
+    def test_legacy_accepts_verified_repository_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = rollout_manifest(pathlib.Path(temp_dir), None)
+            image = f"{IMAGE_REPOSITORY}@sha256:{'a' * 64}"
+            self.assert_resolution(
+                "1.8.155",
+                manifest,
+                image,
+                mode="legacy_rollback",
+                image=image,
+                worker_source="verified_live_worker",
+                run_canary=False,
+                host_runtime_mode="current_safe_degraded",
+            )
 
-    def test_phase3_app_rollback_does_not_downgrade_worker(self) -> None:
-        self.assert_resolution(
-            "1.8.157",
-            f"{IMAGE_REPOSITORY}:1.8.158",
-            mode="phase3",
-            image=f"{IMAGE_REPOSITORY}:1.8.158",
-        )
+    def test_legacy_without_verified_worker_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = rollout_manifest(pathlib.Path(temp_dir), None)
+            proc = resolve("1.8.155", manifest)
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("requires a fully verified immutable", proc.stderr)
 
-    def test_prerelease_ordering_uses_the_same_monotonic_rule(self) -> None:
-        self.assert_resolution(
-            "1.8.157-rc.2",
-            f"{IMAGE_REPOSITORY}:1.8.157-beta.3",
-            mode="phase3",
-            image=f"{IMAGE_REPOSITORY}:1.8.157-rc.2",
-        )
-        self.assert_resolution(
-            "1.8.157-rc.2",
-            f"{IMAGE_REPOSITORY}:1.8.157-rc.3",
-            mode="phase3",
-            image=f"{IMAGE_REPOSITORY}:1.8.157-rc.3",
-        )
+    def test_legacy_rejects_foreign_or_mutable_worker(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = rollout_manifest(pathlib.Path(temp_dir), None)
+            for image in (
+                "ghcr.io/example/sub2api:1.8.200",
+                f"{IMAGE_REPOSITORY}:latest",
+                f"{IMAGE_REPOSITORY}@sha256:not-a-digest",
+            ):
+                with self.subTest(image=image):
+                    proc = resolve("1.8.155", manifest, image)
+                    self.assertNotEqual(proc.returncode, 0)
+                    self.assertIn("requires a fully verified immutable", proc.stderr)
 
-    def test_phase3_release_candidate_is_still_legacy_until_the_compatibility_floor(self) -> None:
-        self.assert_resolution(
-            "1.8.156-rc.1",
-            f"{IMAGE_REPOSITORY}:1.8.156",
-            mode="legacy_rollback",
-            image=f"{IMAGE_REPOSITORY}:1.8.156",
-        )
-
-    def test_legacy_app_rollback_preserves_compatible_worker(self) -> None:
-        self.assert_resolution(
-            "1.8.155",
-            f"{IMAGE_REPOSITORY}:1.8.156",
-            mode="legacy_rollback",
-            image=f"{IMAGE_REPOSITORY}:1.8.156",
-        )
-
-    def test_legacy_app_without_existing_worker_fails_closed(self) -> None:
-        proc = resolve("1.8.155")
-        self.assertNotEqual(proc.returncode, 0)
-        self.assertIn("requires an existing compatible QA Bundle Worker", proc.stderr)
-
-    def test_legacy_app_rejects_pre_phase3_existing_worker(self) -> None:
-        proc = resolve("1.8.155", f"{IMAGE_REPOSITORY}:1.8.155")
-        self.assertNotEqual(proc.returncode, 0)
-        self.assertIn("requires an existing compatible QA Bundle Worker", proc.stderr)
-
-    def test_legacy_app_rejects_foreign_or_unversioned_existing_image(self) -> None:
-        for image in (
-            "ghcr.io/example/sub2api:1.8.156",
-            f"{IMAGE_REPOSITORY}:latest",
-            f"{IMAGE_REPOSITORY}@sha256:{'a' * 64}",
-        ):
-            with self.subTest(image=image):
-                proc = resolve("1.8.155", image)
-                self.assertNotEqual(proc.returncode, 0)
-                self.assertIn("requires an existing compatible QA Bundle Worker", proc.stderr)
+    def test_unknown_or_malformed_contract_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            for manifest in (
+                rollout_manifest(root, "phase4_future"),
+                root / "missing.yaml",
+            ):
+                with self.subTest(manifest=manifest):
+                    proc = resolve("1.8.200", manifest)
+                    self.assertNotEqual(proc.returncode, 0)
+                    self.assertRegex(
+                        proc.stderr,
+                        r"target rollout manifest|unsupported target Bundle runtime contract",
+                    )
 
     def test_invalid_target_tag_is_rejected(self) -> None:
-        for target in ("v1.8.156", "1.8", "1.8.156-preview.1"):
-            with self.subTest(target=target):
-                proc = resolve(target)
-                self.assertNotEqual(proc.returncode, 0)
-                self.assertIn("target tag must match", proc.stderr)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = rollout_manifest(pathlib.Path(temp_dir))
+            for target in ("v1.8.200", "1.8", "1.8.200-preview.1"):
+                with self.subTest(target=target):
+                    proc = resolve(target, manifest)
+                    self.assertNotEqual(proc.returncode, 0)
+                    self.assertIn("target tag must match", proc.stderr)
 
 
 if __name__ == "__main__":

--- a/ops/qa/test_resolve_qa_bundle_worker_image.py
+++ b/ops/qa/test_resolve_qa_bundle_worker_image.py
@@ -99,6 +99,27 @@ class ResolveQABundleWorkerImageTest(unittest.TestCase):
                 host_runtime_mode="current_safe_degraded",
             )
 
+    def test_legacy_manifest_without_user_export_preserves_verified_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = pathlib.Path(temp_dir) / "deploy_rollout.yaml"
+            manifest.write_text(
+                "prod:\n"
+                "  QA_ARCHIVE_ENABLED:\n"
+                "    deploy_inject_default: false\n",
+                encoding="utf-8",
+            )
+            image = f"{IMAGE_REPOSITORY}:1.8.155"
+            self.assert_resolution(
+                "1.8.140",
+                manifest,
+                image,
+                mode="legacy_rollback",
+                image=image,
+                worker_source="verified_live_worker",
+                run_canary=False,
+                host_runtime_mode="current_safe_degraded",
+            )
+
     def test_legacy_accepts_verified_repository_digest(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             manifest = rollout_manifest(pathlib.Path(temp_dir), None)

--- a/ops/qa/verify_qa_bundle_infra.sh
+++ b/ops/qa/verify_qa_bundle_infra.sh
@@ -4,18 +4,31 @@ set -euo pipefail
 
 STACK="${QA_RAW_ARCHIVE_STACK:-tokenkey-prod-qa-raw-archive}"
 REGION="${AWS_REGION:-us-east-1}"
+MODE="${QA_BUNDLE_VERIFY_MODE:-expected}"
 EXPECTED_IMAGE="${QA_BUNDLE_WORKER_IMAGE:-}"
 EXPECTED_DESIRED="${QA_BUNDLE_WORKER_DESIRED_COUNT:-1}"
 
 [[ "${EXPECTED_DESIRED}" =~ ^[1-9][0-9]*$ ]] || { echo "QA_BUNDLE_WORKER_DESIRED_COUNT must be positive" >&2; exit 1; }
+case "${MODE}" in
+  discovery | expected) ;;
+  *) echo "QA_BUNDLE_VERIFY_MODE must be discovery or expected" >&2; exit 1 ;;
+esac
+if [ "${MODE}" = expected ] && [ -z "${EXPECTED_IMAGE}" ]; then
+  echo "QA_BUNDLE_WORKER_IMAGE is required in expected mode" >&2
+  exit 1
+fi
 
 stack_json="$(aws cloudformation describe-stacks --region "${REGION}" --stack-name "${STACK}" --output json)"
 stack_status="$(jq -r '.Stacks[0].StackStatus // empty' <<<"${stack_json}")"
 [[ "${stack_status}" =~ _COMPLETE$ ]] || { echo "QA Bundle stack is not complete: ${stack_status}" >&2; exit 1; }
-if [ -z "${EXPECTED_IMAGE}" ]; then
-  EXPECTED_IMAGE="$(jq -r '.Stacks[0].Parameters[]? | select(.ParameterKey == "BundleWorkerImage") | .ParameterValue' <<<"${stack_json}")"
+stack_image="$(jq -r '.Stacks[0].Parameters[]? | select(.ParameterKey == "BundleWorkerImage") | .ParameterValue' <<<"${stack_json}")"
+[[ -n "${stack_image}" && "${stack_image}" != None ]] || { echo "QA Bundle stack image expectation is unavailable" >&2; exit 1; }
+if [ "${MODE}" = discovery ]; then
+  EXPECTED_IMAGE="${stack_image}"
+elif [ "${stack_image}" != "${EXPECTED_IMAGE}" ]; then
+  echo "QA Bundle stack image mismatch expected=${EXPECTED_IMAGE} parameter=${stack_image}" >&2
+  exit 1
 fi
-[[ -n "${EXPECTED_IMAGE}" && "${EXPECTED_IMAGE}" != None ]] || { echo "QA Bundle worker image expectation is unavailable" >&2; exit 1; }
 
 parameter() {
   local key="$1"
@@ -99,6 +112,7 @@ receipt="$(jq -n \
   --argjson desired "${desired}" --argjson running "${running}" --argjson dlq_depth "${dlq_depth}" \
   '{ok:true,stack:$stack,stack_status:$status,bucket:$bucket,browser_origin:$browser_origin,retention_days:$retention_days,queue_url:$queue_url,dlq_url:$dlq_url,cluster:$cluster,service:$service,image:$image,desired_count:$desired,running_count:$running,dlq_depth:$dlq_depth}')"
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-  printf 'bucket=%s\nqueue_url=%s\n' "${bucket}" "${queue_url}" >> "${GITHUB_OUTPUT}"
+  printf 'bucket=%s\nqueue_url=%s\nworker_image=%s\n' \
+    "${bucket}" "${queue_url}" "${actual_image}" >> "${GITHUB_OUTPUT}"
 fi
 printf '%s\n' "${receipt}"

--- a/ops/qa/verify_qa_bundle_infra.sh
+++ b/ops/qa/verify_qa_bundle_infra.sh
@@ -80,8 +80,23 @@ jq -e --argjson retention_days "${retention_days}" '
   $rules[0].Expiration.Days == $retention_days
 ' <<<"${lifecycle_json}" >/dev/null || { echo "QA Bundle bucket lifecycle drift" >&2; exit 1; }
 
-queue_attrs="$(aws sqs get-queue-attributes --region "${REGION}" --queue-url "${queue_url}" --attribute-names QueueArn ApproximateNumberOfMessages ApproximateNumberOfMessagesNotVisible --output json)"
-dlq_attrs="$(aws sqs get-queue-attributes --region "${REGION}" --queue-url "${dlq_url}" --attribute-names QueueArn ApproximateNumberOfMessages --output json)"
+queue_attrs="$(aws sqs get-queue-attributes --region "${REGION}" --queue-url "${queue_url}" --attribute-names QueueArn RedrivePolicy SqsManagedSseEnabled ApproximateNumberOfMessages ApproximateNumberOfMessagesNotVisible --output json)"
+dlq_attrs="$(aws sqs get-queue-attributes --region "${REGION}" --queue-url "${dlq_url}" --attribute-names QueueArn SqsManagedSseEnabled ApproximateNumberOfMessages --output json)"
+queue_arn="$(jq -r '.Attributes.QueueArn // empty' <<<"${queue_attrs}")"
+dlq_arn="$(jq -r '.Attributes.QueueArn // empty' <<<"${dlq_attrs}")"
+[[ -n "${queue_arn}" && -n "${dlq_arn}" ]] || { echo "QA Bundle queue identity is incomplete" >&2; exit 1; }
+[[ "$(jq -r '.Attributes.SqsManagedSseEnabled // "false"' <<<"${queue_attrs}")" = true ]] || {
+  echo "QA Bundle queue encryption drift" >&2
+  exit 1
+}
+[[ "$(jq -r '.Attributes.SqsManagedSseEnabled // "false"' <<<"${dlq_attrs}")" = true ]] || {
+  echo "QA Bundle DLQ encryption drift" >&2
+  exit 1
+}
+redrive_policy="$(jq -r '.Attributes.RedrivePolicy // empty' <<<"${queue_attrs}")"
+jq -e --arg dlq_arn "${dlq_arn}" '
+  .deadLetterTargetArn == $dlq_arn and (.maxReceiveCount | tostring) == "3"
+' <<<"${redrive_policy}" >/dev/null || { echo "QA Bundle queue redrive drift" >&2; exit 1; }
 dlq_depth="$(jq -r '.Attributes.ApproximateNumberOfMessages // "0"' <<<"${dlq_attrs}")"
 [[ "${dlq_depth}" = 0 ]] || { echo "QA Bundle DLQ is not empty: ${dlq_depth}" >&2; exit 1; }
 
@@ -97,12 +112,29 @@ task_definition="$(jq -r '.services[0].taskDefinition // empty' <<<"${service_js
   exit 1
 }
 
-task_json="$(aws ecs describe-task-definition --region "${REGION}" --task-definition "${task_definition}" --output json)"
-actual_image="$(jq -r '.taskDefinition.containerDefinitions[] | select(.name == "qa-bundle-worker") | .image' <<<"${task_json}")"
-[[ "${actual_image}" = "${EXPECTED_IMAGE}" ]] || {
-  echo "QA Bundle worker image mismatch expected=${EXPECTED_IMAGE} actual=${actual_image}" >&2
+task_list_json="$(aws ecs list-tasks --region "${REGION}" --cluster "${cluster}" --service-name "${service}" --desired-status RUNNING --output json)"
+task_arns=()
+while IFS= read -r task_arn; do
+  [[ -n "${task_arn}" ]] && task_arns+=("${task_arn}")
+done < <(jq -r '.taskArns[]?' <<<"${task_list_json}")
+if (( ${#task_arns[@]} < EXPECTED_DESIRED )); then
+  echo "QA Bundle running task count mismatch listed=${#task_arns[@]} expected=${EXPECTED_DESIRED}" >&2
+  exit 1
+fi
+task_json="$(aws ecs describe-tasks --region "${REGION}" --cluster "${cluster}" --tasks "${task_arns[@]}" --output json)"
+jq -e --arg expected_image "${EXPECTED_IMAGE}" --arg task_definition "${task_definition}" --argjson expected_count "${EXPECTED_DESIRED}" '
+  (.failures | length) == 0 and
+  (.tasks | length) >= $expected_count and
+  all(.tasks[];
+    .lastStatus == "RUNNING" and
+    .taskDefinitionArn == $task_definition and
+    ([.containers[] | select(.name == "qa-bundle-worker") | .image] == [$expected_image])
+  )
+' <<<"${task_json}" >/dev/null || {
+  echo "QA Bundle running task contract drift expected_image=${EXPECTED_IMAGE} task_definition=${task_definition}" >&2
   exit 1
 }
+actual_image="${EXPECTED_IMAGE}"
 
 receipt="$(jq -n \
   --arg stack "${STACK}" --arg status "${stack_status}" --arg bucket "${bucket}" \

--- a/ops/stage0/test_deploy_stage0_workflow.py
+++ b/ops/stage0/test_deploy_stage0_workflow.py
@@ -91,10 +91,17 @@ class DeployStage0WorkflowTest(unittest.TestCase):
     def test_qa_host_artifacts_are_bound_to_target_tag_before_prod_mutation(self) -> None:
         deploy = job_block("deploy")
         target_checkout = deploy.index("name: Checkout target-tag QA host artifacts")
+        resolve = deploy.index("name: Resolve QA infrastructure deploy inputs")
+        infra_mutation = deploy.index("name: Deploy QA Bundle infrastructure")
         image_mutation = deploy.index("name: Deploy via SSM Run-Command")
 
+        self.assertLess(resolve, target_checkout)
+        self.assertLess(target_checkout, infra_mutation)
         self.assertLess(target_checkout, image_mutation)
         target_block = deploy[target_checkout:image_mutation]
+        self.assertEqual(
+            target_block.count("if: steps.qa_infra.outputs.mode == 'phase3'"), 2
+        )
         self.assertIn("ref: v${{ inputs.tag }}", target_block)
         self.assertIn("path: qa-host-runtime", target_block)
         self.assertIn("id: qa_host_artifacts", target_block)
@@ -185,7 +192,7 @@ class DeployStage0WorkflowTest(unittest.TestCase):
 set -euo pipefail
 case "${AWS_SCENARIO}" in
   existing)
-    printf '%s\n' '{"Stacks":[{"Parameters":[{"ParameterKey":"OpsRecoveryPrincipalArn","ParameterValue":"arn:existing"}]}]}'
+    printf '%s\n' '{"Stacks":[{"Parameters":[{"ParameterKey":"OpsRecoveryPrincipalArn","ParameterValue":"arn:existing"},{"ParameterKey":"BundleWorkerImage","ParameterValue":"ghcr.io/youxuanxue/sub2api:1.8.158"}]}]}'
     ;;
   missing)
     echo 'An error occurred (ValidationError) when calling the DescribeStacks operation: Stack with id tokenkey-prod-qa-raw-archive does not exist' >&2
@@ -205,24 +212,69 @@ esac
                 "PATH": f"{fake_bin}:/usr/bin:/bin",
                 "QA_STACK_NAME": "tokenkey-prod-qa-raw-archive",
                 "CONFIGURED_OPS_RECOVERY_PRINCIPAL_ARN": "arn:bootstrap",
+                "INPUT_TAG": "1.8.157",
             }
 
-            for scenario, expected in (("existing", "arn:existing"), ("missing", "arn:bootstrap")):
-                output = root / f"{scenario}-output"
+            for (
+                scenario,
+                target,
+                expected_principal,
+                expected_mode,
+                expected_image,
+            ) in (
+                (
+                    "existing",
+                    "1.8.157",
+                    "arn:existing",
+                    "phase3",
+                    "ghcr.io/youxuanxue/sub2api:1.8.158",
+                ),
+                (
+                    "existing",
+                    "1.8.155",
+                    "arn:existing",
+                    "legacy_rollback",
+                    "ghcr.io/youxuanxue/sub2api:1.8.158",
+                ),
+                (
+                    "missing",
+                    "1.8.157",
+                    "arn:bootstrap",
+                    "phase3",
+                    "ghcr.io/youxuanxue/sub2api:1.8.157",
+                ),
+            ):
+                output = root / f"{scenario}-{target}-output"
                 proc = subprocess.run(
                     ["bash", "-c", script],
-                    env={**base_env, "AWS_SCENARIO": scenario, "GITHUB_OUTPUT": str(output)},
+                    env={
+                        **base_env,
+                        "AWS_SCENARIO": scenario,
+                        "INPUT_TAG": target,
+                        "GITHUB_OUTPUT": str(output),
+                    },
+                    cwd=REPO_ROOT,
                     capture_output=True,
                     text=True,
                     check=False,
                 )
                 self.assertEqual(proc.returncode, 0, msg=proc.stderr)
-                self.assertIn(f"ops_recovery_principal_arn={expected}\n", output.read_text())
+                outputs = output.read_text()
+                self.assertIn(
+                    f"ops_recovery_principal_arn={expected_principal}\n", outputs
+                )
+                self.assertIn(f"resolved_worker_image={expected_image}\n", outputs)
+                self.assertIn(f"mode={expected_mode}\n", outputs)
 
             denied_output = root / "denied-output"
             denied = subprocess.run(
                 ["bash", "-c", script],
-                env={**base_env, "AWS_SCENARIO": "denied", "GITHUB_OUTPUT": str(denied_output)},
+                env={
+                    **base_env,
+                    "AWS_SCENARIO": "denied",
+                    "GITHUB_OUTPUT": str(denied_output),
+                },
+                cwd=REPO_ROOT,
                 capture_output=True,
                 text=True,
                 check=False,
@@ -230,6 +282,41 @@ esac
             self.assertNotEqual(denied.returncode, 0)
             self.assertIn("refusing bootstrap fallback", denied.stderr)
             self.assertFalse(denied_output.exists())
+
+    def test_legacy_bootstrap_without_compatible_worker_fails_before_mutation(self) -> None:
+        script = step_run("Resolve QA infrastructure deploy inputs")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            fake_aws = fake_bin / "aws"
+            fake_aws.write_text(
+                """#!/usr/bin/env bash
+echo 'An error occurred (ValidationError) when calling the DescribeStacks operation: Stack with id tokenkey-prod-qa-raw-archive does not exist' >&2
+exit 255
+""",
+                encoding="utf-8",
+            )
+            fake_aws.chmod(0o755)
+            output = root / "output"
+            proc = subprocess.run(
+                ["bash", "-c", script],
+                env={
+                    **os.environ,
+                    "PATH": f"{fake_bin}:/usr/bin:/bin",
+                    "QA_STACK_NAME": "tokenkey-prod-qa-raw-archive",
+                    "CONFIGURED_OPS_RECOVERY_PRINCIPAL_ARN": "arn:bootstrap",
+                    "INPUT_TAG": "1.8.155",
+                    "GITHUB_OUTPUT": str(output),
+                },
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("requires an existing compatible QA Bundle Worker", proc.stderr)
+            self.assertFalse(output.exists())
 
     def test_bundle_infrastructure_is_ready_before_app_image_swap(self) -> None:
         deploy = job_block("deploy")
@@ -239,13 +326,48 @@ esac
         self.assertLess(infra, verify)
         self.assertLess(verify, image_mutation)
         pre_mutation = deploy[:image_mutation]
-        self.assertIn("QA_BUNDLE_WORKER_IMAGE: ghcr.io/youxuanxue/sub2api:${{ env.INPUT_TAG }}", pre_mutation)
+        resolved_image = "${{ steps.qa_infra.outputs.resolved_worker_image }}"
+        self.assertEqual(pre_mutation.count(f"QA_BUNDLE_WORKER_IMAGE: {resolved_image}"), 2)
+        self.assertNotIn("QA_BUNDLE_WORKER_IMAGE: ghcr.io/youxuanxue/sub2api:${{ env.INPUT_TAG }}", pre_mutation)
         self.assertIn("QA_BUNDLE_WORKER_DESIRED_COUNT: \"1\"", pre_mutation)
         self.assertIn('browser_origin="https://${API_HOST#api.}"', pre_mutation)
         self.assertIn('echo "browser_origin=$browser_origin" >> "$GITHUB_OUTPUT"', pre_mutation)
         self.assertIn("QA_BUNDLE_BROWSER_ALLOWED_ORIGIN: ${{ steps.instance.outputs.browser_origin }}", pre_mutation)
         self.assertIn("deploy_qa_raw_archive_cfn.sh", pre_mutation)
         self.assertIn("verify_qa_bundle_infra.sh", pre_mutation)
+
+    def test_legacy_rollback_preserves_phase3_control_plane_and_reports_degraded(self) -> None:
+        deploy = job_block("deploy")
+        phase3_guard = "if: steps.qa_infra.outputs.mode == 'phase3'"
+        for step_name in (
+            "Sync QA maintenance host runner",
+            "Sync QA boundary host runner and restore durable owner",
+            "Post-deploy QA Bundle canary",
+        ):
+            start = deploy.index(f"- name: {step_name}")
+            end = deploy.find("      - name:", start + 1)
+            block = deploy[start : end if end != -1 else None]
+            self.assertIn(phase3_guard, block)
+
+        warning_start = deploy.index("- name: Report legacy QA rollback degradation")
+        warning_end = deploy.find("      - name:", warning_start + 1)
+        warning = deploy[warning_start : warning_end if warning_end != -1 else None]
+        self.assertIn("if: steps.qa_infra.outputs.mode == 'legacy_rollback'", warning)
+        self.assertIn("QA Phase 3 degraded", warning)
+        self.assertIn("existing Worker and host runners were preserved", warning)
+
+        summary = deploy[deploy.index("- name: Job summary") :]
+        self.assertIn("QA_MODE: ${{ steps.qa_infra.outputs.mode }}", summary)
+        self.assertIn(
+            "QA_WORKER_IMAGE: ${{ steps.qa_infra.outputs.resolved_worker_image }}",
+            summary,
+        )
+        self.assertIn(r"- QA mode: \`${QA_MODE:-not-resolved}\`", summary)
+        self.assertIn(
+            r"- QA Bundle Worker image: \`${QA_WORKER_IMAGE:-not-resolved}\`", summary
+        )
+        self.assertIn("QA Phase 3 degraded", summary)
+        self.assertIn("legacy rollback changed only the app image", summary)
 
     def test_smoke_only_job_is_read_only_and_uses_prod_environment(self) -> None:
         smoke = job_block("smoke-only")

--- a/ops/stage0/test_deploy_stage0_workflow.py
+++ b/ops/stage0/test_deploy_stage0_workflow.py
@@ -2,11 +2,8 @@
 """Security and behavior contract tests for deploy-stage0 workflow modes."""
 from __future__ import annotations
 
-import os
 import pathlib
 import re
-import subprocess
-import tempfile
 import unittest
 
 
@@ -57,7 +54,7 @@ class DeployStage0WorkflowTest(unittest.TestCase):
         self.assertIn("type: choice", body)
         self.assertIn("required: true", body)
         self.assertIn("default: deploy", body)
-        self.assertRegex(body, r"(?ms)options:\s*\n\s*- deploy\s*\n\s*- smoke-only\s*$")
+        self.assertRegex(body, r"(?ms)options:\s*\n\s*- deploy\s*\n\s*- smoke-only\s*\n\s*- qa-infra-check\s*$")
 
     def test_focused_ssot_input_is_optional_and_defaults_empty(self) -> None:
         text = workflow_text()
@@ -88,31 +85,25 @@ class DeployStage0WorkflowTest(unittest.TestCase):
             deploy,
         )
 
-    def test_qa_host_artifacts_are_bound_to_target_tag_before_prod_mutation(self) -> None:
+    def test_target_release_contract_is_bound_before_prod_mutation(self) -> None:
         deploy = job_block("deploy")
-        target_checkout = deploy.index("name: Checkout target-tag QA host artifacts")
+        target_checkout = deploy.index("name: Checkout target-tag QA contract and host artifacts")
+        target_verify = deploy.index("name: Verify target-tag QA release tree")
         resolve = deploy.index("name: Resolve QA infrastructure deploy inputs")
         infra_mutation = deploy.index("name: Deploy QA Bundle infrastructure")
         image_mutation = deploy.index("name: Deploy via SSM Run-Command")
 
-        self.assertLess(resolve, target_checkout)
-        self.assertLess(target_checkout, infra_mutation)
-        self.assertLess(target_checkout, image_mutation)
-        target_block = deploy[target_checkout:image_mutation]
-        self.assertEqual(
-            target_block.count("if: steps.qa_infra.outputs.mode == 'phase3'"), 2
-        )
-        self.assertIn("ref: v${{ inputs.tag }}", target_block)
-        self.assertIn("path: qa-host-runtime", target_block)
-        self.assertIn("id: qa_host_artifacts", target_block)
-        self.assertIn("git -C qa-host-runtime rev-parse HEAD", target_block)
-        self.assertEqual(deploy.count("QA_HOST_ARTIFACT_ROOT: qa-host-runtime"), 2)
-        self.assertEqual(
-            deploy.count(
-                "QA_HOST_ARTIFACT_SHA: ${{ steps.qa_host_artifacts.outputs.sha }}"
-            ),
-            2,
-        )
+        self.assertLess(target_checkout, target_verify)
+        self.assertLess(target_verify, resolve)
+        self.assertLess(resolve, infra_mutation)
+        self.assertLess(infra_mutation, image_mutation)
+        self.assertIn("qa-target-release/ops/qa/deploy_rollout.yaml", deploy)
+        self.assertIn("marker: legacy_release", deploy)
+        self.assertIn("rollout=${ROLLOUT}", deploy)
+        self.assertIn("TARGET_ROLLOUT: ${{ steps.qa_target.outputs.rollout }}", deploy)
+        self.assertIn('--target-rollout "$TARGET_ROLLOUT"', deploy)
+        self.assertIn("ref: v${{ inputs.tag }}", deploy)
+        self.assertEqual(deploy.count("QA_HOST_ARTIFACT_ROOT: qa-target-release"), 2)
 
     def test_bundle_coordinates_come_from_verified_stack_outputs(self) -> None:
         deploy = job_block("deploy")
@@ -180,143 +171,24 @@ class DeployStage0WorkflowTest(unittest.TestCase):
         self.assertNotIn("2>/dev/null || true", block)
         self.assertNotRegex(block, r"describe-stacks[^\n]*\|\|\s*true")
 
-    def test_qa_stack_principal_resolution_only_bootstraps_when_stack_is_absent(self) -> None:
-        script = step_run("Resolve QA infrastructure deploy inputs")
-        with tempfile.TemporaryDirectory() as temp_dir:
-            root = pathlib.Path(temp_dir)
-            fake_bin = root / "bin"
-            fake_bin.mkdir()
-            fake_aws = fake_bin / "aws"
-            fake_aws.write_text(
-                """#!/usr/bin/env bash
-set -euo pipefail
-case "${AWS_SCENARIO}" in
-  existing)
-    printf '%s\n' '{"Stacks":[{"Parameters":[{"ParameterKey":"OpsRecoveryPrincipalArn","ParameterValue":"arn:existing"},{"ParameterKey":"BundleWorkerImage","ParameterValue":"ghcr.io/youxuanxue/sub2api:1.8.158"}]}]}'
-    ;;
-  missing)
-    echo 'An error occurred (ValidationError) when calling the DescribeStacks operation: Stack with id tokenkey-prod-qa-raw-archive does not exist' >&2
-    exit 255
-    ;;
-  denied)
-    echo 'An error occurred (AccessDenied) when calling the DescribeStacks operation' >&2
-    exit 254
-    ;;
-esac
-""",
-                encoding="utf-8",
-            )
-            fake_aws.chmod(0o755)
-            base_env = {
-                **os.environ,
-                "PATH": f"{fake_bin}:/usr/bin:/bin",
-                "QA_STACK_NAME": "tokenkey-prod-qa-raw-archive",
-                "CONFIGURED_OPS_RECOVERY_PRINCIPAL_ARN": "arn:bootstrap",
-                "INPUT_TAG": "1.8.157",
-            }
-
-            for (
-                scenario,
-                target,
-                expected_principal,
-                expected_mode,
-                expected_image,
-            ) in (
-                (
-                    "existing",
-                    "1.8.157",
-                    "arn:existing",
-                    "phase3",
-                    "ghcr.io/youxuanxue/sub2api:1.8.158",
-                ),
-                (
-                    "existing",
-                    "1.8.155",
-                    "arn:existing",
-                    "legacy_rollback",
-                    "ghcr.io/youxuanxue/sub2api:1.8.158",
-                ),
-                (
-                    "missing",
-                    "1.8.157",
-                    "arn:bootstrap",
-                    "phase3",
-                    "ghcr.io/youxuanxue/sub2api:1.8.157",
-                ),
-            ):
-                output = root / f"{scenario}-{target}-output"
-                proc = subprocess.run(
-                    ["bash", "-c", script],
-                    env={
-                        **base_env,
-                        "AWS_SCENARIO": scenario,
-                        "INPUT_TAG": target,
-                        "GITHUB_OUTPUT": str(output),
-                    },
-                    cwd=REPO_ROOT,
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                )
-                self.assertEqual(proc.returncode, 0, msg=proc.stderr)
-                outputs = output.read_text()
-                self.assertIn(
-                    f"ops_recovery_principal_arn={expected_principal}\n", outputs
-                )
-                self.assertIn(f"resolved_worker_image={expected_image}\n", outputs)
-                self.assertIn(f"mode={expected_mode}\n", outputs)
-
-            denied_output = root / "denied-output"
-            denied = subprocess.run(
-                ["bash", "-c", script],
-                env={
-                    **base_env,
-                    "AWS_SCENARIO": "denied",
-                    "GITHUB_OUTPUT": str(denied_output),
-                },
-                cwd=REPO_ROOT,
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            self.assertNotEqual(denied.returncode, 0)
-            self.assertIn("refusing bootstrap fallback", denied.stderr)
-            self.assertFalse(denied_output.exists())
-
-    def test_legacy_bootstrap_without_compatible_worker_fails_before_mutation(self) -> None:
-        script = step_run("Resolve QA infrastructure deploy inputs")
-        with tempfile.TemporaryDirectory() as temp_dir:
-            root = pathlib.Path(temp_dir)
-            fake_bin = root / "bin"
-            fake_bin.mkdir()
-            fake_aws = fake_bin / "aws"
-            fake_aws.write_text(
-                """#!/usr/bin/env bash
-echo 'An error occurred (ValidationError) when calling the DescribeStacks operation: Stack with id tokenkey-prod-qa-raw-archive does not exist' >&2
-exit 255
-""",
-                encoding="utf-8",
-            )
-            fake_aws.chmod(0o755)
-            output = root / "output"
-            proc = subprocess.run(
-                ["bash", "-c", script],
-                env={
-                    **os.environ,
-                    "PATH": f"{fake_bin}:/usr/bin:/bin",
-                    "QA_STACK_NAME": "tokenkey-prod-qa-raw-archive",
-                    "CONFIGURED_OPS_RECOVERY_PRINCIPAL_ARN": "arn:bootstrap",
-                    "INPUT_TAG": "1.8.155",
-                    "GITHUB_OUTPUT": str(output),
-                },
-                cwd=REPO_ROOT,
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            self.assertNotEqual(proc.returncode, 0)
-            self.assertIn("requires an existing compatible QA Bundle Worker", proc.stderr)
-            self.assertFalse(output.exists())
+    def test_legacy_worker_discovery_precedes_resolution_and_all_mutation(self) -> None:
+        deploy = job_block("deploy")
+        discovery = deploy.index("name: Discover existing QA Bundle Worker (read-only)")
+        resolve = deploy.index("name: Resolve QA infrastructure deploy inputs")
+        host_safety = deploy.index("name: Converge current QA maintenance runner before legacy app rollback")
+        infra_mutation = deploy.index("name: Deploy QA Bundle infrastructure")
+        image_mutation = deploy.index("name: Deploy via SSM Run-Command")
+        self.assertLess(discovery, resolve)
+        self.assertLess(resolve, host_safety)
+        self.assertLess(host_safety, infra_mutation)
+        self.assertLess(infra_mutation, image_mutation)
+        pre_mutation = deploy[:infra_mutation]
+        self.assertIn("QA_BUNDLE_VERIFY_MODE: discovery", pre_mutation)
+        self.assertIn("steps.qa_worker_discovery.outputs.worker_image", pre_mutation)
+        self.assertIn(
+            '--verified-existing-image "$VERIFIED_EXISTING_WORKER_IMAGE"',
+            pre_mutation,
+        )
 
     def test_bundle_infrastructure_is_ready_before_app_image_swap(self) -> None:
         deploy = job_block("deploy")
@@ -336,38 +208,47 @@ exit 255
         self.assertIn("deploy_qa_raw_archive_cfn.sh", pre_mutation)
         self.assertIn("verify_qa_bundle_infra.sh", pre_mutation)
 
-    def test_legacy_rollback_preserves_phase3_control_plane_and_reports_degraded(self) -> None:
+    def test_legacy_rollback_converges_safe_control_plane_before_app_mutation(self) -> None:
         deploy = job_block("deploy")
-        phase3_guard = "if: steps.qa_infra.outputs.mode == 'phase3'"
-        for step_name in (
-            "Sync QA maintenance host runner",
-            "Sync QA boundary host runner and restore durable owner",
-            "Post-deploy QA Bundle canary",
-        ):
-            start = deploy.index(f"- name: {step_name}")
-            end = deploy.find("      - name:", start + 1)
-            block = deploy[start : end if end != -1 else None]
-            self.assertIn(phase3_guard, block)
+        maintenance = deploy.index("name: Converge current QA maintenance runner before legacy app rollback")
+        boundary = deploy.index("name: Disable QA boundary before legacy app rollback")
+        app_mutation = deploy.index("name: Deploy via SSM Run-Command")
+        self.assertLess(maintenance, boundary)
+        self.assertLess(boundary, app_mutation)
+        safety = deploy[maintenance:app_mutation]
+        self.assertIn("QA_MAINTENANCE_TIMER_STATE: enabled", safety)
+        self.assertIn("QA_BOUNDARY_TIMER_STATE: disabled", safety)
+        self.assertNotIn("QA_HOST_ARTIFACT_ROOT: qa-target-release", safety)
 
-        warning_start = deploy.index("- name: Report legacy QA rollback degradation")
-        warning_end = deploy.find("      - name:", warning_start + 1)
-        warning = deploy[warning_start : warning_end if warning_end != -1 else None]
-        self.assertIn("if: steps.qa_infra.outputs.mode == 'legacy_rollback'", warning)
+        canary = deploy[deploy.index("- name: Post-deploy QA Bundle canary"):]
+        self.assertIn("if: steps.qa_infra.outputs.run_canary == 'true'", canary)
+        warning = deploy[deploy.index("- name: Report legacy QA rollback degradation"):]
         self.assertIn("QA Phase 3 degraded", warning)
-        self.assertIn("existing Worker and host runners were preserved", warning)
+        self.assertIn("boundary was forced disabled", warning)
+        self.assertIn("DROP is paused", warning)
 
-        summary = deploy[deploy.index("- name: Job summary") :]
-        self.assertIn("QA_MODE: ${{ steps.qa_infra.outputs.mode }}", summary)
-        self.assertIn(
-            "QA_WORKER_IMAGE: ${{ steps.qa_infra.outputs.resolved_worker_image }}",
-            summary,
-        )
-        self.assertIn(r"- QA mode: \`${QA_MODE:-not-resolved}\`", summary)
-        self.assertIn(
-            r"- QA Bundle Worker image: \`${QA_WORKER_IMAGE:-not-resolved}\`", summary
-        )
-        self.assertIn("QA Phase 3 degraded", summary)
-        self.assertIn("legacy rollback changed only the app image", summary)
+    def test_qa_infra_check_is_read_only_and_verifies_oidc_binding(self) -> None:
+        job = job_block("qa-infra-check")
+        self.assertIn("if: inputs.operation == 'qa-infra-check'", job)
+        self.assertIn("environment: prod", job)
+        self.assertIn("contents: read", job)
+        self.assertIn("id-token: write", job)
+        self.assertIn("QAInfraDeploymentRoleArn", job)
+        self.assertIn("QAInfraCloudFormationServiceRoleArn", job)
+        self.assertIn("QA_INFRA_OIDC_ROLE_ARN", job)
+        self.assertIn("aws sts get-caller-identity", job)
+        self.assertIn(".Stacks[0].RoleARN", job)
+        self.assertIn("QaRawArchiveBucketName", job)
+        self.assertIn("QaRawArchiveRecoveryRoleArn", job)
+        self.assertIn("recognized raw-archive contract", job)
+        self.assertIn("legacy_bootstrap_ready", job)
+        self.assertIn("Bundle-era QA stack is not bound", job)
+        for forbidden in (
+            "create-change-set", "execute-change-set", "aws ssm",
+            "deploy_via_ssm", "sync-qa-", "run-qa-bundle-canary",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, job.lower())
 
     def test_smoke_only_job_is_read_only_and_uses_prod_environment(self) -> None:
         smoke = job_block("smoke-only")

--- a/scripts/checks/qa-lifecycle-ssot.py
+++ b/scripts/checks/qa-lifecycle-ssot.py
@@ -40,7 +40,8 @@ REQUIRED = {
         "pause_capture: false",
         "resolved_worker_image",
         "legacy_rollback",
-        "原样保留已经部署的 Phase 3 maintenance/boundary runners",
+        "bundle_runtime_contract: phase3_v1",
+        "当前 release tree 的 Phase 3 runners",
     ),
     "ops/qa/README.md": (
         "only target lifecycle owner",
@@ -50,9 +51,10 @@ REQUIRED = {
         "App rollback does not imply QA control-plane rollback",
     ),
     "ops/qa/resolve_qa_bundle_worker_image.py": (
-        'PHASE3_MINIMUM_TAG = "1.8.156"',
+        'SUPPORTED_RUNTIME_CONTRACT = "phase3_v1"',
         '"mode": "phase3"',
         '"mode": "legacy_rollback"',
+        '"worker_source": "verified_live_worker"',
         'IMAGE_REPOSITORY = "ghcr.io/youxuanxue/sub2api"',
     ),
     ".github/workflows/deploy-stage0.yml": (
@@ -71,7 +73,7 @@ REQUIRED = {
         "S3 Bundle",
         "prod fallback",
         "Observed live: transitional",
-        "legacy app 保留 Phase 3 控制面",
+        "legacy app 只保留 fully verified live Worker",
     ),
     ".testing/user-stories/stories/US-045-qa-phase2-production-integrity.md": (
         "historical/superseded",
@@ -287,6 +289,19 @@ def scan(root: Path) -> list[str]:
         resolved_binding = "QA_BUNDLE_WORKER_IMAGE: ${{ steps.qa_infra.outputs.resolved_worker_image }}"
         if workflow_body.count(resolved_binding) != 2:
             failures.append("QA deploy and verifier must share exactly one resolved Worker image")
+        legacy_maintenance = workflow_body.find(
+            "name: Converge current QA maintenance runner before legacy app rollback"
+        )
+        legacy_boundary = workflow_body.find(
+            "name: Disable QA boundary before legacy app rollback"
+        )
+        app_mutation = workflow_body.find("name: Deploy via SSM Run-Command")
+        if not (0 <= legacy_maintenance < legacy_boundary < app_mutation):
+            failures.append("legacy host safety must converge before app mutation")
+        if "QA_BOUNDARY_TIMER_STATE: disabled" not in workflow_body:
+            failures.append("legacy rollback must force the QA boundary disabled")
+        if "QA_BUNDLE_VERIFY_MODE: discovery" not in workflow_body:
+            failures.append("legacy Worker fallback must come from full live discovery")
         if "QA_BUNDLE_WORKER_IMAGE: ghcr.io/youxuanxue/sub2api:${{ env.INPUT_TAG }}" in workflow_body:
             failures.append("QA Bundle Worker image must not be coupled directly to the app tag")
     for rel, needles in REQUIRED.items():
@@ -428,6 +443,7 @@ def scan(root: Path) -> list[str]:
             "database_job_registry": "retired",
             "bundle_infra_repository_state": "ready",
             "bundle_infra_observed_state": "not_verified",
+            "bundle_runtime_contract": "phase3_v1",
             "bundle_worker_desired_count": 1,
             "bundle_readiness_verifier": "ops/qa/verify_qa_bundle_infra.sh",
             "bundle_canary": "ops/stage0/run-qa-bundle-canary-via-ssm.sh",

--- a/scripts/checks/qa-lifecycle-ssot.py
+++ b/scripts/checks/qa-lifecycle-ssot.py
@@ -38,12 +38,28 @@ REQUIRED = {
         "qa_export_jobs",
         "prod_fallback: forbidden",
         "pause_capture: false",
+        "resolved_worker_image",
+        "legacy_rollback",
+        "原样保留已经部署的 Phase 3 maintenance/boundary runners",
     ),
     "ops/qa/README.md": (
         "only target lifecycle owner",
         "single_owner_not_activated",
         "transition-only",
         "24-hour whole-partition cleanup",
+        "App rollback does not imply QA control-plane rollback",
+    ),
+    "ops/qa/resolve_qa_bundle_worker_image.py": (
+        'PHASE3_MINIMUM_TAG = "1.8.156"',
+        '"mode": "phase3"',
+        '"mode": "legacy_rollback"',
+        'IMAGE_REPOSITORY = "ghcr.io/youxuanxue/sub2api"',
+    ),
+    ".github/workflows/deploy-stage0.yml": (
+        "ops/qa/resolve_qa_bundle_worker_image.py",
+        "steps.qa_infra.outputs.resolved_worker_image",
+        "if: steps.qa_infra.outputs.mode == 'legacy_rollback'",
+        "QA Phase 3 degraded",
     ),
     "docs/deploy/aws-us-openai-gateway-deployment.md": (
         "tokenkey-qa-maintenance.sh",
@@ -55,6 +71,7 @@ REQUIRED = {
         "S3 Bundle",
         "prod fallback",
         "Observed live: transitional",
+        "legacy app 保留 Phase 3 控制面",
     ),
     ".testing/user-stories/stories/US-045-qa-phase2-production-integrity.md": (
         "historical/superseded",
@@ -74,6 +91,14 @@ REQUIRED = {
         "single_owner_activate",
         "qa boundary is retired after single-owner activation",
         "runTransitionBoundary",
+    ),
+    "backend/cmd/server/qa_bundle_worker.go": (
+        "qaBundleWorkerRequested",
+        '"--qa-bundle-worker"',
+    ),
+    "backend/cmd/server/qa_bundle_worker_test.go": (
+        "TestQABundleWorkerRequested",
+        '[]string{"--qa-bundle-worker"}',
     ),
     "scripts/preflight.sh": (
         "python3 ./scripts/checks/qa-lifecycle-ssot.py; then",
@@ -255,9 +280,15 @@ def scan(root: Path) -> list[str]:
                 failures.append(f"hardcoded QA Bundle coordinate remains in {rel}: {match.group(0)}")
     workflow = root / ".github/workflows/deploy-stage0.yml"
     if workflow.is_file():
-        for line in workflow.read_text(encoding="utf-8").splitlines():
+        workflow_body = workflow.read_text(encoding="utf-8")
+        for line in workflow_body.splitlines():
             if "describe-stacks" in line and "QA_STACK_NAME" in line and "|| true" in line:
                 failures.append("QA stack discovery must fail closed except for explicit stack-not-found")
+        resolved_binding = "QA_BUNDLE_WORKER_IMAGE: ${{ steps.qa_infra.outputs.resolved_worker_image }}"
+        if workflow_body.count(resolved_binding) != 2:
+            failures.append("QA deploy and verifier must share exactly one resolved Worker image")
+        if "QA_BUNDLE_WORKER_IMAGE: ghcr.io/youxuanxue/sub2api:${{ env.INPUT_TAG }}" in workflow_body:
+            failures.append("QA Bundle Worker image must not be coupled directly to the app tag")
     for rel, needles in REQUIRED.items():
         path = root / rel
         if not path.is_file():
@@ -544,6 +575,18 @@ def self_test() -> int:
         )
         if not any("hardcoded QA Bundle coordinate" in item for item in scan(fixture)):
             print("self-test failed to detect a hardcoded QA Bundle coordinate")
+            return 1
+        shutil.copy2(ROOT / ".github/workflows/deploy-stage0.yml", workflow)
+        workflow.write_text(
+            workflow.read_text(encoding="utf-8").replace(
+                "QA_BUNDLE_WORKER_IMAGE: ${{ steps.qa_infra.outputs.resolved_worker_image }}",
+                "QA_BUNDLE_WORKER_IMAGE: ghcr.io/youxuanxue/sub2api:${{ env.INPUT_TAG }}",
+                1,
+            ),
+            encoding="utf-8",
+        )
+        if not any("resolved Worker image" in item for item in scan(fixture)):
+            print("self-test failed to detect app/Worker image recoupling")
             return 1
         shutil.copy2(ROOT / ".github/workflows/deploy-stage0.yml", workflow)
         workflow.write_text(


### PR DESCRIPTION
## 摘要

- 将生产应用回滚标签与 QA Bundle Worker 镜像解耦，统一由 release tree 中的 `bundle_runtime_contract` 和解析器确定回滚行为。
- 历史 release manifest 即使尚未包含 `prod.user_export`，也会按“Bundle runtime contract 缺失”进入受保护的 legacy rollback，而不是误判为 malformed。
- legacy 应用回滚前，只有在不可变 Worker 镜像、实际运行中的 ECS task、服务容量与主机 runner 均通过验证时才保留现网 Worker；证明不完整时在 CloudFormation 或应用变更前 fail closed。
- 共享基础设施 readiness verifier 现在校验实际运行 task 的 task definition 与镜像、SQS redrive/DLQ 目标和托管 SSE；`qa-infra-check` 继续负责 OIDC/IAM 与 stack binding 的只读验收，两个 IAM caller role 均具备 `ecs:ListTasks` / `ecs:DescribeTasks` 权限。
- legacy 路径会先收敛 Phase 3 maintenance runner 并关闭边界，再切换应用；archive 可继续，DROP 保持暂停。
- 高风险契约以 `docs/approved/design-prod-qa-24h-s3-lifecycle.md` 第 18.2 节为审批基线。

## 风险

- 这是高风险的生产部署与回滚编排变更，用户已于 2026-08-17 批准本 PR 的修复提交推送。
- 本 PR 未执行真实 AWS/IAM/主机/部署操作：未触发 workflow、未推送镜像、未更新 CloudFormation/IAM、未修改 GitHub variable、未同步生产主机 timer、未激活 single owner、未执行 DROP。
- `tokenkey-cicd-oidc` 与 `QA_INFRA_OIDC_ROLE_ARN` 的生产 bootstrap 仍是独立的生产审批操作；在 `operation=qa-infra-check` 接受真实基础设施前，Stage0 release readiness 会保持阻断。
- `sentinel-registry-reviewed`：load-bearing 部署行为由 `scripts/checks/qa-lifecycle-ssot.py` 与聚焦 workflow/resolver 测试机械锚定，覆盖 release contract、解析后镜像消费者、legacy 主机顺序、边界关闭、canary 决策和防重新耦合行为；无需增加重复 sentinel owner。
- `no-web-impact`：不改变 Web/API 用户行为，仅修改部署期 QA 控制面与回滚编排。
- 本流程不会自动合并。

## 验证

- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：PASS。
- `make test`：PASS；Go unit/integration、golangci-lint、frontend lint/typecheck 均通过，Vitest 15 个文件、175 个测试通过。
- resolver/workflow 聚焦套件：23 个测试通过，并以真实 `v1.8.140` manifest 验证历史回滚兼容性。
- CloudFormation 契约套件：9 个测试通过。
- daily diagnostics：20 个测试通过。
- QA phase：42 个测试通过。
- SettingsView：36 个测试通过。
- QA lifecycle sentinel 与 self-test：PASS。

## 提交

- `884e3fee3` fix(qa): decouple bundle worker rollback from app tag
- `50817e08d` fix(qa): address rollback review findings
- `b8025bfd0` chore(qa): document bootstrap discovery fallback
- `5b6495fea` docs(qa): record rollback contract approval
- `fedbde2f1` fix(qa): verify live Bundle worker readiness
- `0c8fa4433` fix(qa): preserve legacy rollout compatibility

最新提交：`0c8fa4433`
