### PR TITLE
fix(ops): 等待 Edge SSM 角色凭证生效

### DIFF
--- a/deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml
@@ -272,6 +272,7 @@ Resources:
             Resource:
               - !Sub "arn:aws:ssm:*:${AWS::AccountId}:managed-instance/*"
               - !Sub "arn:aws:ssm:*::document/AWS-RunShellScript"
+              - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/tokenkey-lightsail-ssm-hybrid-*"
           - Sid: SsmLightsailStateParams
             Effect: Allow
             Action:

--- a/deploy/aws/cloudformation/test_stage0_edge_qa_s3_boundary.py
+++ b/deploy/aws/cloudformation/test_stage0_edge_qa_s3_boundary.py
@@ -156,6 +156,10 @@ class Stage0EdgeQaS3BoundaryTest(unittest.TestCase):
             item for item in addon_statements if item.get("Sid") == "SsmManagedInstanceCommand"
         )
         self.assertIn("ssm:UpdateManagedInstanceRole", managed["Action"])
+        self.assertIn(
+            "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/tokenkey-lightsail-ssm-hybrid-*",
+            managed["Resource"],
+        )
 
         provision = PROVISION_SCRIPT.read_text(encoding="utf-8")
         self.assertIn('--iam-role "$SSM_HYBRID_ROLE_NAME"', provision)

--- a/ops/lightsail/ensure-edge-ssm-role.sh
+++ b/ops/lightsail/ensure-edge-ssm-role.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 EDGE_ID="${1:-${EDGE_ID:-}}"
 INSTANCE_ID="${2:-${INSTANCE_ID:-}}"
 REGION="${3:-${AWS_REGION:-${AWS_DEFAULT_REGION:-}}}"
-TIMEOUT_SECONDS="${EDGE_SSM_ROLE_TIMEOUT_SECONDS:-60}"
+TIMEOUT_SECONDS="${EDGE_SSM_ROLE_TIMEOUT_SECONDS:-300}"
 POLL_SECONDS="${EDGE_SSM_ROLE_POLL_SECONDS:-2}"
 MODE="${4:-}"
 
@@ -39,35 +39,94 @@ read_role() {
     --output text
 }
 
+read_remote_identity() {
+  local command_id status
+  if ! command_id="$(aws ssm send-command \
+    --region "${REGION}" \
+    --instance-ids "${INSTANCE_ID}" \
+    --document-name AWS-RunShellScript \
+    --comment "verify Edge SSM role credentials for ${EDGE_ID}" \
+    --parameters 'commands=["aws sts get-caller-identity --query Arn --output text"]' \
+    --query 'Command.CommandId' \
+    --output text)"; then
+    return 1
+  fi
+
+  while true; do
+    if ! status="$(aws ssm get-command-invocation \
+      --region "${REGION}" \
+      --command-id "${command_id}" \
+      --instance-id "${INSTANCE_ID}" \
+      --query 'Status' \
+      --output text 2>/dev/null)"; then
+      status=InProgress
+    fi
+    case "${status}" in
+      Success) break ;;
+      Failed|TimedOut|Cancelled|Cancelling) return 1 ;;
+    esac
+    [[ $(date +%s) -ge ${deadline} ]] && return 1
+    sleep "${POLL_SECONDS}"
+  done
+
+  aws ssm get-command-invocation \
+    --region "${REGION}" \
+    --command-id "${command_id}" \
+    --instance-id "${INSTANCE_ID}" \
+    --query 'StandardOutputContent' \
+    --output text | tr -d '\r' | awk 'NF { value=$0 } END { print value }'
+}
+
 current_role="$(read_role)"
-if [[ "${current_role}" == "${desired_role}" ]]; then
-  echo "managed instance ${INSTANCE_ID} role already correct: ${desired_role}"
-  exit 0
-fi
 if [[ -z "${current_role}" || "${current_role}" == None || "${current_role}" == null ]]; then
   echo "ensure_edge_ssm_role: managed instance ${INSTANCE_ID} not found" >&2
   exit 1
 fi
 if [[ "${MODE}" == --check ]]; then
+  if [[ "${current_role}" == "${desired_role}" ]]; then
+    echo "managed instance ${INSTANCE_ID} role already correct: ${desired_role}"
+    exit 0
+  fi
   echo "ensure_edge_ssm_role: role mismatch for ${INSTANCE_ID}; got ${current_role}, expected ${desired_role}" >&2
   exit 1
 fi
 
-aws ssm update-managed-instance-role \
-  --region "${REGION}" \
-  --instance-id "${INSTANCE_ID}" \
-  --iam-role "${desired_role}" >/dev/null
+if [[ "${current_role}" != "${desired_role}" ]]; then
+  aws ssm update-managed-instance-role \
+    --region "${REGION}" \
+    --instance-id "${INSTANCE_ID}" \
+    --iam-role "${desired_role}" >/dev/null
+else
+  echo "managed instance ${INSTANCE_ID} control-plane role already correct: ${desired_role}"
+fi
 
 deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
 while true; do
   current_role="$(read_role)"
   if [[ "${current_role}" == "${desired_role}" ]]; then
-    echo "managed instance ${INSTANCE_ID} role verified: ${desired_role}"
-    exit 0
+    break
   fi
   [[ $(date +%s) -ge ${deadline} ]] && break
   sleep "${POLL_SECONDS}"
 done
 
-echo "ensure_edge_ssm_role: role update not observed for ${INSTANCE_ID}; got ${current_role}, expected ${desired_role}" >&2
+if [[ "${current_role}" != "${desired_role}" ]]; then
+  echo "ensure_edge_ssm_role: role update not observed for ${INSTANCE_ID}; got ${current_role}, expected ${desired_role}" >&2
+  exit 1
+fi
+
+last_remote_arn="<probe failed>"
+while true; do
+  if remote_arn="$(read_remote_identity)"; then
+    last_remote_arn="${remote_arn}"
+    if [[ "${remote_arn}" == *":assumed-role/${desired_role}/"* ]]; then
+      echo "managed instance ${INSTANCE_ID} role credentials verified: ${desired_role}"
+      exit 0
+    fi
+  fi
+  [[ $(date +%s) -ge ${deadline} ]] && break
+  sleep "${POLL_SECONDS}"
+done
+
+echo "ensure_edge_ssm_role: role credentials not observed for ${INSTANCE_ID}; got ${last_remote_arn}, expected assumed-role/${desired_role}/" >&2
 exit 1

--- a/ops/lightsail/test_ensure_edge_ssm_role.sh
+++ b/ops/lightsail/test_ensure_edge_ssm_role.sh
@@ -16,6 +16,24 @@ case "$*" in
   *"update-managed-instance-role"*)
     printf '%s\n' updated >"${FAKE_UPDATED_FILE}"
     ;;
+  *"send-command"*)
+    probe_count=0
+    if [[ -f "${FAKE_PROBE_COUNT_FILE}" ]]; then
+      probe_count="$(cat "${FAKE_PROBE_COUNT_FILE}")"
+    fi
+    probe_count=$((probe_count + 1))
+    printf '%s\n' "${probe_count}" >"${FAKE_PROBE_COUNT_FILE}"
+    printf 'cmd-%s\n' "${probe_count}"
+    ;;
+  *"get-command-invocation"*"StandardOutputContent"*)
+    probe_count="$(cat "${FAKE_PROBE_COUNT_FILE}")"
+    if [[ "${probe_count}" -ge "${FAKE_REMOTE_SWITCH_AFTER}" ]]; then
+      printf 'arn:aws:sts::123456789012:assumed-role/%s/%s\n' "${FAKE_DESIRED_ROLE}" "${FAKE_INSTANCE_ID}"
+    else
+      printf 'arn:aws:sts::123456789012:assumed-role/%s/%s\n' "${FAKE_REMOTE_CURRENT_ROLE}" "${FAKE_INSTANCE_ID}"
+    fi
+    ;;
+  *"get-command-invocation"*"Status"*) printf '%s\n' Success ;;
   *"describe-instance-information"*)
     if [[ -f "${FAKE_UPDATED_FILE}" && "${FAKE_UPDATE_STICKS}" == true ]]; then
       printf '%s\n' "${FAKE_DESIRED_ROLE}"
@@ -29,51 +47,71 @@ EOF
 chmod +x "${tmp}/bin/aws"
 
 run_case() {
-  local name="$1" edge_id="$2" current_role="$3" update_sticks="$4"
-  shift 4
+  local name="$1" edge_id="$2" current_role="$3" update_sticks="$4" remote_switch_after="$5"
+  shift 5
   local case_dir="${tmp}/${name}"
   mkdir -p "${case_dir}"
   PATH="${tmp}/bin:${PATH}" \
     FAKE_AWS_LOG="${case_dir}/aws.log" \
     FAKE_UPDATED_FILE="${case_dir}/updated" \
+    FAKE_PROBE_COUNT_FILE="${case_dir}/probe-count" \
     FAKE_EDGE_ID="${FAKE_EDGE_ID_OVERRIDE:-${edge_id}}" \
     FAKE_CURRENT_ROLE="${current_role}" \
+    FAKE_REMOTE_CURRENT_ROLE=tokenkey-lightsail-ssm-hybrid \
     FAKE_DESIRED_ROLE="tokenkey-lightsail-ssm-hybrid-${edge_id}" \
+    FAKE_INSTANCE_ID=mi-0123456789abcdef0 \
     FAKE_UPDATE_STICKS="${update_sticks}" \
-    EDGE_SSM_ROLE_TIMEOUT_SECONDS=0 \
+    FAKE_REMOTE_SWITCH_AFTER="${remote_switch_after}" \
+    EDGE_SSM_ROLE_TIMEOUT_SECONDS="${EDGE_SSM_ROLE_TIMEOUT_SECONDS_OVERRIDE:-2}" \
     EDGE_SSM_ROLE_POLL_SECONDS=0 \
     bash "${SCRIPT}" "${edge_id}" mi-0123456789abcdef0 us-east-2 "$@"
 }
 
-run_case correct us3 tokenkey-lightsail-ssm-hybrid-us3 false >"${tmp}/correct.out"
-grep -F 'role already correct' "${tmp}/correct.out" >/dev/null
+run_case correct us3 tokenkey-lightsail-ssm-hybrid-us3 false 2 >"${tmp}/correct.out"
+grep -F 'role credentials verified' "${tmp}/correct.out" >/dev/null
 ! grep -F 'update-managed-instance-role' "${tmp}/correct/aws.log" >/dev/null
+test "$(grep -c 'send-command' "${tmp}/correct/aws.log")" -eq 2
 
-run_case update us4 tokenkey-lightsail-ssm-hybrid true >"${tmp}/update.out"
-grep -F 'role verified' "${tmp}/update.out" >/dev/null
+run_case update us4 tokenkey-lightsail-ssm-hybrid true 2 >"${tmp}/update.out"
+grep -F 'role credentials verified' "${tmp}/update.out" >/dev/null
 grep -F 'update-managed-instance-role' "${tmp}/update/aws.log" >/dev/null
+test "$(grep -c 'send-command' "${tmp}/update/aws.log")" -eq 2
 
-if run_case timeout us5 tokenkey-lightsail-ssm-hybrid false >"${tmp}/timeout.out" 2>"${tmp}/timeout.err"; then
+EDGE_SSM_ROLE_TIMEOUT_SECONDS_OVERRIDE=0
+export EDGE_SSM_ROLE_TIMEOUT_SECONDS_OVERRIDE
+if run_case timeout us5 tokenkey-lightsail-ssm-hybrid false 1 >"${tmp}/timeout.out" 2>"${tmp}/timeout.err"; then
   echo 'FAIL: unchanged role must time out' >&2
   exit 1
 fi
 grep -F 'role update not observed' "${tmp}/timeout.err" >/dev/null
 
+if run_case credentials-timeout us5 tokenkey-lightsail-ssm-hybrid true 999 >"${tmp}/credentials-timeout.out" 2>"${tmp}/credentials-timeout.err"; then
+  echo 'FAIL: stale remote credentials must time out' >&2
+  exit 1
+fi
+grep -F 'role credentials not observed' "${tmp}/credentials-timeout.err" >/dev/null
+grep -F 'assumed-role/tokenkey-lightsail-ssm-hybrid/' "${tmp}/credentials-timeout.err" >/dev/null
+
 FAKE_EDGE_ID_OVERRIDE=us6
 export FAKE_EDGE_ID_OVERRIDE
-if run_case wrong-edge us5 tokenkey-lightsail-ssm-hybrid false >"${tmp}/wrong.out" 2>"${tmp}/wrong.err"; then
+if run_case wrong-edge us5 tokenkey-lightsail-ssm-hybrid false 1 >"${tmp}/wrong.out" 2>"${tmp}/wrong.err"; then
   echo 'FAIL: mismatched EdgeId tag must fail closed' >&2
   exit 1
 fi
 grep -F 'belongs to Edge us6, expected us5' "${tmp}/wrong.err" >/dev/null
 ! grep -F 'update-managed-instance-role' "${tmp}/wrong-edge/aws.log" >/dev/null
 
-unset FAKE_EDGE_ID_OVERRIDE
-if run_case check-only us6 tokenkey-lightsail-ssm-hybrid false --check >"${tmp}/check.out" 2>"${tmp}/check.err"; then
+unset FAKE_EDGE_ID_OVERRIDE EDGE_SSM_ROLE_TIMEOUT_SECONDS_OVERRIDE
+if run_case check-only us6 tokenkey-lightsail-ssm-hybrid false 1 --check >"${tmp}/check.out" 2>"${tmp}/check.err"; then
   echo 'FAIL: check mode must fail when the role is stale' >&2
   exit 1
 fi
 grep -F 'role mismatch' "${tmp}/check.err" >/dev/null
 ! grep -F 'update-managed-instance-role' "${tmp}/check-only/aws.log" >/dev/null
+! grep -F 'send-command' "${tmp}/check-only/aws.log" >/dev/null
+
+run_case check-correct us6 tokenkey-lightsail-ssm-hybrid-us6 false 999 --check >"${tmp}/check-correct.out"
+grep -F 'role already correct' "${tmp}/check-correct.out" >/dev/null
+! grep -F 'send-command' "${tmp}/check-correct/aws.log" >/dev/null
 
 echo 'test_ensure_edge_ssm_role: ok'

--- a/ops/lightsail/test_migrate_edge_ssm_roles.sh
+++ b/ops/lightsail/test_migrate_edge_ssm_roles.sh
@@ -71,6 +71,11 @@ case "$*" in
     instance="$(arg_after --instance-id "$@")"; edge="${instance#mi-}"
     if [[ "${FAKE_FAIL_EDGE:-}" == "${edge}" ]]; then exit 77; fi
     touch "${FAKE_STATE_DIR}/${edge}" ;;
+  *"ssm send-command"*) edge="$(edge_from_text "$@")"; echo "cmd-role-${edge}" ;;
+  *"ssm get-command-invocation"*"StandardOutputContent"*)
+    edge="$(edge_from_text "$@")"
+    echo "arn:aws:sts::123456789012:assumed-role/tokenkey-lightsail-ssm-hybrid-${edge}/mi-${edge}" ;;
+  *"ssm get-command-invocation"*"Status"*) echo Success ;;
   *"iam list-role-policies"*)
     if [[ -f "${FAKE_STATE_DIR}/deleted" ]]; then echo None; else echo EdgePgdumpPutOnly; fi ;;
   *"iam list-attached-role-policies"*) echo arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore ;;
@@ -163,9 +168,11 @@ for edge in us3 us4 us5 us6; do
   grep -F "probe_args --target edge:${edge} --expected-instance-id mi-${edge}" "${tmp}/success/actions.log" >/dev/null
   grep -F -- "--env CANARY_CREATE_DUMP=1" "${tmp}/success/actions.log" >/dev/null
   role_action_line="$(grep -n "aws ssm describe-instance-information.*mi-${edge}" "${tmp}/success/actions.log" | tail -1 | cut -d: -f1)"
+  credentials_line="$(grep -n "aws ssm get-command-invocation.*cmd-role-${edge}.*StandardOutputContent" "${tmp}/success/actions.log" | cut -d: -f1)"
   backup_line="$(grep -n "backup ${edge} mi-${edge}" "${tmp}/success/actions.log" | cut -d: -f1)"
   recovery_line="$(grep -n "recovery ${edge} mi-${edge}" "${tmp}/success/actions.log" | cut -d: -f1)"
   test "${role_action_line}" -lt "${backup_line}"
+  test "${credentials_line}" -lt "${backup_line}"
   test "${backup_line}" -lt "${recovery_line}"
   test "${recovery_line}" -lt "$(grep -n 'aws iam delete-role-policy' "${tmp}/success/actions.log" | cut -d: -f1)"
 done

--- a/ops/lightsail/test_prepare_edge_provision.sh
+++ b/ops/lightsail/test_prepare_edge_provision.sh
@@ -19,7 +19,11 @@ case "$*" in
   *"ssm get-parameter"*"/ssm_managed_instance_id"*) echo mi-0123456789abcdef0 ;;
   *"ssm list-tags-for-resource"*) echo us3 ;;
   *"ssm describe-instance-information"*) echo tokenkey-lightsail-ssm-hybrid-us3 ;;
-  *"ssm send-command"*) echo cmd-1 ;;
+  *"ssm send-command"*"verify Edge SSM role credentials"*) echo role-cmd ;;
+  *"ssm send-command"*) echo backup-cmd ;;
+  *"ssm get-command-invocation"*"role-cmd"*"StandardOutputContent"*)
+    echo 'arn:aws:sts::123456789012:assumed-role/tokenkey-lightsail-ssm-hybrid-us3/mi-0123456789abcdef0' ;;
+  *"ssm get-command-invocation"*"role-cmd"*"Status"*) echo Success ;;
   *"ssm get-command-invocation"*"StandardOutputContent"*) echo 'verify: 3 secret line(s)' ;;
   *"ssm get-command-invocation"*"StandardErrorContent"*) : ;;
   *"ssm get-command-invocation"*) echo "${FAKE_BACKUP_STATUS}" ;;
@@ -52,9 +56,11 @@ grep -Fx 'RECREATE_BACKUP_VERIFIED=false' "${tmp}/first/github.env" >/dev/null
 run_prepare recreate true true true Success >"${tmp}/recreate.out"
 grep -Fx 'ALLOW_SECRET_GENERATE=false' "${tmp}/recreate/github.env" >/dev/null
 grep -Fx 'RECREATE_BACKUP_VERIFIED=true' "${tmp}/recreate/github.env" >/dev/null
-describe_line="$(grep -n 'describe-instance-information' "${tmp}/recreate/aws.log" | cut -d: -f1)"
-backup_line="$(grep -n 'send-command' "${tmp}/recreate/aws.log" | cut -d: -f1)"
-test "${describe_line}" -lt "${backup_line}"
+describe_line="$(grep -n 'describe-instance-information' "${tmp}/recreate/aws.log" | tail -1 | cut -d: -f1)"
+credentials_line="$(grep -n 'get-command-invocation.*role-cmd.*StandardOutputContent' "${tmp}/recreate/aws.log" | cut -d: -f1)"
+backup_line="$(grep -n 'send-command.*pre-recreate' "${tmp}/recreate/aws.log" | cut -d: -f1)"
+test "${describe_line}" -lt "${credentials_line}"
+test "${credentials_line}" -lt "${backup_line}"
 
 if run_prepare backup-fails true true true Failed >"${tmp}/fail.out" 2>"${tmp}/fail.err"; then
   echo 'FAIL: failed backup must abort preparation' >&2


### PR DESCRIPTION
## 摘要

- 补齐 `ssm:UpdateManagedInstanceRole` 对目标 Edge IAM role ARN 的授权资源。
- 角色切换后通过 SSM 远端执行 `sts:GetCallerIdentity`，等待数据面凭证真正切到 `tokenkey-lightsail-ssm-hybrid-<edge-id>` 后再允许密钥备份和恢复门禁继续。
- 保持 `--check` 只读，不发送 SSM 命令。

## 风险

- 高风险 IAM/恢复链路变更，受 `docs/approved/design-edge-env-secrets-recovery.md` 审批基线约束。
- 新增权限仅覆盖 `tokenkey-lightsail-ssm-hybrid-*` 角色族；凭证等待有 300 秒上限并失败关闭。
- us4 实证表明 SSM Hybrid 共享凭证可能在 300 秒后仍未轮换；PR 当前保持 fail-closed，Fleet 迁移尚未完成。
- 本次未发布或部署应用镜像。

## 验证

- `bash scripts/preflight.sh`：PASS；PR CI 全绿。
- `test_ensure_edge_ssm_role.sh`、`test_migrate_edge_ssm_roles.sh`、`test_prepare_edge_provision.sh`：PASS。
- CloudFormation 边界单测、`validate-template`、Lightsail OIDC permission coverage：PASS。
- us3 PR-ref infra smoke run `32146846681`：PASS，远端身份、密钥离机备份与 infra smoke 均通过。
- us4 PR-ref infra smoke run `32146985169`：FAIL-CLOSED，300 秒后远端仍为共享角色；密钥备份未执行。
- 失败证据：run `32144589341` 暴露目标 IAM role 资源缺失；run `32144968220` 暴露控制面已切换但远端仍使用共享角色凭证。

## 提交

- `4014ffbb0 fix(ops): wait for Edge SSM role credentials`

最新提交：`4014ffbb0`