### PR TITLE
fix(frontend): 修正 /key-usage 页面 Logo 显示

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 693,
-  "hash": "33ab93095831a039f68074f793790311fe471c031bebc5c29eae9c448e565088",
+  "hash": "94cb291c176c26d89add7772fbede5fc07ad825349883f29898d203c6aea50f8",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/views/KeyUsageView.vue
+++ b/frontend/src/views/KeyUsageView.vue
@@ -5,7 +5,7 @@
       <nav class="mx-auto flex max-w-6xl items-center justify-between">
         <router-link to="/home" class="flex items-center gap-3">
           <div class="h-10 w-10 overflow-hidden rounded-xl shadow-md">
-            <img :src="siteLogo || '/logo.svg'" alt="Logo" class="h-full w-full object-contain" />
+            <img :src="siteLogo" alt="Logo" class="h-full w-full object-contain" />
           </div>
           <span class="text-lg font-semibold tracking-tight text-gray-900 dark:text-white">{{ siteName }}</span>
         </router-link>
@@ -421,6 +421,7 @@ import Icon from '@/components/icons/Icon.vue'
 import { buildGatewayUrl } from '@/api/client'
 import { STATUS_ACTIVE } from '@/constants/channel'
 import { formatDateLocalInput } from '@/utils/format'
+import { sanitizeUrl } from '@/utils/url'
 
 const { t, locale } = useI18n()
 const appStore = useAppStore()
@@ -428,8 +429,18 @@ const appStore = useAppStore()
 // ==================== Site Settings (same as HomeView) ====================
 
 const siteName = computed(() => appStore.cachedPublicSettings?.site_name || appStore.siteName || 'TokenKey')
-const siteLogo = computed(() => appStore.cachedPublicSettings?.site_logo || appStore.siteLogo || '')
-const docUrl = computed(() => appStore.cachedPublicSettings?.doc_url || appStore.docUrl || '')
+const siteLogo = computed(() =>
+  sanitizeUrl(appStore.cachedPublicSettings?.site_logo || appStore.siteLogo || '', {
+    allowRelative: true,
+    allowDataUrl: true,
+  }) || '/logo.png',
+)
+const docUrl = computed(() =>
+  sanitizeUrl(appStore.cachedPublicSettings?.doc_url || appStore.docUrl || '', {
+    allowRelative: true,
+    allowDataUrl: true,
+  }),
+)
 
 // ==================== Theme (same as HomeView) ====================
 

--- a/frontend/src/views/__tests__/KeyUsageView.spec.ts
+++ b/frontend/src/views/__tests__/KeyUsageView.spec.ts
@@ -231,4 +231,22 @@ describe('KeyUsageView daily detail', () => {
 
     wrapper.unmount()
   })
+
+  it('uses the TokenKey logo fallback when no site_logo is configured', () => {
+    const wrapper = mount(KeyUsageView, {
+      global: {
+        stubs: {
+          RouterLink: { template: '<a><slot /></a>' },
+          LocaleSwitcher: true,
+          Icon: true,
+        },
+      },
+    })
+
+    const logo = wrapper.find('header img')
+    expect(logo.attributes('src')).toBe('/logo.png')
+    expect(logo.attributes('src')).not.toBe('/logo.svg')
+
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
## 摘要

- `/key-usage` 在未配置 `site_logo` 时回退到上游 `/logo.svg`（Sub2API 图标），与首页 TokenKey `/logo.png` 不一致
- 将默认 Logo 对齐为 `/logo.png`，并为 `site_logo` / `doc_url` 补上 `sanitizeUrl` 处理

upstream-touch-trivial

## 风险

- 低风险，仅影响公开 Key 用量查询页头部 Logo 与文档链接 sanitization
- 无 API / 计费行为变更

## 验证

- `pnpm test:run src/views/__tests__/KeyUsageView.spec.ts` — 3 passed
- 新增回归：无 `site_logo` 时使用 `/logo.png`，不再使用 `/logo.svg`
- `make build-frontend` + `frontend-dist-freshness.py --check` — ok

## 提交

- 4a11c8a1e fix(frontend): align key-usage page logo with TokenKey branding
- 38db3075c chore(frontend): refresh embedded dist source hash for key-usage logo fix

最新提交：38db3075c