### PR TITLE
fix: use canonical S3 encryption IAM action

### DIFF
--- a/deploy/aws/cloudformation/cicd-oidc.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc.yaml
@@ -228,7 +228,7 @@ Resources:
                   - s3:GetBucketPolicy
                   - s3:PutBucketPolicy
                   - s3:PutBucketPublicAccessBlock
-                  - s3:PutBucketEncryption
+                  - s3:PutEncryptionConfiguration
                   - s3:PutBucketVersioning
                   - s3:PutLifecycleConfiguration
                   - s3:PutBucketCORS

--- a/deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py
+++ b/deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py
@@ -132,6 +132,7 @@ class Stage0QABundleContractTest(unittest.TestCase):
                 "s3:GetBucketVersioning",
                 "s3:GetEncryptionConfiguration",
                 "s3:GetLifecycleConfiguration",
+                "s3:PutEncryptionConfiguration",
             },
             "ManageQaKms": {"kms:CreateAlias", "kms:DeleteAlias", "kms:UntagResource"},
             "ManageQaRoles": {


### PR DESCRIPTION
## 摘要

- 将 QA CloudFormation service role 中不存在的 `s3:PutBucketEncryption` 替换为 AWS 实际鉴权 action `s3:PutEncryptionConfiguration`。
- 补充模板契约测试，防止创建启用 `BucketEncryption` 的 QA Bundle bucket 时再次缺权。
- no-web-impact。

## 设计

- 不改变 QA Bundle 架构、资源范围或部署顺序，只修正一个 IAM action 名称。
- 权限资源仍限制为 `arn:${AWS::Partition}:s3:::tokenkey-prod-qa-*`。
- 用户已明确批准 push 与创建本 PR；合并仍保留独立人工门禁。

## 契约

- prod deploy run `32026327784` 在创建 `QaBundleBucket` 时收到 `s3:PutEncryptionConfiguration` AccessDenied，QA 栈随后干净回滚至 `UPDATE_ROLLBACK_COMPLETE`，prod app 未换镜像。
- AWS Access Analyzer 对现网旧 policy 返回 `INVALID_ACTION`，并明确指出该 API 应授权 `s3:PutEncryptionConfiguration`。

## 迁移

- 合并后先更新 `tokenkey-cicd-oidc`，保留现有 `AllowedSubjects`、`TargetInstanceId`、`GitHubRepo` 与 `CreateOIDCProvider` 参数，再重试 `v1.8.157` prod deploy。
- 无数据迁移；失败时 CloudFormation 可回滚 inline policy。

## 风险

- 这是生产 IAM 权限变更；有效授权范围从不存在的 action 修正为 S3 bucket encryption configuration 写权限。
- blast radius 受 QA bucket ARN 前缀约束，不授予对象数据读写或任意 bucket 权限。

## 验证

- TDD RED：聚焦测试精确失败，缺少 `s3:PutEncryptionConfiguration`。
- TDD GREEN：聚焦测试通过。
- `python3 deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py`：9 tests passed。
- `aws cloudformation validate-template`：通过。
- `bash scripts/preflight.sh`：通过。
- `xj-review`：high / full_conformance / merge-ready / zero findings。

## 提交

- `d5b00e287 fix: use canonical S3 encryption IAM action`
- 最新提交：`d5b00e287`
