### PR TITLE
fix(ops): stabilize backups template round trip

### DIFF
--- a/deploy/aws/cloudformation/stage0-backups.yaml
+++ b/deploy/aws/cloudformation/stage0-backups.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >
-  tokenkey (sub2api fork) Stage 0 standalone S3 stack — does NOT modify the live
+  tokenkey (sub2api fork) Stage 0 standalone S3 stack - does NOT modify the live
   prod instance stack: each bucket policy grants the existing app InstanceRole
   directly (same-account resource-based grant), so no update-stack on
   tokenkey-prod-stage0. Holds two buckets, both using the direct-role-ARN pattern:
@@ -8,7 +8,7 @@ Description: >
   (2) generated-media offload (media_storage): OPT-IN image offload only (set
   MEDIA_STORAGE_IMAGE_OFFLOAD_ENABLED=true), plus re-presign of legacy
   already-offloaded video records. By default NEITHER image nor video rehosts
-  fresh results — they pass through inline (the gateway is not a media CDN).
+  fresh results - they pass through inline (the gateway is not a media CDN).
   media/ prefix, MediaRetentionDays (default 1). No versioning (keys are unique).
 
 Parameters:
@@ -92,10 +92,10 @@ Resources:
               Bool:
                 'aws:SecureTransport': 'false'
           # Grant the app instance role write (and read-for-restore) on the
-          # prod/pgdump/* prefix. The role ARN is named DIRECTLY as Principal —
+          # prod/pgdump/* prefix. The role ARN is named DIRECTLY as Principal -
           # same-account resource-based grant is then sufficient on its own, so we
           # never touch the prod instance stack. (An account-root principal is only
-          # a delegation and would ALSO require an identity policy — verified the
+          # a delegation and would ALSO require an identity policy - verified the
           # hard way: it AccessDenied'd s3:PutObject on first activation.)
           - Sid: AllowAppInstanceRolePutGet
             Effect: Allow
@@ -158,7 +158,7 @@ Resources:
             Condition:
               Bool:
                 'aws:SecureTransport': 'false'
-          # Same direct-role-ARN principal pattern as above — same-account
+          # Same direct-role-ARN principal pattern as above - same-account
           # resource-based grant, so the prod instance stack is never touched. The
           # app writes generated image media (PutObject) and signs/serves
           # presigned GET URLs (GetObject). Legacy video objects may still be
@@ -173,16 +173,16 @@ Resources:
               - 's3:GetObject'
             Resource: !Sub '${MediaBucket.Arn}/media/*'
 
-  # NOTE — the .env SECRETS off-box (SSM SecureString, a DIFFERENT blast radius than this
+  # NOTE - the .env SECRETS off-box (SSM SecureString, a DIFFERENT blast radius than this
   # dump bucket so the decryption keys are not co-located with the ciphertext) needs an
-  # IDENTITY grant (ssm:PutParameter), because SSM Parameters have no resource policy — a
+  # IDENTITY grant (ssm:PutParameter), because SSM Parameters have no resource policy - a
   # bucket-style same-account either/or grant is impossible. That grant therefore canNOT
   # live in this standalone stack without an iam:CreatePolicy capability no available
   # principal has. Its DURABLE home is the prod InstanceRole in stage0-single-ec2.yaml
   # (ssm:PutParameter on .../stage0/env-secrets-backup), applied on the next prod CFN
   # update; until then it is mirrored as a manual inline policy (EnvSecretsBackup) added
   # on the role via the IAM console. See ops/stage0/backup-env-secrets-via-ssm.sh +
-  # RUNBOOK §4.4. The EnvSecretsSsmParam output below documents the param name to wire.
+  # RUNBOOK section 4.4. The EnvSecretsSsmParam output below documents the param name to wire.
 
 Outputs:
   BucketName:
@@ -200,7 +200,7 @@ Outputs:
       + MEDIA_STORAGE_REGION=<region> in the app env to enable legacy video re-presign;
       add MEDIA_STORAGE_IMAGE_OFFLOAD_ENABLED=true to additionally opt back into image
       S3 offload (off by default = images pass through inline). Credentials come from the
-      instance role — leave MEDIA_STORAGE_ACCESS_KEY_ID unset.
+      instance role - leave MEDIA_STORAGE_ACCESS_KEY_ID unset.
     Value: !Ref MediaBucket
   MediaS3Uri:
     Description: s3:// base for generated media; objects land under media/ (reaped by expire-generated-media).

--- a/deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py
+++ b/deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py
@@ -309,6 +309,12 @@ class Stage0QABundleContractTest(unittest.TestCase):
             with self.subTest(surface=surface):
                 self.assertNotIn("QA_CAPTURE_EXPORT_STORAGE", surface.read_text(encoding="utf-8"))
 
+    def test_backups_template_is_ascii_for_cloudformation_round_trip(self) -> None:
+        backups_text = (
+            ROOT / "deploy/aws/cloudformation/stage0-backups.yaml"
+        ).read_text(encoding="utf-8")
+        self.assertTrue(backups_text.isascii())
+
     def test_backups_template_has_no_legacy_export_owner(self) -> None:
         backups = yaml.load(
             (ROOT / "deploy/aws/cloudformation/stage0-backups.yaml").read_text(encoding="utf-8"),


### PR DESCRIPTION
## Summary
- replace non-ASCII punctuation in the Stage0 backups CloudFormation template with ASCII equivalents
- add a focused guard requiring this exact-review template to remain ASCII
- preserve all parameters, resources, policies, outputs, and runtime behavior

## Why
CloudFormation normalized em dashes to question marks when the template was submitted for a no-execute change set. The resource change list was correct, but the returned TemplateBody digest no longer matched the reviewed repository bytes, so the artifact was rejected and deleted. This makes the template byte-stable for the next separately approved no-execute review.

## Validation
- AWS cloudformation validate-template; returned Description matched the local parsed value exactly
- CloudFormation-aware comparison against main: only Description and MediaBucketName.Description punctuation changed; no resource-tree changes
- python3 deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py
- python3 deploy/aws/cloudformation/test_stage0_edge_qa_s3_boundary.py
- python3 deploy/aws/cloudformation/test_stage0_qa_raw_archive_contract.py
- python3 ops/qa/test_qa_phase_ops.py
- staged full scripts/preflight.sh
- make test

New template SHA-256: d3f9de4eff018481c5b4b3e90db66245481fd9cd8a685db9835583f9db4713bf

## Operational boundary
Repository-only fix. No CloudFormation change set was created or executed, and no production stack, bucket, bucket policy, retention, data, deploy, release, or rollout state was changed. A fresh no-execute change set and any later execution remain independent approval gates.

no-web-impact

ai