### PR TITLE
fix(ops): clean failed QA bundle first creates

### DIFF
--- a/deploy/aws/cloudformation/cicd-oidc.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc.yaml
@@ -314,6 +314,7 @@ Resources:
                   - logs:CreateLogGroup
                   - logs:DeleteLogGroup
                   - logs:DescribeLogGroups
+                  - logs:DescribeIndexPolicies
                   - logs:ListTagsForResource
                   - logs:PutRetentionPolicy
                   - logs:TagResource

--- a/deploy/aws/cloudformation/stage0-qa-raw-archive.yaml
+++ b/deploy/aws/cloudformation/stage0-qa-raw-archive.yaml
@@ -368,7 +368,7 @@ Resources:
 
   QaBundleBucket:
     Type: AWS::S3::Bucket
-    DeletionPolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
     UpdateReplacePolicy: Retain
     Properties:
       BucketName: !Sub '${ProjectName}-${Environment}-qa-bundles-${AWS::AccountId}'
@@ -557,7 +557,7 @@ Resources:
 
   QaBundleWorkerLogGroup:
     Type: AWS::Logs::LogGroup
-    DeletionPolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
     UpdateReplacePolicy: Retain
     Properties:
       LogGroupName: !Sub '/tokenkey/${ProjectName}-${Environment}/qa-bundle-worker'

--- a/deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py
+++ b/deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py
@@ -66,6 +66,14 @@ class Stage0QABundleContractTest(unittest.TestCase):
     def test_bundle_bucket_browser_surface_and_app_role_are_scoped(self) -> None:
         self.assert_bundle_bucket_contract(self.template)
 
+    def test_bundle_persistent_resources_clean_up_failed_first_create(self) -> None:
+        resources = self.template["Resources"]
+        for logical_id in ("QaBundleBucket", "QaBundleWorkerLogGroup"):
+            with self.subTest(logical_id=logical_id):
+                resource = resources[logical_id]
+                self.assertEqual(resource["DeletionPolicy"], "RetainExceptOnCreate")
+                self.assertEqual(resource["UpdateReplacePolicy"], "Retain")
+
     def assert_bundle_bucket_contract(self, template: dict) -> None:
         resources = template["Resources"]
         bucket = resources["QaBundleBucket"]["Properties"]
@@ -146,6 +154,7 @@ class Stage0QABundleContractTest(unittest.TestCase):
                 "sqs:GetQueueUrl",
                 "sqs:ListQueueTags",
                 "sqs:UntagQueue",
+                "logs:DescribeIndexPolicies",
                 "logs:UntagResource",
                 "cloudtrail:DeleteTrail",
                 "cloudtrail:GetEventSelectors",


### PR DESCRIPTION
## 摘要

- 将 QA Bundle bucket 与 worker log group 的 `DeletionPolicy` 改为 `RetainExceptOnCreate`，首次创建失败回滚时清理资源，成功纳管后仍保留数据。
- 为 QA CloudFormation service role 增加 `logs:DescribeIndexPolicies`，使 Early Validation 能检查同名 log group。
- 增加回归断言，覆盖首次创建回滚语义与 IAM 动作。

## 风险

- 影响 QA Bundle CloudFormation 生命周期与专用 service role，不改 prod app 运行时代码。
- 现存的空 orphan bucket/log group 不由本 PR 自动删除；合并后需在重新部署前按线上证据做一次性清理。
- Web impact: none。

## 验证

- RED：contract test 对两个 `DeletionPolicy: Retain` 与缺失 `logs:DescribeIndexPolicies` 共报 3 个预期失败。
- GREEN：`python3 -m unittest deploy.aws.cloudformation.test_stage0_qa_bundle_contract`，10 tests passed。
- AWS `validate-template`：`stage0-qa-raw-archive.yaml` 与 `cicd-oidc.yaml` 均通过。
- AWS Access Analyzer：新增 action 的 identity policy 0 ERROR。
- `bash scripts/preflight.sh`：PASS。
- 线上根因证据：prod deploy run `32031128753` 的 change set Early Validation 报 `QaBundleBucket` NAME_CONFLICT；残留 bucket 无对象/版本，残留 log group 为 0 bytes，且两者均不在 stack resource graph。

## 提交

- `8d603f497 fix(ops): clean failed QA bundle first creates`
- 最新提交：8d603f497
