### PR TITLE
feat(ops): 定期验证 Fleet 恢复并推广 Edge 日分区

### DIFF
--- a/.github/workflows/ops-pgdump-restore-canary.yml
+++ b/.github/workflows/ops-pgdump-restore-canary.yml
@@ -1,0 +1,108 @@
+name: Fleet pg_dump Restore Canary
+
+on:
+  schedule:
+    - cron: "37 3 * * 1"
+  workflow_dispatch:
+    inputs:
+      target_selector:
+        description: "Target selector: all, prod, edge:*, or edge:<id>."
+        required: false
+        default: all
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fleet-pgdump-restore-canary
+  cancel-in-progress: false
+
+jobs:
+  discover-targets:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      has_targets: ${{ steps.matrix.outputs.has_targets }}
+    env:
+      TARGET_SELECTOR: ${{ inputs.target_selector || 'all' }}
+      PROD_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      PROD_STACK: ${{ vars.PROD_STACK_NAME || 'tokenkey-prod-stage0' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build restore-canary target matrix
+        id: matrix
+        run: |
+          set -euo pipefail
+          python3 deploy/aws/stage0/resolve-edge-target.py \
+            --prod-ops-matrix \
+            --target-selector "$TARGET_SELECTOR" \
+            --prod-region "$PROD_REGION" \
+            --prod-stack "$PROD_STACK" \
+            --github-output "$GITHUB_OUTPUT"
+
+  restore-canary:
+    needs: discover-targets
+    if: needs.discover-targets.outputs.has_targets == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover-targets.outputs.matrix) }}
+    env:
+      OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
+      TARGET_KIND: ${{ matrix.target_kind }}
+      EDGE_ID: ${{ matrix.edge_id }}
+      TARGET_REGION: ${{ matrix.region }}
+      TARGET_ID: ${{ matrix.target_id }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Require OIDC role
+        run: |
+          set -euo pipefail
+          [ -n "${OIDC_ROLE_ARN:-}" ] || { echo "::error::AWS_OIDC_ROLE_ARN is required"; exit 1; }
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.OIDC_ROLE_ARN }}
+          aws-region: ${{ env.TARGET_REGION }}
+
+      - name: Run isolated pg_dump restore canary
+        run: |
+          set -euo pipefail
+          if [ "$TARGET_KIND" = prod ]; then
+            PROBE_TARGET=prod
+          else
+            PROBE_TARGET="edge:$EDGE_ID"
+          fi
+          bash ops/observability/run-probe.sh \
+            --target "$PROBE_TARGET" \
+            --script ops/stage0/pgdump_restore_canary_remote.sh \
+            --with ops/stage0/pgdump_restore_canary.py \
+            --timeout-seconds 1500 \
+            --comment "weekly pgdump restore canary target=$TARGET_ID" \
+            --env "CANARY_TARGET=$PROBE_TARGET" | tee restore-canary.json
+          jq -e '.mode == "pgdump_restore_canary" and .target == $target and .source_mutated == false and .deletion_authorized == false' \
+            --arg target "$PROBE_TARGET" restore-canary.json >/dev/null
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## pg_dump restore canary"
+            echo "- target: \`$TARGET_ID\`"
+            if [ -s restore-canary.json ]; then
+              echo "- completed: \`$(jq -r '.completed_at' restore-canary.json)\`"
+              echo "- artifact bytes: \`$(jq -r '.artifact_bytes' restore-canary.json)\`"
+              echo "- restored counts: \`$(jq -c '.restored_counts' restore-canary.json)\`"
+            else
+              echo "- result: failed before verified receipt"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/agent_integration.md
+++ b/docs/agent_integration.md
@@ -653,10 +653,13 @@ Root options:
 
 
 
+- `--target` (required):
+
 #### `usage_logs_daily_partition.py prepare`
 
 
 
+- `--target` (required):
 - `--receipt` (required):
 - `--confirm` (required):
 
@@ -664,6 +667,7 @@ Root options:
 
 
 
+- `--target` (required):
 - `--receipt` (required):
 - `--legacy-upper-exclusive` (required):
 - `--confirm` (required):
@@ -672,6 +676,7 @@ Root options:
 
 
 
+- `--target` (required):
 - `--prepare-receipt` (required):
 - `--cutover-receipt` (required):
 - `--confirm` (required):
@@ -680,6 +685,7 @@ Root options:
 
 
 
+- `--target` (required):
 - `--prepare-receipt` (required):
 
 ## MCP

--- a/ops/migration/README.md
+++ b/ops/migration/README.md
@@ -1,41 +1,53 @@
 # usage_logs 日分区切换
 
-该目录的 `usage_logs_daily_partition.py` 是唯一生产入口。它不会由应用启动或 migration
-runner 自动执行，也不会复制历史明细。
+`usage_logs_daily_partition.py` 是 prod 与 Edge 共用的唯一 operator。它不会由应用启动或
+migration runner 自动执行，也不会复制历史明细。每个命令都必须显式指定 `--target prod` 或
+`--target edge:<id>`；confirmation、远端 receipt 和本地 receipt 均与同一 target 绑定，不能跨节点复用。
 
-先并发创建普通 `(request_id, api_key_id)` 查询索引，再在线准备并验证固定上界 CHECK：
+先读取目标状态，再并发创建普通 `(request_id, api_key_id)` 查询索引，并在线准备及验证固定上界
+CHECK。以下以 `edge:us3` 为例：
 
 ```bash
+python3 ops/migration/usage_logs_daily_partition.py status \
+  --target edge:us3
+
 python3 ops/migration/usage_logs_daily_partition.py prepare \
+  --target edge:us3 \
   --receipt /path/to/usage-prepare-receipt.json \
-  --confirm tokenkey-prod-usage-daily-prepare-v1
+  --confirm tokenkey-edge-us3-usage-daily-prepare-v1
 ```
 
-如果 receipt 写入失败或决定取消 cutover，先用 `status` 读取
-`legacy_upper_exclusive`，再用与该上界精确绑定的确认串撤销 CHECK：
+如果 receipt 写入失败或决定取消 cutover，使用与 target 和 receipt 上界精确绑定的确认串撤销
+CHECK：
 
 ```bash
 python3 ops/migration/usage_logs_daily_partition.py abort \
+  --target edge:us3 \
   --receipt /path/to/usage-abort-receipt.json \
   --legacy-upper-exclusive '<legacy_upper_exclusive>' \
-  --confirm 'tokenkey-prod-usage-daily-abort-v1:<legacy_upper_exclusive>'
+  --confirm 'tokenkey-edge-us3-usage-daily-abort-v1:<legacy_upper_exclusive>'
 ```
 
 `abort` 只允许在尚未 cutover、且 CHECK 带有 operator ownership 标记时执行；普通查询索引保留。
 
-准备 receipt 会给出绑定上界的 `required_cutover_confirmation`。维护窗口内原样使用该值执行
-短 catalog cutover：
+prepare receipt 会给出绑定 target 与上界的 `required_cutover_confirmation`。维护窗口内原样使用该值
+执行短 catalog cutover，随后可重复验证：
 
 ```bash
 python3 ops/migration/usage_logs_daily_partition.py cutover \
+  --target edge:us3 \
   --prepare-receipt /path/to/usage-prepare-receipt.json \
   --cutover-receipt /path/to/usage-cutover-receipt.json \
   --confirm '<required_cutover_confirmation>'
+
+python3 ops/migration/usage_logs_daily_partition.py verify \
+  --target edge:us3 \
+  --prepare-receipt /path/to/usage-prepare-receipt.json
 ```
 
-锁等待超过 5 秒、上界过期、CHECK 未验证、出现未知 incoming FK、父表仍有全局唯一索引或
-切换后 legacy 行数小于 prepare receipt、或父表行数小于 legacy 行数时均 fail closed。账务幂等
-仍由 `usage_billing_dedup` 负责。
+锁等待超过 5 秒、上界过期、CHECK 未验证、出现未知 incoming FK、父表仍有全局唯一索引、target
+与 receipt 不一致、切换后 legacy 行数小于 prepare receipt，或父表行数小于 legacy 行数时均 fail
+closed。账务幂等仍由 `usage_billing_dedup` 负责。
 
 ## 分区维护一次性入口
 

--- a/ops/migration/test_usage_logs_daily_partition.py
+++ b/ops/migration/test_usage_logs_daily_partition.py
@@ -21,16 +21,17 @@ import usage_logs_daily_partition as control  # noqa: E402
 import usage_logs_daily_partition_remote as remote  # noqa: E402
 
 
-_INSTANCE = "i-0123456789abcdef0"
+_TARGET = "edge:us3"
+_INSTANCE = "mi-0123456789abcdef0"
 _UPPER = "2026-08-05T00:00:00Z"
-_CONFIRM = remote.CUTOVER_CONFIRMATION_PREFIX + _UPPER
+_CONFIRM = remote.cutover_confirmation_prefix(_TARGET) + _UPPER
 
 
-def _prepare_receipt() -> dict:
+def _prepare_receipt(*, target: str = _TARGET, instance_id: str = _INSTANCE) -> dict:
     return {
-        "mode": "prod_usage_logs_daily_partition_prepare",
-        "environment": "prod",
-        "instance_id": _INSTANCE,
+        "mode": "usage_logs_daily_partition_prepare",
+        "target": target,
+        "instance_id": instance_id,
         "legacy_upper_exclusive": _UPPER,
         "row_count_before": 6_000_000,
         "bound_validated": True,
@@ -73,9 +74,12 @@ class UsageLogsDailyPartitionTest(unittest.TestCase):
         with mock.patch.object(remote, "status", side_effect=[before, after]), mock.patch.object(
             remote, "_query_json", return_value=inventory
         ), mock.patch.object(remote, "_psql", return_value="") as psql:
-            receipt = remote.prepare(remote.PREPARE_CONFIRMATION)
+            receipt = remote.prepare(
+                _TARGET, remote.prepare_confirmation(_TARGET)
+            )
 
         self.assertEqual(receipt["legacy_upper_exclusive"], _UPPER)
+        self.assertEqual(receipt["target"], _TARGET)
         self.assertEqual(psql.call_count, 2)
         self.assertIn("CREATE INDEX CONCURRENTLY", psql.call_args_list[0].args[0])
         self.assertIn(_UPPER, psql.call_args_list[1].args[0])
@@ -83,8 +87,50 @@ class UsageLogsDailyPartitionTest(unittest.TestCase):
     def test_abort_refuses_confirmation_not_bound_to_upper(self) -> None:
         with mock.patch.object(remote, "_psql") as psql:
             with self.assertRaisesRegex(remote.UsagePartitionError, "confirmation"):
-                remote.abort(_UPPER, remote.ABORT_CONFIRMATION_PREFIX + "2026-08-06T00:00:00Z")
+                remote.abort(
+                    _TARGET,
+                    _UPPER,
+                    remote.abort_confirmation_prefix(_TARGET) + "2026-08-06T00:00:00Z",
+                )
         psql.assert_not_called()
+
+    def test_edge_confirmation_cannot_authorize_prod_prepare(self) -> None:
+        with mock.patch.object(remote, "status") as status:
+            with self.assertRaisesRegex(remote.UsagePartitionError, "confirmation"):
+                remote.prepare("prod", remote.prepare_confirmation(_TARGET))
+        status.assert_not_called()
+
+    def test_edge_remote_receipt_binds_managed_instance_and_target(self) -> None:
+        payload = {
+            "mode": "usage_logs_daily_partition_status",
+            "target": _TARGET,
+            "deletion_authorized": False,
+        }
+        completed = subprocess.CompletedProcess(
+            ["bash"],
+            0,
+            stdout=json.dumps(payload) + "\n",
+            stderr=(
+                "[run-probe] resolved region=us-east-2 "
+                f"instance_id={_INSTANCE}\n"
+            ),
+        )
+        with mock.patch.object(control.subprocess, "run", return_value=completed) as run:
+            result = control._run_remote(
+                _TARGET, "status", [], timeout_seconds=120
+            )
+
+        self.assertEqual(result["instance_id"], _INSTANCE)
+        command = run.call_args.args[0]
+        self.assertEqual(command[command.index("--target") + 1], _TARGET)
+        self.assertIn(f"REMOTE_TARGET={_TARGET}", command)
+
+    def test_prepare_receipt_cannot_cross_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            receipt = pathlib.Path(temp) / "prepare.json"
+            receipt.write_text(json.dumps(_prepare_receipt()), encoding="utf-8")
+            with self.assertRaisesRegex(control.UsagePartitionControlError, "validation"):
+                control._load_prepare_receipt(receipt, "edge:us4")
 
     def test_cutover_refuses_confirmation_not_bound_to_upper(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
@@ -94,9 +140,11 @@ class UsageLogsDailyPartitionTest(unittest.TestCase):
             with mock.patch.object(control, "_run_remote") as run_remote:
                 with self.assertRaisesRegex(control.UsagePartitionControlError, "exactly match"):
                     control.cutover(
+                        _TARGET,
                         prepare_path,
                         root / "cutover.json",
-                        remote.CUTOVER_CONFIRMATION_PREFIX + "2026-08-06T00:00:00Z",
+                        remote.cutover_confirmation_prefix(_TARGET)
+                        + "2026-08-06T00:00:00Z",
                     )
             run_remote.assert_not_called()
 
@@ -107,8 +155,8 @@ class UsageLogsDailyPartitionTest(unittest.TestCase):
             cutover_path = root / "cutover.json"
             prepare_path.write_text(json.dumps(_prepare_receipt()), encoding="utf-8")
             remote_result = {
-                "mode": "prod_usage_logs_daily_partition_cutover",
-                "environment": "prod",
+                "mode": "usage_logs_daily_partition_cutover",
+                "target": _TARGET,
                 "instance_id": _INSTANCE,
                 "legacy_upper_exclusive": _UPPER,
                 "source_rows_copied": False,
@@ -124,7 +172,9 @@ class UsageLogsDailyPartitionTest(unittest.TestCase):
                 },
             }
             with mock.patch.object(control, "_run_remote", return_value=remote_result):
-                result = control.cutover(prepare_path, cutover_path, _CONFIRM)
+                result = control.cutover(
+                    _TARGET, prepare_path, cutover_path, _CONFIRM
+                )
             self.assertEqual(result["row_count_before"], 6_000_000)
             self.assertEqual(
                 json.loads(cutover_path.read_text(encoding="utf-8"))["verification"]["parent_row_count"],
@@ -137,8 +187,8 @@ class UsageLogsDailyPartitionTest(unittest.TestCase):
             prepare_path = root / "prepare.json"
             prepare_path.write_text(json.dumps(_prepare_receipt()), encoding="utf-8")
             remote_result = {
-                "mode": "prod_usage_logs_daily_partition_cutover",
-                "environment": "prod",
+                "mode": "usage_logs_daily_partition_cutover",
+                "target": _TARGET,
                 "instance_id": _INSTANCE,
                 "legacy_upper_exclusive": _UPPER,
                 "source_rows_copied": False,
@@ -157,7 +207,12 @@ class UsageLogsDailyPartitionTest(unittest.TestCase):
                 with self.assertRaisesRegex(
                     control.UsagePartitionControlError, "complete verification"
                 ):
-                    control.cutover(prepare_path, root / "cutover.json", _CONFIRM)
+                    control.cutover(
+                        _TARGET,
+                        prepare_path,
+                        root / "cutover.json",
+                        _CONFIRM,
+                    )
 
     def test_raw_usage_conflict_target_removed_but_billing_dedup_kept(self) -> None:
         repo = (_DIR.parents[1] / "backend" / "internal" / "repository" / "usage_log_repo_insert.go").read_text(encoding="utf-8")
@@ -305,17 +360,23 @@ INSERT INTO billing_usage_entries(usage_log_id) VALUES (1);
 """
         )
         with mock.patch.object(remote, "_psql", side_effect=self._psql):
-            first_prepare = remote.prepare(remote.PREPARE_CONFIRMATION)
+            first_prepare = remote.prepare(
+                "prod", remote.prepare_confirmation("prod")
+            )
             aborted = remote.abort(
+                "prod",
                 first_prepare["legacy_upper_exclusive"],
-                remote.ABORT_CONFIRMATION_PREFIX
+                remote.abort_confirmation_prefix("prod")
                 + first_prepare["legacy_upper_exclusive"],
             )
-            prepared = remote.prepare(remote.PREPARE_CONFIRMATION)
+            prepared = remote.prepare(
+                "prod", remote.prepare_confirmation("prod")
+            )
             result = remote.cutover(
+                "prod",
                 prepared["legacy_upper_exclusive"],
                 prepared["row_count_before"],
-                remote.CUTOVER_CONFIRMATION_PREFIX
+                remote.cutover_confirmation_prefix("prod")
                 + prepared["legacy_upper_exclusive"],
             )
 

--- a/ops/migration/usage_logs_daily_partition.py
+++ b/ops/migration/usage_logs_daily_partition.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Operator CLI for the explicit production usage_logs daily partition cutover."""
+"""Operator CLI for explicit Fleet usage_logs daily partition cutovers."""
 
 from __future__ import annotations
 
@@ -22,9 +22,9 @@ REPO = HERE.parents[1]
 RUN_PROBE = REPO / "ops" / "observability" / "run-probe.sh"
 REMOTE = HERE / "usage_logs_daily_partition_remote.py"
 REMOTE_WRAPPER = HERE / "usage_logs_daily_partition_remote.sh"
-INSTANCE_RE = re.compile(r"i-[0-9a-f]{17}")
+INSTANCE_RE = re.compile(r"(?:i|mi)-[0-9a-f]{17}")
 RESOLVED_INSTANCE_RE = re.compile(
-    r"\[run-probe\] resolved region=\S+ instance_id=(i-[0-9a-f]{17})"
+    r"\[run-probe\] resolved region=\S+ instance_id=((?:i|mi)-[0-9a-f]{17})"
 )
 
 
@@ -53,14 +53,21 @@ def _atomic_json(path: pathlib.Path, value: dict[str, Any]) -> None:
         raise
 
 
-def _run_remote(command: str, arguments: list[str], *, timeout_seconds: int) -> dict[str, Any]:
+def _run_remote(
+    target: str,
+    command: str,
+    arguments: list[str],
+    *,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    target = remote._target(target)
     try:
         completed = subprocess.run(
             [
                 "bash",
                 str(RUN_PROBE),
                 "--target",
-                "prod",
+                target,
                 "--script",
                 str(REMOTE_WRAPPER),
                 "--with",
@@ -70,6 +77,8 @@ def _run_remote(command: str, arguments: list[str], *, timeout_seconds: int) -> 
                 "--env",
                 f"REMOTE_COMMAND={command}",
                 "--env",
+                f"REMOTE_TARGET={target}",
+                "--env",
                 f"REMOTE_ARGS_JSON={_canonical_json(arguments)}",
             ],
             capture_output=True,
@@ -78,31 +87,38 @@ def _run_remote(command: str, arguments: list[str], *, timeout_seconds: int) -> 
             check=False,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
-        raise UsagePartitionControlError("production usage partition command could not run") from exc
+        raise UsagePartitionControlError("usage partition command could not run") from exc
     if completed.returncode != 0:
         detail = (completed.stderr or completed.stdout or "probe failed").strip()
-        raise UsagePartitionControlError(f"production usage partition command failed: {detail[:600]}")
+        raise UsagePartitionControlError(f"usage partition command failed: {detail[:600]}")
     instance_match = RESOLVED_INSTANCE_RE.search(completed.stderr)
     if not instance_match:
-        raise UsagePartitionControlError("production usage partition command did not prove its instance")
+        raise UsagePartitionControlError("usage partition command did not prove its instance")
     try:
         payload = json.loads([line for line in completed.stdout.splitlines() if line.strip()][-1])
     except (IndexError, json.JSONDecodeError) as exc:
-        raise UsagePartitionControlError("production usage partition receipt is invalid") from exc
-    if not isinstance(payload, dict) or payload.get("deletion_authorized") is not False:
-        raise UsagePartitionControlError("production usage partition receipt failed safety validation")
+        raise UsagePartitionControlError("usage partition receipt is invalid") from exc
+    if (
+        not isinstance(payload, dict)
+        or payload.get("target") != target
+        or payload.get("deletion_authorized") is not False
+    ):
+        raise UsagePartitionControlError("usage partition receipt failed safety validation")
     return {**payload, "instance_id": instance_match.group(1)}
 
 
-def _load_prepare_receipt(path: str | os.PathLike[str]) -> dict[str, Any]:
+def _load_prepare_receipt(
+    path: str | os.PathLike[str], target: str
+) -> dict[str, Any]:
+    target = remote._target(target)
     try:
         value = json.loads(pathlib.Path(path).expanduser().resolve().read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise UsagePartitionControlError("usage partition prepare receipt cannot be read") from exc
     if (
         not isinstance(value, dict)
-        or value.get("mode") != "prod_usage_logs_daily_partition_prepare"
-        or value.get("environment") != "prod"
+        or value.get("mode") != "usage_logs_daily_partition_prepare"
+        or value.get("target") != target
         or value.get("bound_validated") is not True
         or value.get("source_rows_copied") is not False
         or value.get("deletion_authorized") is not False
@@ -111,34 +127,41 @@ def _load_prepare_receipt(path: str | os.PathLike[str]) -> dict[str, Any]:
         or value.get("row_count_before") < 0
         or INSTANCE_RE.fullmatch(str(value.get("instance_id", ""))) is None
         or value.get("required_cutover_confirmation")
-        != remote.CUTOVER_CONFIRMATION_PREFIX + str(value.get("legacy_upper_exclusive"))
+        != remote.cutover_confirmation_prefix(target)
+        + str(value.get("legacy_upper_exclusive"))
     ):
         raise UsagePartitionControlError("usage partition prepare receipt failed validation")
     remote._upper(str(value["legacy_upper_exclusive"]))
     return value
 
 
-def prepare(receipt_path: str | os.PathLike[str], confirmation: str) -> dict[str, Any]:
+def prepare(
+    target: str, receipt_path: str | os.PathLike[str], confirmation: str
+) -> dict[str, Any]:
+    target = remote._target(target)
     payload = _run_remote(
-        "prepare", ["--confirm", confirmation], timeout_seconds=1200
+        target, "prepare", ["--confirm", confirmation], timeout_seconds=1200
     )
-    if payload.get("mode") != "prod_usage_logs_daily_partition_prepare":
+    if payload.get("mode") != "usage_logs_daily_partition_prepare":
         raise UsagePartitionControlError("remote prepare returned the wrong receipt mode")
     _atomic_json(pathlib.Path(receipt_path), payload)
     return payload
 
 
 def abort(
+    target: str,
     receipt_path: str | os.PathLike[str],
     upper: str,
     confirmation: str,
 ) -> dict[str, Any]:
+    target = remote._target(target)
     upper = remote._upper(upper)
-    if confirmation != remote.ABORT_CONFIRMATION_PREFIX + upper:
+    if confirmation != remote.abort_confirmation_prefix(target) + upper:
         raise UsagePartitionControlError(
             "abort confirmation must exactly match the partition upper bound"
         )
     payload = _run_remote(
+        target,
         "abort",
         [
             "--legacy-upper-exclusive",
@@ -149,7 +172,7 @@ def abort(
         timeout_seconds=120,
     )
     if (
-        payload.get("mode") != "prod_usage_logs_daily_partition_abort"
+        payload.get("mode") != "usage_logs_daily_partition_abort"
         or payload.get("legacy_upper_exclusive") != upper
         or payload.get("bound_removed") is not True
         or payload.get("source_rows_copied") is not False
@@ -160,15 +183,18 @@ def abort(
 
 
 def cutover(
+    target: str,
     prepare_receipt_path: str | os.PathLike[str],
     cutover_receipt_path: str | os.PathLike[str],
     confirmation: str,
 ) -> dict[str, Any]:
-    prepared = _load_prepare_receipt(prepare_receipt_path)
+    target = remote._target(target)
+    prepared = _load_prepare_receipt(prepare_receipt_path, target)
     if confirmation != prepared["required_cutover_confirmation"]:
         raise UsagePartitionControlError("cutover confirmation must exactly match the prepare receipt")
     upper = prepared["legacy_upper_exclusive"]
     payload = _run_remote(
+        target,
         "cutover",
         [
             "--legacy-upper-exclusive",
@@ -184,7 +210,7 @@ def cutover(
         raise UsagePartitionControlError("cutover reached a different production instance")
     verification = payload.get("verification")
     if (
-        payload.get("mode") != "prod_usage_logs_daily_partition_cutover"
+        payload.get("mode") != "usage_logs_daily_partition_cutover"
         or not isinstance(verification, dict)
         or verification.get("partitioned") is not True
         or verification.get("legacy_attached") is not True
@@ -211,19 +237,24 @@ def cutover(
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     commands = parser.add_subparsers(dest="command", required=True)
-    commands.add_parser("status")
+    status_parser = commands.add_parser("status")
+    status_parser.add_argument("--target", required=True)
     prepare_parser = commands.add_parser("prepare")
+    prepare_parser.add_argument("--target", required=True)
     prepare_parser.add_argument("--receipt", required=True)
     prepare_parser.add_argument("--confirm", required=True)
     abort_parser = commands.add_parser("abort")
+    abort_parser.add_argument("--target", required=True)
     abort_parser.add_argument("--receipt", required=True)
     abort_parser.add_argument("--legacy-upper-exclusive", required=True)
     abort_parser.add_argument("--confirm", required=True)
     cutover_parser = commands.add_parser("cutover")
+    cutover_parser.add_argument("--target", required=True)
     cutover_parser.add_argument("--prepare-receipt", required=True)
     cutover_parser.add_argument("--cutover-receipt", required=True)
     cutover_parser.add_argument("--confirm", required=True)
     verify_parser = commands.add_parser("verify")
+    verify_parser.add_argument("--target", required=True)
     verify_parser.add_argument("--prepare-receipt", required=True)
     return parser
 
@@ -232,24 +263,27 @@ def main(argv: Iterable[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         if args.command == "status":
-            payload = _run_remote("status", [], timeout_seconds=120)
+            payload = _run_remote(args.target, "status", [], timeout_seconds=120)
         elif args.command == "prepare":
-            payload = prepare(args.receipt, args.confirm)
+            payload = prepare(args.target, args.receipt, args.confirm)
         elif args.command == "abort":
             payload = abort(
+                args.target,
                 args.receipt,
                 args.legacy_upper_exclusive,
                 args.confirm,
             )
         elif args.command == "cutover":
             payload = cutover(
+                args.target,
                 args.prepare_receipt,
                 args.cutover_receipt,
                 args.confirm,
             )
         elif args.command == "verify":
-            prepared = _load_prepare_receipt(args.prepare_receipt)
+            prepared = _load_prepare_receipt(args.prepare_receipt, args.target)
             payload = _run_remote(
+                args.target,
                 "verify",
                 [
                     "--legacy-upper-exclusive",

--- a/ops/migration/usage_logs_daily_partition_remote.py
+++ b/ops/migration/usage_logs_daily_partition_remote.py
@@ -13,9 +13,7 @@ from collections.abc import Iterable
 from typing import Any
 
 
-PREPARE_CONFIRMATION = "tokenkey-prod-usage-daily-prepare-v1"
-CUTOVER_CONFIRMATION_PREFIX = "tokenkey-prod-usage-daily-cutover-v1:"
-ABORT_CONFIRMATION_PREFIX = "tokenkey-prod-usage-daily-abort-v1:"
+TARGET_RE = re.compile(r"(?:prod|edge:[a-z][a-z0-9]{1,15})")
 BOUND_CONSTRAINT = "usage_logs_partition_upper"
 BOUND_COMMENT_PREFIX = "tokenkey-usage-partition-upper-v1:"
 QUERY_INDEX = "idx_usage_logs_request_api_key_partition"
@@ -29,6 +27,28 @@ class UsagePartitionError(RuntimeError):
 
 def _canonical_json(value: Any) -> str:
     return json.dumps(value, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+
+
+def _target(value: str) -> str:
+    if TARGET_RE.fullmatch(value) is None:
+        raise UsagePartitionError("target must be prod or edge:<id>")
+    return value
+
+
+def _target_token(target: str) -> str:
+    return _target(target).replace(":", "-")
+
+
+def prepare_confirmation(target: str) -> str:
+    return f"tokenkey-{_target_token(target)}-usage-daily-prepare-v1"
+
+
+def cutover_confirmation_prefix(target: str) -> str:
+    return f"tokenkey-{_target_token(target)}-usage-daily-cutover-v1:"
+
+
+def abort_confirmation_prefix(target: str) -> str:
+    return f"tokenkey-{_target_token(target)}-usage-daily-abort-v1:"
 
 
 def _upper(value: str) -> str:
@@ -146,8 +166,9 @@ SELECT row_to_json(v) FROM (
     )
 
 
-def prepare(confirmation: str) -> dict[str, Any]:
-    if confirmation != PREPARE_CONFIRMATION:
+def prepare(target: str, confirmation: str) -> dict[str, Any]:
+    target = _target(target)
+    if confirmation != prepare_confirmation(target):
         raise UsagePartitionError("usage partition prepare confirmation is invalid")
     before = status()
     if before.get("partitioned") is True:
@@ -227,23 +248,24 @@ ALTER TABLE usage_logs VALIDATE CONSTRAINT {BOUND_CONSTRAINT};
     ):
         raise UsagePartitionError("usage_logs fixed upper CHECK was not validated")
     return {
-        "mode": "prod_usage_logs_daily_partition_prepare",
-        "environment": "prod",
+        "mode": "usage_logs_daily_partition_prepare",
+        "target": target,
         "legacy_upper_exclusive": upper,
         "row_count_before": _row_count(before.get("row_count")),
         "bound_constraint": BOUND_CONSTRAINT,
         "bound_validated": True,
         "query_index": QUERY_INDEX,
         "inventory": inventory,
-        "required_cutover_confirmation": CUTOVER_CONFIRMATION_PREFIX + upper,
+        "required_cutover_confirmation": cutover_confirmation_prefix(target) + upper,
         "source_rows_copied": False,
         "deletion_authorized": False,
     }
 
 
-def abort(upper: str, confirmation: str) -> dict[str, Any]:
+def abort(target: str, upper: str, confirmation: str) -> dict[str, Any]:
+    target = _target(target)
     upper = _upper(upper)
-    if confirmation != ABORT_CONFIRMATION_PREFIX + upper:
+    if confirmation != abort_confirmation_prefix(target) + upper:
         raise UsagePartitionError("usage partition abort confirmation is invalid")
     _psql(
         f"""
@@ -278,8 +300,8 @@ COMMIT;
     if after.get("partitioned") is True or after.get("bound_exists") is True:
         raise UsagePartitionError("usage_logs partition prepare abort verification failed")
     return {
-        "mode": "prod_usage_logs_daily_partition_abort",
-        "environment": "prod",
+        "mode": "usage_logs_daily_partition_abort",
+        "target": target,
         "legacy_upper_exclusive": upper,
         "bound_constraint": BOUND_CONSTRAINT,
         "bound_removed": True,
@@ -572,19 +594,20 @@ SELECT row_to_json(v) FROM (
 
 
 def cutover(
-    upper: str, minimum_legacy_row_count: int, confirmation: str
+    target: str, upper: str, minimum_legacy_row_count: int, confirmation: str
 ) -> dict[str, Any]:
+    target = _target(target)
     upper = _upper(upper)
     minimum_legacy_row_count = _row_count(minimum_legacy_row_count)
-    if confirmation != CUTOVER_CONFIRMATION_PREFIX + upper:
+    if confirmation != cutover_confirmation_prefix(target) + upper:
         raise UsagePartitionError("usage partition cutover confirmation is invalid")
     _psql(
         build_cutover_sql(upper, minimum_legacy_row_count), timeout_seconds=120
     )
     result = verify(upper, minimum_legacy_row_count)
     return {
-        "mode": "prod_usage_logs_daily_partition_cutover",
-        "environment": "prod",
+        "mode": "usage_logs_daily_partition_cutover",
+        "target": target,
         "legacy_upper_exclusive": upper,
         "verification": result,
         "source_rows_copied": False,
@@ -595,16 +618,21 @@ def cutover(
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     commands = parser.add_subparsers(dest="command", required=True)
-    commands.add_parser("status")
+    status_parser = commands.add_parser("status")
+    status_parser.add_argument("--target", required=True)
     prepare_parser = commands.add_parser("prepare")
+    prepare_parser.add_argument("--target", required=True)
     prepare_parser.add_argument("--confirm", required=True)
     abort_parser = commands.add_parser("abort")
+    abort_parser.add_argument("--target", required=True)
     abort_parser.add_argument("--legacy-upper-exclusive", required=True)
     abort_parser.add_argument("--confirm", required=True)
     verify_parser = commands.add_parser("verify")
+    verify_parser.add_argument("--target", required=True)
     verify_parser.add_argument("--legacy-upper-exclusive", required=True)
     verify_parser.add_argument("--minimum-legacy-row-count", type=int, required=True)
     cutover_parser = commands.add_parser("cutover")
+    cutover_parser.add_argument("--target", required=True)
     cutover_parser.add_argument("--legacy-upper-exclusive", required=True)
     cutover_parser.add_argument("--minimum-legacy-row-count", type=int, required=True)
     cutover_parser.add_argument("--confirm", required=True)
@@ -614,15 +642,22 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Iterable[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
+        target = _target(args.target)
         if args.command == "status":
-            payload = {"mode": "prod_usage_logs_daily_partition_status", **status(), "deletion_authorized": False}
+            payload = {
+                "mode": "usage_logs_daily_partition_status",
+                "target": target,
+                **status(),
+                "deletion_authorized": False,
+            }
         elif args.command == "prepare":
-            payload = prepare(args.confirm)
+            payload = prepare(target, args.confirm)
         elif args.command == "abort":
-            payload = abort(args.legacy_upper_exclusive, args.confirm)
+            payload = abort(target, args.legacy_upper_exclusive, args.confirm)
         elif args.command == "verify":
             payload = {
-                "mode": "prod_usage_logs_daily_partition_verify",
+                "mode": "usage_logs_daily_partition_verify",
+                "target": target,
                 **verify(
                     args.legacy_upper_exclusive, args.minimum_legacy_row_count
                 ),
@@ -630,6 +665,7 @@ def main(argv: Iterable[str] | None = None) -> int:
             }
         elif args.command == "cutover":
             payload = cutover(
+                target,
                 args.legacy_upper_exclusive,
                 args.minimum_legacy_row_count,
                 args.confirm,

--- a/ops/migration/usage_logs_daily_partition_remote.sh
+++ b/ops/migration/usage_logs_daily_partition_remote.sh
@@ -2,18 +2,27 @@
 set -euo pipefail
 
 REMOTE_COMMAND="${REMOTE_COMMAND:?REMOTE_COMMAND is required}"
+REMOTE_TARGET="${REMOTE_TARGET:?REMOTE_TARGET is required}"
 REMOTE_ARGS_JSON="${REMOTE_ARGS_JSON:-[]}"
-exec python3 - "$REMOTE_COMMAND" "$REMOTE_ARGS_JSON" <<'PY'
+exec python3 - "$REMOTE_COMMAND" "$REMOTE_TARGET" "$REMOTE_ARGS_JSON" <<'PY'
 import json
 import os
 import sys
 
 command = sys.argv[1]
-value = json.loads(sys.argv[2])
+target = sys.argv[2]
+value = json.loads(sys.argv[3])
 if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
     raise SystemExit("REMOTE_ARGS_JSON must be a JSON string array")
 os.execv(
     sys.executable,
-    [sys.executable, "/tmp/usage_logs_daily_partition_remote.py", command, *value],
+    [
+        sys.executable,
+        "/tmp/usage_logs_daily_partition_remote.py",
+        command,
+        "--target",
+        target,
+        *value,
+    ],
 )
 PY

--- a/ops/stage0/pgdump_restore_canary.py
+++ b/ops/stage0/pgdump_restore_canary.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Create, restore, and verify an isolated precious-class PostgreSQL dump."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import fcntl
+import hashlib
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Callable, Iterable
+from typing import Any
+
+
+CORE_TABLES = (
+    "users",
+    "accounts",
+    "api_keys",
+    "groups",
+    "settings",
+    "usage_billing_dedup",
+)
+EXCLUDE_DATA_GLOBS = (
+    "ops_system_logs*",
+    "usage_logs*",
+    "ops_error_logs*",
+    "qa_records*",
+)
+TARGET_RE = re.compile(r"(?:prod|edge:[a-z][a-z0-9]{1,15})")
+LIVE_POSTGRES = "tokenkey-postgres"
+MIN_DUMP_BYTES = 2048
+RunCommand = Callable[..., subprocess.CompletedProcess[str]]
+
+
+class CanaryError(RuntimeError):
+    """The restore canary could not prove a usable dump."""
+
+
+def _default_run(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, **kwargs)
+
+
+def _run(
+    run: RunCommand,
+    args: list[str],
+    *,
+    timeout: int = 120,
+) -> str:
+    try:
+        completed = run(
+            args,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise CanaryError(f"command could not run: {args[0]} {args[1]}") from exc
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "command failed").strip()
+        raise CanaryError(f"command failed: {args[0]} {args[1]}: {detail[:400]}")
+    return completed.stdout.strip()
+
+
+def _best_effort(run: RunCommand, args: list[str]) -> None:
+    try:
+        run(args, capture_output=True, text=True, check=False, timeout=30)
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+
+def _count_sql() -> str:
+    fields = ",".join(
+        f"'{table}',(SELECT count(*) FROM {table})" for table in CORE_TABLES
+    )
+    return f"SELECT json_build_object({fields});"
+
+
+def _counts(run: RunCommand, container: str) -> dict[str, int]:
+    raw = _run(
+        run,
+        [
+            "docker",
+            "exec",
+            container,
+            "psql",
+            "-U",
+            "tokenkey",
+            "-d",
+            "tokenkey",
+            "-X",
+            "-A",
+            "-t",
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-c",
+            _count_sql(),
+        ],
+    )
+    try:
+        value = json.loads([line for line in raw.splitlines() if line.strip()][-1])
+    except (IndexError, json.JSONDecodeError) as exc:
+        raise CanaryError("core-table count result is invalid") from exc
+    if not isinstance(value, dict) or set(value) != set(CORE_TABLES):
+        raise CanaryError("core-table count result is incomplete")
+    for table, count in value.items():
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            raise CanaryError(f"core-table count is invalid for {table}")
+    return value
+
+
+def _validate_counts(
+    before: dict[str, int],
+    after: dict[str, int],
+    restored: dict[str, int],
+) -> None:
+    for table in CORE_TABLES:
+        lower = min(before[table], after[table])
+        upper = max(before[table], after[table])
+        if not lower <= restored[table] <= upper:
+            raise CanaryError(
+                f"restored count for {table} is outside source window "
+                f"[{lower}, {upper}]: {restored[table]}"
+            )
+
+
+def _atomic_receipt(path: pathlib.Path, value: dict[str, Any]) -> None:
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        pathlib.Path(temporary).unlink(missing_ok=True)
+
+
+def _sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def run_canary(
+    target: str,
+    *,
+    receipt_root: pathlib.Path = pathlib.Path("/var/lib/tokenkey/pgdump-canary"),
+    run: RunCommand = _default_run,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    if TARGET_RE.fullmatch(target) is None:
+        raise CanaryError("target must be prod or edge:<id>")
+
+    receipt_root = receipt_root.expanduser().resolve()
+    receipt_root.mkdir(parents=True, exist_ok=True)
+    lock_path = receipt_root / "canary.lock"
+    lock_handle = lock_path.open("a+", encoding="utf-8")
+    try:
+        try:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise CanaryError("another restore canary is already running") from exc
+
+        temporary = pathlib.Path(
+            tempfile.mkdtemp(prefix=".restore-", dir=receipt_root)
+        )
+        data_dir = temporary / "postgres-data"
+        data_dir.mkdir()
+        data_dir.chmod(0o777)
+        dump_path = temporary / "restore.dump"
+        suffix = f"{os.getpid()}"
+        restore_container = f"tokenkey-pgdump-canary-{suffix}"
+        remote_dump = f"/tmp/tokenkey-pgdump-canary-{suffix}.dump"
+        restore_started = False
+        try:
+            running = _run(
+                run,
+                ["docker", "inspect", "--format", "{{.State.Running}}", LIVE_POSTGRES],
+            )
+            if running != "true":
+                raise CanaryError("live PostgreSQL container is not running")
+            image = _run(
+                run,
+                ["docker", "inspect", "--format", "{{.Config.Image}}", LIVE_POSTGRES],
+            )
+            if not image:
+                raise CanaryError("live PostgreSQL image is empty")
+
+            before = _counts(run, LIVE_POSTGRES)
+            dump_command = [
+                "docker",
+                "exec",
+                LIVE_POSTGRES,
+                "pg_dump",
+                "-U",
+                "tokenkey",
+                "-d",
+                "tokenkey",
+                "--format=custom",
+                "--no-owner",
+                "--no-privileges",
+                f"--file={remote_dump}",
+            ]
+            dump_command.extend(
+                f"--exclude-table-data={pattern}" for pattern in EXCLUDE_DATA_GLOBS
+            )
+            _run(run, dump_command, timeout=900)
+            _run(
+                run,
+                ["docker", "cp", f"{LIVE_POSTGRES}:{remote_dump}", str(dump_path)],
+                timeout=120,
+            )
+            artifact_bytes = dump_path.stat().st_size
+            if artifact_bytes < MIN_DUMP_BYTES:
+                raise CanaryError(f"pg_dump artifact is too small: {artifact_bytes} bytes")
+            after = _counts(run, LIVE_POSTGRES)
+
+            _run(
+                run,
+                [
+                    "docker",
+                    "run",
+                    "--detach",
+                    "--name",
+                    restore_container,
+                    "--pull=never",
+                    "--network=none",
+                    "--cpus=0.50",
+                    "--memory=640m",
+                    "--memory-swap=1024m",
+                    "--env",
+                    "POSTGRES_HOST_AUTH_METHOD=trust",
+                    "--env",
+                    "POSTGRES_USER=tokenkey",
+                    "--env",
+                    "POSTGRES_DB=tokenkey",
+                    "--volume",
+                    f"{data_dir}:/var/lib/postgresql/data",
+                    image,
+                ],
+                timeout=120,
+            )
+            restore_started = True
+            for attempt in range(60):
+                try:
+                    _run(
+                        run,
+                        [
+                            "docker",
+                            "exec",
+                            restore_container,
+                            "pg_isready",
+                            "-U",
+                            "tokenkey",
+                            "-d",
+                            "tokenkey",
+                        ],
+                        timeout=10,
+                    )
+                    break
+                except CanaryError:
+                    if attempt == 59:
+                        raise CanaryError("temporary PostgreSQL did not become ready")
+                    sleep(1)
+
+            _run(
+                run,
+                ["docker", "cp", str(dump_path), f"{restore_container}:/tmp/restore.dump"],
+                timeout=120,
+            )
+            _run(
+                run,
+                [
+                    "docker",
+                    "exec",
+                    restore_container,
+                    "pg_restore",
+                    "-U",
+                    "tokenkey",
+                    "-d",
+                    "tokenkey",
+                    "--no-owner",
+                    "--no-privileges",
+                    "--exit-on-error",
+                    "/tmp/restore.dump",
+                ],
+                timeout=1200,
+            )
+            restored = _counts(run, restore_container)
+            _validate_counts(before, after, restored)
+
+            digest = _sha256(dump_path)
+            receipt: dict[str, Any] = {
+                "schema_version": 1,
+                "mode": "pgdump_restore_canary",
+                "target": target,
+                "completed_at": dt.datetime.now(dt.timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z"),
+                "source_container": LIVE_POSTGRES,
+                "restore_image": image,
+                "source_counts": before,
+                "source_counts_after": after,
+                "restored_counts": restored,
+                "artifact_bytes": artifact_bytes,
+                "artifact_sha256": digest,
+                "source_mutated": False,
+                "deletion_authorized": False,
+            }
+            _atomic_receipt(receipt_root / "latest.json", receipt)
+            return receipt
+        finally:
+            if restore_started:
+                _best_effort(run, ["docker", "rm", "-f", restore_container])
+            _best_effort(run, ["docker", "exec", LIVE_POSTGRES, "rm", "-f", remote_dump])
+            shutil.rmtree(temporary, ignore_errors=True)
+    finally:
+        lock_handle.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", required=True)
+    parser.add_argument(
+        "--receipt-root",
+        default=os.environ.get(
+            "TOKENKEY_PGDUMP_CANARY_ROOT", "/var/lib/tokenkey/pgdump-canary"
+        ),
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        receipt = run_canary(
+            args.target, receipt_root=pathlib.Path(args.receipt_root)
+        )
+    except CanaryError as exc:
+        print(f"pgdump restore canary failed: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(receipt, ensure_ascii=True, separators=(",", ":"), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/stage0/pgdump_restore_canary_remote.sh
+++ b/ops/stage0/pgdump_restore_canary_remote.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET="${CANARY_TARGET:-}"
+[ -n "${TARGET}" ] || { echo "pgdump restore canary: CANARY_TARGET is required" >&2; exit 2; }
+
+exec python3 /tmp/pgdump_restore_canary.py --target "${TARGET}"

--- a/ops/stage0/test_pgdump_restore_canary.py
+++ b/ops/stage0/test_pgdump_restore_canary.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Behavior tests for the isolated Fleet pg_dump restore canary."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+HERE = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import pgdump_restore_canary as canary  # noqa: E402
+
+
+BEFORE = {
+    "users": 3,
+    "accounts": 5,
+    "api_keys": 4,
+    "groups": 2,
+    "settings": 8,
+    "usage_billing_dedup": 11,
+}
+
+
+class FakeDocker:
+    def __init__(self, *, restored: dict[str, int] | None = None) -> None:
+        self.calls: list[list[str]] = []
+        self.live_count_calls = 0
+        self.restored = restored if restored is not None else dict(BEFORE)
+
+    def __call__(self, args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        args = list(args)
+        self.calls.append(args)
+        joined = " ".join(args)
+        stdout = ""
+        if args[:2] == ["docker", "inspect"] and "{{.State.Running}}" in args:
+            stdout = "true\n"
+        elif args[:2] == ["docker", "inspect"] and "{{.Config.Image}}" in args:
+            stdout = "postgres:18-alpine\n"
+        elif args[:3] == ["docker", "cp", args[2]] and args[2].startswith(
+            "tokenkey-postgres:/tmp/"
+        ):
+            pathlib.Path(args[3]).write_bytes(b"PGDMP" + b"x" * 4091)
+        elif args[:2] == ["docker", "run"]:
+            stdout = "canary-container-id\n"
+        elif args[:3] == ["docker", "exec", args[2]] and "pg_isready" in args:
+            stdout = "/var/run/postgresql:5432 - accepting connections\n"
+        elif args[:3] == ["docker", "exec", "tokenkey-postgres"] and "json_build_object" in joined:
+            self.live_count_calls += 1
+            stdout = json.dumps(BEFORE) + "\n"
+        elif len(args) >= 3 and args[:2] == ["docker", "exec"] and "json_build_object" in joined:
+            stdout = json.dumps(self.restored) + "\n"
+        return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
+
+
+class PgdumpRestoreCanaryTest(unittest.TestCase):
+    def test_success_restores_precious_tables_and_persists_receipt(self) -> None:
+        fake = FakeDocker()
+        with tempfile.TemporaryDirectory() as temp:
+            root = pathlib.Path(temp)
+            result = canary.run_canary(
+                "edge:us3", receipt_root=root, run=fake, sleep=lambda _: None
+            )
+            persisted = json.loads((root / "latest.json").read_text(encoding="utf-8"))
+            leftovers = sorted(path.name for path in root.iterdir())
+
+        self.assertEqual(result, persisted)
+        self.assertEqual(result["mode"], "pgdump_restore_canary")
+        self.assertEqual(result["target"], "edge:us3")
+        self.assertEqual(result["source_counts"], BEFORE)
+        self.assertEqual(result["restored_counts"], BEFORE)
+        self.assertEqual(result["artifact_bytes"], 4096)
+        self.assertEqual(len(result["artifact_sha256"]), 64)
+        self.assertFalse(result["source_mutated"])
+        self.assertFalse(result["deletion_authorized"])
+        self.assertEqual(leftovers, ["canary.lock", "latest.json"])
+
+        pg_dump = next(call for call in fake.calls if "pg_dump" in call)
+        self.assertIn("--exclude-table-data=usage_logs*", pg_dump)
+        self.assertIn("--exclude-table-data=ops_system_logs*", pg_dump)
+        run = next(call for call in fake.calls if call[:2] == ["docker", "run"])
+        self.assertIn("--network=none", run)
+        self.assertIn("--cpus=0.50", run)
+        self.assertIn("--memory=640m", run)
+        self.assertIn("--pull=never", run)
+        self.assertIn("postgres:18-alpine", run)
+
+    def test_restored_count_outside_source_window_fails_and_keeps_last_success(self) -> None:
+        restored = dict(BEFORE)
+        restored["accounts"] = 4
+        fake = FakeDocker(restored=restored)
+        with tempfile.TemporaryDirectory() as temp:
+            root = pathlib.Path(temp)
+            receipt = root / "latest.json"
+            receipt.write_text('{"previous":true}\n', encoding="utf-8")
+            with self.assertRaisesRegex(canary.CanaryError, "accounts"):
+                canary.run_canary(
+                    "prod", receipt_root=root, run=fake, sleep=lambda _: None
+                )
+            self.assertEqual(receipt.read_text(encoding="utf-8"), '{"previous":true}\n')
+
+        cleanup = [call for call in fake.calls if call[:3] == ["docker", "rm", "-f"]]
+        self.assertEqual(len(cleanup), 1)
+
+    def test_invalid_target_fails_before_docker(self) -> None:
+        fake = FakeDocker()
+        with tempfile.TemporaryDirectory() as temp:
+            with self.assertRaisesRegex(canary.CanaryError, "target"):
+                canary.run_canary(
+                    "edge:../../prod",
+                    receipt_root=pathlib.Path(temp),
+                    run=fake,
+                    sleep=lambda _: None,
+                )
+        self.assertEqual(fake.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/ops/stage0/test_pgdump_restore_canary_workflow.py
+++ b/ops/stage0/test_pgdump_restore_canary_workflow.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Contract tests for scheduled Fleet restore-canary orchestration."""
+
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+import yaml
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "ops-pgdump-restore-canary.yml"
+
+
+class PgdumpRestoreCanaryWorkflowTest(unittest.TestCase):
+    def test_schedule_dispatch_and_dynamic_fleet_matrix_are_fail_closed(self) -> None:
+        workflow = yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+        triggers = workflow["on"]
+        self.assertEqual(len(triggers["schedule"]), 1)
+        self.assertIn("target_selector", triggers["workflow_dispatch"]["inputs"])
+
+        discover = workflow["jobs"]["discover-targets"]
+        self.assertIn("matrix", discover["outputs"])
+        matrix_step = next(
+            step for step in discover["steps"] if step.get("id") == "matrix"
+        )
+        self.assertIn("--prod-ops-matrix", matrix_step["run"])
+        self.assertIn("--target-selector", matrix_step["run"])
+
+        restore = workflow["jobs"]["restore-canary"]
+        self.assertEqual(restore["strategy"]["fail-fast"], "false")
+        self.assertEqual(restore["permissions"]["id-token"], "write")
+        command = next(
+            step["run"]
+            for step in restore["steps"]
+            if step.get("name") == "Run isolated pg_dump restore canary"
+        )
+        self.assertIn("run-probe.sh", command)
+        self.assertIn("pgdump_restore_canary_remote.sh", command)
+        self.assertIn("pgdump_restore_canary.py", command)
+        self.assertNotIn("continue-on-error", restore)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1538,8 +1538,20 @@ elif ! python3 ./ops/migration/test_data_layer_partition_maintenance.py >/dev/nu
     echo "  FAIL: fixed partition maintenance controller contracts"
     echo "        - run: python3 ops/migration/test_data_layer_partition_maintenance.py"
     errors=$((errors + 1))
+elif ! python3 ./ops/migration/test_usage_logs_daily_partition.py >/dev/null 2>&1; then
+    echo "  FAIL: Fleet usage_logs daily partition operator contracts"
+    echo "        - run: python3 ops/migration/test_usage_logs_daily_partition.py"
+    errors=$((errors + 1))
+elif ! python3 ./ops/stage0/test_pgdump_restore_canary.py >/dev/null 2>&1; then
+    echo "  FAIL: Fleet pg_dump restore canary contracts"
+    echo "        - run: python3 ops/stage0/test_pgdump_restore_canary.py"
+    errors=$((errors + 1))
+elif ! python3 ./ops/stage0/test_pgdump_restore_canary_workflow.py >/dev/null 2>&1; then
+    echo "  FAIL: Fleet pg_dump restore canary workflow contracts"
+    echo "        - run: python3 ops/stage0/test_pgdump_restore_canary_workflow.py"
+    errors=$((errors + 1))
 else
-    echo "  ok: fail-closed probes + fixed partition repair controller"
+    echo "  ok: fail-closed probes + Fleet restore and partition operators"
 fi
 
 # ---- sub2api: single app-container resolver owner --------------------------


### PR DESCRIPTION
## 摘要

- 新增每周 Fleet 恢复 canary：动态覆盖 prod 与当前 deployable Edge，在目标主机生成仅含珍贵数据类的 custom-format pg_dump，并在无网络、CPU/内存受限的临时 PostgreSQL 中恢复。
- 恢复成功必须校验 users、accounts、api_keys、groups、settings、usage_billing_dedup 的行数落在源库前后计数窗口内；失败保留上一份成功 receipt，临时 dump 与容器始终清理。
- 将 usage_logs 日分区唯一 operator 从 prod 推广到 prod 与 edge:<id>，confirmation、远端 receipt、本地 receipt 和实例解析均绑定 target，跨节点复用时 fail closed。
- 同步 agent-facing CLI 契约、当前操作文档与 preflight 机械门禁。

## 风险

- 定时 canary 会在每个节点执行一次只读 pg_dump，并短暂启动受限临时 PostgreSQL；临时容器限制为 0.5 CPU、640 MiB 内存且禁用网络。
- canary 不修改线上数据库、不保留临时 dump、不授权删除。
- 本 PR 只交付 Edge 分区 operator，不执行 prepare、cutover、abort 或线上 rollout。
- 本机未安装 actionlint；workflow 已通过仓库 workflow YAML 守卫及 YAML 行为契约测试。

## 验证

- PREFLIGHT_BASE=origin/main bash scripts/preflight.sh
- python3 ops/stage0/test_pgdump_restore_canary.py -v
- python3 ops/stage0/test_pgdump_restore_canary_workflow.py -v
- python3 ops/migration/test_usage_logs_daily_partition.py -v
- python3 scripts/export_agent_contract.py --check
- python3 -m py_compile ops/stage0/pgdump_restore_canary.py ops/migration/usage_logs_daily_partition.py ops/migration/usage_logs_daily_partition_remote.py
- bash -n ops/stage0/pgdump_restore_canary_remote.sh ops/migration/usage_logs_daily_partition_remote.sh

## 提交

- a64173e53 feat(ops): verify Fleet restores and generalize usage partitions

最新提交：a64173e53