### PR TITLE
fix(cloudwise): 归一 /api 前缀，避免测试连接 nginx 404

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -914,6 +914,9 @@ func (a *Account) GetBaseURL() string {
 	if a.Platform == PlatformAntigravity {
 		return strings.TrimRight(baseURL, "/") + "/antigravity"
 	}
+	if normalized, ok := normalizeCloudwiseRelayBaseURL(baseURL); ok {
+		return normalized
+	}
 	return baseURL
 }
 
@@ -1317,16 +1320,6 @@ func (a *Account) IsOpenAICloudwiseRelay() bool {
 	return isCloudwiseRelayBaseURL(a.GetCredential("base_url"))
 }
 
-func isCloudwiseRelayBaseURL(raw string) bool {
-	base := strings.ToLower(strings.TrimSpace(strings.TrimSuffix(raw, "/")))
-	switch base {
-	case "https://api.cloudwise.ai/api", "https://api-us.cloudwise.ai/api":
-		return true
-	default:
-		return false
-	}
-}
-
 func (a *Account) GetOpenAIBaseURL() string {
 	if a == nil {
 		return ""
@@ -1340,6 +1333,9 @@ func (a *Account) GetOpenAIBaseURL() string {
 	if a.Type == AccountTypeAPIKey {
 		baseURL := a.GetCredential("base_url")
 		if baseURL != "" {
+			if normalized, ok := normalizeCloudwiseRelayBaseURL(baseURL); ok {
+				return normalized
+			}
 			return baseURL
 		}
 	}

--- a/backend/internal/service/account_base_url_test.go
+++ b/backend/internal/service/account_base_url_test.go
@@ -99,6 +99,24 @@ func TestGetBaseURL(t *testing.T) {
 			expected: "https://ark.cn-beijing.volces.com",
 		},
 		{
+			name: "cloudwise host-only base_url gains the /api prefix nginx requires",
+			account: Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformOpenAI,
+				Credentials: map[string]any{"base_url": "https://api.cloudwise.ai"},
+			},
+			expected: "https://api.cloudwise.ai/api",
+		},
+		{
+			name: "cloudwise /v1 base_url is rewritten to /api, not /api/v1",
+			account: Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformOpenAI,
+				Credentials: map[string]any{"base_url": "https://api.cloudwise.ai/v1"},
+			},
+			expected: "https://api.cloudwise.ai/api",
+		},
+		{
 			// Legacy rows with an empty platform string predate multi-platform
 			// support and were all anthropic — keep the historical default.
 			name: "legacy empty-platform apikey without base_url keeps anthropic default",

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -808,7 +808,10 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 		if err != nil {
 			return s.sendErrorAndEnd(c, fmt.Sprintf("Invalid base URL: %s", err.Error()))
 		}
-		if !openai_compat.ShouldUseResponsesAPI(account.Extra) {
+		// CloudWise nginx only serves /api/v1/* and does not implement a working
+		// Responses completion path. Host-only /v1/responses is the nginx HTML 404
+		// operators see in admin "测试账号连接".
+		if credentialAccount.IsOpenAICloudwiseRelay() || !openai_compat.ShouldUseResponsesAPI(account.Extra) {
 			return s.testOpenAIChatCompletionsConnection(c, account, testModelID, prompt, normalizedBaseURL, authToken)
 		}
 		apiURL = buildOpenAIResponsesURL(normalizedBaseURL)

--- a/backend/internal/service/account_test_service_openai_test.go
+++ b/backend/internal/service/account_test_service_openai_test.go
@@ -489,6 +489,50 @@ func TestAccountTestService_OpenAIAPIKeyResponsesUnsupportedUsesChatCompletionsP
 	require.NotContains(t, body, "当前测试接口仅支持 Responses API 路径")
 }
 
+func TestAccountTestService_CloudwiseHostOnlyURLUsesChatCompletionsAPIPrefix(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, recorder := newTestContext()
+
+	upstreamBody := strings.Join([]string{
+		`data: {"id":"chatcmpl_test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}`,
+		"",
+		`data: {"id":"chatcmpl_test","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &AccountTestService{
+		httpUpstream: upstream,
+		cfg:          &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
+	}
+	account := &Account{
+		ID:          95,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://api.cloudwise.ai",
+		},
+		// Missing/true responses flag used to send /v1/responses and hit nginx 404.
+		Extra: map[string]any{openai_compat.ExtraKeyResponsesSupported: true},
+	}
+
+	err := svc.testOpenAIAccountConnection(ctx, account, "claude-fable-5", "hi", "")
+	require.NoError(t, err)
+	require.NotNil(t, upstream.lastReq)
+	require.Equal(t, "https://api.cloudwise.ai/api/v1/chat/completions", upstream.lastReq.URL.String())
+	require.Equal(t, "claude-fable-5", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "hi", gjson.GetBytes(upstream.lastBody, "messages.0.content").String())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "input").Exists())
+	require.Contains(t, recorder.Body.String(), `"success":true`)
+}
+
 func TestAccountTestService_OpenAIChatCompletionsPathReturns4xx(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ctx, recorder := newTestContext()

--- a/backend/internal/service/gateway_cloudwise_relay_test.go
+++ b/backend/internal/service/gateway_cloudwise_relay_test.go
@@ -49,6 +49,27 @@ func TestAccount_IsOpenAICloudwiseRelay(t *testing.T) {
 	}
 	require.True(t, us.IsOpenAICloudwiseRelay())
 
+	hostOnly := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://api.cloudwise.ai",
+		},
+	}
+	require.True(t, hostOnly.IsOpenAICloudwiseRelay())
+	require.Equal(t, "https://api.cloudwise.ai/api", hostOnly.GetOpenAIBaseURL())
+	require.Equal(t, "https://api.cloudwise.ai/api", hostOnly.GetBaseURL())
+
+	versioned := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://api.cloudwise.ai/v1",
+		},
+	}
+	require.True(t, versioned.IsOpenAICloudwiseRelay())
+	require.Equal(t, "https://api.cloudwise.ai/api", versioned.GetOpenAIBaseURL())
+
 	other := &Account{
 		Platform: PlatformOpenAI,
 		Type:     AccountTypeAPIKey,

--- a/backend/internal/service/openai_cloudwise_relay_tk.go
+++ b/backend/internal/service/openai_cloudwise_relay_tk.go
@@ -1,6 +1,9 @@
 package service
 
-import "strings"
+import (
+	"net/url"
+	"strings"
+)
 
 // openAICloudwiseRelayAllowedModelPrefixes is the single SSOT for which model
 // families CloudWise MaaS relay accounts may serve. Adjust only here.
@@ -10,6 +13,14 @@ var openAICloudwiseRelayAllowedModelPrefixes = []string{
 	"glm-",
 	"minimax-",
 	"deepseek-",
+}
+
+// cloudwiseRelayCanonicalBaseURLs is the path CloudWise nginx actually serves.
+// Host-only or /v1 spellings resolve to the same /api prefix; without it,
+// /v1/chat/completions and /v1/responses return nginx/1.24.0 HTML 404.
+var cloudwiseRelayCanonicalBaseURLs = map[string]string{
+	"api.cloudwise.ai":    "https://api.cloudwise.ai/api",
+	"api-us.cloudwise.ai": "https://api-us.cloudwise.ai/api",
 }
 
 func openAICloudwiseRelayWildcardModelMappingFloor() map[string]string {
@@ -49,4 +60,30 @@ func applyOpenAICloudwiseRelayUpstreamModelID(account *Account, modelID string) 
 		return modelID
 	}
 	return openAICloudwiseRelayUpstreamModelID(modelID)
+}
+
+func normalizeCloudwiseRelayBaseURL(raw string) (string, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", false
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Host == "" {
+		return "", false
+	}
+	canonical, ok := cloudwiseRelayCanonicalBaseURLs[strings.ToLower(parsed.Hostname())]
+	if !ok {
+		return "", false
+	}
+	switch strings.ToLower(strings.TrimRight(parsed.Path, "/")) {
+	case "", "/api", "/v1", "/api/v1":
+		return canonical, true
+	default:
+		return "", false
+	}
+}
+
+func isCloudwiseRelayBaseURL(raw string) bool {
+	_, ok := normalizeCloudwiseRelayBaseURL(raw)
+	return ok
 }

--- a/backend/internal/service/openai_cloudwise_relay_tk_test.go
+++ b/backend/internal/service/openai_cloudwise_relay_tk_test.go
@@ -8,6 +8,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNormalizeCloudwiseRelayBaseURL(t *testing.T) {
+	for _, tc := range []struct {
+		in     string
+		want   string
+		wantOK bool
+	}{
+		{"https://api.cloudwise.ai/api", "https://api.cloudwise.ai/api", true},
+		{"https://api.cloudwise.ai/api/", "https://api.cloudwise.ai/api", true},
+		{"https://api.cloudwise.ai", "https://api.cloudwise.ai/api", true},
+		{"https://api.cloudwise.ai/", "https://api.cloudwise.ai/api", true},
+		{"https://api.cloudwise.ai/v1", "https://api.cloudwise.ai/api", true},
+		{"https://api.cloudwise.ai/v1/", "https://api.cloudwise.ai/api", true},
+		{"https://api.cloudwise.ai/api/v1", "https://api.cloudwise.ai/api", true},
+		{"https://API.Cloudwise.AI/V1", "https://api.cloudwise.ai/api", true},
+		{"https://api-us.cloudwise.ai", "https://api-us.cloudwise.ai/api", true},
+		{"https://api-us.cloudwise.ai/v1", "https://api-us.cloudwise.ai/api", true},
+		{"https://api.cloudwise.ai/other", "", false},
+		{"https://api.openai.com", "", false},
+		{"", "", false},
+	} {
+		got, ok := normalizeCloudwiseRelayBaseURL(tc.in)
+		require.Equal(t, tc.wantOK, ok, tc.in)
+		require.Equal(t, tc.want, got, tc.in)
+	}
+
+	// Host-only CloudWise URLs are the nginx HTML 404 path operators hit today.
+	require.Equal(t, "https://api.cloudwise.ai/v1/responses", buildOpenAIResponsesURL("https://api.cloudwise.ai"))
+	require.Equal(t, "https://api.cloudwise.ai/v1/chat/completions", buildOpenAIChatCompletionsURL("https://api.cloudwise.ai"))
+	normalized, ok := normalizeCloudwiseRelayBaseURL("https://api.cloudwise.ai")
+	require.True(t, ok)
+	require.Equal(t, "https://api.cloudwise.ai/api/v1/responses", buildOpenAIResponsesURL(normalized))
+	require.Equal(t, "https://api.cloudwise.ai/api/v1/chat/completions", buildOpenAIChatCompletionsURL(normalized))
+}
+
 func TestOpenAICloudwiseRelayAllowedModelPrefixes(t *testing.T) {
 	require.Equal(t, []string{
 		"kimi-",

--- a/ops/pricing/manage-account-model-mapping-runtime.py
+++ b/ops/pricing/manage-account-model-mapping-runtime.py
@@ -62,6 +62,7 @@ import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any, NoReturn
+from urllib.parse import urlparse
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SETTING_KEY = "tk_account_model_mapping_runtime"
@@ -471,13 +472,21 @@ def _is_openai_tokensea_relay(row: dict[str, Any]) -> bool:
     return base == "https://agent.tokensea.ai"
 
 
+def _is_cloudwise_relay_base_url(raw: Any) -> bool:
+    parsed = urlparse(str(raw or "").strip())
+    host = (parsed.hostname or "").lower()
+    if host not in {"api.cloudwise.ai", "api-us.cloudwise.ai"}:
+        return False
+    path = (parsed.path or "").rstrip("/").lower()
+    return path in {"", "/api", "/v1", "/api/v1"}
+
+
 def _is_openai_cloudwise_relay(row: dict[str, Any]) -> bool:
     if str(row.get("platform") or "").strip().lower() != "openai":
         return False
     if str(row.get("type") or "") != "apikey":
         return False
-    base = str(row.get("base_url") or "").strip().lower().rstrip("/")
-    return base in {"https://api.cloudwise.ai/api", "https://api-us.cloudwise.ai/api"}
+    return _is_cloudwise_relay_base_url(row.get("base_url"))
 
 
 def _is_anthropic_tokensea_relay(row: dict[str, Any]) -> bool:

--- a/ops/pricing/model-surface-refresh-report.py
+++ b/ops/pricing/model-surface-refresh-report.py
@@ -18,6 +18,7 @@ import tempfile
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Iterable
+from urllib.parse import urlparse
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_BUNDLE = REPO_ROOT / "ops" / "pricing" / "model-surface-bundle.json"
@@ -134,6 +135,15 @@ def _normalize_base_url(raw: Any) -> str:
     return _BUNDLE.normalize_account_override_base_url(raw)
 
 
+def _is_cloudwise_relay_base_url(raw: Any) -> bool:
+    parsed = urlparse(str(raw or "").strip())
+    host = (parsed.hostname or "").lower()
+    if host not in {"api.cloudwise.ai", "api-us.cloudwise.ai"}:
+        return False
+    path = (parsed.path or "").rstrip("/").lower()
+    return path in {"", "/api", "/v1", "/api/v1"}
+
+
 def _account_shared_scope(row: dict[str, Any], floor: dict[str, Any]) -> str:
     platform = _clean_scope(row.get("platform"))
     account_type = _clean_scope(row.get("type"))
@@ -155,7 +165,7 @@ def _account_shared_scope(row: dict[str, Any], floor: dict[str, Any]) -> str:
             return "openai_ainzy_relay"
         if base_url == "https://agent.tokensea.ai":
             return "openai_tokensea_relay"
-        if base_url in {"https://api.cloudwise.ai/api", "https://api-us.cloudwise.ai/api"}:
+        if _is_cloudwise_relay_base_url(base_url):
             return "openai_cloudwise_relay"
     if platform == "anthropic" and account_type == "apikey":
         if base_url == "https://agent.tokensea.ai":
@@ -846,6 +856,14 @@ def _selftest() -> int:
 
     report_accounts, _ = _active_accounts(inventory, bundle_floor)
     account_by_id = {row["account_id"]: row for row in report_accounts}
+    assert _is_cloudwise_relay_base_url("https://api.cloudwise.ai")
+    assert _is_cloudwise_relay_base_url("https://api.cloudwise.ai/v1")
+    assert _is_cloudwise_relay_base_url("https://api-us.cloudwise.ai/api/")
+    assert not _is_cloudwise_relay_base_url("https://api.cloudwise.ai/other")
+    assert _account_shared_scope(
+        {"platform": "openai", "type": "apikey", "base_url": "https://api.cloudwise.ai"},
+        {},
+    ) == "openai_cloudwise_relay"
     assert _normalize_row_scope(
         {"scope": "openai", "account_id": 3}, account_by_id,
     ) == "openai_cloudwise_relay"

--- a/ops/stage0/probe_account_upstream_models.sh
+++ b/ops/stage0/probe_account_upstream_models.sh
@@ -139,11 +139,12 @@ def derive_account_scope(row):
         return "openai_ainzy_relay"
     if platform == "openai" and account_type == "apikey" and account_base_url == "https://agent.tokensea.ai":
         return "openai_tokensea_relay"
-    if platform == "openai" and account_type == "apikey" and account_base_url in {
-        "https://api.cloudwise.ai/api",
-        "https://api-us.cloudwise.ai/api",
-    }:
-        return "openai_cloudwise_relay"
+    if platform == "openai" and account_type == "apikey":
+        parsed = urlsplit(account_base_url)
+        host = (parsed.hostname or "").lower()
+        path = (parsed.path or "").rstrip("/").lower()
+        if host in {"api.cloudwise.ai", "api-us.cloudwise.ai"} and path in {"", "/api", "/v1", "/api/v1"}:
+            return "openai_cloudwise_relay"
     if platform == "anthropic" and account_type == "apikey" and account_base_url == "https://agent.tokensea.ai":
         return "anthropic_tokensea_relay"
     if platform == "newapi":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

管理端「测试账号连接」对 cloudwise 测 `claude-fable-5` 失败，错误是 `API returned 404` 加上 **nginx/1.24.0 (Ubuntu) HTML 页**，不是 JSON API 错误。

根因不是 Fable 5 没接入。CloudWise 公开 `GET /api/v1/models` 已经列出 `claude-fable-5`。同一份 nginx 404 可以在缺 `/api` 前缀时复现：

- `https://api.cloudwise.ai/v1/responses` → nginx HTML 404（与截图一致）
- `https://api.cloudwise.ai/api/v1/chat/completions` → 401 JSON（路径存在）

Admin 测试在 extra 未标 `openai_responses_supported=false` 时默认打 `/v1/responses`。账号 `base_url` 若写成 `https://api.cloudwise.ai` 或 `.../v1`，就会打到 nginx 没有的路径。

本 PR：

- 把 CloudWise host-only / `/v1` / `/api` 写法归一到 `https://api.cloudwise.ai/api`（us 同理）
- CloudWise 测试连接强制走 `/api/v1/chat/completions`，不再误打 Responses
- ops 侧识别同一组 host 变体，避免 mapping 工具漏掉 host-only 账号

## 风险

常规。只影响 CloudWise MaaS relay 的出站 URL 与 admin 测试路径；不改对外 HTTP 契约。正确的 `.../api` 账号行为不变。

## 验证

- `go test -tags=unit ./internal/service -run 'TestNormalizeCloudwise|TestAccount_IsOpenAICloudwiseRelay|TestGetBaseURL|TestAccountTestService_Cloudwise|TestAccountTestService_OpenAI'` 通过
- `python3 ops/pricing/model-surface-refresh-report.py --selftest` 通过
- 公开路径探测复现了截图里的 nginx HTML 404，并确认 Fable 5 在上游模型列表中
- 本环境无 AWS 凭证，未对 prod account #95 做带密钥的 live probe；发版后请用正确 `base_url` 再点一次测试连接

## 提交

- `366637c82` fix(cloudwise): 归一 /api 前缀，避免测试连接打到 nginx 404
- 最新提交：`366637c82`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://chilli-tax5778.slack.com/archives/C0BQFLLUSD9/p1786967080646749?thread_ts=1786967080.646749&cid=C0BQFLLUSD9)

<div><a href="https://cursor.com/agents/bc-4157fdb7-c279-58a4-b390-0acbe947bf99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4157fdb7-c279-58a4-b390-0acbe947bf99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

