### PR TITLE
fix(qa): bound bundle restore disk residency

### DIFF
--- a/backend/internal/observability/qa/bundle/job.go
+++ b/backend/internal/observability/qa/bundle/job.go
@@ -242,26 +242,37 @@ func ExecuteJob(ctx context.Context, spec JobSpec, rawStore archive.ReadOnlyObje
 			return JobReceipt{}, err
 		}
 		defer func() { _ = os.RemoveAll(workDir) }()
-		var verified []archive.VerifiedCommit
-		for index, commitKey := range spec.CommitKeys {
-			commit, err := verify(ctx, rawStore, commitKey, filepath.Join(workDir, fmt.Sprintf("%02d", index)))
-			if err != nil {
-				closeVerifiedCommits(verified)
-				return JobReceipt{}, fmt.Errorf("verify qa raw commit %d: %w", index, err)
-			}
-			expected := spec.DataFrom.Add(time.Duration(index) * time.Hour)
-			if !commit.Document.WindowStart.Equal(expected) || !commit.Document.WindowEnd.Equal(expected.Add(time.Hour)) {
-				_ = commit.Close()
-				closeVerifiedCommits(verified)
-				return JobReceipt{}, errors.New("qa raw commit window does not match job spec")
-			}
-			verified = append(verified, commit)
-		}
-		defer closeVerifiedCommits(verified)
-		manifest, err := PublishVerifiedCommits(ctx, outputStore, PublishInput{
+		manifest, err := publishRecordSource(ctx, outputStore, PublishInput{
 			Prefix: spec.GenerationPrefix, DataFrom: spec.DataFrom, DataUntil: spec.DataUntil,
 			ArchiveWatermark: spec.ArchiveWatermark,
-		}, verified, spec.UserID, spec.APIKeyID)
+		}, func(yield func(Record) error) error {
+			for index, commitKey := range spec.CommitKeys {
+				commitDir := filepath.Join(workDir, fmt.Sprintf("%02d", index))
+				commit, err := verify(ctx, rawStore, commitKey, commitDir)
+				if err != nil {
+					return fmt.Errorf("verify qa raw commit %d: %w", index, err)
+				}
+				expected := spec.DataFrom.Add(time.Duration(index) * time.Hour)
+				if !commit.Document.WindowStart.Equal(expected) || !commit.Document.WindowEnd.Equal(expected.Add(time.Hour)) {
+					_ = commit.Close()
+					_ = os.RemoveAll(commitDir)
+					return errors.New("qa raw commit window does not match job spec")
+				}
+				projectErr := visitVerifiedSegments(commit.Segments, spec.UserID, spec.APIKeyID, yield)
+				closeErr := commit.Close()
+				removeErr := os.RemoveAll(commitDir)
+				if projectErr != nil {
+					return projectErr
+				}
+				if closeErr != nil {
+					return fmt.Errorf("close qa raw commit %d: %w", index, closeErr)
+				}
+				if removeErr != nil {
+					return fmt.Errorf("remove qa raw commit %d restore directory: %w", index, removeErr)
+				}
+			}
+			return nil
+		})
 		if err != nil {
 			return JobReceipt{}, err
 		}
@@ -294,10 +305,4 @@ func deterministicJobID(kind JobKind, userID, apiKeyID int64, watermark time.Tim
 
 func jobBase(jobID string) string {
 	return "qa-bundles/v1/jobs/" + jobID
-}
-
-func closeVerifiedCommits(commits []archive.VerifiedCommit) {
-	for index := range commits {
-		_ = commits[index].Close()
-	}
 }

--- a/backend/internal/observability/qa/bundle/job_test.go
+++ b/backend/internal/observability/qa/bundle/job_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -36,7 +37,7 @@ func TestBundleJobSpecRequiresExactlyTwentyFourContiguousCommits(t *testing.T) {
 	}
 }
 
-func TestExecuteBundleJobVerifiesEveryCommittedHourBeforePublishing(t *testing.T) {
+func TestExecuteBundleJobVerifiesEveryCommittedHourAndPublishes(t *testing.T) {
 	watermark := time.Date(2026, 8, 15, 10, 0, 0, 0, time.UTC)
 	spec := NewBundleJobSpec(7, 11, watermark)
 	store := &recordingStore{}
@@ -64,6 +65,44 @@ func TestExecuteBundleJobVerifiesEveryCommittedHourBeforePublishing(t *testing.T
 	}
 	if _, ok := store.objects[spec.ReceiptKey]; !ok {
 		t.Fatalf("receipt %s was not published", spec.ReceiptKey)
+	}
+}
+
+func TestExecuteBundleJobRemovesPreviousRestoreBeforeVerifyingNextHour(t *testing.T) {
+	watermark := time.Date(2026, 8, 15, 10, 0, 0, 0, time.UTC)
+	spec := NewBundleJobSpec(7, 11, watermark)
+	restoreRoot := t.TempDir()
+	verified := 0
+	var previousRestoreDir string
+
+	_, err := ExecuteJob(context.Background(), spec, panicReadOnlyStore{}, &recordingStore{}, ExecuteDeps{
+		RestoreRoot: restoreRoot,
+		VerifyCommit: func(_ context.Context, _ archive.ReadOnlyObjectStore, _ string, restoreDir string) (archive.VerifiedCommit, error) {
+			if previousRestoreDir != "" {
+				if _, err := os.Stat(previousRestoreDir); !os.IsNotExist(err) {
+					return archive.VerifiedCommit{}, fmt.Errorf("previous restore directory still exists: %s", previousRestoreDir)
+				}
+			}
+			if err := os.MkdirAll(restoreDir, 0o700); err != nil {
+				return archive.VerifiedCommit{}, err
+			}
+			expected := spec.DataFrom.Add(time.Duration(verified) * time.Hour)
+			verified++
+			previousRestoreDir = restoreDir
+			return archive.VerifiedCommit{Document: archive.CommitDocument{
+				WindowStart: expected,
+				WindowEnd:   expected.Add(time.Hour),
+			}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if verified != len(spec.CommitKeys) {
+		t.Fatalf("verified=%d want=%d", verified, len(spec.CommitKeys))
+	}
+	if _, err := os.Stat(previousRestoreDir); !os.IsNotExist(err) {
+		t.Fatalf("final restore directory still exists: %s", previousRestoreDir)
 	}
 }
 


### PR DESCRIPTION
## 摘要

- 将 QA Bundle 的 24 个小时提交改为逐小时校验、投影、关闭并删除 restore 目录，再处理下一小时。
- 保持 manifest-last：全部小时成功前不发布 manifest；晚期失败产生的页面仍不可见。
- 增加真实文件系统回归测试，证明下一小时开始校验前上一小时目录已经消失，最终小时目录也会清理。

## 风险

- 影响 QA Bundle worker 的内部执行顺序，不改变 job、page、manifest 或 receipt 公共契约。
- 晚期校验失败仍可能留下不可见的 immutable page，与既有发布语义一致；重试由 create-or-verify 保持幂等。
- Web impact: none。

## 验证

- RED：`go test -tags=unit ./internal/observability/qa/bundle -run "^TestExecuteBundleJobRemovesPreviousRestoreBeforeVerifyingNextHour$" -count=1`，旧实现于 commit 1 报上一小时 restore 目录仍存在。
- GREEN：同一聚焦测试通过。
- `go test -tags=unit ./internal/observability/qa/... -count=1`：PASS。
- `bash scripts/preflight.sh`：PASS。

## 提交

- `3a6264c7b fix(qa): bound bundle restore disk residency`
- 最新提交：3a6264c7b