### PR TITLE
fix(openai): OAuth 请求 summary=auto 并在 QA 记录 encrypted_content

### DIFF
--- a/backend/internal/observability/qa/internal_thinking_capture_test.go
+++ b/backend/internal/observability/qa/internal_thinking_capture_test.go
@@ -3,12 +3,61 @@
 package qa
 
 import (
+	"encoding/json"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCaptureEncryptedReasoning_PreservesCiphertext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Set("ops_openai_encrypted_reasoning", []string{
+		`{"item_id":"rs_1","encrypted_content":"gAAAA-REAL-CIPHER"}`,
+	})
+
+	got := captureEncryptedReasoning(c)
+	require.Len(t, got, 1)
+	require.Contains(t, got[0], `"item_id":"rs_1"`)
+	require.Contains(t, got[0], "gAAAA-REAL-CIPHER")
+	require.NotContains(t, got[0], "***")
+}
+
+func TestBuildBlob_EncryptedReasoningField(t *testing.T) {
+	svc := &Service{bodyMaxBytes: 256 * 1024}
+	input := CaptureInput{
+		RequestID:              "req-enc-1",
+		InboundEndpoint:        "/v1/responses",
+		StatusCode:             200,
+		CreatedAt:              time.Now().UTC(),
+		RequestBody:            []byte(`{"model":"gpt-5.4-mini"}`),
+		ResponseBody:           []byte(`{"id":"resp_1"}`),
+		EncryptedReasoningJSON: []string{`{"item_id":"rs_1","encrypted_content":"gAAAA-QA"}`},
+	}
+
+	compressed, _, _, _, err := svc.buildBlob(input)
+	require.NoError(t, err)
+
+	dec, err := zstd.NewReader(nil)
+	require.NoError(t, err)
+	defer dec.Close()
+	raw, err := dec.DecodeAll(compressed, nil)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(raw, &payload))
+	resp, ok := payload["response"].(map[string]any)
+	require.True(t, ok)
+	blocks, ok := resp["encrypted_reasoning"].([]any)
+	require.True(t, ok)
+	require.Len(t, blocks, 1)
+	require.Contains(t, blocks[0], "gAAAA-QA")
+	require.Contains(t, blocks[0], `"item_id":"rs_1"`)
+}
 
 func TestCaptureInternalThinkingBlocks_KiroIndependentOfClientWire(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/backend/internal/observability/qa/service.go
+++ b/backend/internal/observability/qa/service.go
@@ -375,6 +375,7 @@ func (s *Service) CaptureFromContext(c *gin.Context) {
 		Tags:                       captureTags(requestBody, responseBody, status, responseTruncated),
 		CreatedAt:                  time.Now().UTC(),
 		InternalThinkingBlocksJSON: captureInternalThinkingBlocks(c),
+		EncryptedReasoningJSON:     captureEncryptedReasoning(c),
 		SynthSessionID:             synthSession,
 		SynthRole:                  synthRole,
 		SynthEngineerLevel:         synthLevel,
@@ -609,6 +610,11 @@ func (s *Service) buildBlob(input CaptureInput) ([]byte, string, string, []strin
 	if len(input.InternalThinkingBlocksJSON) > 0 {
 		if resp, ok := payload["response"].(map[string]any); ok {
 			resp["internal_thinking_blocks"] = input.InternalThinkingBlocksJSON
+		}
+	}
+	if len(input.EncryptedReasoningJSON) > 0 {
+		if resp, ok := payload["response"].(map[string]any); ok {
+			resp["encrypted_reasoning"] = input.EncryptedReasoningJSON
 		}
 	}
 	raw, err := json.Marshal(payload)
@@ -1010,6 +1016,10 @@ func captureInternalThinkingBlocks(c *gin.Context) []string {
 		return nil
 	}
 	return out
+}
+
+func captureEncryptedReasoning(c *gin.Context) []string {
+	return captureInternalThinkingBlocksFromKey(c, "ops_openai_encrypted_reasoning")
 }
 
 func captureInternalThinkingBlocksFromKey(c *gin.Context, key string) []string {

--- a/backend/internal/observability/qa/types.go
+++ b/backend/internal/observability/qa/types.go
@@ -47,6 +47,9 @@ type CaptureInput struct {
 	Tags                       []string
 	CreatedAt                  time.Time
 	InternalThinkingBlocksJSON []string
+	// EncryptedReasoningJSON 记录 OpenAI OAuth reasoning.encrypted_content
+	//（完整推理密文）。键名不用 signature，避免 logredact 打成 ***。
+	EncryptedReasoningJSON []string
 
 	// issue #59 Gap 2: synthetic-pipeline tagging headers.
 	// X-Synth-Pipeline is only used to compute DialogSynth (no schema

--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -420,6 +420,109 @@ func TestResponsesToAnthropic_Reasoning(t *testing.T) {
 	assert.Equal(t, "42", anth.Content[1].Text)
 }
 
+func TestResponsesToAnthropic_ReasoningTextFromContent(t *testing.T) {
+	anth := ResponsesToAnthropic(&ResponsesResponse{
+		ID:     "resp_cot",
+		Model:  "gpt-5.4-mini",
+		Status: "completed",
+		Output: []ResponsesOutput{
+			{
+				Type:             "reasoning",
+				EncryptedContent: "enc-content-only",
+				Content: []ResponsesContentPart{
+					{Type: "reasoning_text", Text: "content-only thought"},
+				},
+			},
+			{
+				Type: "message",
+				Content: []ResponsesContentPart{
+					{Type: "output_text", Text: "ok"},
+				},
+			},
+		},
+	}, "claude-opus-4-6")
+	require.Len(t, anth.Content, 2)
+	assert.Equal(t, "thinking", anth.Content[0].Type)
+	assert.Equal(t, "content-only thought", anth.Content[0].Thinking)
+	assert.Equal(t, "enc-content-only", anth.Content[0].Signature)
+}
+
+func TestResponsesEventToAnthropic_OutputItemDoneBackfillsReasoningText(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:     "response.created",
+		Response: &ResponsesResponse{ID: "resp_done_only", Model: "gpt-5.4-mini"},
+	}, state)
+
+	events := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:        "response.output_item.done",
+		OutputIndex: 0,
+		Item: &ResponsesOutput{
+			Type:             "reasoning",
+			EncryptedContent: "enc-done-only",
+			Content: []ResponsesContentPart{
+				{Type: "reasoning_text", Text: "done-only thought"},
+			},
+			Summary: []ResponsesSummary{
+				{Type: "summary_text", Text: "short summary"},
+			},
+		},
+	}, state)
+
+	var thinking string
+	var signature string
+	var sawStart, sawStop bool
+	for _, evt := range events {
+		switch evt.Type {
+		case "content_block_start":
+			if evt.ContentBlock != nil && evt.ContentBlock.Type == "thinking" {
+				sawStart = true
+			}
+		case "content_block_delta":
+			if evt.Delta != nil && evt.Delta.Type == "thinking_delta" {
+				thinking += evt.Delta.Thinking
+			}
+			if evt.Delta != nil && evt.Delta.Type == "signature_delta" {
+				signature = evt.Delta.Signature
+			}
+		case "content_block_stop":
+			sawStop = true
+		}
+	}
+	require.True(t, sawStart)
+	require.True(t, sawStop)
+	assert.Equal(t, "short summary", thinking)
+	assert.Equal(t, "enc-done-only", signature)
+}
+
+func TestResponsesEventToAnthropic_OutputItemDoneDoesNotDuplicateReasoningDelta(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:     "response.created",
+		Response: &ResponsesResponse{ID: "resp_dup", Model: "gpt-5.4-mini"},
+	}, state)
+	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:        "response.reasoning_summary_text.delta",
+		OutputIndex: 0,
+		Delta:       "already streamed",
+	}, state)
+
+	events := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:        "response.output_item.done",
+		OutputIndex: 0,
+		Item: &ResponsesOutput{
+			Type:             "reasoning",
+			EncryptedContent: "enc-dup",
+			Summary: []ResponsesSummary{
+				{Type: "summary_text", Text: "already streamed"},
+			},
+		},
+	}, state)
+	require.Len(t, events, 2)
+	assert.Equal(t, "signature_delta", events[0].Delta.Type)
+	assert.Equal(t, "content_block_stop", events[1].Type)
+}
+
 func TestResponsesToAnthropic_StreamEmitsThinkingSignature(t *testing.T) {
 	state := NewResponsesEventToAnthropicState()
 	var all []AnthropicStreamEvent

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
@@ -660,6 +660,30 @@ func isBlankChatContent(raw json.RawMessage) bool {
 // reasoning item. The Chat→Responses bridge writes the upstream reasoning_content
 // verbatim into the summary_text parts (see closeChatReasoningItem), so codex
 // round-trips it there; prefer summary[].text and fall back to content.
+// extractResponsesOutputReasoningText pulls visible reasoning from a typed
+// Responses output item. Prefer summary (short plaintext) then content[].reasoning_text
+// (full text when upstream only ships it on output_item.done).
+func extractResponsesOutputReasoningText(item *ResponsesOutput) string {
+	if item == nil {
+		return ""
+	}
+	var parts []string
+	for _, s := range item.Summary {
+		if s.Text != "" {
+			parts = append(parts, s.Text)
+		}
+	}
+	if len(parts) > 0 {
+		return strings.Join(parts, "")
+	}
+	for _, p := range item.Content {
+		if p.Type == "reasoning_text" && p.Text != "" {
+			parts = append(parts, p.Text)
+		}
+	}
+	return strings.Join(parts, "")
+}
+
 func extractResponsesReasoningText(item map[string]json.RawMessage) string {
 	var parts []string
 	collect := func(raw json.RawMessage) {

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
@@ -656,10 +656,6 @@ func isBlankChatContent(raw json.RawMessage) bool {
 	return chatMessageContentText(raw) == ""
 }
 
-// extractResponsesReasoningText pulls the reasoning text out of a Responses
-// reasoning item. The Chat→Responses bridge writes the upstream reasoning_content
-// verbatim into the summary_text parts (see closeChatReasoningItem), so codex
-// round-trips it there; prefer summary[].text and fall back to content.
 // extractResponsesOutputReasoningText pulls visible reasoning from a typed
 // Responses output item. Prefer summary (short plaintext) then content[].reasoning_text
 // (full text when upstream only ships it on output_item.done).
@@ -684,6 +680,10 @@ func extractResponsesOutputReasoningText(item *ResponsesOutput) string {
 	return strings.Join(parts, "")
 }
 
+// extractResponsesReasoningText pulls the reasoning text out of a Responses
+// reasoning item. The Chat→Responses bridge writes the upstream reasoning_content
+// verbatim into the summary_text parts (see closeChatReasoningItem), so codex
+// round-trips it there; prefer summary[].text and fall back to content.
 func extractResponsesReasoningText(item map[string]json.RawMessage) string {
 	var parts []string
 	collect := func(raw json.RawMessage) {

--- a/backend/internal/pkg/apicompat/responses_to_anthropic.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic.go
@@ -27,19 +27,14 @@ func ResponsesToAnthropic(resp *ResponsesResponse, model string) *AnthropicRespo
 	for _, item := range resp.Output {
 		switch item.Type {
 		case "reasoning":
-			summaryText := ""
-			for _, s := range item.Summary {
-				if s.Type == "summary_text" && s.Text != "" {
-					summaryText += s.Text
-				}
-			}
 			// Always surface encrypted_content as thinking.signature so Claude
 			// Code / multi-turn clients can send it back. Signature-only
 			// thinking blocks are valid when the model omits a visible summary.
-			if summaryText != "" || strings.TrimSpace(item.EncryptedContent) != "" {
+			thinkingText := extractResponsesOutputReasoningText(&item)
+			if thinkingText != "" || strings.TrimSpace(item.EncryptedContent) != "" {
 				blocks = append(blocks, AnthropicContentBlock{
 					Type:      "thinking",
-					Thinking:  summaryText,
+					Thinking:  thinkingText,
 					Signature: item.EncryptedContent,
 				})
 			}
@@ -197,6 +192,8 @@ type ResponsesEventToAnthropicState struct {
 	// PendingThinkingSignature is filled from reasoning.encrypted_content and
 	// emitted as signature_delta before the thinking block is closed.
 	PendingThinkingSignature string
+	// ReasoningTextEmitted 避免 output_item.done 在已有 delta 时重复抄 thinking。
+	ReasoningTextEmitted bool
 
 	// OutputIndexToBlockIdx maps Responses output_index → Anthropic content block index.
 	OutputIndexToBlockIdx map[int]int
@@ -603,6 +600,7 @@ func resToAnthHandleReasoningDelta(evt *ResponsesStreamEvent, state *ResponsesEv
 			Thinking: evt.Delta,
 		},
 	})
+	state.ReasoningTextEmitted = true
 	return events
 }
 
@@ -627,6 +625,24 @@ func resToAnthHandleOutputItemDone(evt *ResponsesStreamEvent, state *ResponsesEv
 	if evt.Item.Type == "reasoning" {
 		if sig := strings.TrimSpace(evt.Item.EncryptedContent); sig != "" {
 			state.PendingThinkingSignature = sig
+		}
+		if !state.ReasoningTextEmitted {
+			if text := extractResponsesOutputReasoningText(evt.Item); text != "" {
+				var events []AnthropicStreamEvent
+				events = append(events, resToAnthEnsureReasoningBlockOpen(state, evt.OutputIndex)...)
+				blockIdx := state.OutputIndexToBlockIdx[evt.OutputIndex]
+				events = append(events, AnthropicStreamEvent{
+					Type:  "content_block_delta",
+					Index: &blockIdx,
+					Delta: &AnthropicDelta{
+						Type:     "thinking_delta",
+						Thinking: text,
+					},
+				})
+				state.ReasoningTextEmitted = true
+				events = append(events, closeCurrentBlock(state)...)
+				return events
+			}
 		}
 	}
 

--- a/backend/internal/pkg/apicompat/responses_to_chatcompletions.go
+++ b/backend/internal/pkg/apicompat/responses_to_chatcompletions.go
@@ -51,11 +51,7 @@ func ResponsesToChatCompletions(resp *ResponsesResponse, model string) *ChatComp
 				},
 			})
 		case "reasoning":
-			for _, s := range item.Summary {
-				if s.Type == "summary_text" && s.Text != "" {
-					reasoningText += s.Text
-				}
-			}
+			reasoningText += extractResponsesOutputReasoningText(&item)
 		case "web_search_call":
 			// silently consumed — results already incorporated into text output
 		}
@@ -126,6 +122,8 @@ type ResponsesEventToChatState struct {
 	OutputIndexToToolIndex map[int]int // Responses output_index → Chat tool_calls index
 	IncludeUsage           bool
 	Usage                  *ChatUsage
+	// ReasoningTextEmitted 避免 output_item.done 在已有 delta 时重复抄 reasoning_content。
+	ReasoningTextEmitted bool
 }
 
 // NewResponsesEventToChatState returns an initialised stream state.
@@ -157,6 +155,8 @@ func ResponsesEventToChatChunks(evt *ResponsesStreamEvent, state *ResponsesEvent
 		// 与 reasoning summary 一样映射为 reasoning_content。
 		"response.reasoning_text.delta":
 		return resToChatHandleReasoningDelta(evt, state)
+	case "response.output_item.done":
+		return resToChatHandleOutputItemDone(evt, state)
 	case "response.reasoning_summary_text.done":
 		return nil
 	// response.done 是 Realtime/WS 与项目透传路径使用的终止别名；
@@ -286,8 +286,21 @@ func resToChatHandleReasoningDelta(evt *ResponsesStreamEvent, state *ResponsesEv
 	if evt.Delta == "" {
 		return nil
 	}
+	state.ReasoningTextEmitted = true
 	reasoning := evt.Delta
 	return []ChatCompletionsChunk{makeChatDeltaChunk(state, ChatDelta{ReasoningContent: &reasoning})}
+}
+
+func resToChatHandleOutputItemDone(evt *ResponsesStreamEvent, state *ResponsesEventToChatState) []ChatCompletionsChunk {
+	if state.ReasoningTextEmitted || evt.Item == nil || evt.Item.Type != "reasoning" {
+		return nil
+	}
+	text := extractResponsesOutputReasoningText(evt.Item)
+	if text == "" {
+		return nil
+	}
+	state.ReasoningTextEmitted = true
+	return []ChatCompletionsChunk{makeChatDeltaChunk(state, ChatDelta{ReasoningContent: &text})}
 }
 
 func resToChatHandleCompleted(evt *ResponsesStreamEvent, state *ResponsesEventToChatState) []ChatCompletionsChunk {

--- a/backend/internal/pkg/apicompat/responses_to_chatcompletions_codex_events_test.go
+++ b/backend/internal/pkg/apicompat/responses_to_chatcompletions_codex_events_test.go
@@ -57,6 +57,73 @@ func TestResponsesEventToChatChunks_ReasoningTextDelta(t *testing.T) {
 	assert.Equal(t, "thinking step", *chunks[0].Choices[0].Delta.ReasoningContent)
 }
 
+func TestResponsesEventToChatChunks_OutputItemDoneBackfillsReasoningText(t *testing.T) {
+	state := NewResponsesEventToChatState()
+	state.Model = "gpt-5.4-mini"
+	state.SentRole = true
+
+	chunks := ResponsesEventToChatChunks(&ResponsesStreamEvent{
+		Type:        "response.output_item.done",
+		OutputIndex: 0,
+		Item: &ResponsesOutput{
+			Type: "reasoning",
+			Content: []ResponsesContentPart{
+				{Type: "reasoning_text", Text: "full chain of thought"},
+			},
+		},
+	}, state)
+	require.Len(t, chunks, 1)
+	require.NotNil(t, chunks[0].Choices[0].Delta.ReasoningContent)
+	assert.Equal(t, "full chain of thought", *chunks[0].Choices[0].Delta.ReasoningContent)
+}
+
+func TestResponsesEventToChatChunks_OutputItemDoneDoesNotDuplicateReasoningDelta(t *testing.T) {
+	state := NewResponsesEventToChatState()
+	state.Model = "gpt-5.4-mini"
+	state.SentRole = true
+
+	chunks := ResponsesEventToChatChunks(&ResponsesStreamEvent{
+		Type:  "response.reasoning_text.delta",
+		Delta: "already streamed",
+	}, state)
+	require.Len(t, chunks, 1)
+
+	chunks = ResponsesEventToChatChunks(&ResponsesStreamEvent{
+		Type:        "response.output_item.done",
+		OutputIndex: 0,
+		Item: &ResponsesOutput{
+			Type: "reasoning",
+			Content: []ResponsesContentPart{
+				{Type: "reasoning_text", Text: "already streamed"},
+			},
+		},
+	}, state)
+	require.Empty(t, chunks)
+}
+
+func TestResponsesToChatCompletions_ReasoningTextFromContent(t *testing.T) {
+	chat := ResponsesToChatCompletions(&ResponsesResponse{
+		ID:     "resp_cot",
+		Status: "completed",
+		Output: []ResponsesOutput{
+			{
+				Type: "reasoning",
+				Content: []ResponsesContentPart{
+					{Type: "reasoning_text", Text: "content-only thought"},
+				},
+			},
+			{
+				Type: "message",
+				Content: []ResponsesContentPart{
+					{Type: "output_text", Text: "ok"},
+				},
+			},
+		},
+	}, "gpt-5.4-mini")
+	require.Len(t, chat.Choices, 1)
+	assert.Equal(t, "content-only thought", chat.Choices[0].Message.ReasoningContent)
+}
+
 // 缓冲（非流式）累加器同样需识别两类新事件。
 func TestBufferedResponseAccumulator_CodexEvents(t *testing.T) {
 	acc := NewBufferedResponseAccumulator()

--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -188,8 +188,12 @@ func applyCodexOAuthTransformWithOptions(reqBody map[string]any, opts codexOAuth
 		}
 	}
 
-	// 请求带 reasoning 时补齐 include:["reasoning.encrypted_content"]，与真实 Codex 对齐
-	// （compact 端点形态不同，单独处理，此处跳过）。
+	// OAuth 出站一律打开 reasoning.summary=auto，才能拿到上游明文 summary；
+	// 同时 reasoning 非空后 complement include encrypted_content，供 QA 记录完整推理密文。
+	// compact 端点形态不同，单独处理，此处跳过。
+	if !opts.IsCompact && ensureCodexReasoningSummaryAuto(reqBody) {
+		result.Modified = true
+	}
 	if !opts.IsCompact && ensureCodexReasoningInclude(reqBody) {
 		result.Modified = true
 	}
@@ -1307,6 +1311,32 @@ func defaultCodexSynthInstructions(model string) string {
 		return instructions
 	}
 	return "You are a helpful coding assistant."
+}
+
+// ensureCodexReasoningSummaryAuto 为 OAuth 出站补齐 reasoning.summary=auto。
+//
+// ChatGPT Codex 只有请求 summary=auto 才会下发明文 reasoning summary；
+// 不带该字段时只有内部 reasoning_tokens，客户端/QA 都看不到摘要。
+// 加法式：无 reasoning 则创建；已有 map 则写入/覆盖 summary=auto，保留 effort 等其它键。
+func ensureCodexReasoningSummaryAuto(reqBody map[string]any) bool {
+	if reqBody == nil {
+		return false
+	}
+	const auto = "auto"
+	switch existing := reqBody["reasoning"].(type) {
+	case nil:
+		reqBody["reasoning"] = map[string]any{"summary": auto}
+		return true
+	case map[string]any:
+		if s, ok := existing["summary"].(string); ok && s == auto {
+			return false
+		}
+		existing["summary"] = auto
+		reqBody["reasoning"] = existing
+		return true
+	default:
+		return false
+	}
 }
 
 // ensureCodexReasoningInclude 在请求带 reasoning 时补齐 include:["reasoning.encrypted_content"]。

--- a/backend/internal/service/openai_codex_transform_additions_test.go
+++ b/backend/internal/service/openai_codex_transform_additions_test.go
@@ -17,12 +17,16 @@ func TestEnsureCodexReasoningSummaryAuto(t *testing.T) {
 
 	body2 := map[string]any{"reasoning": map[string]any{"effort": "medium"}}
 	require.True(t, ensureCodexReasoningSummaryAuto(body2))
-	require.Equal(t, "medium", body2["reasoning"].(map[string]any)["effort"])
-	require.Equal(t, "auto", body2["reasoning"].(map[string]any)["summary"])
+	reasoning2, ok := body2["reasoning"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "medium", reasoning2["effort"])
+	require.Equal(t, "auto", reasoning2["summary"])
 
 	body3 := map[string]any{"reasoning": map[string]any{"effort": "high", "summary": "concise"}}
 	require.True(t, ensureCodexReasoningSummaryAuto(body3))
-	require.Equal(t, "auto", body3["reasoning"].(map[string]any)["summary"])
+	reasoning3, ok := body3["reasoning"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "auto", reasoning3["summary"])
 }
 
 func TestApplyCodexOAuthTransform_AlwaysSetsReasoningSummaryAuto(t *testing.T) {

--- a/backend/internal/service/openai_codex_transform_additions_test.go
+++ b/backend/internal/service/openai_codex_transform_additions_test.go
@@ -7,6 +7,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestEnsureCodexReasoningSummaryAuto(t *testing.T) {
+	body := map[string]any{"model": "gpt-5.4-mini"}
+	require.True(t, ensureCodexReasoningSummaryAuto(body))
+	reasoning, ok := body["reasoning"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "auto", reasoning["summary"])
+	require.False(t, ensureCodexReasoningSummaryAuto(body))
+
+	body2 := map[string]any{"reasoning": map[string]any{"effort": "medium"}}
+	require.True(t, ensureCodexReasoningSummaryAuto(body2))
+	require.Equal(t, "medium", body2["reasoning"].(map[string]any)["effort"])
+	require.Equal(t, "auto", body2["reasoning"].(map[string]any)["summary"])
+
+	body3 := map[string]any{"reasoning": map[string]any{"effort": "high", "summary": "concise"}}
+	require.True(t, ensureCodexReasoningSummaryAuto(body3))
+	require.Equal(t, "auto", body3["reasoning"].(map[string]any)["summary"])
+}
+
+func TestApplyCodexOAuthTransform_AlwaysSetsReasoningSummaryAuto(t *testing.T) {
+	reqBody := map[string]any{"model": "gpt-5.4-mini", "input": "hello"}
+	result := applyCodexOAuthTransform(reqBody, false, false)
+	require.True(t, result.Modified)
+	reasoning, ok := reqBody["reasoning"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "auto", reasoning["summary"])
+	require.Equal(t, []any{"reasoning.encrypted_content"}, reqBody["include"])
+
+	compact := map[string]any{"model": "gpt-5.4-mini", "input": "hello"}
+	applyCodexOAuthTransform(compact, false, true)
+	_, hasReasoning := compact["reasoning"]
+	require.False(t, hasReasoning, "compact 端点形态不同，不强制 reasoning.summary")
+}
+
 // ensureCodexReasoningInclude：带 reasoning 时补齐 include，幂等且保留既有项。
 func TestEnsureCodexReasoningInclude(t *testing.T) {
 	// reasoning 存在、include 缺失 → 注入

--- a/backend/internal/service/openai_encrypted_reasoning_qa.go
+++ b/backend/internal/service/openai_encrypted_reasoning_qa.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
+
+const openaiEncryptedReasoningGinKey = "ops_openai_encrypted_reasoning"
+
+// stashOpenAIEncryptedReasoningFromSSE 从 Responses SSE/JSON 抽出 reasoning.encrypted_content，
+// 写入 gin context 供 QA blob response.encrypted_reasoning 记录。
+func stashOpenAIEncryptedReasoningFromSSE(c *gin.Context, data []byte) {
+	if c == nil || len(data) == 0 || !gjson.ValidBytes(data) {
+		return
+	}
+	if item := gjson.GetBytes(data, "item"); item.Exists() {
+		stashOpenAIEncryptedReasoningItem(c, item)
+	}
+	if output := gjson.GetBytes(data, "response.output"); output.IsArray() {
+		output.ForEach(func(_, item gjson.Result) bool {
+			stashOpenAIEncryptedReasoningItem(c, item)
+			return true
+		})
+		return
+	}
+	if output := gjson.GetBytes(data, "output"); output.IsArray() {
+		output.ForEach(func(_, item gjson.Result) bool {
+			stashOpenAIEncryptedReasoningItem(c, item)
+			return true
+		})
+	}
+}
+
+func stashOpenAIEncryptedReasoningItem(c *gin.Context, item gjson.Result) {
+	if item.Get("type").String() != "reasoning" {
+		return
+	}
+	enc := strings.TrimSpace(item.Get("encrypted_content").String())
+	if enc == "" {
+		return
+	}
+	id := strings.TrimSpace(item.Get("id").String())
+	raw, err := json.Marshal(map[string]string{
+		"item_id":           id,
+		"encrypted_content": enc,
+	})
+	if err != nil {
+		return
+	}
+	block := string(raw)
+	existing, _ := c.Get(openaiEncryptedReasoningGinKey)
+	prior, _ := existing.([]string)
+	for _, seen := range prior {
+		if seen == block {
+			return
+		}
+	}
+	c.Set(openaiEncryptedReasoningGinKey, append(append([]string{}, prior...), block))
+}

--- a/backend/internal/service/openai_encrypted_reasoning_qa_test.go
+++ b/backend/internal/service/openai_encrypted_reasoning_qa_test.go
@@ -1,0 +1,38 @@
+package service
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStashOpenAIEncryptedReasoningFromSSE_OutputItemDone(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	stashOpenAIEncryptedReasoningFromSSE(c, []byte(`{"type":"response.output_item.done","item":{"id":"rs_1","type":"reasoning","encrypted_content":"gAAAA-ITEM"}}`))
+	stashOpenAIEncryptedReasoningFromSSE(c, []byte(`{"type":"response.output_text.delta","delta":"hi"}`))
+	stashOpenAIEncryptedReasoningFromSSE(c, []byte(`{"type":"response.completed","response":{"output":[{"id":"rs_1","type":"reasoning","encrypted_content":"gAAAA-ITEM"},{"id":"rs_2","type":"reasoning","encrypted_content":"gAAAA-DONE"}]}}`))
+
+	got, ok := c.Get(openaiEncryptedReasoningGinKey)
+	require.True(t, ok)
+	blocks, ok := got.([]string)
+	require.True(t, ok)
+	require.Len(t, blocks, 2)
+	require.Contains(t, blocks[0], `"item_id":"rs_1"`)
+	require.Contains(t, blocks[0], "gAAAA-ITEM")
+	require.Contains(t, blocks[1], `"item_id":"rs_2"`)
+	require.Contains(t, blocks[1], "gAAAA-DONE")
+}
+
+func TestStashOpenAIEncryptedReasoningFromSSE_IgnoresEmptyAndNonReasoning(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	stashOpenAIEncryptedReasoningFromSSE(c, []byte(`{"type":"response.output_item.done","item":{"id":"msg_1","type":"message","encrypted_content":""}}`))
+	stashOpenAIEncryptedReasoningFromSSE(c, nil)
+	_, ok := c.Get(openaiEncryptedReasoningGinKey)
+	require.False(t, ok)
+}

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -584,6 +584,7 @@ func (s *OpenAIGatewayService) handleChatStreamingResponse(
 			return false
 		}
 		observer.ObserveOpenAI([]byte(payload), event.Type)
+		stashOpenAIEncryptedReasoningFromSSE(c, []byte(payload))
 		refusalDetector.ObservePayload([]byte(payload))
 
 		// Nested evt.Response.Usage takes precedence over top-level evt.Usage:

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -1053,6 +1053,7 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 			return false
 		}
 		observer.ObserveOpenAI([]byte(payload), event.Type)
+		stashOpenAIEncryptedReasoningFromSSE(c, []byte(payload))
 
 		// 仅按兼容转换器支持的终止事件提取 usage，避免无意扩大事件语义。
 		switch event.Type {

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -1390,6 +1390,7 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 				}
 			}
 			eventType := strings.TrimSpace(gjson.Get(trimmedData, "type").String())
+			stashOpenAIEncryptedReasoningFromSSE(c, dataBytes)
 			if eventType == "response.failed" {
 				failedMessage = extractOpenAISSEErrorMessage(dataBytes)
 				// response.failed 自带上游已消耗的 usage（input token 通常已扣）；必须先解析

--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -845,9 +845,42 @@ func normalizeOpenAIPassthroughOAuthBody(body []byte, compact bool) ([]byte, boo
 			normalized = next
 			changed = true
 		}
+		next, includeChanged, err := ensureOpenAIPassthroughReasoningInclude(normalized)
+		if err != nil {
+			return body, false, err
+		}
+		if includeChanged {
+			normalized = next
+			changed = true
+		}
 	}
 
 	return normalized, changed, nil
+}
+
+func ensureOpenAIPassthroughReasoningInclude(body []byte) ([]byte, bool, error) {
+	const encrypted = "reasoning.encrypted_content"
+	include := gjson.GetBytes(body, "include")
+	if !include.Exists() {
+		next, err := sjson.SetBytes(body, "include", []string{encrypted})
+		if err != nil {
+			return body, false, fmt.Errorf("normalize passthrough body include: %w", err)
+		}
+		return next, true, nil
+	}
+	if !include.IsArray() {
+		return body, false, nil
+	}
+	for _, item := range include.Array() {
+		if item.String() == encrypted {
+			return body, false, nil
+		}
+	}
+	next, err := sjson.SetBytes(body, "include.-1", encrypted)
+	if err != nil {
+		return body, false, fmt.Errorf("normalize passthrough body append include: %w", err)
+	}
+	return next, true, nil
 }
 
 func normalizeOpenAIPassthroughAPIKeyBody(body []byte) ([]byte, bool, error) {

--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -837,6 +837,14 @@ func normalizeOpenAIPassthroughOAuthBody(body []byte, compact bool) ([]byte, boo
 			normalized = next
 			changed = true
 		}
+		if summary := gjson.GetBytes(normalized, "reasoning.summary"); !summary.Exists() || summary.String() != "auto" {
+			next, err := sjson.SetBytes(normalized, "reasoning.summary", "auto")
+			if err != nil {
+				return body, false, fmt.Errorf("normalize passthrough body reasoning.summary=auto: %w", err)
+			}
+			normalized = next
+			changed = true
+		}
 	}
 
 	return normalized, changed, nil

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -1216,8 +1216,12 @@ func (s *OpenAIGatewayService) handleNonStreamingResponse(ctx context.Context, r
 	}
 	if bodyHasSSEFraming(body) {
 		observeOpenAISSEBody(observer, string(body))
+		forEachOpenAISSEDataPayload(string(body), func(data []byte) {
+			stashOpenAIEncryptedReasoningFromSSE(c, data)
+		})
 	} else {
 		observer.ObserveOpenAI(body, strings.TrimSpace(gjson.GetBytes(body, "type").String()))
+		stashOpenAIEncryptedReasoningFromSSE(c, body)
 	}
 
 	// Detect SSE responses for ALL account types via Content-Type header.
@@ -1316,6 +1320,9 @@ func bodyHasSSEFraming(body []byte) bool {
 
 func (s *OpenAIGatewayService) handleSSEToJSON(resp *http.Response, c *gin.Context, body []byte, originalModel, mappedModel string) (*openaiNonStreamingResult, error) {
 	bodyText := string(body)
+	forEachOpenAISSEDataPayload(bodyText, func(data []byte) {
+		stashOpenAIEncryptedReasoningFromSSE(c, data)
+	})
 	finalResponse, ok := extractCodexFinalResponse(bodyText)
 
 	usage := &OpenAIUsage{}

--- a/backend/internal/service/openai_passthrough_normalization_test.go
+++ b/backend/internal/service/openai_passthrough_normalization_test.go
@@ -93,17 +93,26 @@ func TestNormalizeOpenAIPassthroughOAuthBody_SetsReasoningSummaryAuto(t *testing
 	require.NoError(t, err)
 	require.True(t, changed)
 	require.Equal(t, "auto", gjson.GetBytes(normalized, "reasoning.summary").String())
+	require.Equal(t, `["reasoning.encrypted_content"]`, gjson.GetBytes(normalized, "include").Raw)
 
-	already := []byte(`{"model":"gpt-5.4-mini","input":[{"type":"message","role":"user","content":"hi"}],"reasoning":{"effort":"medium","summary":"concise"}}`)
+	already := []byte(`{"model":"gpt-5.4-mini","input":[{"type":"message","role":"user","content":"hi"}],"reasoning":{"effort":"medium","summary":"concise"},"include":["foo"]}`)
 	normalized, _, err = normalizeOpenAIPassthroughOAuthBody(already, false)
 	require.NoError(t, err)
 	require.Equal(t, "auto", gjson.GetBytes(normalized, "reasoning.summary").String())
 	require.Equal(t, "medium", gjson.GetBytes(normalized, "reasoning.effort").String())
+	require.Equal(t, "foo", gjson.GetBytes(normalized, "include.0").String())
+	require.Equal(t, "reasoning.encrypted_content", gjson.GetBytes(normalized, "include.1").String())
+
+	withInclude := []byte(`{"model":"gpt-5.4-mini","input":[{"type":"message","role":"user","content":"hi"}],"include":["reasoning.encrypted_content"]}`)
+	normalized, _, err = normalizeOpenAIPassthroughOAuthBody(withInclude, false)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(gjson.GetBytes(normalized, "include").Array()))
 
 	compact := []byte(`{"model":"gpt-5.4-mini","input":[{"type":"message","role":"user","content":"hi"}]}`)
 	normalized, _, err = normalizeOpenAIPassthroughOAuthBody(compact, true)
 	require.NoError(t, err)
 	require.False(t, gjson.GetBytes(normalized, "reasoning.summary").Exists(), "compact 不强制 reasoning.summary")
+	require.False(t, gjson.GetBytes(normalized, "include").Exists(), "compact 不强制 include")
 }
 
 func TestDetectOpenAIPassthroughInstructionsRejectReason(t *testing.T) {

--- a/backend/internal/service/openai_passthrough_normalization_test.go
+++ b/backend/internal/service/openai_passthrough_normalization_test.go
@@ -86,6 +86,26 @@ func TestNormalizeOpenAIPassthroughOAuthBody_ArrayInputUnchanged(t *testing.T) {
 	require.Equal(t, "message", input.Array()[0].Get("type").String())
 }
 
+func TestNormalizeOpenAIPassthroughOAuthBody_SetsReasoningSummaryAuto(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4-mini","input":[{"type":"message","role":"user","content":"hi"}]}`)
+
+	normalized, changed, err := normalizeOpenAIPassthroughOAuthBody(body, false)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, "auto", gjson.GetBytes(normalized, "reasoning.summary").String())
+
+	already := []byte(`{"model":"gpt-5.4-mini","input":[{"type":"message","role":"user","content":"hi"}],"reasoning":{"effort":"medium","summary":"concise"}}`)
+	normalized, _, err = normalizeOpenAIPassthroughOAuthBody(already, false)
+	require.NoError(t, err)
+	require.Equal(t, "auto", gjson.GetBytes(normalized, "reasoning.summary").String())
+	require.Equal(t, "medium", gjson.GetBytes(normalized, "reasoning.effort").String())
+
+	compact := []byte(`{"model":"gpt-5.4-mini","input":[{"type":"message","role":"user","content":"hi"}]}`)
+	normalized, _, err = normalizeOpenAIPassthroughOAuthBody(compact, true)
+	require.NoError(t, err)
+	require.False(t, gjson.GetBytes(normalized, "reasoning.summary").Exists(), "compact 不强制 reasoning.summary")
+}
+
 func TestDetectOpenAIPassthroughInstructionsRejectReason(t *testing.T) {
 	for _, tt := range []struct {
 		name string

--- a/backend/internal/service/openai_ws_forwarder_payload.go
+++ b/backend/internal/service/openai_ws_forwarder_payload.go
@@ -189,6 +189,8 @@ func (s *OpenAIGatewayService) buildOpenAIWSCreatePayload(reqBody map[string]any
 	// OAuth 默认保持 store=false，避免误依赖服务端历史。
 	if account != nil && account.Type == AccountTypeOAuth && !s.isOpenAIWSStoreRecoveryAllowed(account) {
 		payload["store"] = false
+		_ = ensureCodexReasoningSummaryAuto(payload)
+		_ = ensureCodexReasoningInclude(payload)
 	}
 	return payload
 }

--- a/backend/internal/service/openai_ws_forwarder_test.go
+++ b/backend/internal/service/openai_ws_forwarder_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
@@ -12,6 +13,18 @@ import (
 // 重点验证终止事件（response.completed / response.done）不再被当作 token event，
 // 否则当上游没有可识别的 delta 时，firstTokenMs 会被填到终止时刻，
 // 等于把"总耗时"误报为"首 token 延迟"（issue #2651）。
+func TestBuildOpenAIWSCreatePayload_OAuthSetsReasoningSummaryAuto(t *testing.T) {
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	account := &Account{ID: 1, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	payload := svc.buildOpenAIWSCreatePayload(map[string]any{
+		"model": "gpt-5.4-mini",
+		"input": "hello",
+	}, account)
+	reasoning, ok := payload["reasoning"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "auto", reasoning["summary"])
+}
+
 func TestIsOpenAIWSTokenEvent_TerminalEventsExcluded(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/backend/internal/service/openai_ws_forwarder_test.go
+++ b/backend/internal/service/openai_ws_forwarder_test.go
@@ -23,6 +23,7 @@ func TestBuildOpenAIWSCreatePayload_OAuthSetsReasoningSummaryAuto(t *testing.T) 
 	reasoning, ok := payload["reasoning"].(map[string]any)
 	require.True(t, ok)
 	require.Equal(t, "auto", reasoning["summary"])
+	require.Equal(t, []any{"reasoning.encrypted_content"}, payload["include"])
 }
 
 func TestIsOpenAIWSTokenEvent_TerminalEventsExcluded(t *testing.T) {


### PR DESCRIPTION
## 摘要
- OpenAI OAuth 出站（Codex transform / `/v1/responses` 透传 / WS）一律补 `reasoning.summary=auto`，否则上游只计 `reasoning_tokens`、不发明文 summary。
- 非 compact 出站同时幂等补 `include: reasoning.encrypted_content`，才能拿到完整推理密文。
- QA blob 新增 `response.encrypted_reasoning`，按 `{item_id, encrypted_content}` 记录密文；键名不用 `signature`，避免 logredact 打成 `***`。
- 修复 converter 缺口：上游只在 `output_item.done` 给出 `reasoning_text` / summary、没有 delta 时，补进 thinking / `reasoning_content`。Responses→Anthropic 请求回放仍丢弃 `reasoning_text`（避免 Anthropic 400）；未改 `AnthropicToResponses` 的 US-027 Include 约束。

## 风险
- 常规风险：OAuth 出站行为变化（summary=auto + include encrypted_content）；QA blob 为加法字段。
- compact 路径不强制 summary / include。
- Web impact: none

sentinel-registry-reviewed

## 验证
- `go test -tags=unit ./internal/service/`（transform / passthrough / WS / stash）
- `go test -tags=unit ./internal/pkg/apicompat/`
- `go test -tags=unit ./internal/observability/qa/`
- `python3 scripts/export_agent_contract.py --check`
- `./scripts/preflight.sh` PASS

## 提交
- `00a9ad22d` fix(openai): request summary=auto and persist encrypted reasoning in QA
- `dca6f5f66` fix(openai): address R-001..R-003 — passthrough include for QA ciphertext
- `01cc5859d` fix(openai): address golangci errcheck on reasoning summary tests
- 最新提交：`01cc5859d`