### PR TITLE
fix(kiro): 捕获上游 reasoning signature 并回填 QA traj

### DIFF
--- a/.cursor/skills/tokenkey-account-model-probe/SKILL.md
+++ b/.cursor/skills/tokenkey-account-model-probe/SKILL.md
@@ -74,6 +74,18 @@ bash ops/observability/run-probe.sh \
   --env 'MODELS=<control_model> <candidate_model>'
 ```
 
+To verify Kiro adaptive-thinking wire fields (`reasoningContentEvent` +
+`signature`) on a live edge OAuth account:
+
+```bash
+bash ops/observability/run-probe.sh \
+  --target edge:<edge_id> \
+  --script ops/stage0/probe_kiro_upstream_thinking_fields.sh \
+  --with ops/kiro/probe_upstream_thinking_fields.py \
+  --env ACCOUNT_ID=<account_id> \
+  --env MODEL=auto
+```
+
 For an Antigravity OAuth account, query its canonical upstream
 `fetchAvailableModels` result through the account service without modifying
 `model_mapping`:

--- a/backend/internal/integration/kiro/client.go
+++ b/backend/internal/integration/kiro/client.go
@@ -238,14 +238,18 @@ type InferenceConfig struct {
 
 // KiroStreamCallback stream response callbacks
 type KiroStreamCallback struct {
-	OnText         func(text string, isThinking bool)
-	OnToolUse      func(toolUse KiroToolUse)
-	OnStopReason   func(stopReason string)
-	OnStopMetadata func(metadata KiroStopMetadata)
-	OnComplete     func(inputTokens, outputTokens int)
-	OnError        func(err error)
-	OnCredits      func(credits float64)
-	OnContextUsage func(percentage float64)
+	OnText func(text string, isThinking bool)
+	// OnReasoningContent carries Kiro adaptive-thinking frames
+	// (reasoningContentEvent and reasoningText variants). Signature is
+	// upstream-provided and may appear only on the first frame.
+	OnReasoningContent func(text, signature string)
+	OnToolUse          func(toolUse KiroToolUse)
+	OnStopReason       func(stopReason string)
+	OnStopMetadata     func(metadata KiroStopMetadata)
+	OnComplete         func(inputTokens, outputTokens int)
+	OnError            func(err error)
+	OnCredits          func(credits float64)
+	OnContextUsage     func(percentage float64)
 	// ResetForRetry resets consumer-side state after a response-body read error.
 	// Returning true permits retrying the next endpoint; false preserves the
 	// error, which is required once streaming output has been committed.
@@ -575,12 +579,22 @@ func parseEventStream(body io.Reader, callback *KiroStreamCallback) error {
 					callback.OnText(normalized, false)
 				}
 			}
-		case "reasoningContentEvent":
-			if text, ok := event["text"].(string); ok && text != "" {
-				normalized := normalizeChunk(text, &lastReasoningContent)
-				if normalized != "" && callback.OnText != nil {
-					callback.OnText(normalized, true)
+			if reasoningText := kiroReasoningTextFromEvent(event); reasoningText != "" {
+				normalized := normalizeChunk(reasoningText, &lastReasoningContent)
+				if normalized != "" {
+					dispatchKiroReasoningContent(callback, normalized, "")
 				}
+			}
+		case "reasoningContentEvent":
+			text, _ := event["text"].(string)
+			signature, _ := event["signature"].(string)
+			if text != "" {
+				normalized := normalizeChunk(text, &lastReasoningContent)
+				if normalized != "" {
+					dispatchKiroReasoningContent(callback, normalized, signature)
+				}
+			} else if strings.TrimSpace(signature) != "" {
+				dispatchKiroReasoningContent(callback, "", signature)
 			}
 		case "toolUseEvent":
 			currentToolUse = handleToolUseEvent(event, currentToolUse, callback)
@@ -909,6 +923,38 @@ func firstBoolField(m map[string]interface{}, keys ...string) bool {
 		}
 	}
 	return false
+}
+
+func kiroReasoningTextFromEvent(event map[string]interface{}) string {
+	raw, ok := event["reasoningText"]
+	if !ok || raw == nil {
+		return ""
+	}
+	switch v := raw.(type) {
+	case string:
+		return v
+	case map[string]interface{}:
+		if text, ok := v["text"].(string); ok {
+			return text
+		}
+		if text, ok := v["Text"].(string); ok {
+			return text
+		}
+	}
+	return ""
+}
+
+func dispatchKiroReasoningContent(callback *KiroStreamCallback, text, signature string) {
+	if callback == nil {
+		return
+	}
+	if callback.OnReasoningContent != nil {
+		callback.OnReasoningContent(text, signature)
+		return
+	}
+	if text != "" && callback.OnText != nil {
+		callback.OnText(text, true)
+	}
 }
 
 // extractEventType extracts the event type string from AWS Event Stream message headers.

--- a/backend/internal/integration/kiro/eventstream_test.go
+++ b/backend/internal/integration/kiro/eventstream_test.go
@@ -124,3 +124,50 @@ func TestParseEventStream_MetadataStopReason(t *testing.T) {
 		t.Fatalf("expected refusal category %q, got %q", "policy", gotMetadata.StopDetails.Refusal.Category)
 	}
 }
+
+func TestParseEventStream_ReasoningContentEventSignature(t *testing.T) {
+	frame := buildEventStreamMessage("reasoningContentEvent", []byte(`{"text":"plan","signature":"UPSTREAM_SIG_XYZ"}`))
+	frame = append(frame, buildEventStreamMessage("metadataEvent", []byte(`{"stopReason":"END_TURN"}`))...)
+
+	var gotText string
+	var gotSig string
+	cb := &KiroStreamCallback{
+		OnReasoningContent: func(text, signature string) {
+			gotText += text
+			if signature != "" && gotSig == "" {
+				gotSig = signature
+			}
+		},
+	}
+
+	if err := parseEventStream(bytes.NewReader(frame), cb); err != nil {
+		t.Fatalf("parseEventStream returned error: %v", err)
+	}
+	if gotText != "plan" {
+		t.Fatalf("expected reasoning text %q, got %q", "plan", gotText)
+	}
+	if gotSig != "UPSTREAM_SIG_XYZ" {
+		t.Fatalf("expected signature %q, got %q", "UPSTREAM_SIG_XYZ", gotSig)
+	}
+}
+
+func TestParseEventStream_ReasoningContentEventSignatureOnlyFrame(t *testing.T) {
+	frame := buildEventStreamMessage("reasoningContentEvent", []byte(`{"signature":"SIG_ONLY"}`))
+	frame = append(frame, buildEventStreamMessage("metadataEvent", []byte(`{"stopReason":"END_TURN"}`))...)
+
+	var gotSig string
+	cb := &KiroStreamCallback{
+		OnReasoningContent: func(text, signature string) {
+			if signature != "" {
+				gotSig = signature
+			}
+		},
+	}
+
+	if err := parseEventStream(bytes.NewReader(frame), cb); err != nil {
+		t.Fatalf("parseEventStream returned error: %v", err)
+	}
+	if gotSig != "SIG_ONLY" {
+		t.Fatalf("expected signature-only frame %q, got %q", "SIG_ONLY", gotSig)
+	}
+}

--- a/backend/internal/observability/trajectory/projection_v2_test.go
+++ b/backend/internal/observability/trajectory/projection_v2_test.go
@@ -414,7 +414,7 @@ func TestBuildTrajSessionsV2_KiroInternalThinkingFromBlob(t *testing.T) {
 	blob.Request.Body = mustBody(t, req)
 	blob.Response.Body = mustBody(t, resp)
 	blob.Response.InternalThinkingBlocks = []any{
-		`{"type":"thinking","thinking":"kiro plain chain"}`,
+		`{"type":"thinking","thinking":"kiro plain chain","signature":"UPSTREAM_SIG_LIVE"}`,
 	}
 
 	sources := []SourceRecord{{
@@ -443,6 +443,9 @@ func TestBuildTrajSessionsV2_KiroInternalThinkingFromBlob(t *testing.T) {
 	tb, _ := a.Blocks[0].(map[string]any)
 	if tb["type"] != "thinking" || tb["thinking"] != "kiro plain chain" {
 		t.Errorf("thinking export wrong: %+v", tb)
+	}
+	if sig, _ := tb["signature"].(string); sig != "UPSTREAM_SIG_LIVE" {
+		t.Errorf("expected upstream thinking signature on Kiro internal block, got %+v", tb)
 	}
 	if a.CallMeta["thinking_source"] != "present" {
 		t.Errorf("thinking_source = %v", a.CallMeta["thinking_source"])

--- a/backend/internal/service/account_tk_kiro.go
+++ b/backend/internal/service/account_tk_kiro.go
@@ -50,9 +50,9 @@ const KiroDefaultTestModel = "claude-sonnet-4-5"
 // IDs for admin account tests and mapping presets. Dated Anthropic snapshot IDs
 // (e.g. claude-haiku-4-5-20251001) are normalized by the Kiro translator before
 // upstream; this list intentionally exposes the short undated IDs operators should
-// pick in the admin UI. Live probe sources: ops/stage0/probe_kiro_claude_models.sh
-// and the direct runtime probe ops/stage0/probe_kiro_upstream_models.sh. Opus 5
-// returned HTTP 200 on independent us3/us4/us5/us6 OAuth accounts on 2026-07-26.
+// pick in the admin UI. Live probe sources: ops/stage0/probe_kiro_claude_models.sh,
+// ops/stage0/probe_kiro_upstream_models.sh, and ops/stage0/probe_kiro_upstream_thinking_fields.sh.
+// Opus 5 returned HTTP 200 on independent us3/us4/us5/us6 OAuth accounts on 2026-07-26.
 func KiroAdminTestModels() []claude.Model {
 	return []claude.Model{
 		{

--- a/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
+++ b/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
@@ -1144,7 +1144,7 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_StripsKiroInternalThinkingSSE
 	}
 
 	thinking := "prod-only mirror hop reasoning"
-	payload := encodeKiroInternalThinkingPayload(kiroInternalThinkingBlocksFromPlaintext(thinking))
+	payload := encodeKiroInternalThinkingPayload(kiroInternalThinkingBlocksFromCapture(thinking, "SIG_TEST"))
 	commentLine := kiroInternalThinkingSSECommentPfx + payload
 
 	resp := &http.Response{

--- a/backend/internal/service/gateway_service_tk_kiro_mirror_hop_test.go
+++ b/backend/internal/service/gateway_service_tk_kiro_mirror_hop_test.go
@@ -103,7 +103,7 @@ func TestGatewayService_HandleStreamingResponse_StripsKiroInternalThinkingSSECom
 	}
 
 	thinking := "prod mirror stub reasoning"
-	payload := encodeKiroInternalThinkingPayload(kiroInternalThinkingBlocksFromPlaintext(thinking))
+	payload := encodeKiroInternalThinkingPayload(kiroInternalThinkingBlocksFromCapture(thinking, "SIG_TEST"))
 	commentLine := kiroInternalThinkingSSECommentPfx + payload
 
 	resp := &http.Response{

--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -534,6 +534,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 		textBuf          string // client-visible text across all turns
 		billingTextBuf   string // all model text, including hidden continuations
 		thinkingBuf      string
+		thinkingSigBuf   string
 		clientToolUses   []kiroproto.KiroToolUse
 		billingToolUses  []kiroproto.KiroToolUse
 		mappedStopReason string
@@ -542,15 +543,24 @@ func (s *KiroGatewayService) forwardNonStreaming(
 
 	for turn := 1; turn <= maxClaudeCodeCompletionTurns; turn++ {
 		var (
-			turnText     string
-			turnThinking string
-			turnToolUses []kiroproto.KiroToolUse
-			callbackErr  error
-			stopReason   string
-			redactor     kiroproto.InlineThinkingRedactor
+			turnText        string
+			turnThinking    string
+			turnThinkingSig string
+			turnToolUses    []kiroproto.KiroToolUse
+			callbackErr     error
+			stopReason      string
+			redactor        kiroproto.InlineThinkingRedactor
 		)
 
 		callback := &kiroproto.KiroStreamCallback{
+			OnReasoningContent: func(text, signature string) {
+				if text != "" {
+					turnThinking += text
+				}
+				if signature != "" && turnThinkingSig == "" {
+					turnThinkingSig = signature
+				}
+			},
 			OnText: func(text string, isThinking bool) {
 				if isThinking {
 					turnThinking += text
@@ -577,6 +587,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 			ResetForRetry: func() bool {
 				turnText = ""
 				turnThinking = ""
+				turnThinkingSig = ""
 				turnToolUses = nil
 				callbackErr = nil
 				stopReason = ""
@@ -622,6 +633,9 @@ func (s *KiroGatewayService) forwardNonStreaming(
 		textBuf += visibleTurnText
 		billingTextBuf += turnText
 		thinkingBuf += turnThinking
+		if turnThinkingSig != "" && thinkingSigBuf == "" {
+			thinkingSigBuf = turnThinkingSig
+		}
 		billingToolUses = append(billingToolUses, turnToolUses...)
 
 		if shouldContinueClaudeCodeCompletion(payload, stopReason, visibleToolUses, completionAccepted) {
@@ -662,7 +676,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 
 	if c != nil {
 		c.Header("x-request-id", requestID)
-		publishKiroInternalThinkingSideChannel(c, nil, c.Writer.Header(), thinkingBuf)
+		publishKiroInternalThinkingSideChannel(c, nil, c.Writer.Header(), thinkingBuf, thinkingSigBuf)
 		c.JSON(http.StatusOK, resp)
 	}
 
@@ -724,6 +738,7 @@ func (s *KiroGatewayService) forwardStreaming(
 		textBuf          string // client-visible text across all turns
 		billingTextBuf   string // all model text, including hidden continuations
 		thinkingBuf      string
+		thinkingSigBuf   string
 		clientToolUses   []kiroproto.KiroToolUse
 		billingToolUses  []kiroproto.KiroToolUse
 		mappedStopReason string
@@ -761,6 +776,7 @@ func (s *KiroGatewayService) forwardStreaming(
 		var (
 			turnText            string
 			turnThinking        string
+			turnThinkingSig     string
 			turnToolUses        []kiroproto.KiroToolUse
 			callbackErr         error
 			stopReason          string
@@ -785,6 +801,16 @@ func (s *KiroGatewayService) forwardStreaming(
 		}
 
 		callback := &kiroproto.KiroStreamCallback{
+			OnReasoningContent: func(text, signature string) {
+				mu.Lock()
+				defer mu.Unlock()
+				if text != "" {
+					turnThinking += text
+				}
+				if signature != "" && turnThinkingSig == "" {
+					turnThinkingSig = signature
+				}
+			},
 			OnText: func(text string, isThinking bool) {
 				mu.Lock()
 				defer mu.Unlock()
@@ -842,6 +868,7 @@ func (s *KiroGatewayService) forwardStreaming(
 				}
 				turnText = ""
 				turnThinking = ""
+				turnThinkingSig = ""
 				turnToolUses = nil
 				callbackErr = nil
 				stopReason = ""
@@ -925,6 +952,9 @@ func (s *KiroGatewayService) forwardStreaming(
 		textBuf += visibleTurnText
 		billingTextBuf += turnText
 		thinkingBuf += turnThinking
+		if turnThinkingSig != "" && thinkingSigBuf == "" {
+			thinkingSigBuf = turnThinkingSig
+		}
 		billingToolUses = append(billingToolUses, turnToolUses...)
 
 		if shouldContinueClaudeCodeCompletion(payload, stopReason, visibleToolUses, completionAccepted) {
@@ -978,7 +1008,7 @@ func (s *KiroGatewayService) forwardStreaming(
 	// usage into the same accumulator used for billing.
 	enc.writeMessageDelta(inputTokens, outputToks, mappedStopReason)
 	enc.writeMessageStop()
-	publishKiroInternalThinkingSideChannel(c, w, nil, thinkingBuf)
+	publishKiroInternalThinkingSideChannel(c, w, nil, thinkingBuf, thinkingSigBuf)
 	flusher.Flush()
 
 	return &ForwardResult{

--- a/backend/internal/service/kiro_internal_thinking_tk.go
+++ b/backend/internal/service/kiro_internal_thinking_tk.go
@@ -51,42 +51,46 @@ func setKiroInternalThinkingMirrorHopHeaderForAccount(hdr http.Header, account *
 	setKiroInternalThinkingMirrorHopHeader(hdr)
 }
 
-// publishKiroInternalThinkingSideChannel stashes plaintext thinking for QA and,
+// publishKiroInternalThinkingSideChannel stashes upstream thinking + signature for QA and,
 // only on prod→edge mirror hops, emits the wire side channel (SSE comment or
 // response header) that prod passthrough reads and strips before the end client.
-func publishKiroInternalThinkingSideChannel(c *gin.Context, w io.Writer, hdr http.Header, thinking string) {
-	stashKiroInternalThinkingBlocks(c, thinking)
+func publishKiroInternalThinkingSideChannel(c *gin.Context, w io.Writer, hdr http.Header, thinking, signature string) {
+	stashKiroInternalThinkingBlocks(c, thinking, signature)
 	if !kiroInternalThinkingMirrorHopRequested(c) {
 		return
 	}
 	if w != nil {
-		_ = writeKiroInternalThinkingSSEComment(w, thinking)
+		_ = writeKiroInternalThinkingSSEComment(w, thinking, signature)
 	}
 	if hdr != nil {
-		writeKiroInternalThinkingResponseHeader(hdr, thinking)
+		writeKiroInternalThinkingResponseHeader(hdr, thinking, signature)
 	}
 }
 
 // kiroInternalThinkingBlockJSON returns one Anthropic-shaped thinking block JSON
-// string for QA/traj export. Kiro upstream has no signature token; only plaintext
-// thinking is stashed; unsigned Kiro reasoning stays off the client-facing wire.
-func kiroInternalThinkingBlockJSON(thinking string) string {
+// string for QA/traj export. Signature is included only when Kiro upstream sent it.
+func kiroInternalThinkingBlockJSON(thinking, signature string) string {
 	thinking = strings.TrimSpace(thinking)
-	if thinking == "" {
+	signature = strings.TrimSpace(signature)
+	if thinking == "" && signature == "" {
 		return ""
 	}
-	b, err := json.Marshal(map[string]any{
-		"type":     "thinking",
-		"thinking": thinking,
-	})
+	block := map[string]any{"type": "thinking"}
+	if thinking != "" {
+		block["thinking"] = thinking
+	}
+	if signature != "" {
+		block["signature"] = signature
+	}
+	b, err := json.Marshal(block)
 	if err != nil {
 		return ""
 	}
 	return string(b)
 }
 
-func kiroInternalThinkingBlocksFromPlaintext(thinking string) []string {
-	block := kiroInternalThinkingBlockJSON(thinking)
+func kiroInternalThinkingBlocksFromCapture(thinking, signature string) []string {
+	block := kiroInternalThinkingBlockJSON(thinking, signature)
 	if block == "" {
 		return nil
 	}
@@ -130,11 +134,11 @@ func decodeKiroInternalThinkingPayload(encoded string) []string {
 	return out
 }
 
-func stashKiroInternalThinkingBlocks(c *gin.Context, thinking string) {
+func stashKiroInternalThinkingBlocks(c *gin.Context, thinking, signature string) {
 	if c == nil {
 		return
 	}
-	blocks := kiroInternalThinkingBlocksFromPlaintext(thinking)
+	blocks := kiroInternalThinkingBlocksFromCapture(thinking, signature)
 	if len(blocks) == 0 {
 		return
 	}
@@ -152,19 +156,19 @@ func applyKiroInternalThinkingBlocks(c *gin.Context, blocks []string) {
 	c.Set(kiroInternalThinkingGinKey, blocks)
 }
 
-func writeKiroInternalThinkingResponseHeader(hdr http.Header, thinking string) {
+func writeKiroInternalThinkingResponseHeader(hdr http.Header, thinking, signature string) {
 	if hdr == nil {
 		return
 	}
-	payload := encodeKiroInternalThinkingPayload(kiroInternalThinkingBlocksFromPlaintext(thinking))
+	payload := encodeKiroInternalThinkingPayload(kiroInternalThinkingBlocksFromCapture(thinking, signature))
 	if payload == "" {
 		return
 	}
 	hdr.Set(kiroInternalThinkingResponseHeader, payload)
 }
 
-func writeKiroInternalThinkingSSEComment(w io.Writer, thinking string) error {
-	payload := encodeKiroInternalThinkingPayload(kiroInternalThinkingBlocksFromPlaintext(thinking))
+func writeKiroInternalThinkingSSEComment(w io.Writer, thinking, signature string) error {
+	payload := encodeKiroInternalThinkingPayload(kiroInternalThinkingBlocksFromCapture(thinking, signature))
 	if payload == "" || w == nil {
 		return nil
 	}

--- a/backend/internal/service/kiro_internal_thinking_tk_test.go
+++ b/backend/internal/service/kiro_internal_thinking_tk_test.go
@@ -12,9 +12,10 @@ import (
 )
 
 func TestKiroInternalThinking_EncodeDecodeRoundTrip(t *testing.T) {
-	blocks := kiroInternalThinkingBlocksFromPlaintext("reason step one")
+	blocks := kiroInternalThinkingBlocksFromCapture("reason step one", "UPSTREAM_SIG_abc")
 	require.Len(t, blocks, 1)
 	require.Contains(t, blocks[0], `"type":"thinking"`)
+	require.Contains(t, blocks[0], `"signature":"UPSTREAM_SIG_abc"`)
 	require.Contains(t, blocks[0], "reason step one")
 
 	payload := encodeKiroInternalThinkingPayload(blocks)
@@ -22,15 +23,22 @@ func TestKiroInternalThinking_EncodeDecodeRoundTrip(t *testing.T) {
 	require.Equal(t, blocks, got)
 }
 
+func TestKiroInternalThinkingBlockJSON_OmitsSyntheticSignature(t *testing.T) {
+	block := kiroInternalThinkingBlockJSON("plain only", "")
+	require.Contains(t, block, `"thinking":"plain only"`)
+	require.NotContains(t, block, `"signature"`)
+}
+
 func TestParseKiroInternalThinkingSSECommentLine(t *testing.T) {
 	thinking := "streamed reasoning"
-	payload := encodeKiroInternalThinkingPayload(kiroInternalThinkingBlocksFromPlaintext(thinking))
+	payload := encodeKiroInternalThinkingPayload(kiroInternalThinkingBlocksFromCapture(thinking, "SIG_LIVE"))
 	line := kiroInternalThinkingSSECommentPfx + payload
 
 	blocks, ok := parseKiroInternalThinkingSSECommentLine(line)
 	require.True(t, ok)
 	require.Len(t, blocks, 1)
 	require.Contains(t, blocks[0], thinking)
+	require.Contains(t, blocks[0], "SIG_LIVE")
 
 	_, bad := parseKiroInternalThinkingSSECommentLine(": unrelated comment")
 	require.False(t, bad)
@@ -40,8 +48,8 @@ func TestStashKiroInternalThinkingBlocks_GinContext(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
 
-	stashKiroInternalThinkingBlocks(c, "first")
-	stashKiroInternalThinkingBlocks(c, "second")
+	stashKiroInternalThinkingBlocks(c, "first", "SIG1")
+	stashKiroInternalThinkingBlocks(c, "second", "")
 
 	raw, ok := c.Get(kiroInternalThinkingGinKey)
 	require.True(t, ok)
@@ -52,12 +60,13 @@ func TestStashKiroInternalThinkingBlocks_GinContext(t *testing.T) {
 
 func TestWriteKiroInternalThinkingResponseHeader(t *testing.T) {
 	hdr := httptest.NewRecorder().Header()
-	writeKiroInternalThinkingResponseHeader(hdr, "non-stream reasoning")
+	writeKiroInternalThinkingResponseHeader(hdr, "non-stream reasoning", "SIG_HDR")
 	require.NotEmpty(t, hdr.Get(kiroInternalThinkingResponseHeader))
 
 	got := kiroInternalThinkingBlocksFromUpstream(hdr)
 	require.Len(t, got, 1)
 	require.Contains(t, got[0], "non-stream reasoning")
+	require.Contains(t, got[0], "SIG_HDR")
 }
 
 func TestPublishKiroInternalThinkingSideChannel_DirectEdgeOmitsWire(t *testing.T) {
@@ -66,7 +75,7 @@ func TestPublishKiroInternalThinkingSideChannel_DirectEdgeOmitsWire(t *testing.T
 	c, _ := gin.CreateTestContext(rec)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
 
-	publishKiroInternalThinkingSideChannel(c, rec, rec.Header(), "edge-only reasoning")
+	publishKiroInternalThinkingSideChannel(c, rec, rec.Header(), "edge-only reasoning", "SIG_EDGE")
 
 	require.NotContains(t, rec.Body.String(), kiroInternalThinkingSSECommentPfx)
 	require.Empty(t, rec.Header().Get(kiroInternalThinkingResponseHeader))
@@ -77,6 +86,7 @@ func TestPublishKiroInternalThinkingSideChannel_DirectEdgeOmitsWire(t *testing.T
 	require.True(t, ok)
 	require.Len(t, blocks, 1)
 	require.Contains(t, blocks[0], "edge-only reasoning")
+	require.Contains(t, blocks[0], "SIG_EDGE")
 }
 
 func TestPublishKiroInternalThinkingSideChannel_MirrorHopEmitsWire(t *testing.T) {
@@ -86,7 +96,7 @@ func TestPublishKiroInternalThinkingSideChannel_MirrorHopEmitsWire(t *testing.T)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
 	c.Request.Header.Set(kiroInternalThinkingMirrorHopRequestHeader, "1")
 
-	publishKiroInternalThinkingSideChannel(c, rec, rec.Header(), "mirror hop reasoning")
+	publishKiroInternalThinkingSideChannel(c, rec, rec.Header(), "mirror hop reasoning", "SIG_MIRROR")
 
 	require.Contains(t, rec.Body.String(), kiroInternalThinkingSSECommentPfx)
 	require.NotEmpty(t, rec.Header().Get(kiroInternalThinkingResponseHeader))

--- a/backend/internal/service/kiro_sse_encoder_tk_thinking_redact_test.go
+++ b/backend/internal/service/kiro_sse_encoder_tk_thinking_redact_test.go
@@ -67,6 +67,46 @@ func TestKiroGatewayService_Forward_Streaming_WithReasoningEvent(t *testing.T) {
 	require.NotContains(t, out, "plan step one")
 }
 
+func TestKiroGatewayService_Forward_Streaming_StashesReasoningSignature(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	reasoningFrame := buildKiroEventStreamMessage("reasoningContentEvent",
+		[]byte(`{"text":"plan step one","signature":"UPSTREAM_SIG_GATEWAY"}`))
+	textFrame := buildKiroEventStreamMessage("assistantResponseEvent",
+		[]byte(`{"content":"final answer"}`))
+	body := append(reasoningFrame, textFrame...)
+	body = appendKiroTerminalStop(body, "END_TURN")
+	upstream := &kiroFakeUpstream{body: body}
+
+	svc := NewKiroGatewayService(upstream, nil, nil)
+	reqBody, _ := json.Marshal(map[string]any{
+		"model":      "claude-sonnet-4-6",
+		"messages":   []map[string]any{{"role": "user", "content": "hi"}},
+		"max_tokens": 32,
+		"stream":     true,
+		"thinking":   map[string]any{"type": "enabled", "budget_tokens": 1000},
+	})
+	parsed := &ParsedRequest{Body: NewRequestBodyRef(reqBody), Model: "claude-sonnet-4-6", Stream: true}
+
+	_, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), parsed, time.Now())
+	require.NoError(t, err)
+
+	out := rec.Body.String()
+	require.NotContains(t, out, "UPSTREAM_SIG_GATEWAY")
+	require.NotContains(t, out, "plan step one")
+	require.Contains(t, out, "final answer")
+
+	raw, ok := c.Get(kiroInternalThinkingGinKey)
+	require.True(t, ok)
+	blocks, ok := raw.([]string)
+	require.True(t, ok)
+	require.Len(t, blocks, 1)
+	require.Contains(t, blocks[0], "plan step one")
+	require.Contains(t, blocks[0], "UPSTREAM_SIG_GATEWAY")
+}
+
 func TestKiroGatewayService_Forward_Streaming_OmitsSplitInlineThinkingTags(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()

--- a/ops/kiro/probe_upstream_thinking_fields.py
+++ b/ops/kiro/probe_upstream_thinking_fields.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Capture Kiro upstream Event Stream field shapes (secrets redacted).
+
+Reads OAuth credentials JSON (TokenKey account.credentials shape or CLI cache),
+calls generateAssistantResponse with thinking enabled, and reports event types +
+payload keys + signature lengths. Safe to run on edge via SSM.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import ssl
+import struct
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import HTTPSHandler, ProxyHandler, Request, build_opener
+
+RUNTIME = "https://runtime.us-east-1.kiro.dev/generateAssistantResponse"
+MANAGEMENT = "https://management.us-east-1.kiro.dev"
+X_AMZ_TARGET = "AmazonCodeWhispererStreamingService.GenerateAssistantResponse"
+THINKING_PREFIX = (
+    "<thinking_mode>enabled</thinking_mode>\n"
+    "<max_thinking_length>32000</max_thinking_length>\n\n"
+)
+DEFAULT_UA = "kiro-cli/2.18.0"
+DEFAULT_AMZ_UA = "aws-sdk-js/1.0.0 KiroIDE-0.0.0"
+
+
+def load_credentials(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("credentials must be an object")
+    access = str(payload.get("access_token") or payload.get("accessToken") or "").strip()
+    if not access:
+        raise ValueError("missing access_token")
+    profile_arn = str(payload.get("profile_arn") or payload.get("profileArn") or "").strip()
+    return {"access_token": access, "profile_arn": profile_arn}
+
+
+def http_json(method: str, url: str, token: str, body: dict | None = None, extra: dict | None = None) -> tuple[int, bytes]:
+    host = url.split("/")[2]
+    headers = {
+        "Authorization": f"Bearer {token['access_token']}",
+        "Content-Type": "application/json",
+        "Accept": "*/*",
+        "Host": host,
+        "User-Agent": DEFAULT_UA,
+        "x-amz-user-agent": DEFAULT_AMZ_UA,
+        "x-amzn-codewhisperer-optout": "false",
+    }
+    if extra:
+        headers.update(extra)
+    data = None if body is None else json.dumps(body, separators=(",", ":")).encode()
+    req = Request(url, data=data, method=method, headers=headers)
+    opener = build_opener(HTTPSHandler(context=ssl.create_default_context()))
+    try:
+        with opener.open(req, timeout=60) as resp:
+            return resp.status, resp.read()
+    except HTTPError as exc:
+        return exc.code, exc.read()
+
+
+def resolve_profile_arn(token: dict[str, Any]) -> str:
+    if token.get("profile_arn"):
+        return token["profile_arn"]
+    code, raw = http_json("POST", f"{MANAGEMENT}/List-Available-Profiles", token, {"maxResults": 10})
+    if code != 200:
+        raise RuntimeError(f"List-Available-Profiles HTTP {code}: {raw[:200]!r}")
+    payload = json.loads(raw)
+    profiles = payload.get("profiles") or []
+    if not profiles:
+        raise RuntimeError("List-Available-Profiles returned no profiles")
+    return str(profiles[0].get("arn") or "")
+
+
+def extract_event_type(headers: bytes) -> str:
+    i = 0
+    while i < len(headers):
+        name_len = headers[i]
+        i += 1
+        name = headers[i : i + name_len].decode("utf-8", "replace")
+        i += name_len
+        vtype = headers[i]
+        i += 1
+        if vtype == 7:
+            vlen = struct.unpack(">H", headers[i : i + 2])[0]
+            i += 2
+            val = headers[i : i + vlen].decode("utf-8", "replace")
+            i += vlen
+        else:
+            break
+        if name == ":event-type":
+            return val
+    return ""
+
+
+def parse_event_stream(raw: bytes) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    off = 0
+    while off + 12 <= len(raw):
+        total = struct.unpack(">I", raw[off : off + 4])[0]
+        if total < 16 or off + total > len(raw):
+            break
+        headers_len = struct.unpack(">I", raw[off + 4 : off + 8])[0]
+        payload = raw[off + 12 + headers_len : off + total - 4]
+        event_type = extract_event_type(raw[off + 12 : off + 12 + headers_len])
+        keys: list[str] = []
+        redacted: dict[str, Any] = {}
+        if payload:
+            try:
+                obj = json.loads(payload)
+                if isinstance(obj, dict):
+                    keys = sorted(obj.keys())
+                    for key, val in obj.items():
+                        if key == "signature" and val:
+                            redacted[key] = {"len": len(str(val)), "prefix": str(val)[:16]}
+                        elif key in ("text", "content", "reasoningText"):
+                            if isinstance(val, dict):
+                                redacted[key] = {"keys": sorted(val.keys())}
+                            else:
+                                redacted[key] = {"len": len(str(val)) if val is not None else 0}
+                        else:
+                            redacted[key] = {"type": type(val).__name__}
+            except json.JSONDecodeError:
+                redacted = {"raw_len": len(payload)}
+        events.append({"event_type": event_type, "payload_keys": keys, "payload_redacted": redacted})
+        off += total
+    return events
+
+
+def probe(token: dict[str, Any], model_id: str, message: str) -> dict[str, Any]:
+    profile_arn = resolve_profile_arn(token)
+    body = {
+        "conversationState": {
+            "chatTriggerType": "MANUAL",
+            "conversationId": f"tk-upstream-probe-{uuid.uuid4()}",
+            "currentMessage": {
+                "userInputMessage": {
+                    "content": THINKING_PREFIX + message,
+                    "modelId": model_id,
+                    "origin": "AI_EDITOR",
+                }
+            },
+        },
+        "profileArn": profile_arn,
+        "additionalModelRequestFields": {
+            "output_config": {"effort": "high"},
+            "thinking": {"type": "adaptive", "display": "summarized"},
+            "max_tokens": 32000,
+        },
+    }
+    code, raw = http_json(
+        "POST",
+        RUNTIME,
+        token,
+        body,
+        extra={
+            "X-Amz-Target": X_AMZ_TARGET,
+            "x-amzn-kiro-agent-mode": "vibe",
+        },
+    )
+    report: dict[str, Any] = {
+        "http_status": code,
+        "model_id": model_id,
+        "profile_arn_present": bool(profile_arn),
+        "body_len": len(raw),
+    }
+    if code != 200:
+        report["error_body_prefix"] = raw[:300].decode("utf-8", "replace")
+        return report
+    events = parse_event_stream(raw)
+    report["frame_count"] = len(events)
+    report["event_types"] = [e["event_type"] for e in events]
+    report["payload_keys_by_event_type"] = {
+        et: sorted({k for e in events if e["event_type"] == et for k in e["payload_keys"]})
+        for et in sorted({e["event_type"] for e in events})
+    }
+    sig_frames = [e for e in events if "signature" in e.get("payload_keys", [])]
+    report["frames_with_signature_key"] = len(sig_frames)
+    if sig_frames:
+        report["signature_frame_samples"] = [
+            {"event_type": e["event_type"], **e["payload_redacted"].get("signature", {})}
+            for e in sig_frames[:3]
+        ]
+    reasoning = [e for e in events if e["event_type"] == "reasoningContentEvent"]
+    report["reasoningContentEvent_count"] = len(reasoning)
+    if reasoning:
+        report["first_reasoning_frame"] = reasoning[0]
+        report["last_reasoning_frame"] = reasoning[-1]
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("credentials", type=Path, help="path to credentials JSON")
+    parser.add_argument("--model", default="auto")
+    parser.add_argument(
+        "--message",
+        default="What is 17+25? Reply with only the number.",
+    )
+    args = parser.parse_args()
+    try:
+        token = load_credentials(args.credentials)
+        report = probe(token, args.model, args.message)
+    except (ValueError, RuntimeError, URLError, json.JSONDecodeError) as exc:
+        print(json.dumps({"verdict": "setup_error", "error": str(exc)}, ensure_ascii=False))
+        return 1
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0 if report.get("http_status") == 200 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/stage0/probe_kiro_upstream_thinking_fields.sh
+++ b/ops/stage0/probe_kiro_upstream_thinking_fields.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Direct upstream Kiro thinking/signature field probe for one edge OAuth account.
+set -euo pipefail
+
+ACCOUNT_ID="${ACCOUNT_ID:-}"
+MODEL="${MODEL:-auto}"
+MESSAGE="${MESSAGE:-What is 17+25? Reply with only the number.}"
+PROBE_PY="${PROBE_PY:-/tmp/probe_upstream_thinking_fields.py}"
+
+fail_json() {
+  python3 - "$1" <<'PY'
+import json, sys
+print(json.dumps({"verdict": "setup_error", "error": sys.argv[1]}, ensure_ascii=False))
+PY
+  exit 0
+}
+
+if [[ ! "$ACCOUNT_ID" =~ ^[0-9]+$ ]]; then
+  fail_json "ACCOUNT_ID must be numeric"
+fi
+if [[ ! -f "$PROBE_PY" ]]; then
+  fail_json "missing probe_upstream_thinking_fields.py companion"
+fi
+
+PSQL=(sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -q -A -t -v ON_ERROR_STOP=1)
+PROBE_DIR="$(mktemp -d /tmp/tk-kiro-thinking-probe.XXXXXX)"
+CREDENTIALS_FILE="$PROBE_DIR/credentials.json"
+cleanup() {
+  rm -f "$CREDENTIALS_FILE"
+  rmdir "$PROBE_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+"${PSQL[@]}" -c "
+SELECT credentials::text
+FROM accounts
+WHERE id = ${ACCOUNT_ID}
+  AND deleted_at IS NULL
+  AND platform = 'kiro'
+  AND type = 'oauth';
+" >"$CREDENTIALS_FILE"
+chmod 600 "$CREDENTIALS_FILE"
+
+python3 "$PROBE_PY" "$CREDENTIALS_FILE" --model "$MODEL" --message "$MESSAGE"

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -4772,9 +4772,12 @@
       "must_contain": [
         "TestSetKiroInternalThinkingMirrorHopHeaderForAccount_ExplicitEdgeBaseURL",
         "TestSetKiroInternalThinkingMirrorHopHeaderForAccount_NativeEdgeRelayOmitsHop",
+        "TestGatewayService_HandleStreamingResponse_StripsKiroInternalThinkingSSEComment",
+        "kiroInternalThinkingBlocksFromCapture",
+        "SIG_TEST",
         "mirror_platform"
       ],
-      "rationale": "Regression guard for prod mirror-hop vs native edge relay: only Anthropic API-key stubs with mirror_platform=kiro emit kiroInternalThinkingMirrorHopRequestHeader; cc-us5/cc-us6 native edge relays with base_url but no mirror_platform must omit the header so Fable/Opus 4.1 requests are not misclassified as Kiro-sidecar traffic on edge."
+      "rationale": "Regression guard for prod mirror-hop vs native edge relay and passthrough stripping of internal-thinking SSE comments while stashing upstream thinking blocks (including optional signature) for QA/traj export. Only Anthropic API-key stubs with mirror_platform=kiro emit kiroInternalThinkingMirrorHopRequestHeader; cc-us5/cc-us6 native edge relays with base_url but no mirror_platform must omit the header so Fable/Opus 4.1 requests are not misclassified as Kiro-sidecar traffic on edge."
     },
     {
       "path": "backend/internal/service/gateway_forward_as_chat_completions_tk_image.go",

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -175,6 +175,10 @@
         "func CallKiroAPIWithDoerContext",
         "func callKiroAPIOnce",
         "ResetForRetry func() bool",
+        "OnReasoningContent func(text, signature string)",
+        "func dispatchKiroReasoningContent",
+        "case \"reasoningContentEvent\":",
+        "event[\"signature\"]",
         "OnStopReason",
         "OnStopMetadata",
         "KiroStopMetadata",
@@ -191,7 +195,7 @@
         "runtime.us-east-1.kiro.dev",
         "q.us-east-1.amazonaws.com"
       ],
-      "rationale": "Streaming call entry + hand-rolled AWS EventStream binary decoder + the HTTPDoer injection seam that lets the TK gateway supply a TLS/proxy-aware doer. CallKiroAPIWithDoerContext binds upstream attempts to the customer request lifetime, while ResetForRetry permits response-read failover only when the consumer can discard all partial state. OnStopReason plus KiroStopMetadata preserve Kiro's authoritative terminal outcome and structured refusal details; losing them turns policy outcomes back into opaque empty-response 502s. Losing parseEventStream breaks all streaming responses; losing the HTTPDoer seam breaks fingerprint/proxy egress. The endpoint anchors pin the official current runtime host followed only by Kiro's explicitly transitional q host; an upstream merge must not restore undocumented codewhisperer or alternate AmazonQ protocol retries."
+      "rationale": "Streaming call entry + hand-rolled AWS EventStream binary decoder + the HTTPDoer injection seam that lets the TK gateway supply a TLS/proxy-aware doer. OnReasoningContent plus dispatchKiroReasoningContent preserve upstream reasoningContentEvent text and signature for QA/traj export without forging client-wire redacted_thinking blocks. CallKiroAPIWithDoerContext binds upstream attempts to the customer request lifetime, while ResetForRetry permits response-read failover only when the consumer can discard all partial state. OnStopReason plus KiroStopMetadata preserve Kiro's authoritative terminal outcome and structured refusal details; losing them turns policy outcomes back into opaque empty-response 502s. Losing parseEventStream breaks all streaming responses; losing the HTTPDoer seam breaks fingerprint/proxy egress. The endpoint anchors pin the official current runtime host followed only by Kiro's explicitly transitional q host; an upstream merge must not restore undocumented codewhisperer or alternate AmazonQ protocol retries."
     },
     {
       "path": "backend/internal/integration/kiro/eventstream_test.go",
@@ -199,10 +203,12 @@
         "TestParseEventStream_MetadataStopReason",
         "TestParseEventStream_FrameAlignedEOFWithoutStopReasonFails",
         "TestParseEventStream_TerminalStopIgnoresTruncatedTrailingFrame",
+        "TestParseEventStream_ReasoningContentEventSignature",
+        "TestParseEventStream_ReasoningContentEventSignatureOnlyFrame",
         "KiroStopMetadata",
         "CONTENT_FILTERED"
       ],
-      "rationale": "Protocol-level evidence that metadataEvent.stopReason survives EventStream decoding. Without this callback the service cannot distinguish an upstream content-policy terminal outcome from a broken empty response."
+      "rationale": "Protocol-level evidence that metadataEvent.stopReason survives EventStream decoding and that reasoningContentEvent signature tokens survive EventStream decoding for QA/traj export. Without these callbacks the service cannot distinguish an upstream content-policy terminal outcome from a broken empty response, or silently drops upstream thinking signatures."
     },
     {
       "path": "backend/internal/integration/kiro/client_endpoints_test.go",
@@ -312,9 +318,11 @@
         "gateway.kiro_completion_protocol",
         "unsupported_stop_reason",
         "classifyAndRecordKiroForwardError",
+        "OnReasoningContent: func(text, signature string)",
+        "thinkingSigBuf",
         "publishKiroInternalThinkingSideChannel"
       ],
-      "rationale": "The sixth-platform forwarder translates /v1/messages onto Kiro EventStream and estimates usage because upstream reports credits only. The context-aware call and ResetForRetry callbacks protect retry integrity. The stop-reason mapper preserves Kiro's authoritative terminal outcome; for positively identified Claude Code payloads, the private completion signal and bounded continuation loop separate model END_TURN from agent completion. Continuation turns are transport-only wiring: default zero client-visible text; only ordinary client tools, non-completion terminal outcomes, and deduped short blocker questions may pass. shouldExposeClaudeCodeCompletionMessage and completionSignalTextDelta enforce turn>=2 complete silence plus isShortBlockerQuestion gating after continuationTextDelta dedupe. stripCompletionMarkdownPrefix accepts only explicit marker-plus-space decoration so semantic prefixes such as negative signs survive. flushContinuationText preserves text-before-tool ordering in SSE. Every private-tool consume/hide site is guarded by payload.ClaudeCodeCompletionProtocol so ordinary API clients retain same-name tools. billingTextBuf keeps hidden continuation output billable even when presentation is suppressed, while private completion input is counted exactly once through billingToolUses. Both stop/completion actions remain observable, and the visible-text-aware pre-content error guard keeps failures visible instead of returning an empty 200 stream. Losing these anchors silently regresses reliability, billing, response integrity, completion semantics, or incident diagnosability."
+      "rationale": "The sixth-platform forwarder translates /v1/messages onto Kiro EventStream and estimates usage because upstream reports credits only. OnReasoningContent plus thinkingSigBuf accumulate upstream reasoningContentEvent signatures into the internal QA side channel without exposing them on the client wire. The context-aware call and ResetForRetry callbacks protect retry integrity. The stop-reason mapper preserves Kiro's authoritative terminal outcome; for positively identified Claude Code payloads, the private completion signal and bounded continuation loop separate model END_TURN from agent completion. Continuation turns are transport-only wiring: default zero client-visible text; only ordinary client tools, non-completion terminal outcomes, and deduped short blocker questions may pass. shouldExposeClaudeCodeCompletionMessage and completionSignalTextDelta enforce turn>=2 complete silence plus isShortBlockerQuestion gating after continuationTextDelta dedupe. stripCompletionMarkdownPrefix accepts only explicit marker-plus-space decoration so semantic prefixes such as negative signs survive. flushContinuationText preserves text-before-tool ordering in SSE. Every private-tool consume/hide site is guarded by payload.ClaudeCodeCompletionProtocol so ordinary API clients retain same-name tools. billingTextBuf keeps hidden continuation output billable even when presentation is suppressed, while private completion input is counted exactly once through billingToolUses. Both stop/completion actions remain observable, and the visible-text-aware pre-content error guard keeps failures visible instead of returning an empty 200 stream. Losing these anchors silently regresses reliability, billing, response integrity, completion semantics, or incident diagnosability."
     },
     {
       "path": "backend/internal/service/kiro_gateway_service_test.go",
@@ -389,9 +397,10 @@
       "path": "backend/internal/service/kiro_sse_encoder_tk_thinking_redact_test.go",
       "must_contain": [
         "TestKiroGatewayService_Forward_Streaming_WithReasoningEvent",
+        "TestKiroGatewayService_Forward_Streaming_StashesReasoningSignature",
         "TestKiroGatewayService_Forward_Streaming_OmitsSplitInlineThinkingTags"
       ],
-      "rationale": "Client-wire compatibility guard for unsigned Kiro reasoning. Kiro reasoning is retained through the internal QA side channel but must not be forged into redacted_thinking blocks: the hash placeholder is not Anthropic-signed or replayable and breaks strict clients. These tests pin both explicit reasoning events and split inline thinking on the full streaming forward path so an upstream merge cannot silently restore the incompatible block."
+      "rationale": "Client-wire compatibility guard for unsigned Kiro reasoning plus forward-path evidence that upstream reasoningContentEvent signatures reach the internal QA stash. Kiro reasoning is retained through the internal side channel but must not be forged into redacted_thinking blocks: the hash placeholder is not Anthropic-signed or replayable and breaks strict clients. These tests pin explicit reasoning events, signature stash wiring, and split inline thinking on the full streaming forward path so an upstream merge cannot silently restore the incompatible block or drop signatures."
     },
     {
       "path": "backend/internal/integration/kiro/thinking_redact_test.go",
@@ -431,21 +440,26 @@
       "path": "backend/internal/service/kiro_internal_thinking_tk.go",
       "must_contain": [
         "func publishKiroInternalThinkingSideChannel",
+        "func kiroInternalThinkingBlockJSON(thinking, signature string)",
+        "kiroInternalThinkingBlocksFromCapture",
+        "block[\"signature\"]",
         "kiroInternalThinkingMirrorHopRequestHeader",
         "func setKiroInternalThinkingMirrorHopHeaderForAccount",
         "IsKiroMirrorStub()",
         "func setKiroInternalThinkingMirrorHopHeader",
         "func parseKiroInternalThinkingSSECommentLine"
       ],
-      "rationale": "Kiro plaintext-thinking side channel for prod mirror QA/traj export. setKiroInternalThinkingMirrorHopHeaderForAccount must gate on IsKiroMirrorStub(): only prod Anthropic API-key stubs with mirror_platform=kiro emit the hop header; native cc-us5/cc-us6 edge relays must omit it or edge treats Fable/Opus as Kiro-sidecar traffic and rejects. Edge emits the wire side channel only when the prod mirror hop header is present; direct edge clients get gin-context stash only. Losing publishKiroInternalThinkingSideChannel or the mirror-stub gate regresses to leaking plaintext thinking on edge direct SSE/headers or drops prod passthrough stash."
+      "rationale": "Kiro upstream thinking + signature side channel for prod mirror QA/traj export. Signature is included only when Kiro upstream sent it; synthetic placeholders are forbidden. setKiroInternalThinkingMirrorHopHeaderForAccount must gate on IsKiroMirrorStub(): only prod Anthropic API-key stubs with mirror_platform=kiro emit the hop header; native cc-us5/cc-us6 edge relays must omit it or edge treats Fable/Opus as Kiro-sidecar traffic and rejects. Edge emits the wire side channel only when the prod mirror hop header is present; direct edge clients get gin-context stash only. Losing publishKiroInternalThinkingSideChannel or the mirror-stub gate regresses to leaking plaintext thinking on edge direct SSE/headers or drops prod passthrough stash."
     },
     {
       "path": "backend/internal/service/kiro_internal_thinking_tk_test.go",
       "must_contain": [
         "TestPublishKiroInternalThinkingSideChannel_DirectEdgeOmitsWire",
-        "TestPublishKiroInternalThinkingSideChannel_MirrorHopEmitsWire"
+        "TestPublishKiroInternalThinkingSideChannel_MirrorHopEmitsWire",
+        "TestKiroInternalThinkingBlockJSON_OmitsSyntheticSignature",
+        "UPSTREAM_SIG_abc"
       ],
-      "rationale": "Regression guard for the mirror-hop gate: edge direct must not emit wire side channel; prod mirror hop must."
+      "rationale": "Regression guard for the mirror-hop gate and upstream signature capture: edge direct must not emit wire side channel; prod mirror hop must; blocks omit signature when upstream did not send one."
     },
     {
       "path": "backend/internal/service/gateway_anthropic_apikey_passthrough_test.go",


### PR DESCRIPTION
## 摘要

- Kiro 上游 `reasoningContentEvent` 帧含 `{text, signature}`，TokenKey 此前只读 `text`，导致 QA traj 导出 signature 计数为 0。
- 新增 `OnReasoningContent` 回调，经 gateway side-channel 写入 `internal_thinking_blocks`，traj v2 投影时保留真实 upstream signature（不再 synthetic）。
- 新增 edge 直连探针 `ops/stage0/probe_kiro_upstream_thinking_fields.sh`；edge-us4 account 16 实测已确认 signature 字段存在。
- xj-review 修复：补 kiro/gateway-tk sentinel 锚点 + gateway forward 回归测试。

## 风险

- 常规风险：仅影响 Kiro internal thinking 捕获与 QA/traj 导出，客户端 wire 行为不变。
- 若上游某次响应无 signature 帧，traj 仍可能缺 signature（符合真实上游，不再伪造）。

## 验证

- `go test -tags=unit ./internal/integration/kiro/ ./internal/service/ ./internal/observability/trajectory/ -run 'Kiro|InternalThinking|ReasoningContent|TrajSessionsV2_Kiro|StashesReasoningSignature'`
- `./scripts/preflight.sh` → PASS
- edge-us4 `kiro-deborahwalters101@gmail.com`（account 16）直连 upstream：`reasoningContentEvent` payload keys = `signature,text`，signature len=98

## 提交

- b1f74cc70 fix(kiro): capture upstream reasoning signature for QA traj export
- 3d6e4610a chore(ops): wire Kiro thinking upstream probe into skill registry
- 1fd1dd7af fix(kiro): anchor reasoning signature sentinels and gateway forward test
- 7dc098925 fix(kiro): extend gateway-tk sentinel for mirror-hop signature test
- 最新提交：7dc098925