### PR TITLE
chore(ops): retire legacy QA exports owner

### DIFF
--- a/deploy/aws/cloudformation/stage0-backups.yaml
+++ b/deploy/aws/cloudformation/stage0-backups.yaml
@@ -3,11 +3,9 @@ Description: >
   tokenkey (sub2api fork) Stage 0 standalone S3 stack — does NOT modify the live
   prod instance stack: each bucket policy grants the existing app InstanceRole
   directly (same-account resource-based grant), so no update-stack on
-  tokenkey-prod-stage0. Holds three buckets, all direct-role-ARN pattern:
+  tokenkey-prod-stage0. Holds two buckets, both using the direct-role-ARN pattern:
   (1) pg_dump ledger backups (tokenkey-pgdump.sh hourly; RetentionDays);
-  (2) user-requested QA trajectory export artifacts (qa_capture.export_storage;
-  QaExportsRetentionDays; lifecycle owner: docs/approved/design-prod-qa-24h-s3-lifecycle.md);
-  (3) generated-media offload (media_storage): OPT-IN image offload only (set
+  (2) generated-media offload (media_storage): OPT-IN image offload only (set
   MEDIA_STORAGE_IMAGE_OFFLOAD_ENABLED=true), plus re-presign of legacy
   already-offloaded video records. By default NEITHER image nor video rehosts
   fresh results — they pass through inline (the gateway is not a media CDN).
@@ -26,15 +24,6 @@ Parameters:
     MinValue: 1
     MaxValue: 365
     Description: Days to keep each pg_dump copy before lifecycle expiry.
-  QaExportsRetentionDays:
-    Type: Number
-    Default: 7
-    MinValue: 1
-    MaxValue: 365
-    Description: >
-      Days to keep each QA trajectory export ZIP (traj-exports/ prefix) before
-      lifecycle expiry. Separate from RetentionDays so QA-export and pg_dump
-      retention can be tuned independently.
   MediaRetentionDays:
     Type: Number
     Default: 1
@@ -123,62 +112,6 @@ Resources:
             Action: 's3:ListBucket'
             Resource: !GetAtt PgdumpBackupBucket.Arn
 
-  QaExportsBucket:
-    Type: AWS::S3::Bucket
-    # Retain on stack delete so finished export ZIPs are not lost by an accidental teardown.
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
-    Properties:
-      BucketName: !Sub '${ProjectName}-${Environment}-qa-exports-${AWS::AccountId}'
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
-      VersioningConfiguration:
-        Status: Suspended
-      LifecycleConfiguration:
-        Rules:
-          - Id: expire-traj-exports
-            Status: Enabled
-            Prefix: traj-exports/
-            ExpirationInDays: !Ref QaExportsRetentionDays
-            AbortIncompleteMultipartUpload:
-              DaysAfterInitiation: 1
-
-  QaExportsBucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref QaExportsBucket
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          # Enforce TLS for all access.
-          - Sid: DenyInsecureTransport
-            Effect: Deny
-            Principal: '*'
-            Action: 's3:*'
-            Resource:
-              - !GetAtt QaExportsBucket.Arn
-              - !Sub '${QaExportsBucket.Arn}/*'
-            Condition:
-              Bool:
-                'aws:SecureTransport': 'false'
-          - Sid: DenyLightsailEdgeRole
-            Effect: Deny
-            Principal: '*'
-            Action: 's3:*'
-            Resource:
-              - !GetAtt QaExportsBucket.Arn
-              - !Sub '${QaExportsBucket.Arn}/*'
-            Condition:
-              ArnEquals:
-                'aws:PrincipalArn': !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/tokenkey-lightsail-ssm-hybrid'
-
   MediaBucket:
     Type: AWS::S3::Bucket
     # Retain on stack delete for consistency with the sibling buckets; media is
@@ -258,14 +191,6 @@ Outputs:
   PgdumpS3Uri:
     Description: Set this as TOKENKEY_PGDUMP_S3_URI in /var/lib/tokenkey/.env on the app host.
     Value: !Sub 's3://${PgdumpBackupBucket}/${Environment}/pgdump'
-  QaExportsBucketName:
-    Description: >
-      Retained legacy trajectory ZIP artifact bucket; it is not an active QA runtime surface.
-    Value: !Ref QaExportsBucket
-  QaExportsS3Uri:
-    Description: >
-      Retained legacy artifact location; active user QA uses the dedicated Bundle stack.
-    Value: !Sub 's3://${QaExportsBucket}'
   EnvSecretsSsmParam:
     Description: Set this as TOKENKEY_ENV_SECRETS_SSM in /var/lib/tokenkey/.env; SecureString holding the off-box .env secrets.
     Value: !Sub '/${ProjectName}/${Environment}/stage0/env-secrets-backup'

--- a/deploy/aws/cloudformation/test_stage0_edge_qa_s3_boundary.py
+++ b/deploy/aws/cloudformation/test_stage0_edge_qa_s3_boundary.py
@@ -119,10 +119,10 @@ class Stage0EdgeQaS3BoundaryTest(unittest.TestCase):
                 "${QaRawArchiveBucket.Arn}/*",
             ),
             (
-                self.backups,
-                "QaExportsBucketPolicy",
-                "QaExportsBucket.Arn",
-                "${QaExportsBucket.Arn}/*",
+                self.raw,
+                "QaBundleBucketPolicy",
+                "QaBundleBucket.Arn",
+                "${QaBundleBucket.Arn}/*",
             ),
         )
         for template, policy_name, bucket_arn, object_arn in cases:

--- a/deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py
+++ b/deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py
@@ -31,7 +31,6 @@ ACTIVE_RUNTIME_SURFACES = DEPLOY_SURFACES + (
     ROOT / "ops/qa/prod_phase2_baseline.py",
     ROOT / "ops/qa/verify_raw_archive_iam_contract.py",
     ROOT / "ops/qa/test_qa_phase_ops.py",
-    ROOT / "deploy/aws/cloudformation/stage0-backups.yaml",
 )
 EDGE_ROLE_ARN = "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/tokenkey-lightsail-ssm-hybrid"
 
@@ -305,17 +304,21 @@ class Stage0QABundleContractTest(unittest.TestCase):
         with self.assertRaises(AssertionError):
             self.assert_worker_contract(broadened_worker)
 
-    def test_active_runtime_has_no_legacy_export_alias_or_app_role_grant(self) -> None:
+    def test_active_runtime_has_no_legacy_export_alias(self) -> None:
         for surface in ACTIVE_RUNTIME_SURFACES:
             with self.subTest(surface=surface):
                 self.assertNotIn("QA_CAPTURE_EXPORT_STORAGE", surface.read_text(encoding="utf-8"))
 
+    def test_backups_template_has_no_legacy_export_owner(self) -> None:
         backups = yaml.load(
             (ROOT / "deploy/aws/cloudformation/stage0-backups.yaml").read_text(encoding="utf-8"),
             Loader=CloudFormationLoader,
         )
-        statements = backups["Resources"]["QaExportsBucketPolicy"]["Properties"]["PolicyDocument"]["Statement"]
-        self.assertFalse(any(statement.get("Principal") == {"AWS": "AppInstanceRoleArn"} for statement in statements))
+        self.assertNotIn("QaExportsRetentionDays", backups["Parameters"])
+        self.assertNotIn("QaExportsBucket", backups["Resources"])
+        self.assertNotIn("QaExportsBucketPolicy", backups["Resources"])
+        self.assertNotIn("QaExportsBucketName", backups["Outputs"])
+        self.assertNotIn("QaExportsS3Uri", backups["Outputs"])
 
     def test_guarded_deploy_renders_bundle_parameters_and_runtime_surfaces_drop_export_aliases(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/ops/qa/test_qa_phase_ops.py
+++ b/ops/qa/test_qa_phase_ops.py
@@ -224,8 +224,8 @@ class TestQAPhaseOps(unittest.TestCase):
             "tokenkey-prod-qa-raw-archive-123456789012": statements(
                 "tokenkey-prod-qa-raw-archive-123456789012"
             ),
-            "tokenkey-prod-qa-exports-123456789012": statements(
-                "tokenkey-prod-qa-exports-123456789012"
+            "tokenkey-prod-qa-bundles-123456789012": statements(
+                "tokenkey-prod-qa-bundles-123456789012"
             ),
         }
         verdict = iam_contract.evaluate_edge_qa_boundary(
@@ -243,7 +243,7 @@ class TestQAPhaseOps(unittest.TestCase):
         edge_role = (
             f"arn:aws:iam::{account_id}:role/tokenkey-lightsail-ssm-hybrid"
         )
-        bucket = "tokenkey-prod-qa-exports-123456789012"
+        bucket = "tokenkey-prod-qa-bundles-123456789012"
         verdict = iam_contract.evaluate_edge_qa_boundary(
             account_id=account_id,
             buckets={
@@ -310,7 +310,7 @@ class TestQAPhaseOps(unittest.TestCase):
             output_calls.append((stack, key))
             return {
                 (iam_contract.RAW_ARCHIVE_STACK, "QaRawArchiveBucketName"): "raw-bucket",
-                (iam_contract.BACKUPS_STACK, "QaExportsBucketName"): "exports-bucket",
+                (iam_contract.RAW_ARCHIVE_STACK, "QaBundleBucketName"): "bundle-bucket",
             }[(stack, key)]
 
         def fake_policy(bucket: str) -> list[dict]:
@@ -344,10 +344,10 @@ class TestQAPhaseOps(unittest.TestCase):
             output_calls,
             [
                 (iam_contract.RAW_ARCHIVE_STACK, "QaRawArchiveBucketName"),
-                (iam_contract.BACKUPS_STACK, "QaExportsBucketName"),
+                (iam_contract.RAW_ARCHIVE_STACK, "QaBundleBucketName"),
             ],
         )
-        self.assertEqual(policy_calls, ["raw-bucket", "exports-bucket"])
+        self.assertEqual(policy_calls, ["raw-bucket", "bundle-bucket"])
 
     def test_verify_raw_archive_iam_contract_flags_missing_s3_gateway_route(self) -> None:
         iam_contract = _load_module(

--- a/ops/qa/verify_raw_archive_iam_contract.py
+++ b/ops/qa/verify_raw_archive_iam_contract.py
@@ -13,7 +13,6 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[2]
 PROD_REGION = "us-east-1"
 RAW_ARCHIVE_STACK = "tokenkey-prod-qa-raw-archive"
-BACKUPS_STACK = "tokenkey-stage0-backups"
 STAGE0_STACK = "tokenkey-prod-stage0"
 STAGE0_PUBLIC_ROUTE_TABLE_LOGICAL = "PublicRouteTable"
 EDGE_ROLE_NAME = "tokenkey-lightsail-ssm-hybrid"
@@ -294,10 +293,10 @@ def evaluate_edge_qa_boundary(
 def verify_live_edge_qa_boundary(account_id: str) -> dict[str, Any]:
     try:
         raw_bucket = _stack_output(RAW_ARCHIVE_STACK, "QaRawArchiveBucketName")
-        exports_bucket = _stack_output(BACKUPS_STACK, "QaExportsBucketName")
+        bundle_bucket = _stack_output(RAW_ARCHIVE_STACK, "QaBundleBucketName")
         buckets = {
             raw_bucket: _live_bucket_policy(raw_bucket),
-            exports_bucket: _live_bucket_policy(exports_bucket),
+            bundle_bucket: _live_bucket_policy(bundle_bucket),
         }
     except RuntimeError as exc:
         return {
@@ -470,7 +469,7 @@ def main() -> int:
     parser.add_argument(
         "--edge-qa-boundary",
         action="store_true",
-        help="read both prod QA bucket policies and verify the shared edge-role deny",
+        help="read prod raw archive and QA Bundle policies and verify the shared edge-role deny",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary

- remove the obsolete `QaExportsBucket` CloudFormation owner, parameter, policy, and outputs from the Stage0 backups template
- make the existing edge QA boundary verifier inspect the active raw archive and QA Bundle buckets
- keep the raw archive template, raw audit bucket, backend/frontend runtime, deploy injection, migrations, and rollout state unchanged

## CloudFormation semantics and residual risk

This repository change does not create or execute a change set.

A later separately approved update of `tokenkey-stage0-backups` is expected to remove exactly:

- `QaExportsBucket` (`AWS::S3::Bucket`)
- `QaExportsBucketPolicy` (`AWS::S3::BucketPolicy`)

`QaExportsBucket` has `DeletionPolicy: Retain` and `UpdateReplacePolicy: Retain`, so its physical bucket, configuration, lifecycle, and data remain after the stack stops owning it. The independent bucket policy has no retain policy and will be deleted. That intentionally removes the historical app-role resource-policy grants, but it also removes that policy's explicit TLS and Lightsail edge-role denies from the retained inactive bucket. This is accepted only as a bounded intermediate state for the currently empty, writerless legacy bucket; it is not evidence that no identity-based IAM path can reach the bucket.

Physical bucket deletion, no-execute change-set review, execution of an exact approved change-set ARN, and post-apply readback are separate approval gates. This PR authorizes none of them.

## Validation

Exact head `b0b67c45d8b2` includes current `origin/main` (`82d94d69385a`) with no overlapping file changes.

- focused QA/CloudFormation suites: 63 tests passed
- `./scripts/preflight.sh`
- `make test`
  - Go unit tests
  - `golangci-lint` (0 issues)
  - frontend ESLint and Vue typecheck
  - frontend Vitest: 175 tests passed
- `git diff --check`
- independent semantic review completed; no code change required

## Scope boundaries

- no AWS change set created or executed
- no live bucket policy or IAM mutation
- no S3 object or bucket deletion
- no release, deploy, or rollout-state update
- no raw audit changes
- no paid video traffic

no-web-impact

ai
