### PR TITLE
fix(timezone): 去掉 Asia/Shanghai 暗默，出站 TZ 跟服务器

### DIFF
--- a/.github/workflows/anthropic-cc-issue-watchdog.yml
+++ b/.github/workflows/anthropic-cc-issue-watchdog.yml
@@ -22,8 +22,8 @@ on:
       - 'scripts/anthropic/cc-issue-*.py'
       - '.github/workflows/anthropic-cc-issue-watchdog.yml'
   schedule:
-    # 06:37 Asia/Shanghai. GitHub cron is UTC. Off-minute and offset ~77 min after
-    # the Upstream Issue Watchdog (21:20 UTC) so the two watchdogs don't contend.
+    # GitHub cron is UTC. Off-minute and offset after the Upstream Issue Watchdog
+    # so the two watchdogs don't contend.
     - cron: '37 22 * * *'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/client-fidelity-watch.yml
+++ b/.github/workflows/client-fidelity-watch.yml
@@ -7,7 +7,7 @@ name: Client Fidelity Watch
 
 on:
   schedule:
-    # 08:03 Asia/Shanghai (23:03 UTC). Sequential: release scan → registry-gate → prod-aggregate → edge-oauth-mimic.
+    # GitHub cron is UTC. Sequential: release scan → registry-gate → prod-aggregate → edge-oauth-mimic.
     - cron: "3 23 * * *"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/upstream-issue-watchdog.yml
+++ b/.github/workflows/upstream-issue-watchdog.yml
@@ -22,7 +22,7 @@ on:
       - 'scripts/upstream/issue-*.py'
       - '.github/workflows/upstream-issue-watchdog.yml'
   schedule:
-    # 05:20 Asia/Shanghai. GitHub cron is UTC. Runs after the daily upstream merge agent.
+    # GitHub cron is UTC. Runs after the daily upstream merge agent.
     - cron: '20 21 * * *'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/upstream-merge-agent-daily.yml
+++ b/.github/workflows/upstream-merge-agent-daily.yml
@@ -8,7 +8,7 @@ name: Daily Upstream Merge Agent
 
 on:
   schedule:
-    # 04:00 Asia/Shanghai. GitHub cron is UTC.
+    # GitHub cron is UTC.
     - cron: '0 20 * * *'
   workflow_dispatch:
     inputs:
@@ -223,7 +223,7 @@ jobs:
 
           ## Daily automation task
 
-          Run the TokenKey upstream merge workflow unattended for the daily 04:00 Asia/Shanghai automation.
+          Run the TokenKey upstream merge workflow unattended for the daily scheduled automation.
 
           Required behavior:
           - Target branch: $BRANCH.

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1620,10 +1620,30 @@ func (d *DatabaseConfig) DSN() string {
 	)
 }
 
-// DSNWithTimezone returns DSN with timezone setting
+// resolveBusinessTimezone 解析业务日界。
+// 已配置的 timezone / TIMEZONE 优先；都空才用服务器 TZ；再空或非法则报错。
+func resolveBusinessTimezone(configured string) (string, error) {
+	if tz := strings.TrimSpace(configured); tz != "" {
+		if _, err := time.LoadLocation(tz); err != nil {
+			return "", fmt.Errorf("invalid timezone %q: %w", tz, err)
+		}
+		return tz, nil
+	}
+	if tz := strings.TrimSpace(os.Getenv("TZ")); tz != "" {
+		if _, err := time.LoadLocation(tz); err != nil {
+			return "", fmt.Errorf("invalid TZ %q: %w", tz, err)
+		}
+		return tz, nil
+	}
+	return "", fmt.Errorf("timezone is required: set config timezone, TIMEZONE, or TZ")
+}
+
+// DSNWithTimezone returns DSN with timezone setting.
+// tz should already be resolved; empty falls back to UTC, never Asia/Shanghai.
 func (d *DatabaseConfig) DSNWithTimezone(tz string) string {
+	tz = strings.TrimSpace(tz)
 	if tz == "" {
-		tz = "Asia/Shanghai"
+		tz = "UTC"
 	}
 	// 当密码为空时不包含 password 参数，避免 libpq 解析错误
 	if d.Password == "" {
@@ -1873,9 +1893,8 @@ func load(allowMissingJWTSecret bool) (*Config, error) {
 	// 环境变量支持
 	viper.AutomaticEnv()
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	// TK: 容器 TZ 只服务 OS/Postgres/日志。业务日界认 TIMEZONE / config.yaml /
-	// 默认 Asia/Shanghai。Stage0 固定 TZ=UTC，若用它覆盖 timezone，今日/昨日/
-	// cleanup/Groups 日桶会静默切到 UTC。
+	// TK: 业务日界认 config.yaml timezone / TIMEZONE，都空才回落容器 TZ。
+	// 没有可解析值就启动失败，不再暗默 Asia/Shanghai。TZ 不得覆盖已配置的 timezone。
 	if err := viper.BindEnv("server.enable_server_timing", "ENABLE_SERVER_TIMING"); err != nil {
 		return nil, fmt.Errorf("bind ENABLE_SERVER_TIMING: %w", err)
 	}
@@ -1905,6 +1924,11 @@ func load(allowMissingJWTSecret bool) (*Config, error) {
 		cfg.Security.ForwardedClientIPHeaders = normalizeStringSlice(strings.Split(forwardedClientIPHeadersEnv, ","))
 	}
 	cfg.Server.TrustedProxiesConfigured = trustedProxiesConfigured
+	resolvedTimezone, err := resolveBusinessTimezone(cfg.Timezone)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Timezone = resolvedTimezone
 	if cfg.Gateway.OpenAIScheduler.StickyEscapeTTFTMs == 0 {
 		cfg.Gateway.OpenAIScheduler.StickyEscapeTTFTMs = 15000
 	}
@@ -2398,9 +2422,6 @@ func setDefaults() {
 	viper.SetDefault("pricing.update_interval_hours", 24)
 	viper.SetDefault("pricing.hash_check_interval_minutes", 10)
 
-	// Timezone (default to Asia/Shanghai for Chinese users)
-	viper.SetDefault("timezone", "Asia/Shanghai")
-
 	// API Key auth cache
 	viper.SetDefault("api_key_auth_cache.l1_size", 65535)
 	viper.SetDefault("api_key_auth_cache.l1_ttl_seconds", 15)
@@ -2734,6 +2755,9 @@ func setDefaults() {
 // environment. Any subsystem that wants a richer default still applies it after
 // unmarshal, exactly as before.
 func setEnvReachableDefaults() {
+	// Empty default only makes TIMEZONE env-reachable. Resolution still
+	// requires config timezone, TIMEZONE, or TZ — never invent Asia/Shanghai.
+	viper.SetDefault("timezone", "")
 	viper.SetDefault("gateway.forced_codex_instructions_template_file", "")
 	viper.SetDefault("gateway.session_idle_timeout_minutes", 0)
 	viper.SetDefault("gateway.user_message_queue.mode", "")

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -14,6 +14,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMain(m *testing.M) {
+	if strings.TrimSpace(os.Getenv("TIMEZONE")) == "" && strings.TrimSpace(os.Getenv("TZ")) == "" {
+		_ = os.Setenv("TZ", "UTC")
+	}
+	os.Exit(m.Run())
+}
+
 func resetViperWithJWTSecret(t *testing.T) {
 	t.Helper()
 	viper.Reset()
@@ -21,6 +28,13 @@ func resetViperWithJWTSecret(t *testing.T) {
 	t.Setenv("CONFIG_FILE", "")
 	t.Setenv("DATA_DIR", "")
 	t.Setenv("JWT_SECRET", strings.Repeat("x", 32))
+	if prev, ok := os.LookupEnv("TIMEZONE"); ok {
+		t.Cleanup(func() { _ = os.Setenv("TIMEZONE", prev) })
+	} else {
+		t.Cleanup(func() { _ = os.Unsetenv("TIMEZONE") })
+	}
+	_ = os.Unsetenv("TIMEZONE")
+	t.Setenv("TZ", "UTC")
 }
 
 func TestLoadTimezonePrecedence(t *testing.T) {
@@ -31,7 +45,7 @@ func TestLoadTimezonePrecedence(t *testing.T) {
 		tzEnv        string
 		want         string
 	}{
-		{name: "default", want: "Asia/Shanghai"},
+		{name: "tz_fallback", tzEnv: "UTC", want: "UTC"},
 		{name: "config_file", fileTimezone: "Europe/London", want: "Europe/London"},
 		{name: "timezone_env", fileTimezone: "Europe/London", timezoneEnv: "UTC", want: "UTC"},
 		{name: "tz_does_not_override_timezone_env", fileTimezone: "Europe/London", timezoneEnv: "UTC", tzEnv: "America/New_York", want: "UTC"},
@@ -41,7 +55,9 @@ func TestLoadTimezonePrecedence(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resetViperWithJWTSecret(t)
-			t.Setenv("TIMEZONE", tt.timezoneEnv)
+			if tt.timezoneEnv != "" {
+				t.Setenv("TIMEZONE", tt.timezoneEnv)
+			}
 			t.Setenv("TZ", tt.tzEnv)
 			if tt.fileTimezone != "" {
 				configFile := filepath.Join(t.TempDir(), "config.yaml")
@@ -54,6 +70,15 @@ func TestLoadTimezonePrecedence(t *testing.T) {
 			require.Equal(t, tt.want, cfg.Timezone)
 		})
 	}
+
+	t.Run("missing_timezone_errors", func(t *testing.T) {
+		resetViperWithJWTSecret(t)
+		t.Setenv("TIMEZONE", "")
+		t.Setenv("TZ", "")
+		_, err := Load()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "timezone is required")
+	})
 }
 
 func TestLoadServerTimingConfig(t *testing.T) {
@@ -1234,8 +1259,8 @@ func TestConfigAddressHelpers(t *testing.T) {
 		t.Fatalf("DatabaseConfig.DSNWithTimezone() should omit password when empty")
 	}
 
-	if !strings.Contains(dbCfg.DSNWithTimezone(""), "TimeZone=Asia/Shanghai") {
-		t.Fatalf("DatabaseConfig.DSNWithTimezone() should use default timezone")
+	if !strings.Contains(dbCfg.DSNWithTimezone(""), "TimeZone=UTC") {
+		t.Fatalf("DatabaseConfig.DSNWithTimezone() should not invent Asia/Shanghai")
 	}
 	if !strings.Contains(dbCfg.DSNWithTimezone("UTC"), "TimeZone=UTC") {
 		t.Fatalf("DatabaseConfig.DSNWithTimezone() should use provided timezone")

--- a/backend/internal/pkg/timezone/timezone.go
+++ b/backend/internal/pkg/timezone/timezone.go
@@ -6,6 +6,7 @@ package timezone
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 )
 
@@ -20,8 +21,9 @@ var (
 // This should be called once at application startup.
 // Example timezone values: "Asia/Shanghai", "America/New_York", "UTC"
 func Init(tz string) error {
+	tz = strings.TrimSpace(tz)
 	if tz == "" {
-		tz = "Asia/Shanghai" // Default timezone
+		return fmt.Errorf("timezone is required")
 	}
 
 	loc, err := time.LoadLocation(tz)

--- a/backend/internal/pkg/timezone/timezone_test.go
+++ b/backend/internal/pkg/timezone/timezone_test.go
@@ -35,6 +35,12 @@ func TestInitInvalidTimezone(t *testing.T) {
 	}
 }
 
+func TestInitEmptyTimezone(t *testing.T) {
+	if err := Init(""); err == nil {
+		t.Fatal("Init should fail when timezone is empty")
+	}
+}
+
 func TestTimeNowAffected(t *testing.T) {
 	// Reset to UTC first
 	if err := Init("UTC"); err != nil {

--- a/backend/internal/service/gateway_request_tk_cc_geo_stego.go
+++ b/backend/internal/service/gateway_request_tk_cc_geo_stego.go
@@ -15,8 +15,8 @@ import (
 //   - lab keyword in host → other apostrophe codepoints
 //
 // TokenKey cannot control the user's machine, but we can rewrite the wire body
-// to the first-party shape (ASCII apostrophe + dashed ISO date) so upstream
-// does not see "client says CN, egress says US". Observed in Agent SDK -p
+// to the first-party shape (ASCII apostrophe + dashed ISO date + egress TZ)
+// so upstream does not see "client says CN, egress says US". Observed in Agent SDK -p
 // traffic under messages[].content[].text <system-reminder> (#currentDate),
 // not in system[] billing blocks.
 //

--- a/backend/internal/service/gateway_request_tk_cc_prompt_surface.go
+++ b/backend/internal/service/gateway_request_tk_cc_prompt_surface.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 )
 
 const (
@@ -35,7 +37,7 @@ func tkNormalizeCCPromptSurfaceText(text, oauthEmail string) (string, bool) {
 		return text, false
 	}
 	changed := false
-	if out, ok := tkStripCCEnvironmentSection(text); ok {
+	if out, ok := tkRewriteCCEnvironmentSection(text); ok {
 		text = out
 		changed = true
 	}
@@ -87,33 +89,77 @@ func tkCCPromptSurfaceClassTracksLeaks(cls tkCCPromptSurfaceClass) bool {
 	}
 }
 
-func tkStripCCEnvironmentSection(text string) (string, bool) {
+func tkOutboundTimezoneName() string {
+	name := strings.TrimSpace(timezone.Name())
+	if name == "" || strings.EqualFold(name, "Local") {
+		return ""
+	}
+	return name
+}
+
+func tkRewriteCCEnvironmentSection(text string) (string, bool) {
 	if !strings.Contains(text, "# Environment") {
 		return text, false
 	}
+	outboundTZ := tkOutboundTimezoneName()
 	lines := strings.Split(text, "\n")
 	out := make([]string, 0, len(lines))
-	skip := false
+	inEnv := false
 	changed := false
+	wroteTZ := false
+	flushTZ := func() {
+		if outboundTZ == "" || wroteTZ {
+			return
+		}
+		out = append(out, "TZ="+outboundTZ)
+		wroteTZ = true
+		changed = true
+	}
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "# Environment" {
-			skip = true
-			changed = true
+			if inEnv {
+				flushTZ()
+			}
+			inEnv = true
+			out = append(out, line)
 			continue
 		}
-		if skip {
+		if inEnv {
 			if strings.HasPrefix(trimmed, "# ") {
-				skip = false
+				flushTZ()
+				inEnv = false
 				out = append(out, line)
 				continue
 			}
-			if tkIsCCEnvironmentKVLine(trimmed) {
+			if strings.HasPrefix(trimmed, "TZ=") {
+				if outboundTZ == "" {
+					changed = true
+					continue
+				}
+				if trimmed != "TZ="+outboundTZ {
+					changed = true
+				}
+				if !wroteTZ {
+					out = append(out, "TZ="+outboundTZ)
+					wroteTZ = true
+				}
 				continue
 			}
-			skip = false
+			if tkIsCCEnvironmentLocalKVLine(trimmed) {
+				changed = true
+				continue
+			}
+			if trimmed == "" {
+				continue
+			}
+			flushTZ()
+			inEnv = false
 		}
 		out = append(out, line)
+	}
+	if inEnv {
+		flushTZ()
 	}
 	if !changed {
 		return text, false
@@ -121,11 +167,11 @@ func tkStripCCEnvironmentSection(text string) (string, bool) {
 	return strings.TrimSpace(strings.Join(out, "\n")), true
 }
 
-func tkIsCCEnvironmentKVLine(line string) bool {
+func tkIsCCEnvironmentLocalKVLine(line string) bool {
 	if line == "" {
 		return true
 	}
-	for _, prefix := range []string{"TZ=", "Proxy=", "proxy=", "PWD=", "cwd="} {
+	for _, prefix := range []string{"Proxy=", "proxy=", "PWD=", "cwd="} {
 		if strings.HasPrefix(line, prefix) {
 			return true
 		}
@@ -367,10 +413,22 @@ func tkCCPromptSurfaceTextUnknownSurfaces(text string) []string {
 	if dateClass != "NONE" && dateClass != "ISO_DASH_ASCII" {
 		surfaces = appendUniqueString(surfaces, "geo_stego_date_line")
 	}
-	if strings.Contains(text, "# Environment") || tkCCWireCNTimezoneRE.MatchString(text) {
+	if tkCCEnvironmentSectionLeaks(text) {
 		surfaces = appendUniqueString(surfaces, "cc_environment_section")
 	}
 	return surfaces
+}
+
+func tkCCEnvironmentSectionLeaks(text string) bool {
+	if tkCCWireCNTimezoneRE.MatchString(text) {
+		return true
+	}
+	for _, marker := range []string{"Proxy=", "proxy=", "PWD=", "cwd="} {
+		if strings.Contains(text, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func tkCCPromptSurfaceTextHasPromptSignal(text string) bool {

--- a/backend/internal/service/gateway_request_tk_cc_prompt_surface_test.go
+++ b/backend/internal/service/gateway_request_tk_cc_prompt_surface_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 )
 
 func TestAccountGetOAuthAccountEmail(t *testing.T) {
@@ -19,12 +21,15 @@ func TestAccountGetOAuthAccountEmail(t *testing.T) {
 	require.Equal(t, "edge@tokenkey.dev", acct.GetOAuthAccountEmail())
 }
 
-func TestTkStripCCEnvironmentSection(t *testing.T) {
+func TestTkRewriteCCEnvironmentSection(t *testing.T) {
+	require.NoError(t, timezone.Init("UTC"))
 	in := "<system-reminder>\n# Environment\nTZ=Asia/Shanghai\nProxy=http://127.0.0.1:7890\n\nThe user's email address is client@gmail.com.\n\n# currentDate\nToday's date is 2026/07/01.\n</system-reminder>"
-	out, changed := tkStripCCEnvironmentSection(in)
+	out, changed := tkRewriteCCEnvironmentSection(in)
 	require.True(t, changed)
-	require.NotContains(t, out, "# Environment")
+	require.Contains(t, out, "# Environment")
+	require.Contains(t, out, "TZ=UTC")
 	require.NotContains(t, out, "Asia/Shanghai")
+	require.NotContains(t, out, "Proxy=")
 	require.Contains(t, out, "client@gmail.com")
 	require.Contains(t, out, "# currentDate")
 }
@@ -92,11 +97,14 @@ func TestTkClassifyCCPromptSurfaceText(t *testing.T) {
 }
 
 func TestTkNormalizeAnthropicCCPromptSurfaceMessagesEnvironmentAndEmail(t *testing.T) {
+	require.NoError(t, timezone.Init("UTC"))
 	in := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"<system-reminder>\n# Environment\nTZ=Asia/Shanghai\n\nThe user's email address is client@gmail.com.\n\n# currentDate\nToday\u2019s date is 2026/07/01.\n</system-reminder>"}]}]}`)
 	out, changed := tkNormalizeAnthropicCCPromptSurface(in, "edge-oauth@tokenkey.dev")
 	require.True(t, changed)
 	got := string(out)
-	require.NotContains(t, got, "# Environment")
+	require.Contains(t, got, "# Environment")
+	require.Contains(t, got, "TZ=UTC")
+	require.NotContains(t, got, "Asia/Shanghai")
 	require.Contains(t, got, "edge-oauth@tokenkey.dev")
 	require.Contains(t, got, "Today's date is 2026-07-01.")
 }
@@ -134,21 +142,26 @@ func TestTkNormalizeAnthropicCCPromptSurfaceLeavesQuotedReminderUserText(t *test
 }
 
 func TestTkNormalizeAnthropicCCPromptSurfaceNormalizesKnownSystemText(t *testing.T) {
+	require.NoError(t, timezone.Init("UTC"))
 	in := []byte(`{"system":[{"type":"text","text":"You are Claude Code, Anthropic's official CLI for Claude.\n# Environment\nTZ=Asia/Shanghai\nThe user's email address is client@gmail.com.\nToday's date is 2026/07/01."}]}`)
 	out, changed := tkNormalizeAnthropicCCPromptSurface(in, "edge-oauth@tokenkey.dev")
 	require.True(t, changed)
 	got := string(out)
-	require.NotContains(t, got, "# Environment")
+	require.Contains(t, got, "# Environment")
+	require.Contains(t, got, "TZ=UTC")
+	require.NotContains(t, got, "Asia/Shanghai")
 	require.Contains(t, got, "edge-oauth@tokenkey.dev")
 	require.Contains(t, got, "Today's date is 2026-07-01.")
 }
 
 func TestTkNormalizeAnthropicCCPromptSurfaceNormalizesInteractiveCLIToolSystemText(t *testing.T) {
+	require.NoError(t, timezone.Init("UTC"))
 	in := []byte(`{"system":[{"type":"text","text":"x-anthropic-billing-header: cc-session"},{"type":"text","text":"You are an interactive CLI tool that helps users safely and efficiently.\n# Environment\nTZ=Asia/Shanghai\nPWD=/work\n\nToday's date is 2026/07/01."}],"messages":[{"role":"user","content":"hi"}]}`)
 	out, changed := tkNormalizeAnthropicCCPromptSurface(in, "edge-oauth@tokenkey.dev")
 	require.True(t, changed)
 	got := string(out)
-	require.NotContains(t, got, "# Environment")
+	require.Contains(t, got, "# Environment")
+	require.Contains(t, got, "TZ=UTC")
 	require.NotContains(t, got, "Asia/Shanghai")
 	require.NotContains(t, got, "PWD=/work")
 	require.Contains(t, got, "Today's date is 2026-07-01.")

--- a/backend/internal/service/gateway_request_tk_prompt_fingerprint_test.go
+++ b/backend/internal/service/gateway_request_tk_prompt_fingerprint_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 )
 
 func TestTkExtractAnthropicPromptFingerprint_GeoStegoInReminder(t *testing.T) {
@@ -232,6 +234,7 @@ func TestTkNormalizeAnthropicRequestBody_FingerprintCanonicalAfterGeo(t *testing
 // ops/anthropic/probe_prompt_surfaces.py --check-gateway via
 // TOKENKEY_PROMPT_SURFACE_PROBE_JSONL=<capture.jsonl>.
 func TestTkProbePromptSurfaceGatewayCoverageJSONL(t *testing.T) {
+	require.NoError(t, timezone.Init("UTC"))
 	path := os.Getenv("TOKENKEY_PROMPT_SURFACE_PROBE_JSONL")
 	if path == "" {
 		path = os.Getenv("TOKENKEY_CC_GEO_PROBE_JSONL")

--- a/backend/internal/setup/setup.go
+++ b/backend/internal/setup/setup.go
@@ -460,10 +460,9 @@ func createAdminUser(cfg *SetupConfig) (bool, string, error) {
 }
 
 func writeConfigFile(cfg *SetupConfig) error {
-	// Ensure timezone has a default value
 	tz := cfg.Timezone
 	if tz == "" {
-		tz = "Asia/Shanghai"
+		return fmt.Errorf("timezone is required: set timezone in setup")
 	}
 
 	// Prepare config for YAML (exclude sensitive data and admin config)
@@ -568,10 +567,12 @@ func AutoSetupFromEnv() error {
 	logger.LegacyPrintf("setup", "%s", "Auto setup enabled, configuring from environment variables...")
 	logger.LegacyPrintf("setup", "Data directory: %s", GetDataDir())
 
-	// Get timezone from TZ or TIMEZONE env var (TZ is standard for Docker)
 	tz := getEnvOrDefault("TZ", "")
 	if tz == "" {
-		tz = getEnvOrDefault("TIMEZONE", "Asia/Shanghai")
+		tz = getEnvOrDefault("TIMEZONE", "")
+	}
+	if tz == "" {
+		return fmt.Errorf("timezone is required: set TZ or TIMEZONE")
 	}
 
 	// Build config from environment variables

--- a/backend/internal/setup/setup_test.go
+++ b/backend/internal/setup/setup_test.go
@@ -185,11 +185,22 @@ func TestSetupMigrationTimeout(t *testing.T) {
 	})
 }
 
+func TestWriteConfigFileRejectsMissingTimezone(t *testing.T) {
+	t.Setenv("DATA_DIR", t.TempDir())
+	err := writeConfigFile(&SetupConfig{})
+	if err == nil {
+		t.Fatal("writeConfigFile() should reject empty timezone")
+	}
+	if !strings.Contains(err.Error(), "timezone is required") {
+		t.Fatalf("writeConfigFile() error = %v", err)
+	}
+}
+
 func TestWriteConfigFileKeepsDefaultUserConcurrency(t *testing.T) {
 	t.Setenv("RUN_MODE", "simple")
 	t.Setenv("DATA_DIR", t.TempDir())
 
-	if err := writeConfigFile(&SetupConfig{}); err != nil {
+	if err := writeConfigFile(&SetupConfig{Timezone: "UTC"}); err != nil {
 		t.Fatalf("writeConfigFile() error = %v", err)
 	}
 
@@ -207,6 +218,7 @@ func TestWriteConfigFileIncludesRedisUsername(t *testing.T) {
 	t.Setenv("DATA_DIR", t.TempDir())
 
 	if err := writeConfigFile(&SetupConfig{
+		Timezone: "UTC",
 		Redis: RedisConfig{
 			Host:     "redis",
 			Port:     6379,

--- a/scripts/sentinels/cc-geo-stego-static.json
+++ b/scripts/sentinels/cc-geo-stego-static.json
@@ -16,7 +16,7 @@
       "path": "backend/internal/service/gateway_request_tk_cc_prompt_surface.go",
       "must_contain": [
         "func tkNormalizeAnthropicCCPromptSurface",
-        "func tkStripCCEnvironmentSection",
+        "func tkRewriteCCEnvironmentSection",
         "func tkNormalizeCCUserEmailLine"
       ]
     },

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3043,12 +3043,12 @@
         "tkCCPromptSurfaceGenericUserText",
         "tkCCPromptSurfaceUnknownSystem",
         "func tkNormalizeAnthropicCCPromptSurface",
-        "func tkStripCCEnvironmentSection",
+        "func tkRewriteCCEnvironmentSection",
         "func tkNormalizeCCUserEmailLine",
         "tkNormalizeChangeCCEnvironmentStrip",
         "tkNormalizeChangeCCUserEmailReplaced"
       ],
-      "rationale": "Unified CC prompt-surface normalizer: geo-stego date lines + # Environment strip + client userEmail replace/strip (OAuth account email when scheduled). Classification is load-bearing: known CC system/reminder text may be rewritten; plain user/generic system text must stay untouched; unknown system-shaped drift is observed but not rewritten."
+      "rationale": "Unified CC prompt-surface normalizer: geo-stego date lines + # Environment TZ rewrite to server timezone (strip Proxy/PWD) + client userEmail replace/strip (OAuth account email when scheduled). Classification is load-bearing: known CC system/reminder text may be rewritten; plain user/generic system text must stay untouched; unknown system-shaped drift is observed but not rewritten."
     },
     {
       "path": "backend/internal/service/gateway_anthropic_request_normalize_tk.go",


### PR DESCRIPTION
## 摘要
- 业务日界不再暗默 `Asia/Shanghai`：认 `config.yaml timezone` / `TIMEZONE`，都空才回落容器 `TZ`，再空或非法则启动失败。
- Claude Code 出站 `# Environment` 的 `TZ=` 改写成出站进程时区（Stage0 为 UTC），仍剥掉 `Proxy=` / `PWD=`。
- GitHub cron 去掉「上海本地时间」注释，避免 agent 把注释当事实。
- 飞书告警保持 `UTC RFC3339（北京时间 HH:MM:SS）`。
- DeepSeek 峰谷窗、已发布迁移、社区 compose 默认未改。

## 风险
常规。线上 Stage0 已有 `timezone: UTC` + `TZ=UTC`，解析路径与现网日界一致。CC 出站从「整段丢掉 Environment」改为「保留 Environment 并写服务器 TZ」，属于指纹 wire 调整，需发版后观察 OAuth 出站。无 Web 页面/契约变更。
Web impact: none
sentinel-registry-reviewed

## 验证
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：通过
- `go test -tags=unit ./internal/config ./internal/pkg/timezone ./internal/setup`：通过
- `go test -tags=unit ./internal/service -run 'TestFormatAlertTime|TestTkRewriteCCEnvironmentSection|TestTkNormalizeAnthropicCCPromptSurface|TestTkWireStillHasCCPromptSurfaceLeaks'`：通过

## 提交
- `455a59898` fix(timezone): require an explicit timezone instead of defaulting to Shanghai
- 最新提交：`455a59898`

Made with [Cursor](https://cursor.com)