### PR TITLE
feat(catalog): 上架 gemini-3.7-flash

### DIFF
--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -128,6 +128,13 @@ var DefaultAntigravityModelMapping = map[string]string{
 	// Gemini 3.6 Flash public id routes to the tiered wire id returned by
 	// Antigravity on us3/us4 (2026-07-22 live account probes).
 	"gemini-3.6-flash": "gemini-3.6-flash-tiered",
+	// Gemini 3.7 Flash (2026-08-19 fetchAvailableModels on us3/us4/us6):
+	// upstream lists thinking-tier wire ids only; Google's default thinking
+	// level is medium, so the public id remaps there. No -tiered wire id yet.
+	"gemini-3.7-flash":        "gemini-3.7-flash-medium",
+	"gemini-3.7-flash-high":   "gemini-3.7-flash-high",
+	"gemini-3.7-flash-low":    "gemini-3.7-flash-low",
+	"gemini-3.7-flash-medium": "gemini-3.7-flash-medium",
 	// Gemini 3.1 Pro (High) 实测 wire id（gemini-3.1-pro-high 上游已废弃 → gemini-pro-agent）
 	"gemini-pro-agent": "gemini-pro-agent",
 }

--- a/backend/internal/domain/constants_test.go
+++ b/backend/internal/domain/constants_test.go
@@ -118,6 +118,19 @@ func TestDefaultAntigravityModelMapping_Gemini36TieredBoundary(t *testing.T) {
 	}
 }
 
+func TestDefaultAntigravityModelMapping_Gemini37MediumDefault(t *testing.T) {
+	t.Parallel()
+
+	if got := DefaultAntigravityModelMapping["gemini-3.7-flash"]; got != "gemini-3.7-flash-medium" {
+		t.Fatalf("gemini-3.7-flash must map to the live medium wire id, got %q", got)
+	}
+	for _, wire := range []string{"gemini-3.7-flash-low", "gemini-3.7-flash-medium", "gemini-3.7-flash-high"} {
+		if got := DefaultAntigravityModelMapping[wire]; got != wire {
+			t.Fatalf("%s must be an identity wire mapping, got %q", wire, got)
+		}
+	}
+}
+
 func TestDefaultAntigravityModelMapping_Gemini31ProAliases(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/service/account_model_mapping_vertex_tk.go
+++ b/backend/internal/service/account_model_mapping_vertex_tk.go
@@ -24,6 +24,7 @@ var vertexSharedModelMappingIDs = []string{
 	"gemini-2.5-flash-lite",
 	"gemini-3.5-flash-lite",
 	"gemini-3.6-flash",
+	"gemini-3.7-flash",
 	"gemini-embedding-001",
 	"veo-3.1-generate-001",
 }

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -323,6 +323,14 @@ func (s *BillingService) initFallbackPricing() {
 		CacheReadPricePerToken: 0.15e-6,
 		SupportsCacheBreakdown: false,
 	}
+	// Gemini 3.7 Flash introductory list (through 2026-12-31): $0.75 input /
+	// $3.75 output / $0.075 cached input per MTok.
+	s.fallbackPrices["gemini-3.7-flash"] = &ModelPricing{
+		InputPricePerToken:     0.75e-6,
+		OutputPricePerToken:    3.75e-6,
+		CacheReadPricePerToken: 0.075e-6,
+		SupportsCacheBreakdown: false,
+	}
 
 	// OpenAI GPT-5.4（业务指定价格）
 	s.fallbackPrices["gpt-5.4"] = &ModelPricing{
@@ -624,6 +632,9 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 	}
 	if strings.Contains(modelLower, "gemini-3.1-pro") || strings.Contains(modelLower, "gemini-3-1-pro") {
 		return s.fallbackPrices["gemini-3.1-pro"]
+	}
+	if strings.Contains(modelLower, "gemini-3.7-flash") || strings.Contains(modelLower, "gemini-3-7-flash") {
+		return s.fallbackPrices["gemini-3.7-flash"]
 	}
 	if strings.Contains(modelLower, "gemini-3.6-flash") || strings.Contains(modelLower, "gemini-3-6-flash") {
 		return s.fallbackPrices["gemini-3.6-flash"]

--- a/backend/internal/service/billing_service_tk_registry_alias.go
+++ b/backend/internal/service/billing_service_tk_registry_alias.go
@@ -89,7 +89,7 @@ func (s *BillingService) getRegistryAliasPricing(model string) *ModelPricing {
 	owners := []string{
 		"claude-sonnet-4", "claude-3-5-sonnet", "claude-3-5-haiku",
 		"claude-3-opus", "claude-3-haiku", "claude-fable-5",
-		"gemini-3.1-pro", "gemini-3.6-flash", "gemini-2.5-pro",
+		"gemini-3.1-pro", "gemini-3.7-flash", "gemini-3.6-flash", "gemini-2.5-pro",
 		"gemini-2.5-flash-lite", "gemini-2.5-flash", "glm-4.7-flash",
 		"glm-4.5-flash", "kimi-k3", "kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2",
 		"minimax-m3", "minimax-m2.7-highspeed", "minimax-m2.7",

--- a/backend/internal/service/pricing_catalog_supported_models_tk.go
+++ b/backend/internal/service/pricing_catalog_supported_models_tk.go
@@ -191,6 +191,8 @@ var supportedAnthropicTokenseaRelayCatalogModels = map[string]struct{}{
 // supportedGeminiCatalogModels — gemini/Vertex IDs confirmed servable through
 // the prod Vertex pool. Gemini 3.5 Flash Lite and 3.6 Flash were confirmed on
 // accounts 47/57/58/59/74 via direct global generateContent on 2026-07-22.
+// Gemini 3.7 Flash was confirmed on accounts 47/57/59 via the same global
+// generateContent path on 2026-08-19 (us-central1 returns 404).
 // While EMPTY the catalog/menu gates fall through to passthrough/canonical (no
 // regression).
 var supportedGeminiCatalogModels = map[string]struct{}{
@@ -200,6 +202,7 @@ var supportedGeminiCatalogModels = map[string]struct{}{
 	"gemini-2.5-pro":                {},
 	"gemini-3.5-flash-lite":         {},
 	"gemini-3.6-flash":              {},
+	"gemini-3.7-flash":              {},
 	"imagen-4.0-fast-generate-001":  {},
 	"imagen-4.0-generate-001":       {},
 	"imagen-4.0-ultra-generate-001": {},
@@ -211,7 +214,9 @@ var supportedGeminiCatalogModels = map[string]struct{}{
 // supportedAntigravityCatalogModels — antigravity wire/client ids confirmed
 // servable (Gemini 2026-06 probes + PR #1265 Antigravity Claude live subset).
 // Gemini 3.6 Flash was confirmed on us3 account 3 and us4 account 5 through the
-// gemini-3.6-flash-tiered wire id on 2026-07-22; Gemini 3.5 Flash Lite remained
+// gemini-3.6-flash-tiered wire id on 2026-07-22. Gemini 3.7 Flash was listed by
+// fetchAvailableModels on us3/us4/us6 on 2026-08-19 as
+// gemini-3.7-flash-{low,medium,high} (no -tiered wire id). Gemini 3.5 Flash Lite remained
 // upstream-unsupported and is intentionally Vertex-only. Hand-maintained (see
 // header). While EMPTY the catalog/menu gates fall through to
 // passthrough/canonical (no regression).
@@ -234,6 +239,7 @@ var supportedAntigravityCatalogModels = map[string]struct{}{
 	"gemini-3.5-flash-extra-low":     {},
 	"gemini-3.5-flash-low":           {},
 	"gemini-3.6-flash":               {},
+	"gemini-3.7-flash":               {},
 	"gemini-pro-agent":               {},
 	// servable-allowlist:end antigravity
 }

--- a/backend/internal/service/pricing_service.go
+++ b/backend/internal/service/pricing_service.go
@@ -914,15 +914,16 @@ func normalizeModelNameForPricing(model string) string {
 	return normalizeGeminiThinkingTierAlias(model)
 }
 
-// normalizeGeminiThinkingTierAlias maps Antigravity's Gemini 3.6 Flash
-// thinking-tier model IDs to the public base model. The tier controls reasoning
-// behavior, not the published token rate, so this keeps -high/-low/-medium and
-// -tiered requests on the same price card as gemini-3.6-flash.
+// normalizeGeminiThinkingTierAlias maps Antigravity Gemini Flash thinking-tier
+// model IDs to the public base model. The tier controls reasoning behavior, not
+// the published token rate, so -high/-low/-medium/-tiered stay on the same
+// price card as the public id.
 func normalizeGeminiThinkingTierAlias(model string) string {
-	const baseModel = "gemini-3.6-flash"
-	for _, tier := range []string{"-high", "-low", "-medium", "-tiered"} {
-		if model == baseModel+tier {
-			return baseModel
+	for _, baseModel := range []string{"gemini-3.6-flash", "gemini-3.7-flash"} {
+		for _, tier := range []string{"-high", "-low", "-medium", "-tiered"} {
+			if model == baseModel+tier {
+				return baseModel
+			}
 		}
 	}
 	return model

--- a/backend/internal/service/pricing_service_test.go
+++ b/backend/internal/service/pricing_service_test.go
@@ -478,6 +478,28 @@ func TestGetModelPricing_OpenAICompactAliasUsesRegistryOwner(t *testing.T) {
 	require.InDelta(t, 3e-5, got.OutputCostPerToken, 1e-12)
 }
 
+func TestPricingService_Gemini37FlashThinkingTiersUseBasePricing(t *testing.T) {
+	basePricing := &LiteLLMModelPricing{
+		InputCostPerToken:       0.75e-6,
+		OutputCostPerToken:      3.75e-6,
+		CacheReadInputTokenCost: 0.075e-6,
+	}
+	svc := &PricingService{pricingData: map[string]*LiteLLMModelPricing{
+		"gemini-3.7-flash": basePricing,
+	}}
+
+	for _, model := range []string{
+		"gemini-3.7-flash",
+		"gemini-3.7-flash-high",
+		"gemini-3.7-flash-low",
+		"gemini-3.7-flash-medium",
+	} {
+		t.Run(model, func(t *testing.T) {
+			require.Same(t, basePricing, svc.GetModelPricing(model))
+		})
+	}
+}
+
 func TestPricingService_Gemini36FlashThinkingTiersUseBasePricing(t *testing.T) {
 	basePricing := &LiteLLMModelPricing{
 		InputCostPerToken:       1.5e-6,

--- a/backend/internal/service/pricing_service_tk_overlay_test.go
+++ b/backend/internal/service/pricing_service_tk_overlay_test.go
@@ -262,6 +262,7 @@ func TestTKPricingOverlay_FillsGemini35LiteAnd36FlashAtOfficialRates(t *testing.
 	}{
 		"gemini-3.5-flash-lite": {input: 3e-7, output: 2.5e-6, cache: 3e-8},
 		"gemini-3.6-flash":      {input: 1.5e-6, output: 7.5e-6, cache: 1.5e-7},
+		"gemini-3.7-flash":      {input: 7.5e-7, output: 3.75e-6, cache: 7.5e-8},
 	}
 	for modelID, want := range cases {
 		pricing := data[modelID]

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -3969,6 +3969,22 @@
     "supports_web_search": true,
     "web_search_billing_unit": "per_query"
   },
+  "gemini-3.7-flash": {
+    "cache_read_input_token_cost": 7.5e-08,
+    "input_cost_per_token": 7.5e-07,
+    "litellm_provider": "vertex_ai-language-models",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "max_tokens": 65536,
+    "mode": "chat",
+    "output_cost_per_reasoning_token": 3.75e-06,
+    "output_cost_per_token": 3.75e-06,
+    "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-3.7-flash ; https://blog.google/innovation-and-ai/models-and-research/gemini-models/introducing-gemini-3.7-flash/ introductory list $0.75/$3.75 per 1M in/out through 2026-12-31, cache read 10% of input; captured 2026-08-19.",
+    "supports_function_calling": true,
+    "supports_prompt_caching": true,
+    "supports_reasoning": true,
+    "supports_vision": true
+  },
   "gemini-embedding-001": {
     "input_cost_per_token": 1.5e-07,
     "litellm_provider": "vertex_ai-embedding-models",

--- a/backend/internal/service/vertex_service_account.go
+++ b/backend/internal/service/vertex_service_account.go
@@ -99,7 +99,7 @@ func (a *Account) VertexLocation(model string) string {
 func vertexModelUsesGlobalLocation(model string) bool {
 	model = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(model), "models/"))
 	switch model {
-	case "gemini-3.5-flash-lite", "gemini-3.6-flash":
+	case "gemini-3.5-flash-lite", "gemini-3.6-flash", "gemini-3.7-flash":
 		return true
 	default:
 		return false

--- a/backend/internal/service/vertex_service_account_test.go
+++ b/backend/internal/service/vertex_service_account_test.go
@@ -35,6 +35,7 @@ func TestVertexLocationUsesGlobalForGlobalOnlyGeminiModels(t *testing.T) {
 
 	require.Equal(t, vertexGlobalLocation, account.VertexLocation("gemini-3.5-flash-lite"))
 	require.Equal(t, vertexGlobalLocation, account.VertexLocation("models/gemini-3.6-flash"))
+	require.Equal(t, vertexGlobalLocation, account.VertexLocation("gemini-3.7-flash"))
 	require.Equal(t, "us-central1", account.VertexLocation("gemini-2.5-flash"))
 }
 

--- a/ops/pricing/model-surface-bundle.json
+++ b/ops/pricing/model-surface-bundle.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 4,
-  "floor_sha256": "09eb39ad73902a2f01190389fa9ae66a2f81553aa72c6cd88000ae0a3e00968f",
+  "floor_sha256": "9bf2140bc735a76864ea08812438a094c67f76f1d093b7d39d8dbf2770025ba1",
   "account_model_mapping": {
     "platforms": {
       "anthropic": {
@@ -45,6 +45,7 @@
         "gemini-3.5-flash-extra-low": "gemini-3.5-flash-extra-low",
         "gemini-3.5-flash-low": "gemini-3.5-flash-low",
         "gemini-3.6-flash": "gemini-3.6-flash-tiered",
+        "gemini-3.7-flash": "gemini-3.7-flash-medium",
         "gemini-pro-agent": "gemini-pro-agent"
       },
       "bedrock": {
@@ -74,6 +75,7 @@
         "gemini-2.5-pro": "gemini-2.5-pro",
         "gemini-3.5-flash-lite": "gemini-3.5-flash-lite",
         "gemini-3.6-flash": "gemini-3.6-flash",
+        "gemini-3.7-flash": "gemini-3.7-flash",
         "gemini-embedding-001": "gemini-embedding-001",
         "imagen-4.0-fast-generate-001": "imagen-4.0-fast-generate-001",
         "imagen-4.0-generate-001": "imagen-4.0-generate-001",
@@ -272,6 +274,7 @@
         "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
         "gemini-3.5-flash-lite": "gemini-3.5-flash-lite",
         "gemini-3.6-flash": "gemini-3.6-flash",
+        "gemini-3.7-flash": "gemini-3.7-flash",
         "gemini-embedding-001": "gemini-embedding-001",
         "veo-3.1-generate-001": "veo-3.1-generate-001"
       },
@@ -389,6 +392,7 @@
         "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
         "gemini-3.5-flash-lite": "gemini-3.5-flash-lite",
         "gemini-3.6-flash": "gemini-3.6-flash",
+        "gemini-3.7-flash": "gemini-3.7-flash",
         "gemini-embedding-001": "gemini-embedding-001",
         "imagen-4.0-ultra-generate-001": "imagen-4.0-ultra-generate-001",
         "veo-3.1-generate-001": "veo-3.1-generate-001"
@@ -399,6 +403,7 @@
         "gemini-2.5-pro": "gemini-2.5-pro",
         "gemini-3.5-flash-lite": "gemini-3.5-flash-lite",
         "gemini-3.6-flash": "gemini-3.6-flash",
+        "gemini-3.7-flash": "gemini-3.7-flash",
         "gemini-embedding-001": "gemini-embedding-001",
         "veo-3.1-generate-001": "veo-3.1-generate-001"
       },
@@ -408,6 +413,7 @@
         "gemini-2.5-pro": "gemini-2.5-pro",
         "gemini-3.5-flash-lite": "gemini-3.5-flash-lite",
         "gemini-3.6-flash": "gemini-3.6-flash",
+        "gemini-3.7-flash": "gemini-3.7-flash",
         "gemini-embedding-001": "gemini-embedding-001",
         "imagen-4.0-fast-generate-001": "imagen-4.0-fast-generate-001",
         "imagen-4.0-generate-001": "imagen-4.0-generate-001",
@@ -419,6 +425,7 @@
         "gemini-2.5-pro": "gemini-2.5-pro",
         "gemini-3.5-flash-lite": "gemini-3.5-flash-lite",
         "gemini-3.6-flash": "gemini-3.6-flash",
+        "gemini-3.7-flash": "gemini-3.7-flash",
         "gemini-embedding-001": "gemini-embedding-001",
         "imagen-4.0-generate-001": "imagen-4.0-generate-001",
         "veo-3.1-generate-001": "veo-3.1-generate-001"

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6528,6 +6528,14 @@
         "authenticated.GET(\"/me/api-keys/:id/capabilities\", h.APIKey.GetCapabilities)"
       ],
       "rationale": "The per-key capability API must remain under authenticated user routes. Losing the route leaves website discovery unable to query automatic keys even though gateway discovery still works."
+    },
+    {
+      "path": "backend/internal/service/vertex_service_account.go",
+      "must_contain": [
+        "func vertexModelUsesGlobalLocation(model string) bool",
+        "\"gemini-3.5-flash-lite\", \"gemini-3.6-flash\", \"gemini-3.7-flash\""
+      ],
+      "rationale": "Gemini 3.5 Flash Lite / 3.6 Flash / 3.7 Flash are publisher-global-only on Vertex. vertexModelUsesGlobalLocation must keep these ids on the global endpoint; an upstream merge that drops the case or the 3.7 id sends traffic to the account default us-central1 and the publisher model 404s. Live extras can write vertex_model_locations, but the compiled owner is what survives the next release and empty extras."
     }
   ]
 }


### PR DESCRIPTION
## 摘要
- 把 `gemini-3.7-flash` 写入 Gemini/Antigravity catalog、Vertex mapping floor、Antigravity 默认 remap（public id → `gemini-3.7-flash-medium`）和完整定价 registry。
- Vertex 编译期把该模型钉到 `global`；`us-central1` 会 404。
- 线上已热更 Vertex 47/57/58/59/74 的 mapping + `vertex_model_locations`，以及 prod Antigravity 61/62 extras。Google-Vertex 组现在就能打。
- 已 merge 当前 `origin/main`，恢复 `main-ancestry-guard` 祖先关系。

## 风险
- 常规风险：公开 catalog / Menu / `/pricing` 会在发版后出现新模型；全局官方价在本 PR 合并后由 pricing-registry publisher 热生效，无需应用发版。
- 审批基线：`docs/approved/model-surface-activation-contract.md`。
- 发版前 Antigravity 原生路径仍走旧编译期白名单；不要写 edge 空 mapping。
- Menu / `/pricing` 由 catalog API 驱动，前端无硬编码清单。no-web-impact
- catalog / pricing 注释改写未改既有 allowlist anchor。sentinel-registry-reviewed
- `vertex_service_account.go` 的 global-only case 已钉进 `scripts/sentinels/gateway-tk.json`。

## 验证
- `go test -tags=unit ./internal/domain/ ./internal/service/ -run TestDefaultAntigravityModelMapping_Gemini37|TestVertexLocationUsesGlobalForGlobalOnlyGeminiModels|TestPricingService_Gemini37FlashThinkingTiersUseBasePricing|TestTKPricingOverlay_FillsGemini35LiteAnd36FlashAtOfficialRates` 通过。
- `PREFLIGHT_BASE=origin/main ./scripts/preflight.sh` 通过。
- prod 账号 47 `probe_account_model.sh`：`verdict=servable`，HTTP 200，`usage_match.account_id=47`。

## 提交
- `5288096a4` feat(catalog): add gemini-3.7-flash to the served model surface
- `aa6a3e01d` fix(ops): address R-001 R-002 — pin Vertex global-only Gemini ids
- `d72f4bf74` Merge remote-tracking branch 'origin/main' into feature/gemini-3.7-flash
- 最新提交：`d72f4bf74`