### PR TITLE
fix(gateway): CloudWise/tokensea 的 chat 不再误走 Responses

### DIFF
--- a/backend/internal/service/gateway_cloudwise_relay_test.go
+++ b/backend/internal/service/gateway_cloudwise_relay_test.go
@@ -122,3 +122,63 @@ func TestForwardAsAnthropic_CloudwiseNonClaudeUsesChatFallback(t *testing.T) {
 	require.Equal(t, "MiniMax-M3", gjson.GetBytes(upstream.lastBody, "model").String())
 	require.Contains(t, rec.Body.String(), "OK")
 }
+
+// Prod account #95 has openai_responses_supported=true because the capability
+// probe treats HTTP 400 as "endpoint exists". CloudWise does not implement
+// /v1/responses for GLM/MiniMax (comment on IsOpenAICloudwiseRelay). Inbound
+// /v1/chat/completions must stay on raw chat, otherwise CloudWise returns
+// 400 "messages is invalid or missing" after CC→Responses conversion.
+func TestForwardAsChatCompletions_CloudwiseNonClaudeUsesRawChatEvenWhenResponsesFlagTrue(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"glm-5.3","max_tokens":8,"messages":[{"role":"user","content":"Reply OK only."}],"stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid_cw_glm53"}},
+		Body: io.NopCloser(strings.NewReader(
+			`{"id":"chatcmpl-test","object":"chat.completion","model":"glm-5.3","choices":[{"index":0,"message":{"role":"assistant","content":"OK"},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":1,"total_tokens":8}}`,
+		)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+	account := cloudwiseNativeMessagesAccount()
+	account.Extra[openai_compat.ExtraKeyResponsesSupported] = true
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, upstream.lastReq)
+	require.Equal(t, "https://api.cloudwise.ai/api/v1/chat/completions", upstream.lastReq.URL.String())
+	require.True(t, gjson.GetBytes(upstream.lastBody, "messages").Exists(),
+		"raw chat must keep messages; Responses conversion would drop them")
+	require.Equal(t, "glm-5.3", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Contains(t, rec.Body.String(), "OK")
+}
+
+func TestShouldForwardOpenAIResponsesViaRawChatCompletions_DualStackRelaysIgnoreResponsesFlag(t *testing.T) {
+	cloudwise := cloudwiseNativeMessagesAccount()
+	cloudwise.Extra[openai_compat.ExtraKeyResponsesSupported] = true
+	require.True(t, shouldForwardOpenAIResponsesViaRawChatCompletions(cloudwise))
+
+	tokensea := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://agent.tokensea.ai",
+		},
+		Extra: map[string]any{openai_compat.ExtraKeyResponsesSupported: true},
+	}
+	require.True(t, shouldForwardOpenAIResponsesViaRawChatCompletions(tokensea))
+
+	generic := rawChatCompletionsTestAccount()
+	generic.Extra = map[string]any{openai_compat.ExtraKeyResponsesSupported: true}
+	require.False(t, shouldForwardOpenAIResponsesViaRawChatCompletions(generic),
+		"ordinary OpenAI APIKey with a real Responses probe must keep the Responses path")
+}

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -48,9 +48,11 @@ var cursorResponsesUnsupportedFields = []string{
 // 正确的，但 sub2api 接入 DeepSeek/Kimi/GLM 等第三方 OpenAI 兼容上游后假设破裂：
 // 这些上游普遍只支持 /v1/chat/completions，无 /v1/responses 端点。
 //
-// 当前路由策略（基于账号覆盖模式/探测标记，详见 openai_compat.ShouldUseResponsesAPI）：
+// 当前路由策略（shouldForwardOpenAIResponsesViaRawChatCompletions）：
 //   - APIKey 账号 + 强制或探测确认不支持 Responses → 走 forwardAsRawChatCompletions
 //     直转上游 /v1/chat/completions，不做协议转换
+//   - CloudWise / tokensea 双栈中继：即使 extra.openai_responses_supported=true
+//     也走 raw chat（这些上游没有可用的 /v1/responses，探测 400 是假阳性）
 //   - 其他所有情况（OAuth、APIKey 强制/探测确认支持、未探测）→ 走原有 CC→Responses
 //     转换路径（保留旧行为，存量未探测账号零兼容破坏）
 func (s *OpenAIGatewayService) ForwardAsChatCompletions(
@@ -90,7 +92,7 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		}
 		return s.forwardAsRawChatCompletions(ctx, c, account, body, defaultMappedModel)
 	}
-	if account.Type == AccountTypeAPIKey && !openai_compat.ShouldUseResponsesAPI(account.Extra) {
+	if shouldForwardOpenAIResponsesViaRawChatCompletions(account) {
 		return s.forwardAsRawChatCompletions(ctx, c, account, body, defaultMappedModel)
 	}
 

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -1087,9 +1087,17 @@ func openAIStreamFailoverBlockedByClientOutput(firstTokenMs *int) bool {
 }
 
 func shouldForwardOpenAIResponsesViaRawChatCompletions(account *Account) bool {
-	return account != nil &&
-		account.Type == AccountTypeAPIKey &&
-		!openai_compat.ShouldUseResponsesAPI(account.Extra)
+	if account == nil || account.Type != AccountTypeAPIKey {
+		return false
+	}
+	// Dual-stack MaaS relays advertise /v1/responses (probe treats 400 as
+	// "endpoint exists") but only implement Chat + Anthropic Messages.
+	// Sending CC→Responses there drops `messages` and CloudWise returns
+	// 400 "messages is invalid or missing" (prod #95 glm-5.3, 2026-08-19).
+	if account.IsOpenAICloudwiseRelay() || account.IsOpenAITokenseaRelay() {
+		return true
+	}
+	return !openai_compat.ShouldUseResponsesAPI(account.Extra)
 }
 
 func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.Context, account *Account, body []byte, token string, isStream bool, promptCacheKey string, isCodexCLI bool) (*http.Request, error) {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1160,10 +1160,11 @@
         "TestOpenAICloudwiseRelayFloorUsesPrefixWildcards",
         "TestForwardAsAnthropic_CloudwiseNativeMessagesPassthrough",
         "TestForwardAsAnthropic_CloudwiseNonClaudeUsesChatFallback",
+        "TestForwardAsChatCompletions_CloudwiseNonClaudeUsesRawChatEvenWhenResponsesFlagTrue",
         "https://api.cloudwise.ai/api/v1/messages",
         "https://api.cloudwise.ai/api/v1/chat/completions"
       ],
-      "rationale": "Focused regressions for CloudWise MaaS relay (prod account #95): prefix wildcard model_mapping floor, native /v1/messages passthrough for claude-*, and chat fallback for MiniMax-M3."
+      "rationale": "Focused regressions for CloudWise MaaS relay (prod account #95): prefix wildcard model_mapping floor, native /v1/messages passthrough for claude-*, chat fallback for MiniMax-M3, and inbound /v1/chat/completions staying on raw chat even when openai_responses_supported is a false-positive true."
     },
     {
       "path": "backend/internal/service/gateway_tokensea_anthropic_relay_test.go",


### PR DESCRIPTION
## 摘要
CloudWise account #95 的 `openai_responses_supported=true` 是假阳性（探测把 HTTP 400 当成端点存在）。网关因此把 `/v1/chat/completions` 转成 `/v1/responses`，`glm-5.3` 被上游打回 `messages is invalid or missing`。直打 CloudWise chat 是 200。本次让 CloudWise / tokensea 双栈中继一律走 raw chat，不再看这个 flag。

## 风险
常规。只改双栈中继的上游路由，不改对外契约字段。普通 OpenAI APIKey 仍按探测结果走 Responses。代码发版后才会进生产；定价 overlay 那条热更新路径覆盖不了这次。

## 验证
- `go test -tags=unit -count=1 -run 'TestForwardAsChatCompletions_CloudwiseNonClaudeUsesRawChatEvenWhenResponsesFlagTrue|TestShouldForwardOpenAIResponsesViaRawChatCompletions_DualStackRelays|TestForwardAsAnthropic_Cloudwise' ./internal/service/` → PASS
- `./scripts/preflight.sh` → PASS
- 直打 CloudWise `/v1/chat/completions` `glm-5.3` 已实测 200；网关独占探测 400 的复现由上述单测锁定

## 提交
- `0d7751af6` fix(gateway): keep CloudWise/tokensea chat on raw CC when the Responses probe is a false positive
- 最新提交：`0d7751af6`

Web impact: none

Made with [Cursor](https://cursor.com)