### PR TITLE
feat(ops): 保护 Edge 密钥并交付 QA 单 owner 切换

### DIFF
--- a/.github/workflows/deploy-edge-lightsail-stage0.yml
+++ b/.github/workflows/deploy-edge-lightsail-stage0.yml
@@ -255,6 +255,16 @@ jobs:
           STAGE0_SSM_OUTPUT_DIR: .
         run: bash ops/stage0/sync-edge-host-units-via-ssm.sh "$INSTANCE_ID" "edge-host-units edge=${{ steps.edge.outputs.edge_id }}"
 
+      - name: Backup Edge env secrets off-box
+        if: inputs.operation == 'provision' || inputs.operation == 'upgrade' || inputs.operation == 'rollback' || inputs.operation == 'smoke'
+        env:
+          INSTANCE_ID: ${{ steps.instance.outputs.managed_instance_id }}
+          AWS_REGION: ${{ steps.edge.outputs.lightsail_region }}
+          TK_ENV_SECRETS_SOURCE: /var/lib/tokenkey/.env.secret
+          TK_ENV_SECRETS_PARAM: /tokenkey/edge/${{ steps.edge.outputs.edge_id }}/stage0/env-secrets-backup
+          STAGE0_SSM_OUTPUT_DIR: .edge-env-secrets-backup
+        run: bash ops/stage0/backup-env-secrets-via-ssm.sh "$INSTANCE_ID" "edge-env-secrets-backup edge=${{ steps.edge.outputs.edge_id }}"
+
       - name: Edge smoke
         if: inputs.operation == 'smoke' || inputs.operation == 'upgrade' || inputs.operation == 'rollback'
         env:

--- a/deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml
@@ -47,6 +47,17 @@ Resources:
             Action: sts:AssumeRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      Policies:
+        - PolicyName: EdgeEnvSecretsBackup
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: ReadWriteOwnFleetEnvSecrets
+                Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                  - ssm:PutParameter
+                Resource: !Sub "arn:${AWS::Partition}:ssm:*:${AWS::AccountId}:parameter/tokenkey/edge/*/stage0/env-secrets-backup"
 
   LightsailEdgeAddonPolicy:
     Type: AWS::IAM::Policy

--- a/deploy/aws/cloudformation/test_stage0_edge_qa_s3_boundary.py
+++ b/deploy/aws/cloudformation/test_stage0_edge_qa_s3_boundary.py
@@ -157,6 +157,36 @@ class Stage0EdgeQaS3BoundaryTest(unittest.TestCase):
                 "${QaRawArchiveBucket.Arn}/*",
             )
 
+    def test_edge_role_and_deploy_workflow_own_off_box_env_secrets(self) -> None:
+        role = self.addon["Resources"]["LightsailSsmHybridRole"]["Properties"]
+        policies = role.get("Policies", [])
+        backup = [
+            item for item in policies if item.get("PolicyName") == "EdgeEnvSecretsBackup"
+        ]
+        self.assertEqual(len(backup), 1)
+        statements = backup[0]["PolicyDocument"]["Statement"]
+        self.assertEqual(
+            statements,
+            [
+                {
+                    "Sid": "ReadWriteOwnFleetEnvSecrets",
+                    "Effect": "Allow",
+                    "Action": ["ssm:GetParameter", "ssm:PutParameter"],
+                    "Resource": "arn:${AWS::Partition}:ssm:*:${AWS::AccountId}:parameter/tokenkey/edge/*/stage0/env-secrets-backup",
+                }
+            ],
+        )
+
+        workflow = yaml.safe_load(EDGE_WORKFLOW.read_text(encoding="utf-8"))
+        steps = workflow["jobs"]["edge"]["steps"]
+        step = next(item for item in steps if item.get("name") == "Backup Edge env secrets off-box")
+        self.assertEqual(step["env"]["TK_ENV_SECRETS_SOURCE"], "/var/lib/tokenkey/.env.secret")
+        self.assertEqual(
+            step["env"]["TK_ENV_SECRETS_PARAM"],
+            "/tokenkey/edge/${{ steps.edge.outputs.edge_id }}/stage0/env-secrets-backup",
+        )
+        self.assertIn("backup-env-secrets-via-ssm.sh", step["run"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/deploy/aws/lightsail/README.md
+++ b/deploy/aws/lightsail/README.md
@@ -40,6 +40,12 @@ aws cloudformation deploy \
 # (us-east-1 + eu-west-2); override only when adding new region-scoped roles.
 ```
 
+The addon also grants the shared Hybrid role access only to
+`/tokenkey/edge/*/stage0/env-secrets-backup`. Every Edge workflow run writes the
+three `.env.secret` values to its own SecureString and verifies the readback. On a
+replacement instance, bootstrap restores that value before PostgreSQL starts. Only
+`ParameterNotFound` permits first-provision generation; IAM/network errors fail closed.
+
 ### 2) 各 Edge region 写入 GHCR PAT
 
 路径默认：`/tokenkey/lightsail/<edge_id>/ghcr/pat`（与 EC2 Edge 的 `/tokenkey/edge/<id>/ghcr/pat` 分开）。

--- a/deploy/aws/lightsail/generated-launch-script.sh
+++ b/deploy/aws/lightsail/generated-launch-script.sh
@@ -13,13 +13,9 @@ echo "LIGHTSAIL_BOOTSTRAP_START $(date -u +%FT%TZ)"
 : "${LIGHTSAIL_REGION:?LIGHTSAIL_REGION required}"
 : "${SSM_ACTIVATION_ID:?SSM_ACTIVATION_ID required}"
 : "${SSM_ACTIVATION_CODE:?SSM_ACTIVATION_CODE required}"
-# GHCR auth is OPTIONAL: empty GHCR_PAT_SSM_NAME -> anonymous pull (public
-# ghcr.io image). Set it to an SSM SecureString name if the image goes private.
 : "${GHCR_PAT_SSM_NAME:=}"
 : "${GHCR_PULL_USER:=}"
 
-# Align kernel hostname with Lightsail instance name so SSM ComputerName-based
-# discovery matches provision-edge.sh fallbacks (AL2023 default is often a dhcp name).
 if command -v hostnamectl >/dev/null 2>&1; then
   hostnamectl set-hostname "${INSTANCE_NAME}" || true
 else
@@ -43,8 +39,6 @@ if ! docker compose version >/dev/null 2>&1; then
   chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 fi
 
-# Swap (2 GiB): micro Lightsail bundles have no swap by default; without this,
-# memory spikes can hang the VM.
 SWAP_SIZE_GIB="${SWAP_SIZE_GIB:-2}"
 if [ "${SWAP_SIZE_GIB}" -gt 0 ] && [ ! -f /swapfile ]; then
   fallocate -l "${SWAP_SIZE_GIB}G" /swapfile || dd if=/dev/zero of=/swapfile bs=1M count=$((SWAP_SIZE_GIB * 1024)) status=progress
@@ -88,6 +82,7 @@ install -d -m 0755 -o 1000 -g 1000 /var/lib/tokenkey/app
 COMPOSE_GZB64='H4sIAAAAAAACA9VY6XPb1hH/rr9ih/Y0cWKI1EFHgUO7EAmLrHgFAH11OghEPJKoQQAGQMlsxjN2Gjd2Y6dxk0wTx5nOuFfSNHbSmVyNUv8vjShRn/wvdB9AHDxEqbG+1AdI7O7bt+d7++MRyBzmn5kjIJmXiLFKusCdE0F0lSZJsZBVVLXLmIbeBc1o2sRxjoNla+uKS6BqOi4lJQWiapRObEdzXGK4qE1VXAU6hkpsSK4rdlLX1pIu3eES6R4HxVBBgbrZbmsuY2mGQVSQKqt8eZW/IBdK3AoPDdtsw0o+K8yitsP1deYKE5jC6GaziZ6x8JNR0gyAip4Sm4VfOqbBNDSdIM20XM00HBa/ArSVK4yj/YqwkJhLpdqJkEiFkZhOzMw4xF7X6sRbUafh9JdqbYwwO6DMM4qOYSAep24aroIvtmwobRQJDfNkPRGMuqvYLosR1jEnjOOalkVUjxd69NwEjwAs03YH1gMwkFhKsUupRPS+uLjA4n+fsm7qnTaJiY/lMukZlfTqxHM6Sdz6GNE299VAC4b1nvuKYoAaWpMdfHriKrGIoTqyaQS2BmuCdy+uqkaTx8IgJ7IXxUHcDOJumPalmLNh/AasmZlRtYMkHn11uHjZ0yPFrDmYsssdzcY6f5bMNmeh2arbs5qZfMncwEyfSjqdtXnF0tiXsPFOHbs6tRD8PHZ0XbZMXat3WVD0DaXrPG1pHIHe7+7u3Lq5tfn+7oc3etfvb9//15PNexhb3exC//V72/f/sbV5r3fjJsqBWFipicIc9B9+0n/84c7Hb+Kzd+Mv2DRo85PN2zuf3YJkiyi624Kdx99BOrXww7Xrg400Q27oWrPlZlLQe/ut7Vt3+l9+Dq+oZv0SnhjU5ldQxfZnf97+w1d0J4kXSvA8bH3z5u5HD2BuKeXAzr3XoWkrdUIPHs1UYevxR/1HwQa77z0GUeSh/+vv+1/f7T28/cO11xTLgp1PH0UnjZivSbnKubIsFUp8pSbJIp+tlHNiZi6dgu1H7w709z6/CwspBw0aKN/57gOImQr9N/7e+/qLnfc+oKauFopF2Nl8p/ebf+Ke3goqJHu6ZN9W1nPB43V0DQ/BsOoM02uYsGgds4G5xMMF/4TElmKrQ0RyxTIdMtTVQVMfoIUxLix9RN1HjHXNNo02nuXRQnG1UJVznMTJ2TwGLTMXcriaVMHYSbVqxrU7JFrBC2d5Qc5XRCmTmvX+jvKqFUHKUGtHGaVKjs8cfTX2xjI20YnikKujsmeESlniyzm5JhSjNXEqy0SLhFo50B58ZbFN8E7CsEZi1NNlTuR9863BZTfO9jxILy7Mj7NqaAnuUkUFKwIveu9sePdM2KrKieK5ipCLLwpo7OkxUvxcmaAtt1zmSnxcV2556vaiWPQCg9e5sqaTcYESd16uVPmyjG1SFlHzHhyWSaeuTl5eyBX5ycsjDsvMxZYLfK4g+lmw6aQxwvDif2LhhRdH6VEshwlDteBxcsuhEI3Q2N7VSqUoi4WLfKQroFBT5xdHF5QK5WFHJ5GHveRylMuXuAIt4dgbyyhqWzN+GuRtVjfrij66MObtMCHu7c/OeUecwEsoFr2wp6Pvw1eVibeq4+hg04GNaZErsDB/bFgff75aEGiT1ISB0hgFXYykpYpUlflyVrhQlQqVsowncIbenGNUen2OEf8nw6SLVPNFlqlJ2bgB+537sYt8Lxl0KartI7CM1y1DGg2cqtCYDXDxiGoT1+6C01JUc2M2GJPFl4tofxvvRgeHPsM0NMziSRi0mgprXRxiGkpHd2cjg/kiX+Il4YLMCdl84SyPMeGWizzN8p48lmkoevyQHJcU+BWM6kQlPiteNOMyy7XsqldCe7GmL68K/JnC+YnLfRbLWLapJjGcTBjOaQpfrvE1PujPaWyWWZp7cX5/VfQ0Wr4g8eIUfaEMyywspNM4Mk9VTMX5s3xZmqJ4RIaeD4tL6RdOTM0FJ2Xze/sesVlmPj1VEx4Wq3hrZiu18uTcxgVYZnGarjPFmpiXC3j9Cme5Yry9DiiKF8jUEsJ+nNC7B5GLn7oIelfB6dgNnMyYLBs0IOJdnNLVJsFpjDEt5ySYCANtTSWQ8Xrr2CyUNNs2bQc8sbpiKXXN7QIO7CbQ4oV6nXkO577OmhO18won8ec4PFqyeT5XKxbKKzJXlvJCpVrI0ivhTGEF+w+/ZAtFL9DlbE0Q8Bi8gDeHIFSEWPsfmi4cCHBkG4qI6BILeFhTdMXA8behm6YdC06jAc96Pq5puo7YIYjgsZN+NGZxekSE5TrgTYM/2v9lrsiVs7RCKk/j+kQ1Q4fkOHgMpr2p4NHHNt2BiDeaHFj+AGDTT0fOhxnbbz3Y/f3N7dtv9N6+G6AqHOLXyZPNm/TDQKj3ZPMWQpStb+70H3zqozDoff9F7507/7n2Lv7bvf64d+MO+GhuoN2yCeNL7r7/1fbDL/t/+yuFdgNsQ2HNbz8OECWCGQ/Qw+5rf+r/+9utb/84wZwA8fikeovUL4WAHNWw8PNEtpRLHIfERpO49JO57D0l+kx7Xyv0mVTJetJAjEtfWq6LCCXpDT4tTA1LAUN828QvBptohovRVnSKjoJB0dXaxOzg3mknzJVra5hdWBgQPAdDbHYCl86MFsEA6ofEuaUD/WYzhBueApsfCkw8ABYM/QtZAeWyvt+vM1ZT7bQxUf7n3kCyukLn/sy+OwzhpoPgqDGA9FQ4Koaa9sdQ4xPnAVt8eqcwYp4vFmkPWE1Zc2yiYAMyNdg7GMCosJe1P7ZN0hPbZM5vk9jBN+gRn3Kw/ogQ3f9Bc/iORUVKf8BGAMLCqSBALWDq8Ey4ibeAoRcAsUMiwzjKOsFTBuZiNMWil5D3S3s3/JkhYjScrlEHgnq6DqmH7DFs+zzDDCrZUhwHEkeH+Ymrz+zdl5NRk6cgWyzIXE3K7wmmD6XaaZ37Iavrmlf0mOHDLVqUm4nbOmqlb1Xww/8aDn1NMvNffG1crm0ZAAA='
 CADDY_GZB64='H4sIAAAAAAACA61VbW8TRxD+bP+KUcIHqLB9jhOEqFBxQwBLAaIkFe2nY323trc531539xyMFSkgEghNRIoCKi8SrXgroPJSUZEmRkj9KdRnO5/yFzp7F9s4pagfKiW2d3b2mZlnZp8dBMVnqDtDq/DnG8iemYIxu0hhShH8NLRtlNh2tcAcGh+EUYf7diLnMgW+pBKoW5F+XioocAF7atmJnHn09Mls7tTcfr0cPTlmjuFyHJfEtRFgT03vmsez02Nnst+Y2fHx02fGjpqjuaOTc0mYpA6pgkdUSQIRFFyuwPPzDrN0OIHhlMB9zlwlkzodKpTUWzA9PpXIjk+cShhp2MtdGB7O7PscTkxPT2gLk2AzSfIOtSFPLaJPqBKFcVYsKUmYg1gFJugscRyYodSTnbAeFwoOGmA5XFI7GY/X4jFaxhP95cVjg0CsMjUtAiWlPHkoldLrhEQemVtMVIyhJPFY0qFKUtcSVU8luSimbIxqKS6q8bk4JhFy73tSCUrKIF3meVRt1283l+abd5eCayuNzfvBlZfdnh06aGByrduXIO9wawaChVeNjWftd7ca6/ONzbdbCyutt8+368sIvXXhXbCwAmdL2AiHwhEslc9S2xSa87MQXF+GAtryBGE6TrU53Fi91Np83bz6IIIMXtTbl1836xdbjzf/mr+IwM21PzDg1uXl4OUr/N3YWGyso/NTiEC263c8we3eGEFw56fG+kZw7alGRL9uvVENzd9+bq390ilex9irZsyO0z7ADghaoUJSE4HPVXeRgduxguPLkolTQkWFOJBIo20QggsPg403zfvzzXsPW7/ebN14GKwuQ39yyDWxFKtQaP/+ElIlShxV2q5fsQVhboLM4lRu15c0oxpxKnf8q6nJNLxfvN7xPTxiZKD9/EkECTtgrWffB1c2m1ev9opt/vDj1q0HyI6NRVMR4kUQVokiDZqDHcyUozF2GhhmEkaMDoKgOGRCaZ6JlNoTqW0/fxAijhhDqRFjGCto3lhoXrrWWF8JVp+hOfN+fg3/WquLrbVX7ReP2o8v/IOKpfajxdadm62791pPNpp37+lexGJRTqYvWCe/nrFL+YjsGRUrU+4ryGhbAe+OafuCKIbXNHQrk3OmNkvQffLd6FjVxLKUL3UJ+D+MW07exPvfO50xZM/aDZ3eCW1TgVMDXycmES+Rm4CaoGWuqFniUs3t8jnGBfbWprb+9R89JwRXHGoS+1Wm/+52AkGg1oFSgrgyVBWtE+G0xmxGnC5LISUxLUIkbHt6yOi3mAxvlWlx15VwQNMSs3jZwymQmhNeKKAJI81pRemTZB0MtYfbFM5LZUPxPPPi8dgRzTNKnU5FSy+kcIxQplKfdQ0OL/Kk5xa7hgKpMMwgiR860k7l0IH6YpQgKYlRjnrNHRiIxHQ/YKcT+K4czqRHMgcMw9gPrFz2lRbmAcxE4QiEWWhiLY4rtKSTQ9FXBneYlD7G0dIaUfdRLdaMhmpvao5Nq4S6Rt0i7RCDNYeqZ0YvTa/wSvqDolkZU/2QhQqzKd+9Dh1CyD5B/R9AYztDyLxPvppR9I+qepgEK4fT9oGE9p/YzQQOksddGwaofotE90XWj6iWGsEsRe0BGDYyfUCfiiXodz4eNfPcjpLSV16y8zjdhnHyy8gJhyzcw0vg4T3ACcVfWjG4KBMF30ru6tuO0u9A7tSx09GI/w1OHHzNwAgAAA=='
 PRUNE_B64='H4sIAAAAAAACA7VV627iRhT+76c48WYDSdfYRKutlgSkKCUpSpasAq3abio02Mcwwh67M2MSmiD1IfqEfZKe8YXAhk2bVisZCc+cy/d95+JXO+6YC3fM1NR6BcNkhuICFzDQbIIe/PXHn5DKTCBEic8iOP/+9BpYmgKP6R7ISAELNUpA5k/BT+I0UQhpFkVQ50LQhfIlT/V+g6IPUM4xgFAmMQwGH6DRaLiTqS+dPEVj/O4t1AkIvnu7f0QJWUDuTIObKenm+XOo2mCc4aLwcvIABMkxYBo5ixC1P0VCJgLAO/QV6ClXEPIIG3CBmJoDhDhRGiT6KDRcdLsfR/2C0HhR0juVyDQB1jzGN5BGmQKco1xQCjKEMJF5nMKYwAguJsAFySA044a8XYG1ib9RIMmkjy0IMI2Shctulatypf+JVV4JiaFE+j/nbEuEccajwPFDQeZG7atU80SwqAXDq4tu/6L788iUb5RTHZ6cDwxUd85IWz5e5XcbKOZQDzBkWaSh6VHlLIUaHMwSSHlKFzyyrEKwtr17/4XoLafpLW2r2/9xdNa77Lbt7alsy+IhfIIdcEKgaJX90oZfj4y8wgJAf5o8arlNohbEXCmj/0aIzt6hcb/jGjwr5BbJoqYYRdQe/gwCrtg4wvbgtOm99wqWzGpswsiPv2ElTOd3WKfc+3By3m05Lwa7GQAwTvViC9rr7ser9pN8r1sHBGsNjjEzEODhgc4eD9pPsb4YqZ9kUQAi0ZAySaMtMU2KCd4MvA39D/1+r38+6n3XtnO8QeLPaCi4UCn6GqrE0HEDnLvCLI3Dzl5zhW89wG79M29ql9r9faNnhm+5rK2i7dt5cpVIGl3jF8806UvHM5r8cONES5ZCTcZl7xU+JBH9z42Xdg26P/WGlnU7peVB5FkAjjSDeERsCGJZAjow+u/t5bPPRYZ059Mqq+5o1A5qxyIR2Kkd7K+s4OgIUDHfWJst82We5S4yTMuQh2uyUeHzYtaa77/1HK9Jz9DzWvnzS42YAnAePKPiM4G1zDCPkEouNNm/Vje6/AnjlCO3K297lzLZVkBU4RiOVwlNndRaczoO7c+Y1rvJf01dpbhO5GK5bNH7kE0MoG1I4IagPMDl6ejk8rJ9CqZo4GiKXK8A3miiDM6s+aYpobNWWMtq5e9lcauy9s4G7SfuVa1HPtEyFTcKblb9nk6L4f+s8sVsipztqocru0+lRMV4bt6vWr8azkLTzjpooA9ZKe8GtRdxGf17MjNaAUK3vRUvtTYfG5BLy936rQ9OlMOrzEzxwAmgBrX9ggEUq6rwMf0wMcNyX3xXKhhjQj4rEu/AhHYPOGd3vz222ir+Wqf8fw2/5pj/RyblFMmYPzOl67S+wuRZVrnc/wZ6n3lINAoAAA=='
+RESTORE_SECRETS_B64='H4sIAAAAAAACA7VXXVPiSBR9z6+4IquiGwNoze7KhilrxKnZnVEKcJ0px6FacoGUSSd2d1BXmd++tzsJRMHBeVgflG5un3vu1+l2fc1JpHCufO4gn8AVk2NLogIbkwhiP8Yh8wPLah92Dj+1eq2OWypZp2e99llPf+q03n84PXFL5YfD824/XR3Y6eqodXx49rE3251OS5Z1O/YDhAsolddLYI8UVOGyAV5kAQyYRNqvlcDntASw7ZgJFqJCUYECgfJDndBKDZBjf6igDo1GZh8lKk5UBXKCL1luVwAH4whKAqWKBNrojegXn9gSBwKVPICEX/PolgMToyRErkATa27UG4B3voL9aoqFkg0sL+JoWRc6qocZz2kJ3O/wzVHRNfJrvHe0D+eC2f9W7T/syx1HKjbCqlPwal+xwXUSl+HyEh4f4UHjr6Dp8wkLfA/0NzBLl2GqT6dUrWlGLs2LZgbOdu5lpQ92JaMgUQhpesmNGoPAm8QX6D1NSgOMK5trb2nhydtrHVHXEO7Ij/gP4C0TMFPYT8/1h9RRWxWTrSAasMDwc3Uj0Q5xGWouek8zgY0N2lsD++OTXaJHUIngUDOHSuUtdnsNm62TI+IdC58a4KQDO9Su0835yQr1MN7A3gJCSoSqDoMoobPEOUGKIsaBQq8fIB+pMdkNI2GsfA7t027vfafV7bcPu93z084R/HXe63db7zqtHvROe+1+6+Rd50u7Rznt/936kk0NpB7cjLF97II90Zi6++kPhbdZroHrGj8Ufep7q1ytQDNf0FcVCq5GsRq0nR2YQjH2NIrF8A0B01rGYprmo7aQD0gz8EqWuVeZXEkliOqvz4jWK8t4+MOUSornLskoSY0aI39eCHf/d2qxQC5UyH2z34Chn0ZpsE0Y2Whf0CAze3i5YwbWNBZZrOcmOhO0fga5pN2MfAA1ZZ4anYq17+B821oI4XHeFI9LmqJSdjR4ocZ/urNVLa/xFfPc2qzCZrZoC95SeQ/IoJhakg7L5NXGJwJiYrjIxmi+m+bXMuVeGNInppm+rVY4oieVz0eQ7oBB8mWufLnU5WKnEzrVt8k4jDyovqlWi25nimr0Ul94mR9ggUDm3VPnodRyTxo0jqQq5SpatagPLFJYTIfN8wUnsS2CUxv6nFQ9CMD2wA6h+lvqPT1F3hWGsT4cXutPha+c3RxmfX3bme5+Nj8aEYWIhEnfqw4a88Lxp2nQhyn3uitnsERrECDjSZyJKJV7EIUh456eUTkmFYam4+HE4QmFVm9u1GZlhux7O3kZnk7MT+vODzNNfoENmFE04KtNqShTSwkWQxYEtD5/6JmeZbeSngTZfVK8jqQMYYRq/rqAr5Z+PeT1LF7htn3rq7HtUZfcx0ojpbY3CYp7aOcIu/8Ygc9fIKDwTkFzTrzefEZ95aBkB189Jt3up+yWodkIWUA3S4gL01HPpiOcLCS2MCI/OzsZKw+GIgo1E2rbgCowEhiToN3A5ixRJ5E6ppvC24SXEnJQyBstzU0wJITnSuj+Ir9yDbMVxcilDECYlh3jHdT36WZuLsWZ6+ePAPbqLwIsUd2fRHpFyVeWe4QcBWF4cwET+EQT80fTXuN/qPjcvX7BDH0h6VkoookvaUR09c0Av6ZnteqC/h8DvQYthoksaL2IFNNDl7exIjuwB1Cr1vcXZKb45N3Xav0fg5oDEdsMAAA='
 printf '%s' "$COMPOSE_GZB64" | base64 -d | gunzip > /var/lib/tokenkey/docker-compose.yml
 printf '%s' "$CADDY_GZB64" | base64 -d | gunzip > /var/lib/tokenkey/caddy/Caddyfile.template
 envsubst '${API_DOMAIN} ${ACME_EMAIL} ${MAIN_GATEWAY_ALLOWED_CIDR}' \
@@ -96,18 +91,13 @@ envsubst '${API_DOMAIN} ${ACME_EMAIL} ${MAIN_GATEWAY_ALLOWED_CIDR}' \
 printf '%s' "$PRUNE_B64" | base64 -d | gunzip > /usr/local/bin/tokenkey-prune-ghcr-app-tags-core.sh
 chmod +x /usr/local/bin/tokenkey-prune-ghcr-app-tags-core.sh
 
+printf '%s' "$RESTORE_SECRETS_B64" | base64 -d | gunzip > /usr/local/bin/tokenkey-restore-edge-env-secrets.sh
+chmod 0755 /usr/local/bin/tokenkey-restore-edge-env-secrets.sh
+
 SECRET_FILE=/var/lib/tokenkey/.env.secret
-if [ ! -f "$SECRET_FILE" ]; then
-  umask 077
-  gen_secret() { openssl rand -hex 32; }
-  gen_pwd() { openssl rand -hex 24; }
-  cat > "$SECRET_FILE" <<SECEOF
-POSTGRES_PASSWORD=$(gen_pwd)
-JWT_SECRET=$(gen_secret)
-TOTP_ENCRYPTION_KEY=$(gen_secret)
-SECEOF
-  chmod 0600 "$SECRET_FILE"
-fi
+AWS_REGION="${LIGHTSAIL_REGION}" /usr/local/bin/tokenkey-restore-edge-env-secrets.sh \
+  --parameter "/tokenkey/edge/${EDGE_ID}/stage0/env-secrets-backup" \
+  --output "$SECRET_FILE"
 set -a; . "$SECRET_FILE"; set +a
 
 cat > /var/lib/tokenkey/.env <<ENVEOF

--- a/deploy/aws/lightsail/render-bootstrap.sh
+++ b/deploy/aws/lightsail/render-bootstrap.sh
@@ -17,7 +17,8 @@ fi
 for f in \
   "${STAGE0}/docker-compose.yml" \
   "${STAGE0}/Caddyfile.edge" \
-  "${STAGE0}/tokenkey-prune-ghcr-app-tags.sh"; do
+  "${STAGE0}/tokenkey-prune-ghcr-app-tags.sh" \
+  "${HERE}/restore-edge-env-secrets.sh"; do
   [[ -f "$f" ]] || { echo "missing $f" >&2; exit 1; }
 done
 
@@ -27,6 +28,7 @@ done
 compose_b64="$(gzip -9n -c "${STAGE0}/docker-compose.yml" | base64 | tr -d '\n')"
 caddy_b64="$(gzip -9n -c "${STAGE0}/Caddyfile.edge" | base64 | tr -d '\n')"
 prune_b64="$(gzip -9n -c "${STAGE0}/tokenkey-prune-ghcr-app-tags.sh" | base64 | tr -d '\n')"
+restore_secrets_b64="$(gzip -9n -c "${HERE}/restore-edge-env-secrets.sh" | base64 | tr -d '\n')"
 
 cat >"${OUT}.tmp" <<'LAUNCH_HEAD'
 #!/bin/bash
@@ -44,13 +46,9 @@ echo "LIGHTSAIL_BOOTSTRAP_START $(date -u +%FT%TZ)"
 : "${LIGHTSAIL_REGION:?LIGHTSAIL_REGION required}"
 : "${SSM_ACTIVATION_ID:?SSM_ACTIVATION_ID required}"
 : "${SSM_ACTIVATION_CODE:?SSM_ACTIVATION_CODE required}"
-# GHCR auth is OPTIONAL: empty GHCR_PAT_SSM_NAME -> anonymous pull (public
-# ghcr.io image). Set it to an SSM SecureString name if the image goes private.
 : "${GHCR_PAT_SSM_NAME:=}"
 : "${GHCR_PULL_USER:=}"
 
-# Align kernel hostname with Lightsail instance name so SSM ComputerName-based
-# discovery matches provision-edge.sh fallbacks (AL2023 default is often a dhcp name).
 if command -v hostnamectl >/dev/null 2>&1; then
   hostnamectl set-hostname "${INSTANCE_NAME}" || true
 else
@@ -74,8 +72,6 @@ if ! docker compose version >/dev/null 2>&1; then
   chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 fi
 
-# Swap (2 GiB): micro Lightsail bundles have no swap by default; without this,
-# memory spikes can hang the VM.
 SWAP_SIZE_GIB="${SWAP_SIZE_GIB:-2}"
 if [ "${SWAP_SIZE_GIB}" -gt 0 ] && [ ! -f /swapfile ]; then
   fallocate -l "${SWAP_SIZE_GIB}G" /swapfile || dd if=/dev/zero of=/swapfile bs=1M count=$((SWAP_SIZE_GIB * 1024)) status=progress
@@ -122,6 +118,7 @@ cat >>"${OUT}.tmp" <<LAUNCH_EMBED
 COMPOSE_GZB64='${compose_b64}'
 CADDY_GZB64='${caddy_b64}'
 PRUNE_B64='${prune_b64}'
+RESTORE_SECRETS_B64='${restore_secrets_b64}'
 LAUNCH_EMBED
 
 # Renderer-side notes (kept OUT of the embedded artifact — Lightsail user-data
@@ -143,18 +140,13 @@ envsubst '${API_DOMAIN} ${ACME_EMAIL} ${MAIN_GATEWAY_ALLOWED_CIDR}' \
 printf '%s' "$PRUNE_B64" | base64 -d | gunzip > /usr/local/bin/tokenkey-prune-ghcr-app-tags-core.sh
 chmod +x /usr/local/bin/tokenkey-prune-ghcr-app-tags-core.sh
 
+printf '%s' "$RESTORE_SECRETS_B64" | base64 -d | gunzip > /usr/local/bin/tokenkey-restore-edge-env-secrets.sh
+chmod 0755 /usr/local/bin/tokenkey-restore-edge-env-secrets.sh
+
 SECRET_FILE=/var/lib/tokenkey/.env.secret
-if [ ! -f "$SECRET_FILE" ]; then
-  umask 077
-  gen_secret() { openssl rand -hex 32; }
-  gen_pwd() { openssl rand -hex 24; }
-  cat > "$SECRET_FILE" <<SECEOF
-POSTGRES_PASSWORD=$(gen_pwd)
-JWT_SECRET=$(gen_secret)
-TOTP_ENCRYPTION_KEY=$(gen_secret)
-SECEOF
-  chmod 0600 "$SECRET_FILE"
-fi
+AWS_REGION="${LIGHTSAIL_REGION}" /usr/local/bin/tokenkey-restore-edge-env-secrets.sh \
+  --parameter "/tokenkey/edge/${EDGE_ID}/stage0/env-secrets-backup" \
+  --output "$SECRET_FILE"
 set -a; . "$SECRET_FILE"; set +a
 
 cat > /var/lib/tokenkey/.env <<ENVEOF

--- a/deploy/aws/lightsail/restore-edge-env-secrets.sh
+++ b/deploy/aws/lightsail/restore-edge-env-secrets.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PARAMETER=""
+OUTPUT=""
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --parameter) PARAMETER="${2:-}"; shift 2 ;;
+    --output) OUTPUT="${2:-}"; shift 2 ;;
+    *) echo "restore-edge-env-secrets: unknown argument $1" >&2; exit 40 ;;
+  esac
+done
+
+[[ "${PARAMETER}" =~ ^/tokenkey/edge/[a-z0-9-]+/stage0/env-secrets-backup$ ]] || {
+  echo "restore-edge-env-secrets: invalid edge parameter" >&2
+  exit 40
+}
+[[ "${OUTPUT}" = /* ]] || { echo "restore-edge-env-secrets: absolute output path required" >&2; exit 40; }
+[[ -n "${REGION}" ]] || { echo "restore-edge-env-secrets: AWS region required" >&2; exit 40; }
+
+validate_secret_file() {
+  local path="$1"
+  [ -f "${path}" ] && [ ! -L "${path}" ] || return 1
+  [ "$(awk 'END { print NR + 0 }' "${path}")" -eq 3 ] || return 1
+  local key count value expected_length
+  for key in POSTGRES_PASSWORD JWT_SECRET TOTP_ENCRYPTION_KEY; do
+    count="$(awk -F= -v key="${key}" '$1 == key && length($0) > length(key) + 1 { count++ } END { print count + 0 }' "${path}")"
+    [ "${count}" -eq 1 ] || return 1
+    value="$(awk -F= -v key="${key}" '$1 == key { print substr($0, length(key) + 2) }' "${path}")"
+    if [ "${key}" = POSTGRES_PASSWORD ]; then expected_length=48; else expected_length=64; fi
+    [[ "${value}" =~ ^[0-9a-f]+$ ]] && [ "${#value}" -eq "${expected_length}" ] || return 1
+  done
+  ! awk -F= '$1 !~ /^(POSTGRES_PASSWORD|JWT_SECRET|TOTP_ENCRYPTION_KEY)$/ || length($0) <= length($1) + 1 { bad=1 } END { exit bad ? 0 : 1 }' "${path}"
+}
+
+if [ -e "${OUTPUT}" ] || [ -L "${OUTPUT}" ]; then
+  validate_secret_file "${OUTPUT}" || {
+    echo "restore-edge-env-secrets: existing secret file is invalid" >&2
+    exit 41
+  }
+  chmod 0600 "${OUTPUT}"
+  echo "edge env secrets already present on host"
+  exit 0
+fi
+
+parent="$(dirname "${OUTPUT}")"
+install -d -m 0700 "${parent}"
+temp="$(mktemp "${parent}/.${OUTPUT##*/}.XXXXXX")"
+error_file="$(mktemp "${parent}/.${OUTPUT##*/}.error.XXXXXX")"
+chmod 0600 "${temp}" "${error_file}"
+cleanup() {
+  if command -v shred >/dev/null 2>&1; then
+    shred -u "${temp}" "${error_file}" 2>/dev/null || rm -f "${temp}" "${error_file}"
+  else
+    rm -f "${temp}" "${error_file}"
+  fi
+}
+trap cleanup EXIT
+
+if aws --region "${REGION}" ssm get-parameter \
+  --name "${PARAMETER}" --with-decryption \
+  --query Parameter.Value --output text >"${temp}" 2>"${error_file}"; then
+  validate_secret_file "${temp}" || {
+    echo "restore-edge-env-secrets: SSM value is malformed" >&2
+    exit 42
+  }
+  mv -f "${temp}" "${OUTPUT}"
+  chmod 0600 "${OUTPUT}"
+  echo "edge env secrets restored from SSM"
+elif grep -Fq 'ParameterNotFound' "${error_file}"; then
+  : >"${temp}"
+  printf 'POSTGRES_PASSWORD=%s\n' "$(openssl rand -hex 24)" >>"${temp}"
+  printf 'JWT_SECRET=%s\n' "$(openssl rand -hex 32)" >>"${temp}"
+  printf 'TOTP_ENCRYPTION_KEY=%s\n' "$(openssl rand -hex 32)" >>"${temp}"
+  validate_secret_file "${temp}" || { echo "restore-edge-env-secrets: generated secrets are invalid" >&2; exit 43; }
+  mv -f "${temp}" "${OUTPUT}"
+  chmod 0600 "${OUTPUT}"
+  echo "edge env secrets generated for first provision"
+else
+  echo "restore-edge-env-secrets: SSM read failed; refusing secret rotation" >&2
+  tail -c 1024 "${error_file}" >&2
+  exit 44
+fi

--- a/deploy/aws/lightsail/test_render_bootstrap.py
+++ b/deploy/aws/lightsail/test_render_bootstrap.py
@@ -111,6 +111,13 @@ class RenderBootstrapTests(unittest.TestCase):
             "PRUNE_B64 must be gzip-decoded; otherwise user-data bloats past 16KB",
         )
 
+    def test_generated_artifact_restores_platform_neutral_edge_secrets(self):
+        content = GENERATED.read_text(encoding="utf-8")
+        self.assertIn("/usr/local/bin/tokenkey-restore-edge-env-secrets.sh", content)
+        self.assertIn(
+            '"/tokenkey/edge/${EDGE_ID}/stage0/env-secrets-backup"', content
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/deploy/aws/lightsail/test_restore_edge_env_secrets.sh
+++ b/deploy/aws/lightsail/test_restore_edge_env_secrets.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SCRIPT="${ROOT}/deploy/aws/lightsail/restore-edge-env-secrets.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+fake_bin="${tmp}/bin"
+mkdir -p "${fake_bin}"
+
+cat >"${fake_bin}/aws" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${FAKE_AWS_LOG}"
+case "${FAKE_AWS_RESULT:-success}" in
+  success)
+    cat "${FAKE_SSM_VALUE}"
+    printf '\n'
+    ;;
+  notfound)
+    echo 'ParameterNotFound' >&2
+    exit 254
+    ;;
+  denied)
+    echo 'AccessDeniedException' >&2
+    exit 254
+    ;;
+esac
+EOF
+chmod +x "${fake_bin}/aws"
+
+valid_value="${tmp}/valid"
+printf '%s\n%s\n%s' \
+  'JWT_SECRET=1111111111111111111111111111111111111111111111111111111111111111' \
+  'POSTGRES_PASSWORD=222222222222222222222222222222222222222222222222' \
+  'TOTP_ENCRYPTION_KEY=3333333333333333333333333333333333333333333333333333333333333333' >"${valid_value}"
+expected_restored="${tmp}/expected-restored"
+printf '%s\n' \
+  'JWT_SECRET=1111111111111111111111111111111111111111111111111111111111111111' \
+  'POSTGRES_PASSWORD=222222222222222222222222222222222222222222222222' \
+  'TOTP_ENCRYPTION_KEY=3333333333333333333333333333333333333333333333333333333333333333' >"${expected_restored}"
+
+run_restore() {
+  local result="$1"
+  local output="$2"
+  PATH="${fake_bin}:${PATH}" \
+    FAKE_AWS_LOG="${tmp}/aws.log" \
+    FAKE_AWS_RESULT="${result}" \
+    FAKE_SSM_VALUE="${valid_value}" \
+    AWS_REGION=us-east-2 \
+    bash "${SCRIPT}" \
+      --parameter /tokenkey/edge/us3/stage0/env-secrets-backup \
+      --output "${output}"
+}
+
+# A valid off-box value is restored exactly and locked to owner-only access.
+restored="${tmp}/restored.secret"
+run_restore success "${restored}" >"${tmp}/restore.out"
+cmp -s "${expected_restored}" "${restored}"
+test "$(stat -f '%Lp' "${restored}" 2>/dev/null || stat -c '%a' "${restored}")" = 600
+grep -F 'edge env secrets restored from SSM' "${tmp}/restore.out" >/dev/null
+
+# Existing host state is authoritative and must not make a network call.
+: >"${tmp}/aws.log"
+run_restore denied "${restored}" >"${tmp}/existing.out"
+test ! -s "${tmp}/aws.log"
+cmp -s "${expected_restored}" "${restored}"
+
+# Only ParameterNotFound authorizes first-boot generation.
+generated="${tmp}/generated.secret"
+run_restore notfound "${generated}" >"${tmp}/generated.out"
+grep -F 'edge env secrets generated for first provision' "${tmp}/generated.out" >/dev/null
+grep -Eq '^JWT_SECRET=[0-9a-f]{64}$' "${generated}"
+grep -Eq '^POSTGRES_PASSWORD=[0-9a-f]{48}$' "${generated}"
+grep -Eq '^TOTP_ENCRYPTION_KEY=[0-9a-f]{64}$' "${generated}"
+
+# IAM/network failures cannot silently rotate secrets by falling back to generation.
+denied="${tmp}/denied.secret"
+if run_restore denied "${denied}" >"${tmp}/denied.out" 2>"${tmp}/denied.err"; then
+  echo 'FAIL: AccessDenied must fail closed' >&2
+  exit 1
+fi
+test ! -e "${denied}"
+
+# A malformed SecureString cannot become host state.
+malformed="${tmp}/malformed.secret"
+printf '%s\n' 'POSTGRES_PASSWORD=only-one-key' >"${tmp}/malformed-value"
+if PATH="${fake_bin}:${PATH}" \
+  FAKE_AWS_LOG="${tmp}/aws.log" \
+  FAKE_AWS_RESULT=success \
+  FAKE_SSM_VALUE="${tmp}/malformed-value" \
+  AWS_REGION=us-east-2 \
+  bash "${SCRIPT}" \
+    --parameter /tokenkey/edge/us3/stage0/env-secrets-backup \
+    --output "${malformed}" >"${tmp}/malformed.out" 2>"${tmp}/malformed.err"; then
+  echo 'FAIL: malformed SSM value must fail closed' >&2
+  exit 1
+fi
+test ! -e "${malformed}"
+
+echo 'test_restore_edge_env_secrets: ok'

--- a/deploy/aws/lightsail/test_restore_edge_env_secrets.sh
+++ b/deploy/aws/lightsail/test_restore_edge_env_secrets.sh
@@ -58,7 +58,7 @@ run_restore() {
 restored="${tmp}/restored.secret"
 run_restore success "${restored}" >"${tmp}/restore.out"
 cmp -s "${expected_restored}" "${restored}"
-test "$(stat -f '%Lp' "${restored}" 2>/dev/null || stat -c '%a' "${restored}")" = 600
+test "$(stat -c '%a' "${restored}" 2>/dev/null || stat -f '%Lp' "${restored}")" = 600
 grep -F 'edge env secrets restored from SSM' "${tmp}/restore.out" >/dev/null
 
 # Existing host state is authoritative and must not make a network call.

--- a/docs/approved/design-edge-env-secrets-recovery.md
+++ b/docs/approved/design-edge-env-secrets-recovery.md
@@ -1,0 +1,32 @@
+---
+title: Edge Stage0 env secrets off-box recovery
+status: approved
+approved_by: "feng (direct execution approval, 2026-08-18)"
+approved_at: 2026-08-18
+risk: high
+---
+
+# Edge Stage0 Env Secrets Off-box Recovery
+
+Each deployable Edge owns one platform-neutral SSM SecureString at
+`/tokenkey/edge/<edge-id>/stage0/env-secrets-backup`. It contains exactly
+`POSTGRES_PASSWORD`, `JWT_SECRET`, and `TOTP_ENCRYPTION_KEY`; no workflow output,
+receipt, or repository artifact may contain their values.
+Values retain the existing bootstrap contract: 48 lowercase hexadecimal characters
+for the PostgreSQL password and 64 for each application key. This makes the restored
+file safe to source and rejects executable shell syntax.
+
+The instance writes and immediately reads back the encrypted parameter after every
+provision, upgrade, rollback, and smoke operation. A rejected write, malformed value,
+or failed readback fails the workflow. The shared Lightsail Hybrid role receives only
+`GetParameter` and `PutParameter` on this fleet prefix.
+
+Replacement bootstrap keeps an existing local `.env.secret`. If it is absent, bootstrap
+tries the Edge SecureString before starting PostgreSQL. A valid value is restored with
+mode `0600`; only an explicit `ParameterNotFound` result authorizes new random secrets.
+Access denial, transport failure, or malformed content stops bootstrap so a recoverable
+database can never be paired silently with new credentials.
+
+Rollout order is: merge and deploy the IAM addon, run the Edge smoke workflow once per
+deployable Edge to create and verify all backups, then permit replacement operations.
+Repository merge alone does not prove that a live parameter exists.

--- a/ops/qa/README.md
+++ b/ops/qa/README.md
@@ -32,6 +32,20 @@ App rollback does not imply QA control-plane rollback. The target release tree e
 
 The repository may be `single_owner_ready` while observed live state remains `single_owner_not_activated`. Editing rollout metadata never proves deployment.
 
+The production handoff has one local SSM entry. `plan` is read-only and prints the
+current immutable plan hash. `activate` requires that exact hash and confirmation;
+the host runner still owns drain, lock, receipt, and boundary retirement.
+
+```bash
+bash ops/stage0/activate-qa-single-owner-via-ssm.sh plan <prod-instance-id>
+bash ops/stage0/activate-qa-single-owner-via-ssm.sh activate <prod-instance-id> \
+  --plan-hash=<sha256> \
+  --confirm=tokenkey-prod-qa-single-owner-activate-v1:<sha256>
+```
+
+Plan failure is a hard stop. In particular, missing capture seals must age naturally
+out of the approved 24-hour horizon; operators must not fabricate or backfill them.
+
 ```bash
 python3 scripts/checks/qa-lifecycle-ssot.py --self-test
 python3 scripts/checks/qa-lifecycle-ssot.py

--- a/ops/stage0/activate-qa-single-owner-via-ssm.sh
+++ b/ops/stage0/activate-qa-single-owner-via-ssm.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-}"
+INSTANCE_ID="${2:-${INSTANCE_ID:-}}"
+shift $(( $# >= 2 ? 2 : $# ))
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-east-1}}"
+TIMEOUT_SECONDS="${STAGE0_SSM_TIMEOUT_SECONDS:-900}"
+PLAN_HASH=""
+CONFIRM=""
+
+for argument in "$@"; do
+  case "${argument}" in
+    --plan-hash=*) PLAN_HASH="${argument#--plan-hash=}" ;;
+    --confirm=*) CONFIRM="${argument#--confirm=}" ;;
+    *) echo "qa-single-owner-via-ssm: unknown argument ${argument}" >&2; exit 40 ;;
+  esac
+done
+
+[[ "${INSTANCE_ID}" =~ ^i-[0-9a-f]{17}$ ]] || { echo "qa-single-owner-via-ssm: valid prod instance id required" >&2; exit 40; }
+[[ "${TIMEOUT_SECONDS}" =~ ^[1-9][0-9]*$ ]] || { echo "qa-single-owner-via-ssm: timeout must be a positive integer" >&2; exit 40; }
+
+case "${MODE}" in
+  plan)
+    [ -z "${PLAN_HASH}${CONFIRM}" ] || { echo "qa-single-owner-via-ssm: plan accepts no confirmation arguments" >&2; exit 40; }
+    remote_command='sudo /usr/local/bin/tokenkey-qa-maintenance.sh --plan-single-owner'
+    ;;
+  activate)
+    [[ "${PLAN_HASH}" =~ ^[0-9a-f]{64}$ ]] || { echo "qa-single-owner-via-ssm: valid plan hash required" >&2; exit 40; }
+    expected="tokenkey-prod-qa-single-owner-activate-v1:${PLAN_HASH}"
+    [ "${CONFIRM}" = "${expected}" ] || { echo "qa-single-owner-via-ssm: confirmation mismatch" >&2; exit 40; }
+    remote_command="set -euo pipefail; sudo /usr/local/bin/tokenkey-qa-maintenance.sh --activate-single-owner --plan-hash=${PLAN_HASH} --confirm=${CONFIRM}; test \"\$(sudo systemctl show tokenkey-qa-boundary.timer --property=UnitFileState --value)\" = disabled; test \"\$(sudo systemctl show tokenkey-qa-boundary.timer --property=ActiveState --value)\" = inactive; sudo systemctl is-enabled --quiet tokenkey-qa-maintenance.timer; sudo systemctl is-active --quiet tokenkey-qa-maintenance.timer; test \"\$(docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1 -c \"SELECT count(*) FROM qa_lifecycle_receipts WHERE phase='single_owner_activate'\" | tr -d '[:space:]')\" = 1"
+    ;;
+  *)
+    echo "usage: $0 plan|activate <prod-instance-id> [--plan-hash=<sha256> --confirm=<token>]" >&2
+    exit 40
+    ;;
+esac
+
+parameters="$(jq -cn --arg command "${remote_command}" '{commands:[$command]}')"
+command_id="$(aws --region "${REGION}" ssm send-command \
+  --instance-ids "${INSTANCE_ID}" \
+  --document-name AWS-RunShellScript \
+  --comment "prod QA single-owner ${MODE}" \
+  --parameters "${parameters}" \
+  --query Command.CommandId --output text)"
+echo "ssm command-id=${command_id}" >&2
+
+deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+status=InProgress
+while [[ "${status}" =~ ^(Pending|InProgress|Delayed)$ ]]; do
+  if [ "$(date +%s)" -ge "${deadline}" ]; then
+    echo "qa-single-owner-via-ssm: timed out waiting for ${command_id}" >&2
+    exit 1
+  fi
+  sleep 3
+  status="$(aws --region "${REGION}" ssm get-command-invocation \
+    --command-id "${command_id}" --instance-id "${INSTANCE_ID}" \
+    --query Status --output text)"
+done
+
+stdout="$(aws --region "${REGION}" ssm get-command-invocation \
+  --command-id "${command_id}" --instance-id "${INSTANCE_ID}" \
+  --query StandardOutputContent --output text)"
+stderr="$(aws --region "${REGION}" ssm get-command-invocation \
+  --command-id "${command_id}" --instance-id "${INSTANCE_ID}" \
+  --query StandardErrorContent --output text)"
+code="$(aws --region "${REGION}" ssm get-command-invocation \
+  --command-id "${command_id}" --instance-id "${INSTANCE_ID}" \
+  --query ResponseCode --output text)"
+printf '%s\n' "${stdout}"
+[ -z "${stderr}" ] || printf '%s\n' "${stderr}" >&2
+[[ "${status}" = Success && "${code}" = 0 ]] || {
+  echo "qa-single-owner-via-ssm: SSM failed status=${status} code=${code}" >&2
+  exit 1
+}

--- a/ops/stage0/backup-env-secrets-via-ssm.sh
+++ b/ops/stage0/backup-env-secrets-via-ssm.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Off-box the prod .env SECRETS to an SSM SecureString (operator-run).
+# Off-box Stage0 .env secrets to an SSM SecureString (operator-run).
 #
 # Why a separate ops script (not in tokenkey-pgdump.sh): the secrets rotate rarely,
 # the dump script is already at the SSM Standard-tier embed-size limit, and we do NOT
@@ -24,6 +24,7 @@
 #   ops/stage0/backup-env-secrets-via-ssm.sh <instance_id> [comment]
 # Env:
 #   TK_ENV_SECRETS_PARAM   SSM param name (default /tokenkey/prod/stage0/env-secrets-backup)
+#   TK_ENV_SECRETS_SOURCE  source file (default /var/lib/tokenkey/.env)
 #   AWS_REGION / AWS_DEFAULT_REGION   region for SSM (optional)
 #   STAGE0_SSM_TIMEOUT_SECONDS        SSM poll timeout (default 180)
 #   STAGE0_SSM_OUTPUT_DIR             where to drop ssm-params/stdout/stderr (default .)
@@ -32,6 +33,7 @@ set -euo pipefail
 INSTANCE_ID="${1:-${INSTANCE_ID:-}}"
 COMMENT="${2:-${SSM_COMMENT:-backup-env-secrets}}"
 PARAM="${TK_ENV_SECRETS_PARAM:-/tokenkey/prod/stage0/env-secrets-backup}"
+SOURCE="${TK_ENV_SECRETS_SOURCE:-/var/lib/tokenkey/.env}"
 TIMEOUT_SECONDS="${STAGE0_SSM_TIMEOUT_SECONDS:-180}"
 OUTPUT_DIR="${STAGE0_SSM_OUTPUT_DIR:-.}"
 
@@ -39,6 +41,8 @@ if [[ -z "${INSTANCE_ID}" ]]; then
   echo "backup_env_secrets_via_ssm: instance id is required" >&2
   exit 1
 fi
+[[ "${PARAM}" =~ ^/[A-Za-z0-9._/-]+$ ]] || { echo "backup_env_secrets_via_ssm: invalid parameter name" >&2; exit 1; }
+[[ "${SOURCE}" =~ ^/[A-Za-z0-9._/-]+$ ]] || { echo "backup_env_secrets_via_ssm: invalid source path" >&2; exit 1; }
 
 ssm_region_args=()
 if [[ -n "${AWS_REGION:-${AWS_DEFAULT_REGION:-}}" ]]; then
@@ -57,6 +61,7 @@ stderr_file="${OUTPUT_DIR}/stderr.txt"
 HOST_B64="$(base64 <<HOSTEOF | tr -d '\n'
 set -euo pipefail
 PARAM="${PARAM}"
+SOURCE="${SOURCE}"
 T=\$(mktemp); C=\$(mktemp); chmod 600 "\$T" "\$C"
 cleanup() {
   if command -v shred >/dev/null 2>&1; then
@@ -66,11 +71,11 @@ cleanup() {
   fi
 }
 trap cleanup EXIT
-grep -E '^(POSTGRES_PASSWORD|JWT_SECRET|TOTP_ENCRYPTION_KEY)=' /var/lib/tokenkey/.env | sort > "\$T" || true
+awk 'index(\$0, "POSTGRES_PASSWORD=") == 1 || index(\$0, "JWT_SECRET=") == 1 || index(\$0, "TOTP_ENCRYPTION_KEY=") == 1' "\$SOURCE" | sort > "\$T"
 for K in POSTGRES_PASSWORD JWT_SECRET TOTP_ENCRYPTION_KEY; do
   N=\$(awk -v key="\$K" 'index(\$0, key "=") == 1 { count++ } END { print count + 0 }' "\$T")
   if [ "\$N" -ne 1 ]; then
-    echo "::error::expected exactly one \${K} assignment in /var/lib/tokenkey/.env" >&2
+    echo "::error::expected exactly one \${K} assignment in \$SOURCE" >&2
     exit 1
   fi
 done

--- a/ops/stage0/test_activate_qa_single_owner_via_ssm.sh
+++ b/ops/stage0/test_activate_qa_single_owner_via_ssm.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT}/ops/stage0/activate-qa-single-owner-via-ssm.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+fake_bin="${tmp}/bin"
+mkdir -p "${fake_bin}"
+
+cat >"${fake_bin}/aws" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${FAKE_AWS_LOG}"
+args="$*"
+case "${args}" in
+  *'ssm send-command'*) echo test-command-id ;;
+  *'ssm get-command-invocation'*'Status'*) echo Success ;;
+  *'ssm get-command-invocation'*'ResponseCode'*) echo 0 ;;
+  *'ssm get-command-invocation'*'StandardOutputContent'*)
+    if grep -F -- '--activate-single-owner' "${FAKE_AWS_LOG}" >/dev/null; then
+      echo '{"ok":true,"phase":"single_owner_activate","plan_hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}'
+    else
+      echo '{"schema_version":"qa-single-owner-activation-plan-v1","plan_hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}'
+    fi
+    ;;
+  *'ssm get-command-invocation'*'StandardErrorContent'*) ;;
+  *) echo "unexpected aws invocation: ${args}" >&2; exit 2 ;;
+esac
+EOF
+chmod +x "${fake_bin}/aws"
+
+export PATH="${fake_bin}:${PATH}"
+export FAKE_AWS_LOG="${tmp}/aws.log"
+export STAGE0_SSM_OUTPUT_DIR="${tmp}/output"
+
+bash "${SCRIPT}" plan i-0123456789abcdef0 >"${tmp}/plan.out"
+grep -F '"plan_hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' "${tmp}/plan.out" >/dev/null
+grep -F -- '--plan-single-owner' "${FAKE_AWS_LOG}" >/dev/null
+
+: >"${FAKE_AWS_LOG}"
+if bash "${SCRIPT}" activate i-0123456789abcdef0 \
+  --plan-hash=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  --confirm=wrong >"${tmp}/invalid.out" 2>"${tmp}/invalid.err"; then
+  echo 'FAIL: confirmation mismatch must fail' >&2
+  exit 1
+fi
+test ! -s "${FAKE_AWS_LOG}"
+
+bash "${SCRIPT}" activate i-0123456789abcdef0 \
+  --plan-hash=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  --confirm=tokenkey-prod-qa-single-owner-activate-v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  >"${tmp}/activate.out"
+grep -F '"phase":"single_owner_activate"' "${tmp}/activate.out" >/dev/null
+grep -F -- '--activate-single-owner' "${FAKE_AWS_LOG}" >/dev/null
+
+echo 'test_activate_qa_single_owner_via_ssm: ok'

--- a/ops/stage0/test_backup_env_secrets_via_ssm.sh
+++ b/ops/stage0/test_backup_env_secrets_via_ssm.sh
@@ -13,6 +13,13 @@ output_dir="${tmp}/output"
 work_dir="${tmp}/work"
 mkdir -p "${local_bin}" "${remote_bin}" "${output_dir}" "${work_dir}"
 
+secret_file="${tmp}/env.secret"
+cat >"${secret_file}" <<'EOF'
+TOTP_ENCRYPTION_KEY=totp-test-secret
+POSTGRES_PASSWORD=postgres-test-secret
+JWT_SECRET=jwt-test-secret
+EOF
+
 cat >"${local_bin}/aws" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -38,6 +45,8 @@ chmod +x "${local_bin}/aws"
 
 PATH="${local_bin}:${PATH}" \
   STAGE0_SSM_OUTPUT_DIR="${output_dir}" \
+  TK_ENV_SECRETS_SOURCE="${secret_file}" \
+  TK_ENV_SECRETS_PARAM="/tokenkey/edge/us3/stage0/env-secrets-backup" \
   AWS_REGION=us-east-2 \
   bash "${SCRIPT}" mi-test rendered-payload-test >"${tmp}/outer.out"
 
@@ -47,19 +56,15 @@ host_rendered="${tmp}/host-rendered.sh"
 host_script="${tmp}/host-under-test.sh"
 printf '%s' "${host_b64}" | base64 -d >"${host_rendered}"
 
-secret_file="${tmp}/env.secret"
-cat >"${secret_file}" <<'EOF'
-TOTP_ENCRYPTION_KEY=totp-test-secret
-POSTGRES_PASSWORD=postgres-test-secret
-JWT_SECRET=jwt-test-secret
-EOF
 expected_parameter="${tmp}/expected.parameter"
 printf '%s\n%s\n%s' \
   'JWT_SECRET=jwt-test-secret' \
   'POSTGRES_PASSWORD=postgres-test-secret' \
   'TOTP_ENCRYPTION_KEY=totp-test-secret' >"${expected_parameter}"
-sed "s#/var/lib/tokenkey/.env#${secret_file}#g" \
-  "${host_rendered}" >"${host_script}"
+cp "${host_rendered}" "${host_script}"
+
+grep -F "SOURCE=\"${secret_file}\"" "${host_script}" >/dev/null
+grep -F 'PARAM="/tokenkey/edge/us3/stage0/env-secrets-backup"' "${host_script}" >/dev/null
 
 cat >"${remote_bin}/aws" <<'EOF'
 #!/usr/bin/env bash

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1716,12 +1716,22 @@ else
 fi
 
 echo "=== sub2api: env secret backup fail-closed contract ==="
-if ! bash ./ops/stage0/test_backup_env_secrets_via_ssm.sh >/dev/null 2>&1; then
+if ! bash ./ops/stage0/test_backup_env_secrets_via_ssm.sh >/dev/null 2>&1 || \
+   ! bash ./deploy/aws/lightsail/test_restore_edge_env_secrets.sh >/dev/null 2>&1; then
     echo "  FAIL: env secret backup fail-closed contract test"
-    echo "        — run: bash ops/stage0/test_backup_env_secrets_via_ssm.sh"
+    echo "        — run: bash ops/stage0/test_backup_env_secrets_via_ssm.sh && bash deploy/aws/lightsail/test_restore_edge_env_secrets.sh"
     errors=$((errors + 1))
 else
-    echo "  ok: rejected writes fail and verified backups succeed"
+    echo "  ok: rejected writes fail and verified backup/restore succeeds"
+fi
+
+echo "=== sub2api: QA single-owner SSM operator contract ==="
+if ! bash ./ops/stage0/test_activate_qa_single_owner_via_ssm.sh >/dev/null 2>&1; then
+    echo "  FAIL: QA single-owner SSM operator contract test"
+    echo "        — run: bash ops/stage0/test_activate_qa_single_owner_via_ssm.sh"
+    errors=$((errors + 1))
+else
+    echo "  ok: QA activation confirmation is fail-closed"
 fi
 
 echo "=== sub2api: ghcr-prune-daily timer contract ==="


### PR DESCRIPTION
## 摘要

- 将每个 Edge 的 `.env.secret` 三项密钥备份到独立 SSM SecureString，并在实例重建时 fail-closed 恢复。
- 为 Lightsail Hybrid role 增加最小 SSM 参数读写权限，部署、升级、回滚和 smoke 后自动校验离机备份。
- 新增 prod QA single-owner 的 `plan` / `activate` 操作器，使用精确 plan hash、确认 token、receipt 和 systemd 状态完成交接校验。
- 当前只交付激活能力；线上仍保持 `single_owner_not_activated`，不得绕过 24 小时 capture seal 证据门禁。

## 设计

- 安全边界与恢复语义记录在 `docs/approved/design-edge-env-secrets-recovery.md`。
- 密钥明文只在 Edge 主机内读取和写入 SSM，不进入 workflow 输出、S3 dump 或 operator 输出。

## 迁移

1. 合并后先部署 `tokenkey-cicd-lightsail-addon`，使四个 Edge 获得参数最小权限。
2. 依次对四个 Edge 执行一次 smoke，生成并校验 `/tokenkey/edge/<edge-id>/stage0/env-secrets-backup`。
3. 仅在四个参数均验证成功后，才允许依赖自动恢复执行实例重建。
4. prod QA 需等 24 小时证据门禁自然满足后重新运行 `plan`；plan 成功后按 hash 执行 `activate`，再等待下一次自然 maintenance 验证。

## 风险

- SSM 不可达、权限不足、参数缺失但并非首次启动、或参数格式异常时均停止恢复，避免静默生成新密钥造成数据库和账号数据不可用。
- QA 激活是高风险状态切换；operator 不会伪造 seal、缩短门禁或手工触发 DROP。
- `docs/approved/` 的新增设计文件需要 reviewer 确认审批语义。

## 验证

- `bash ops/stage0/test_backup_env_secrets_via_ssm.sh`
- `bash deploy/aws/lightsail/test_restore_edge_env_secrets.sh`
- Debian/GNU coreutils 容器中执行恢复测试，覆盖 GitHub runner 的权限位读取路径。
- `bash ops/stage0/test_activate_qa_single_owner_via_ssm.sh`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- 完整 preflight 通过，新增 silent-error-swallow 为 0；Lightsail user-data 保持在大小上限内。

## 提交

- `25be421f5 feat(ops): protect edge secrets and QA owner cutover`
- `dbba4bf78 fix(ops): make secret restore permission check portable`

最新提交：`dbba4bf78`