### PR TITLE
fix: allow QA CloudFormation truncated role names

### DIFF
--- a/deploy/aws/cloudformation/cicd-oidc.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc.yaml
@@ -275,7 +275,7 @@ Resources:
                   - iam:UpdateAssumeRolePolicy
                   - iam:UpdateRole
                   - iam:UpdateRoleDescription
-                Resource: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/tokenkey-prod-qa-raw-archive-*"
+                Resource: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/tokenkey-prod-qa-raw-arch*"
               - Sid: CreateEcsServiceLinkedRole
                 Effect: Allow
                 Action: iam:CreateServiceLinkedRole

--- a/deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py
+++ b/deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py
@@ -159,6 +159,17 @@ class Stage0QABundleContractTest(unittest.TestCase):
             with self.subTest(sid=sid):
                 self.assertTrue(actions <= statements[sid], actions - statements[sid])
 
+        manage_roles = next(
+            statement
+            for policy in policies
+            for statement in policy["PolicyDocument"]["Statement"]
+            if statement["Sid"] == "ManageQaRoles"
+        )
+        self.assertEqual(
+            manage_roles["Resource"],
+            "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/tokenkey-prod-qa-raw-arch*",
+        )
+
         service_linked_role = next(
             statement
             for policy in policies


### PR DESCRIPTION
## 摘要

- 修正 QA CloudFormation service role 的 IAM Resource 前缀，使其匹配 CloudFormation 对长物理角色名的确定性截断。
- 增加回归断言，防止权限 action 存在但 resource pattern 无法命中的静默漂移。
- 现网证据：deploy run 32014445269 中 QaBundleWorkerExecutionRole 创建因 CreateRole 无权限失败；实际物理名以 tokenkey-prod-qa-raw-arch- 开头。

## 风险

- 安全边界变更，但仍限制在当前 AWS account 与 tokenkey-prod-qa-raw-arch 前缀；不改变 trust policy、OIDC subject 或 action 集。
- 设计基线：docs/approved/design-prod-qa-24h-s3-lifecycle.md。
- Web impact: none。

## 验证

- RED：聚焦测试在旧 archive-* pattern 上按预期失败。
- GREEN：python3 -m unittest deploy.aws.cloudformation.test_stage0_qa_bundle_contract，9 项通过。
- aws cloudformation validate-template：通过。
- bash scripts/preflight.sh：PASS。

## 提交

- 12b627fdc fix: allow QA CloudFormation truncated role names
- 最新提交：12b627fdc