### PR TITLE
fix(qa): tolerate transient bundle canary HEAD denial

### DIFF
--- a/backend/internal/observability/qa/archive/store.go
+++ b/backend/internal/observability/qa/archive/store.go
@@ -18,7 +18,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
-var ErrPreconditionFailed = errors.New("qa archive object precondition failed")
+var (
+	ErrPreconditionFailed = errors.New("qa archive object precondition failed")
+	ErrAccessDenied       = errors.New("qa archive object access denied")
+)
 
 const archiveMultipartPartSize int64 = 64 << 20
 
@@ -235,7 +238,7 @@ func (s *s3ObjectStore) HeadInfo(ctx context.Context, key string) (ObjectInfo, e
 	})
 	if err != nil {
 		if isAccessDenied(err) {
-			return ObjectInfo{}, fmt.Errorf("head archive object %s: access denied", key)
+			return ObjectInfo{}, fmt.Errorf("head archive object %s: %w", key, ErrAccessDenied)
 		}
 		if isObjectStoreNotFound(err) {
 			return ObjectInfo{}, err
@@ -264,7 +267,8 @@ func isAccessDenied(err error) bool {
 		return false
 	}
 	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "403") || strings.Contains(msg, "accessdenied")
+	return errors.Is(err, ErrAccessDenied) || strings.Contains(msg, "403") ||
+		strings.Contains(msg, "accessdenied") || strings.Contains(msg, "access denied")
 }
 
 func isObjectStoreNotFound(err error) bool {

--- a/backend/internal/observability/qa/service_bundle_canary.go
+++ b/backend/internal/observability/qa/service_bundle_canary.go
@@ -105,17 +105,17 @@ func runBundleCanary(
 	defer ticker.Stop()
 	for {
 		failed, err := store.Head(ctx, spec.FailureKey)
-		if err != nil {
+		if err != nil && !errors.Is(err, archive.ErrAccessDenied) {
 			return result, err
 		}
-		if failed {
+		if err == nil && failed {
 			return result, errors.New("qa bundle canary worker reported failure")
 		}
 		ready, err := store.Head(ctx, spec.ReceiptKey)
-		if err != nil {
+		if err != nil && !errors.Is(err, archive.ErrAccessDenied) {
 			return result, err
 		}
-		if ready {
+		if err == nil && ready {
 			return validateBundleCanaryResult(ctx, store, spec, opts.Now().UTC())
 		}
 		select {

--- a/backend/internal/observability/qa/service_bundle_canary_test.go
+++ b/backend/internal/observability/qa/service_bundle_canary_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -21,6 +22,23 @@ type canaryBundleQueue struct {
 
 func (q canaryBundleQueue) Enqueue(ctx context.Context, key string) error {
 	return q.enqueue(ctx, key)
+}
+
+type canaryHeadFaultStore struct {
+	bundle.Store
+	accessDeniedRemaining int
+	headError             error
+}
+
+func (s *canaryHeadFaultStore) Head(ctx context.Context, key string) (bool, error) {
+	if s.headError != nil {
+		return false, s.headError
+	}
+	if s.accessDeniedRemaining > 0 {
+		s.accessDeniedRemaining--
+		return false, fmt.Errorf("head archive object %s: %w", key, archive.ErrAccessDenied)
+	}
+	return s.Store.Head(ctx, key)
 }
 
 func TestRunBundleCanaryTraversesSpecQueueWorkerReceiptAndManifest(t *testing.T) {
@@ -82,4 +100,64 @@ func TestRunBundleCanaryCreatesANewJobForSameSecondRetries(t *testing.T) {
 	}
 	require.Len(t, keys, 2)
 	require.NotEqual(t, keys[0], keys[1])
+}
+
+func TestRunBundleCanaryRetriesTransientHeadAccessDenied(t *testing.T) {
+	objects := archive.NewMemoryObjectStore()
+	baseStore := bundle.NewArchiveStore(objects)
+	store := &canaryHeadFaultStore{Store: baseStore, accessDeniedRemaining: 3}
+	watermark := time.Date(2026, 8, 15, 10, 0, 0, 0, time.UTC)
+	now := watermark.Add(17 * time.Minute)
+	queue := canaryBundleQueue{enqueue: func(ctx context.Context, key string) error {
+		specBody, err := store.Read(ctx, key)
+		require.NoError(t, err)
+		spec, err := bundle.ParseJobSpec(specBody)
+		require.NoError(t, err)
+		manifest, err := bundle.Publish(ctx, store, bundle.PublishInput{
+			Prefix: spec.GenerationPrefix, DataFrom: spec.DataFrom, DataUntil: spec.DataUntil,
+			ArchiveWatermark: spec.ArchiveWatermark,
+		})
+		require.NoError(t, err)
+		receipt := bundle.JobReceipt{
+			SchemaVersion: bundle.JobSchemaVersion, Kind: bundle.JobKindBundle, JobID: spec.JobID,
+			ManifestKey: manifest.ManifestKey, DataFrom: spec.DataFrom, DataUntil: spec.DataUntil,
+			ArchiveWatermark: spec.ArchiveWatermark, RecordCount: 0, CompletedAt: now,
+		}
+		body, err := json.Marshal(receipt)
+		require.NoError(t, err)
+		_, err = objects.Create(ctx, spec.ReceiptKey, bytes.NewReader(body), int64(len(body)), "application/json")
+		return err
+	}}
+
+	receipt, err := runBundleCanary(context.Background(), store, queue, func(context.Context) (time.Time, error) {
+		return watermark, nil
+	}, bundleCanaryOptions{Now: func() time.Time { return now }, Timeout: time.Second, PollInterval: time.Millisecond})
+	require.NoError(t, err)
+	require.True(t, receipt.OK)
+	require.Zero(t, store.accessDeniedRemaining)
+}
+
+func TestRunBundleCanaryTimesOutWhenHeadAccessDeniedPersists(t *testing.T) {
+	baseStore := bundle.NewArchiveStore(archive.NewMemoryObjectStore())
+	store := &canaryHeadFaultStore{Store: baseStore, accessDeniedRemaining: 1_000}
+	watermark := time.Date(2026, 8, 15, 10, 0, 0, 0, time.UTC)
+	queue := canaryBundleQueue{enqueue: func(context.Context, string) error { return nil }}
+
+	_, err := runBundleCanary(context.Background(), store, queue, func(context.Context) (time.Time, error) {
+		return watermark, nil
+	}, bundleCanaryOptions{Now: func() time.Time { return watermark }, Timeout: 20 * time.Millisecond, PollInterval: time.Millisecond})
+	require.EqualError(t, err, "qa bundle canary timed out")
+}
+
+func TestRunBundleCanaryFailsImmediatelyForOtherHeadErrors(t *testing.T) {
+	headErr := errors.New("head archive object: transport unavailable")
+	baseStore := bundle.NewArchiveStore(archive.NewMemoryObjectStore())
+	store := &canaryHeadFaultStore{Store: baseStore, headError: headErr}
+	watermark := time.Date(2026, 8, 15, 10, 0, 0, 0, time.UTC)
+	queue := canaryBundleQueue{enqueue: func(context.Context, string) error { return nil }}
+
+	_, err := runBundleCanary(context.Background(), store, queue, func(context.Context) (time.Time, error) {
+		return watermark, nil
+	}, bundleCanaryOptions{Now: func() time.Time { return watermark }, Timeout: time.Second, PollInterval: time.Millisecond})
+	require.ErrorIs(t, err, headErr)
 }


### PR DESCRIPTION
## 摘要

- 将 S3 HEAD 的 access-denied 归一为可判定的 `archive.ErrAccessDenied`。
- QA Bundle canary 在既有有界轮询窗口内重试该瞬态错误；receipt 出现后仍完整读取并校验 receipt/manifest。
- 持续 access-denied 仍在既有 timeout 上硬失败，其他 HEAD 错误仍立即失败。
- no-web-impact

## 风险

- 仅放宽 canary readiness 轮询中的明确 access-denied；worker failure marker、receipt/manifest 内容校验和未知错误保持 fail closed。

## 验证

- `go test -tags=unit ./internal/observability/qa/... -count=1`
- `bash scripts/preflight.sh`
- TDD RED：瞬态和持续 access-denied 用例在修复前均于首次 HEAD 立即失败。

## 提交

- `7e4d2120b fix(qa): retry transient bundle canary HEAD denial`
- 最新提交：`7e4d2120b`