### PR TITLE
fix(video): preserve submit and polling contracts

### DIFF
--- a/backend/internal/handler/openai_gateway_tk_video.go
+++ b/backend/internal/handler/openai_gateway_tk_video.go
@@ -3,11 +3,13 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/engine"
+	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
 	pkghttputil "github.com/Wei-Shaw/sub2api/internal/pkg/httputil"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ip"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
@@ -186,6 +188,11 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Selected account's channel_type does not support video generation")
 		return
 	}
+	if videoDurationBelowProviderMinimum(account, body) {
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error",
+			fmt.Sprintf("duration must be at least %d seconds for this video provider", newapiintegration.XRTokenVideoMinDurationSeconds))
+		return
+	}
 	setOpsSelectedAccount(c, account.ID, account.Platform)
 	openAIMarkAffinitySelected(c, groupName, account.ID)
 
@@ -200,11 +207,12 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 	publicTaskID := generateVideoTaskID()
 
 	TkSetBridgeGinAuth(c, subject.UserID, groupName)
+	writerSizeBeforeForward := c.Writer.Size()
 	outcome, err := h.gatewayService.ForwardAsVideoSubmitDispatched(c.Request.Context(), c, account, publicTaskID, body)
 	tkRecordForwardResponseTail(c, forwardStart)
 
 	if err != nil {
-		if TkTryWriteNewAPIRelayErrorJSON(c, err, false, 0) {
+		if TkTryWriteNewAPIRelayErrorJSON(c, err, false, writerSizeBeforeForward) {
 			reqLog.Warn("openai_video_submit.forward_failed", zap.Error(err))
 			return
 		}
@@ -323,16 +331,16 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 // clients that poll after that will see 404.
 //
 // Authorization model:
-//   - Route layer (tkOpenAICompatVideoFetchHandler) gates on the caller's
-//     group.platform being OpenAI-compatible (openai or newapi). Anthropic /
-//     Gemini / Antigravity callers never reach this handler.
+//   - Route layer sends registry-owned vt_ ids here regardless of the temporary
+//     backing platform selected by a model-less universal-key GET. Non-vt_ ids
+//     retain the platform-specific route gate.
 //   - Handler enforces ownership: record.UserID must equal the caller's
 //     subject.UserID. A leaked or guessed task_id from another user surfaces
 //     as 404 (deliberately indistinguishable from "expired" — we do not leak
 //     existence). This is the same invariant the rest of the gateway uses
 //     for per-user resources.
 func (h *OpenAIGatewayHandler) VideoFetch(c *gin.Context) {
-	publicTaskID := strings.TrimSpace(c.Param("task_id"))
+	publicTaskID := videoTaskParam(c)
 	if publicTaskID == "" {
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "task_id is required")
 		return
@@ -376,9 +384,10 @@ func (h *OpenAIGatewayHandler) VideoFetch(c *gin.Context) {
 		Platform:  rec.Platform,
 		AccountID: rec.AccountID,
 	}
+	writerSizeBeforeForward := c.Writer.Size()
 	out, err := h.gatewayService.ForwardAsVideoFetchDispatched(c.Request.Context(), c, in)
 	if err != nil {
-		if TkTryWriteNewAPIRelayErrorJSON(c, err, false, 0) {
+		if TkTryWriteNewAPIRelayErrorJSON(c, err, false, writerSizeBeforeForward) {
 			return
 		}
 		h.errorResponse(c, http.StatusBadGateway, "api_error", "Video fetch failed")
@@ -418,6 +427,22 @@ func (h *OpenAIGatewayHandler) VideoFetch(c *gin.Context) {
 		// logs are the audit trail.
 		h.scheduleVideoRefundAttempt(c.Request.Context(), rec, 0)
 	}
+}
+
+func videoTaskParam(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	if taskID := strings.TrimSpace(c.Param("task_id")); taskID != "" {
+		return taskID
+	}
+	return strings.TrimSpace(c.Param("request_id"))
+}
+
+func videoDurationBelowProviderMinimum(account *service.Account, body []byte) bool {
+	return account != nil &&
+		newapiintegration.IsXRTokenBaseURL(account.ChannelType, account.GetBaseURL()) &&
+		videoRequestedSeconds(body) < newapiintegration.XRTokenVideoMinDurationSeconds
 }
 
 // videoRefund* bound the terminal-failure refund re-attempt. The submit-time

--- a/backend/internal/handler/openai_gateway_tk_video_test.go
+++ b/backend/internal/handler/openai_gateway_tk_video_test.go
@@ -7,12 +7,17 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	newapitypes "github.com/QuantumNous/new-api/types"
+	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
 	"github.com/Wei-Shaw/sub2api/internal/repository"
 	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
 )
 
 // TestVideoFetch_CrossUser_Returns404 enforces the per-user authorization
@@ -107,6 +112,130 @@ func TestVideoFetch_MissingTaskID_Returns400(t *testing.T) {
 	h.VideoFetch(c)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestVideoFetch_FailedTerminalDeletesTaskAndSchedulesRefund(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/api/v3/contents/generations/tasks/upstream-failed") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"upstream-failed","status":"failed","error":{"message":"generation failed"}}`))
+	}))
+	defer upstream.Close()
+
+	cache := repository.NewVideoTaskCache(nil)
+	record := &service.VideoTaskRecord{
+		PublicTaskID:   "vt_failed",
+		UpstreamTaskID: "upstream-failed",
+		UserID:         1,
+		ChannelType:    newapiconstant.ChannelTypeVolcEngine,
+		BaseURL:        upstream.URL,
+		APIKey:         "test-key",
+	}
+	if err := cache.Save(context.Background(), record); err != nil {
+		t.Fatalf("seed registry: %v", err)
+	}
+
+	gatewayService := service.NewOpenAIGatewayService(
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+	)
+	h := &OpenAIGatewayHandler{gatewayService: gatewayService}
+	h.SetVideoTaskCache(cache)
+	logSink, restore := captureHandlerStructuredLog(t)
+	defer restore()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v1/videos/vt_failed", nil)
+	c.Params = gin.Params{{Key: "task_id", Value: "vt_failed"}}
+	c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{UserID: 1})
+
+	h.VideoFetch(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("failed terminal status should be returned to the owner, got %d body=%s", w.Code, w.Body.String())
+	}
+	if _, ok := cache.Lookup(context.Background(), "vt_failed"); ok {
+		t.Fatal("failed terminal task must be deleted from the registry")
+	}
+	require.True(t, logSink.ContainsMessageAtLevel("openai_video_refund.skipped_no_billing_request_id", "warn"),
+		"failed terminal fetch must schedule the refund path")
+}
+
+func TestVideoFetch_RequestIDAliasReadsTokenKeyTask(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cache := repository.NewVideoTaskCache(nil)
+	if err := cache.Save(context.Background(), &service.VideoTaskRecord{
+		PublicTaskID: "vt_alias_owned",
+		UserID:       1,
+	}); err != nil {
+		t.Fatalf("seed registry: %v", err)
+	}
+
+	h := &OpenAIGatewayHandler{}
+	h.SetVideoTaskCache(cache)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v1/videos/generations/vt_alias_owned", nil)
+	c.Params = gin.Params{{Key: "request_id", Value: "vt_alias_owned"}}
+	c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{UserID: 2})
+
+	h.VideoFetch(c)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("request_id alias must reach the same ownership check, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestVideoDurationBelowProviderMinimum(t *testing.T) {
+	xrToken := &service.Account{
+		Platform:    service.PlatformNewAPI,
+		Type:        service.AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeDoubaoVideo,
+		Credentials: map[string]any{"base_url": newapiintegration.XRTokenBaseURL},
+	}
+	nonXRToken := &service.Account{
+		Platform:    service.PlatformNewAPI,
+		Type:        service.AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeDoubaoVideo,
+		Credentials: map[string]any{"base_url": "https://ark.cn-beijing.volces.com"},
+	}
+
+	if !videoDurationBelowProviderMinimum(xrToken, []byte(`{"seconds":1}`)) {
+		t.Fatal("XRToken one-second request must be rejected before dispatch")
+	}
+	if videoDurationBelowProviderMinimum(xrToken, []byte(`{"seconds":4}`)) {
+		t.Fatal("XRToken four-second request must satisfy local validation")
+	}
+	if videoDurationBelowProviderMinimum(nonXRToken, []byte(`{"seconds":1}`)) {
+		t.Fatal("provider-specific minimum must not affect non-XRToken accounts")
+	}
+}
+
+func TestTryWriteVideoRelayErrorUsesUnwrittenWriterBaseline(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	before := c.Writer.Size()
+	err := &service.NewAPIRelayError{Err: newapitypes.NewErrorWithStatusCode(
+		http.ErrAbortHandler,
+		newapitypes.ErrorCodeInvalidRequest,
+		http.StatusBadRequest,
+		newapitypes.ErrOptionWithSkipRetry(),
+	)}
+
+	if !TkTryWriteNewAPIRelayErrorJSON(c, err, false, before) {
+		t.Fatal("relay error must be recognized")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("upstream 400 must render as client 400, got %d body=%s", w.Code, w.Body.String())
+	}
+	if w.Body.Len() == 0 {
+		t.Fatal("upstream 400 must render a JSON error body")
 	}
 }
 

--- a/backend/internal/integration/newapi/xrtoken.go
+++ b/backend/internal/integration/newapi/xrtoken.go
@@ -35,6 +35,11 @@ import (
 // task adaptor registered via relay.GetTaskAdaptor("54").
 const XRTokenBaseURL = "https://api.xrtoken.net"
 
+// XRTokenVideoMinDurationSeconds is the provider's submit-time lower bound.
+// Validate it before dispatch so an invalid request cannot become a paid task
+// attempt or depend on upstream error-shape handling.
+const XRTokenVideoMinDurationSeconds = 4
+
 // IsXRTokenBaseURL reports whether channelType/base resolve to the XRToken
 // ARK-compatible endpoint.
 //

--- a/backend/internal/relay/bridge/video_relay_test.go
+++ b/backend/internal/relay/bridge/video_relay_test.go
@@ -190,10 +190,10 @@ func TestDispatchVideoSubmit_MissingModel(t *testing.T) {
 	}
 }
 
-func TestDispatchVideoSubmit_BoundsUpstreamErrorBody(t *testing.T) {
+func TestDispatchVideoSubmit_PreservesUpstreamStatusAndBoundsErrorBody(t *testing.T) {
 	const marker = "must-not-reach-error"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusBadGateway)
+		w.WriteHeader(http.StatusBadRequest)
 		_, _ = io.CopyN(w, strings.NewReader(strings.Repeat("x", int(videoSubmitErrorBodyMaxBytes))), videoSubmitErrorBodyMaxBytes)
 		_, _ = w.Write([]byte(marker))
 	}))
@@ -208,6 +208,9 @@ func TestDispatchVideoSubmit_BoundsUpstreamErrorBody(t *testing.T) {
 	_, apiErr := DispatchVideoSubmit(context.Background(), c, in, "vt_error", body)
 	if apiErr == nil {
 		t.Fatal("expected upstream status error, got nil")
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Fatalf("upstream status = %d, want %d", apiErr.StatusCode, http.StatusBadRequest)
 	}
 	if strings.Contains(apiErr.Error(), marker) {
 		t.Fatalf("error body exceeded %d-byte bound", videoSubmitErrorBodyMaxBytes)

--- a/backend/internal/server/middleware/api_key_auth.go
+++ b/backend/internal/server/middleware/api_key_auth.go
@@ -27,7 +27,7 @@ func skipsBillingEnforcement(method, path string) bool {
 	if path == "/v1/sub2api/billing" {
 		return true
 	}
-	if isAsyncImageTaskRead(method, path) {
+	if isAsyncImageTaskRead(method, path) || isTokenKeyVideoTaskRead(method, path) {
 		return true
 	}
 	if method != http.MethodGet {
@@ -483,4 +483,28 @@ func isAsyncImageTaskRead(method, path string) bool {
 		return false
 	}
 	return strings.HasPrefix(path, "/v1/images/tasks/") || strings.HasPrefix(path, "/images/tasks/")
+}
+
+// isTokenKeyVideoTaskRead identifies registry-owned video status reads. The
+// public vt_ id is sufficient because VideoFetch performs the authoritative
+// registry existence and user-ownership checks before using the pinned route.
+func isTokenKeyVideoTaskRead(method, path string) bool {
+	if !strings.EqualFold(method, http.MethodGet) {
+		return false
+	}
+	for _, root := range []string{
+		"/video/generations/",
+		"/videos/generations/",
+		"/videos/edits/",
+		"/videos/extensions/",
+		"/videos/",
+	} {
+		for _, prefix := range []string{root, "/v1" + root} {
+			if taskID, ok := strings.CutPrefix(path, prefix); ok {
+				taskID = strings.TrimSpace(taskID)
+				return !strings.Contains(taskID, "/") && strings.HasPrefix(taskID, "vt_")
+			}
+		}
+	}
+	return false
 }

--- a/backend/internal/server/middleware/api_key_auth_image_task_test.go
+++ b/backend/internal/server/middleware/api_key_auth_image_task_test.go
@@ -13,3 +13,21 @@ func TestIsAsyncImageTaskRead(t *testing.T) {
 	require.False(t, isAsyncImageTaskRead(http.MethodPost, "/v1/images/tasks/imgtask_123"))
 	require.False(t, isAsyncImageTaskRead(http.MethodGet, "/v1/images/generations"))
 }
+
+func TestIsTokenKeyVideoTaskRead(t *testing.T) {
+	for _, path := range []string{
+		"/v1/video/generations/vt_123",
+		"/video/generations/vt_123",
+		"/v1/videos/vt_123",
+		"/videos/generations/vt_123",
+		"/v1/videos/edits/vt_123",
+	} {
+		require.True(t, isTokenKeyVideoTaskRead(http.MethodGet, path), path)
+		require.True(t, skipsBillingEnforcement(http.MethodGet, path), path)
+	}
+
+	require.False(t, isTokenKeyVideoTaskRead(http.MethodPost, "/v1/videos/vt_123"))
+	require.False(t, isTokenKeyVideoTaskRead(http.MethodGet, "/v1/videos/request-native"))
+	require.False(t, isTokenKeyVideoTaskRead(http.MethodGet, "/v1/videos/vt_123/content"))
+	require.False(t, skipsBillingEnforcement(http.MethodGet, "/v1/videos/request-native"))
+}

--- a/backend/internal/server/middleware/universal_routing_tk.go
+++ b/backend/internal/server/middleware/universal_routing_tk.go
@@ -43,8 +43,18 @@ func MaybeResolveUniversal(c *gin.Context, apiKey *service.APIKey, resolver *ser
 		fullPath = c.Request.URL.Path
 	}
 	method := http.MethodGet
+	requestPath := fullPath
 	if c.Request != nil {
 		method = c.Request.Method
+		if c.Request.URL != nil {
+			requestPath = c.Request.URL.Path
+		}
+	}
+	if isTokenKeyVideoTaskRead(method, requestPath) {
+		// A vt_ poll is a read of an existing registry-owned resource, not a new
+		// scheduling decision. VideoFetch authorizes the user and consumes the
+		// submit-time pinned upstream route.
+		return false
 	}
 
 	shape := service.UniversalShapeForRequest(fullPath, method)

--- a/backend/internal/server/middleware/universal_routing_tk_test.go
+++ b/backend/internal/server/middleware/universal_routing_tk_test.go
@@ -103,10 +103,12 @@ func captureMiddlewareStructuredLog(t *testing.T) (*middlewareInMemoryLogSink, f
 
 type stubSpanLister struct {
 	groups []service.Group
+	calls  int
 	err    error
 }
 
 func (s *stubSpanLister) GetAvailableGroups(_ context.Context, _ int64) ([]service.Group, error) {
+	s.calls++
 	if s.err != nil {
 		return nil, s.err
 	}
@@ -566,20 +568,41 @@ func TestMaybeResolveUniversal_ImageEditMultipartRoutesByModel(t *testing.T) {
 	require.Equal(t, body, rest, "downstream image-edit handler must see original multipart body after peek")
 }
 
-// The GET poll path carries no body and no model — it must NOT attempt to read a
-// body (poll uses the VideoTaskCache's submit-time pinned upstream route, not a
-// fresh selection), and any openai-compat group satisfies the route-layer platform
-// gate. Asserts poll resolves model-lessly without erroring.
-func TestMaybeResolveUniversal_VideoPollNoBodyResolves(t *testing.T) {
-	resolver := service.NewUniversalRoutingResolver(&stubSpanLister{groups: []service.Group{activeGroup(30, service.PlatformNewAPI)}})
+// A TokenKey vt_ poll reads the route pinned by VideoTaskCache at submit time.
+// Re-resolving a backing group is both unnecessary and incorrect: a model-less
+// GET can land on OpenAI even though the registry says the task belongs to
+// NewAPI, preventing the handler from polling or issuing a terminal refund.
+func TestMaybeResolveUniversal_TokenKeyVideoPollKeepsRegistryRouteAuthoritative(t *testing.T) {
+	lister := &stubSpanLister{groups: []service.Group{
+		activeGroup(20, service.PlatformOpenAI),
+		activeGroup(30, service.PlatformNewAPI),
+	}}
+	resolver := service.NewUniversalRoutingResolver(lister)
 	c, _ := newTestCtx(http.MethodGet, "/v1/video/generations/vt_abc", "")
 	apiKey := &service.APIKey{ID: 1, UserID: 1, RoutingMode: service.RoutingModeUniversal}
 
 	if handled := MaybeResolveUniversal(c, apiKey, resolver); handled {
-		t.Fatalf("video poll resolve should succeed model-lessly")
+		t.Fatalf("registry-owned video poll should continue authentication")
 	}
-	if apiKey.GroupID == nil || *apiKey.GroupID != 30 {
-		t.Fatalf("video poll should route to the only eligible newapi group, got %v", apiKey.GroupID)
+	if lister.calls != 0 {
+		t.Fatalf("registry-owned video poll must not select a fresh backing group; calls=%d", lister.calls)
+	}
+	if apiKey.GroupID != nil || apiKey.Group != nil {
+		t.Fatalf("registry-owned video poll must leave universal key group unset, got %v", apiKey.GroupID)
+	}
+}
+
+func TestMaybeResolveUniversal_NativeVideoPollStillResolvesPlatform(t *testing.T) {
+	lister := &stubSpanLister{groups: []service.Group{activeGroup(30, service.PlatformNewAPI)}}
+	resolver := service.NewUniversalRoutingResolver(lister)
+	c, _ := newTestCtx(http.MethodGet, "/v1/videos/request-native", "")
+	apiKey := &service.APIKey{ID: 1, UserID: 1, RoutingMode: service.RoutingModeUniversal}
+
+	if handled := MaybeResolveUniversal(c, apiKey, resolver); handled {
+		t.Fatalf("native video poll should resolve model-lessly")
+	}
+	if lister.calls != 1 || apiKey.GroupID == nil || *apiKey.GroupID != 30 {
+		t.Fatalf("native video poll must retain platform resolution, calls=%d group=%v", lister.calls, apiKey.GroupID)
 	}
 }
 

--- a/backend/internal/server/routes/gateway_test.go
+++ b/backend/internal/server/routes/gateway_test.go
@@ -280,6 +280,37 @@ func TestGatewayRoutesCompositeChatCompletionsWithGrokModelUsesOpenAIGateway(t *
 	}
 }
 
+func TestGatewayRoutesTokenKeyVideoPollBypassesTemporaryPlatformGate(t *testing.T) {
+	for _, platform := range []string{
+		service.PlatformOpenAI,
+		service.PlatformGrok,
+		service.PlatformComposite,
+	} {
+		for _, path := range []string{
+			"/v1/video/generations/vt_123",
+			"/video/generations/vt_123",
+			"/v1/videos/vt_123",
+			"/videos/vt_123",
+			"/v1/videos/generations/vt_123",
+			"/videos/generations/vt_123",
+			"/v1/videos/edits/vt_123",
+			"/videos/edits/vt_123",
+			"/v1/videos/extensions/vt_123",
+			"/videos/extensions/vt_123",
+		} {
+			router := newGatewayRoutesTestRouter(platform)
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusServiceUnavailable, w.Code,
+				"platform=%s path=%s should reach registry-owned VideoFetch", platform, path)
+			require.NotContains(t, w.Body.String(), "Videos API is not supported for this platform")
+		}
+	}
+}
+
 func TestGatewayRoutesNonGrokVideosAreRejectedAtPlatformGate(t *testing.T) {
 	router := newGatewayRoutesTestRouter(service.PlatformOpenAI)
 

--- a/backend/internal/server/routes/gateway_tk_openai_compat_handlers.go
+++ b/backend/internal/server/routes/gateway_tk_openai_compat_handlers.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/Wei-Shaw/sub2api/internal/handler"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -93,6 +94,16 @@ func isGrokNativeVideoStatusRoute(c *gin.Context) bool {
 	default:
 		return false
 	}
+}
+
+func videoTaskRouteID(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	if taskID := strings.TrimSpace(c.Param("task_id")); taskID != "" {
+		return taskID
+	}
+	return strings.TrimSpace(c.Param("request_id"))
 }
 
 func isGrokNativeVideoContentRoute(c *gin.Context) bool {
@@ -206,6 +217,14 @@ func tkOpenAICompatVideoSubmitHandler(h *handler.Handlers) gin.HandlerFunc {
 func tkOpenAICompatVideoFetchHandler(h *handler.Handlers) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		platform := getGroupPlatform(c)
+		// TokenKey task IDs are resolved and authorized by VideoFetch's registry
+		// lookup. A status GET has no request model, so its temporary group cannot
+		// identify the submit platform. Route vt_ first even for Grok/composite
+		// callers; non-TokenKey IDs retain their platform-specific handlers.
+		if strings.HasPrefix(videoTaskRouteID(c), "vt_") {
+			h.OpenAIGateway.VideoFetch(c)
+			return
+		}
 		if (platform == service.PlatformGrok || platform == service.PlatformComposite) && isGrokNativeVideoStatusRoute(c) {
 			h.OpenAIGateway.GrokVideoStatus(c)
 			return

--- a/backend/internal/service/universal_routing_tk_endpoint_map.go
+++ b/backend/internal/service/universal_routing_tk_endpoint_map.go
@@ -61,10 +61,9 @@ func UniversalShapeForRequest(fullPath, method string) UniversalShape {
 	case strings.Contains(p, "/images/generations"):
 		return ShapeOpenAIImages
 	case strings.Contains(p, "/video/generations"), strings.Contains(p, "/videos"):
-		// submit(POST) 与 poll(GET /…/:task_id) 都要落到 openai-compat 处理器 —— 视频派发器
-		// (tkOpenAICompatVideoFetchHandler)按 getGroupPlatform(c) 路由,GET 也必须解析出一个
-		// openai-compat 后端组,否则 404。GET poll 无模型(resolver 以空模型按确定规则挑组);
-		// 解析只在用户已授权的跨度内挑组,poll 不产生实质计费,故不存在误拒/串费。
+		// Submit requests resolve by model. Registry-owned vt_ polls are filtered
+		// before this mapper because they reuse the submit-time pinned route; native
+		// provider status IDs still resolve here for their platform-specific handler.
 		return ShapeOpenAIVideo
 	case strings.Contains(p, "/v1beta/models"):
 		if !isPost {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2761,9 +2761,10 @@
         "RefundVideoUsageOnFailure",
         "videoSubmitHasVideoInput",
         "videoTerminalOutcome",
-        "TkVideoModelUnpriced"
+        "TkVideoModelUnpriced",
+        "videoDurationBelowProviderMinimum"
       ],
-      "rationale": "Per-second video billing: VideoSubmitBillingParamsFromBody resolves resolution/audio/image-input once and the explicit ForwardResult assignments carry those exact dimensions into settlement; dropping any one silently flattens tier billing even when submit still succeeds. videoRequestedSeconds anchors duration, RefundVideoUsageOnFailure anchors terminal-failed refund, and videoSubmitHasVideoInput anchors the unpriced video-input reject guard."
+      "rationale": "Per-second video billing: VideoSubmitBillingParamsFromBody resolves resolution/audio/image-input once and the explicit ForwardResult assignments carry those exact dimensions into settlement; dropping any one silently flattens tier billing even when submit still succeeds. videoRequestedSeconds anchors duration, RefundVideoUsageOnFailure anchors terminal-failed refund, and videoSubmitHasVideoInput anchors the unpriced video-input reject guard. videoDurationBelowProviderMinimum keeps XRToken's four-second floor local and before paid upstream dispatch."
     },
     {
       "path": "backend/internal/service/billing_service_tk_video_test.go",
@@ -5184,9 +5185,25 @@
         "func MaybeResolveUniversal(",
         "apiKey.Group = backing",
         "apiKey.GroupID = &backing.ID",
-        "c.Request.Body = io.NopCloser(bytes.NewReader(raw))"
+        "c.Request.Body = io.NopCloser(bytes.NewReader(raw))",
+        "isTokenKeyVideoTaskRead"
       ],
-      "rationale": "Universal Key auth-time glue: peeks the model (restoring the EXACT original body + headers so the handler is byte-identical), resolves the backing group, and presents the request as a normal key bound to that group (swap apiKey.Group/GroupID). It deliberately does NOT set ForcePlatform (so anthropic+antigravity mixed scheduling and other per-group semantics are preserved) and only READS ForcePlatform to constrain candidates on /antigravity. Removing the body-restore line corrupts every universal-key request body; removing the swap disables the feature."
+      "rationale": "Universal Key auth-time glue: peeks the model (restoring the EXACT original body + headers so the handler is byte-identical), resolves the backing group, and presents the request as a normal key bound to that group (swap apiKey.Group/GroupID). It deliberately does NOT set ForcePlatform (so anthropic+antigravity mixed scheduling and other per-group semantics are preserved) and only READS ForcePlatform to constrain candidates on /antigravity. Registry-owned vt_ video polls are the exception: isTokenKeyVideoTaskRead must bypass fresh model-less group resolution so VideoFetch can consume the submit-time pinned route. Removing the body-restore line corrupts every universal-key request body; removing the swap or poll bypass disables the corresponding feature."
+    },
+    {
+      "path": "backend/internal/server/routes/gateway_tk_openai_compat_handlers.go",
+      "must_contain": [
+        "strings.HasPrefix(videoTaskRouteID(c), \"vt_\")",
+        "h.OpenAIGateway.VideoFetch(c)"
+      ],
+      "rationale": "Registry-owned vt_ status reads must reach VideoFetch before Grok/composite/native platform gates because the model-less GET's temporary platform cannot identify the submit route. Non-vt_ provider request IDs continue through their native status handlers."
+    },
+    {
+      "path": "backend/internal/server/routes/gateway_test.go",
+      "must_contain": [
+        "TestGatewayRoutesTokenKeyVideoPollBypassesTemporaryPlatformGate"
+      ],
+      "rationale": "Route-level regression spans canonical and xAI-shaped aliases across OpenAI, Grok, and composite temporary platforms, proving every TokenKey vt_ id reaches the registry owner without weakening native provider status routing."
     },
     {
       "path": "backend/internal/server/middleware/api_key_auth.go",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -148,9 +148,10 @@
       "path": "backend/internal/relay/bridge/video_relay_test.go",
       "must_contain": [
         "TestNormalizeVideoSubmitBodyForTaskAdaptor_TopLevelTiersOverrideMetadata",
-        "TestNormalizeVideoSubmitBodyForTaskAdaptor_NormalizesSizeAndMetadataAudio"
+        "TestNormalizeVideoSubmitBodyForTaskAdaptor_NormalizesSizeAndMetadataAudio",
+        "TestDispatchVideoSubmit_PreservesUpstreamStatusAndBoundsErrorBody"
       ],
-      "rationale": "Focused bridge regressions prove that public resolution/size/audio dimensions become the exact adaptor metadata values used upstream, including conflict precedence and metadata-only audio aliases."
+      "rationale": "Focused bridge regressions prove that public resolution/size/audio dimensions become the exact adaptor metadata values used upstream, including conflict precedence and metadata-only audio aliases. The non-2xx regression also pins upstream status preservation and bounded error-body reads so provider 400 responses cannot collapse into an empty client 200 or an unbounded allocation."
     },
     {
       "path": "backend/internal/relay/bridge/embedding_relay.go",
@@ -668,9 +669,10 @@
         "XRTokenVideoVendorPrefix",
         "XRTokenUpstreamVideoModel",
         "volcengine/",
-        "XRTokenClientFacingVideoModel"
+        "XRTokenClientFacingVideoModel",
+        "XRTokenVideoMinDurationSeconds"
       ],
-      "rationale": "XRToken base-url detection for ch54 (DoubaoVideo) accounts — an ARK-compatible reseller whose task paths differ from official Ark by one middle segment (/v1/ vs /api/v3/). Without it the bridge selects the upstream doubao adaptor and every submit/poll 404s. NormalizeXRTokenBaseURL collapses the SDK-documented '.../v1' spelling so the wrapper cannot emit /v1/v1/contents/...; the ChannelTypeDoubaoVideo scope keeps a ch45 account on the same host from being treated as XRToken (that channel additionally exposes chat/embeddings/images paths XRToken does not serve). XRTokenVideoVendorPrefix / XRTokenUpstreamVideoModel encode the one wire fact that XRToken publishes every Ark video SKU as `volcengine/<ark-id>` and rejects the bare Ark id. It lives here (applied by the task adaptor) and NOT as a credentials.model_mapping target because the compiled mapping floor can only express identity mappings, so a prefixed target is both unrepresentable in the SSOT and reverted to identity by the next routine apply-accounts. Dropping these makes every XRToken seedance submit fail upstream while the account still looks correctly provisioned. The vendor-namespace pair is the wire contract for XRToken video: XRTokenUpstreamVideoModel adds `volcengine/` on submit (XRToken rejects the bare Ark id) and XRTokenClientFacingVideoModel removes it from the verbatim-passthrough poll body, so one task never reports two model ids across POST and GET. Encoding the rule here rather than in credentials.model_mapping is load-bearing: the mapping SSOT can only express identity targets (accountModelMappingForAccount -> identityModelMapping), so a prefixed target is unrepresentable AND would be reverted to identity by the next routine apply-accounts."
+      "rationale": "XRToken base-url detection for ch54 (DoubaoVideo) accounts — an ARK-compatible reseller whose task paths differ from official Ark by one middle segment (/v1/ vs /api/v3/). Without it the bridge selects the upstream doubao adaptor and every submit/poll 404s. NormalizeXRTokenBaseURL collapses the SDK-documented '.../v1' spelling so the wrapper cannot emit /v1/v1/contents/...; the ChannelTypeDoubaoVideo scope keeps a ch45 account on the same host from being treated as XRToken (that channel additionally exposes chat/embeddings/images paths XRToken does not serve). XRTokenVideoVendorPrefix / XRTokenUpstreamVideoModel encode the one wire fact that XRToken publishes every Ark video SKU as `volcengine/<ark-id>` and rejects the bare Ark id. It lives here (applied by the task adaptor) and NOT as a credentials.model_mapping target because the compiled mapping floor can only express identity mappings, so a prefixed target is both unrepresentable in the SSOT and reverted to identity by the next routine apply-accounts. Dropping these makes every XRToken seedance submit fail upstream while the account still looks correctly provisioned. The vendor-namespace pair is the wire contract for XRToken video: XRTokenUpstreamVideoModel adds `volcengine/` on submit (XRToken rejects the bare Ark id) and XRTokenClientFacingVideoModel removes it from the verbatim-passthrough poll body, so one task never reports two model ids across POST and GET. XRTokenVideoMinDurationSeconds is the provider's four-second submit floor consumed by the handler's local pre-dispatch validation. Encoding these rules here rather than in credentials.model_mapping is load-bearing: the mapping SSOT can only express identity targets (accountModelMappingForAccount -> identityModelMapping), so a prefixed target is unrepresentable AND would be reverted to identity by the next routine apply-accounts."
     },
     {
       "path": "backend/internal/integration/newapi/xrtoken_test.go",


### PR DESCRIPTION
## Summary

- keep registry-owned `vt_` video status reads on their submit-time pinned NewAPI route instead of resolving a fresh universal-key group
- route canonical and xAI-shaped status aliases through the same ownership-checked `VideoFetch` path while preserving native provider IDs
- enforce XRToken's four-second minimum before upstream dispatch and preserve upstream video relay HTTP errors
- anchor the load-bearing video routing, provider validation, and relay regressions in the gateway/NewAPI sentinel registries

## Regression coverage

- universal-key `vt_` polls skip backing-group resolution while native IDs still resolve normally
- OpenAI, Grok, and composite temporary platforms route all registered `vt_` aliases to `VideoFetch`
- cross-user task IDs and request-id aliases remain indistinguishable from missing tasks with HTTP 404
- failed terminal status deletes the registry record and schedules the refund path
- XRToken rejects one-second requests locally and accepts four seconds; non-XRToken accounts are unaffected
- upstream submit HTTP 400 remains HTTP 400 with a bounded error body and non-empty JSON response

## Validation

- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- `make test`
- focused Go suites for bridge, handler, middleware, routes, and service
- `git diff --check`

## Operational scope

- no production configuration or state changes
- no paid video-generation request
- no release or deployment

no-web-impact
