### PR TITLE
fix(pricing): 为 glm-5.3 补 BigModel 真价，停止按 glm-5 家族 floor 计费

### DIFF
--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -664,6 +664,9 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 			return pricing
 		}
 	}
+	if strings.Contains(modelLower, "glm-5.3") {
+		return tkOverlayModelPricing("glm-5.3")
+	}
 	if strings.Contains(modelLower, "glm-5.2") {
 		return tkOverlayModelPricing("glm-5.2")
 	}

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -192,6 +192,28 @@ func TestGetModelPricing_GLM52UsesBigModelPriceWithBaseTax(t *testing.T) {
 	require.InDelta(t, glmCNYPerMTokWithTax(28), got.OutputPricePerToken, 1e-12)
 }
 
+// 2026-08-19 prod served_at_fallback: glm-5.3 被 glm-5 家族 floor（¥4/¥18）计费。
+// 官方 BigModel 按量价与 glm-5.2 同档（¥8/¥28/缓存命中 ¥2），必须走自己的 registry owner。
+func TestGetModelPricing_GLM53UsesBigModelPriceNotGLM5Floor(t *testing.T) {
+	svc := newTestBillingService()
+
+	got, err := svc.GetModelPricing("glm-5.3")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	require.InDelta(t, glmCNYPerMTokWithTax(8), got.InputPricePerToken, 1e-12)
+	require.InDelta(t, glmCNYPerMTokWithTax(28), got.OutputPricePerToken, 1e-12)
+	require.InDelta(t, glmCNYPerMTokWithTax(2), got.CacheReadPricePerToken, 1e-12)
+
+	floor, err := svc.GetModelPricing("glm-5")
+	require.NoError(t, err)
+	require.NotNil(t, floor)
+	require.Greater(t, got.InputPricePerToken, floor.InputPricePerToken,
+		"glm-5.3 official list is above the glm-5 family floor; exact owner must win")
+	require.False(t, svc.IsServedViaFamilyFloor("glm-5.3"),
+		"exact overlay owner must stop served_at_fallback")
+}
+
 func TestGetModelPricing_UnknownClaudeModelFallsBackToSonnet(t *testing.T) {
 	svc := newTestBillingService()
 
@@ -527,6 +549,13 @@ func TestGetFallbackPricing_FamilyMatching(t *testing.T) {
 
 		// ---- 智谱 GLM（BigModel 人民币价 ÷6.7；内部 fallback 保存税前价）----
 		{
+			name:              "glm 5.3 flagship",
+			model:             "glm-5.3",
+			expectedInput:     glmCNYPerMTokPreTax(8),
+			expectedOutput:    floatPtr(glmCNYPerMTokPreTax(28)),
+			expectedCacheRead: floatPtr(glmCNYPerMTokPreTax(2)),
+		},
+		{
 			name:              "glm 5.2 flagship",
 			model:             "glm-5.2",
 			expectedInput:     glmCNYPerMTokPreTax(8),
@@ -613,7 +642,14 @@ func TestGetFallbackPricing_FamilyMatching(t *testing.T) {
 			model:            "glm-4.5-airx",
 			expectNilPricing: true,
 		},
-		// 关键：5.2 / 5.1 必须先于 5 匹配（避免被 glm-5 抢走）
+		// 关键：5.3 / 5.2 / 5.1 必须先于 5 匹配（避免被 glm-5 抢走）
+		{
+			name:              "glm 5.3 vs glm 5 ordering",
+			model:             "glm-5.3",
+			expectedInput:     glmCNYPerMTokPreTax(8), // = glm-5.3 价格，不是 glm-5 的 ¥4/M
+			expectedOutput:    floatPtr(glmCNYPerMTokPreTax(28)),
+			expectedCacheRead: floatPtr(glmCNYPerMTokPreTax(2)),
+		},
 		{
 			name:              "glm 5.2 vs glm 5 ordering",
 			model:             "glm-5.2",

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -10142,5 +10142,13 @@
     "output_cost_per_token": 5.373134328358209e-06,
     "cache_read_input_token_cost": 1.7910447761194032e-06,
     "source": "Alibaba DashScope qwen3.8-max official China-mainland pricing https://help.aliyun.com/zh/model-studio/model-pricing, captured 2026-08-14: input ¥12/Mtok, output ¥36/Mtok; CNY/USD=6.7. Pre-tax official list rates; overlay official_list_base_tax policy applies at resolution/catalog time. Cache discount not separately listed, so cache-read conservatively equals input."
+  },
+  "glm-5.3": {
+    "litellm_provider": "zhipu",
+    "mode": "chat",
+    "input_cost_per_token": 0.0000011940298507462686,
+    "output_cost_per_token": 0.00000417910447761194,
+    "cache_read_input_token_cost": 0.00000029850746268656716,
+    "source": "BigModel official pricing https://bigmodel.cn/pricing, captured 2026-08-19: GLM-5.3 input ¥8/Mtok, output ¥28/Mtok, cache-hit ¥2/Mtok, 1M context, no input-tier split; CNY/USD=6.7. Cross-checked Z.AI international https://docs.z.ai/guides/overview/pricing same day: GLM-5.3 $1.4/$0.26/$4.4 per 1M tokens (USD list; TokenKey GLM owner remains BigModel CNY÷6.7, matching glm-5.2). LiteLLM has no glm-5.3 row (lookup 2026-08-19). Pricing source only: serving remains the configured OpenAI-compat / DashScope path (runtime DB/config, not pricing truth), not BigModel/Zhipu direct. Overlay stores pre-tax official list rates; TokenKey applies the official_list_base_tax zhipu multiplier at resolution/catalog time. Cache storage is listed as limited-time free."
   }
 }


### PR DESCRIPTION
## 摘要

prod `openai` / GPT专线(#2) 把 `glm-5.3` 按 `glm-5` 家族兜底价（¥4/¥18）计费，触发 served_at_fallback。registry 没有 `glm-5.3` owner，`contains("glm-5")` 把它抢成旧旗舰价。

官方核价（2026-08-19）：
- BigModel 按量：输入 ¥8/Mtok、输出 ¥28/Mtok、缓存命中 ¥2/Mtok（与 glm-5.2 同档，无阶梯）
- Z.AI 国际表：\$1.4 / \$0.26 / \$4.4 per 1M（USD 列表；TokenKey GLM owner 仍走 BigModel CNY÷6.7）
- LiteLLM lookup：无 `glm-5.3` 行，不能当价源

本次只补 complete registry owner，并把家族 matcher 的 `glm-5.3` 放在 `glm-5` 之前。合并受保护 main 后 publisher 热生效，无需应用发版。未改 catalog / Menu / model_mapping。

## 风险

常规风险。公共契约未删；公开 catalog/Menu 未放行 `glm-5.3`。渠道专属价未写。补真价后该请求模型不再走家族 floor。

## 验证

- 复现：`GetModelPricing("glm-5.3")` 修前命中 glm-5 floor（税后 input `6.328e-07`），修后为 ¥8/¥28/¥2（税后 input `1.266e-06`），`IsServedViaFamilyFloor("glm-5.3") == false`
- `go test -tags=unit -count=1 -run 'TestGetModelPricing|TestGetFallbackPricing|TestIsServedViaFamilyFloor|TestNotifyServedAtFallback' ./internal/service/` 通过
- `python3 scripts/checks/pricing-overlay.py`、`pricing-registry-publication.py`、`catalog-serving-drift.py` 通过
- `python3 ops/pricing/apply-pricing-hotfix.py selftest` 通过
- `./scripts/preflight.sh` 通过

## 提交

- `9af6ed977` fix(pricing): give glm-5.3 its own BigModel owner so it stops billing at the glm-5 family floor
- 最新提交：`9af6ed977`


Made with [Cursor](https://cursor.com)