### PR TITLE
fix(ops): restore canary 等得及临时 Postgres，并修好告警投递

### DIFF
--- a/.github/workflows/ops-pgdump-restore-canary.yml
+++ b/.github/workflows/ops-pgdump-restore-canary.yml
@@ -128,7 +128,8 @@ jobs:
           FEISHU_SIGNING_SECRET: ${{ secrets.TK_FEISHU_SIGNING_SECRET }}
         run: |
           set -euo pipefail
-          python3 ops/observability/edge_health_delivery.py \
+          python3 ops/observability/pgdump_restore_canary_alert.py \
+            --deliver \
             --decision restore-canary-decision.json \
             --key-file ".pgdump-canary-state/$TARGET_ID/key"
 

--- a/ops/observability/pgdump_restore_canary_alert.py
+++ b/ops/observability/pgdump_restore_canary_alert.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python3
-"""Build a deduplicated firing/recovery decision for one restore-canary target."""
+"""Build and deliver a deduplicated firing/recovery decision for one restore-canary target."""
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import pathlib
 import re
 import sys
 from typing import Any
 
 if __package__:
+    from .edge_health_delivery import DeliveryError, _atomic_write, post_feishu
     from .pgdump_restore_canary_verdict import receipt_problem
 else:
+    from edge_health_delivery import DeliveryError, _atomic_write, post_feishu
     from pgdump_restore_canary_verdict import receipt_problem
 
 
@@ -61,14 +64,79 @@ def build_decision(
     }
 
 
+def apply_key_decision(
+    decision: dict[str, Any],
+    *,
+    key_file: pathlib.Path,
+    dry_run: bool = False,
+    webhook_url: str = "",
+    signing_secret: str = "",
+) -> str:
+    """Post one Feishu alert when needed, then persist only the canary key."""
+    should_alert = decision.get("should_alert")
+    message = decision.get("message")
+    key = decision.get("key")
+    if not isinstance(should_alert, bool) or not isinstance(message, str) or not isinstance(key, str) or not key:
+        raise DeliveryError("decision must contain boolean should_alert, string message, and non-empty key")
+
+    if dry_run:
+        if should_alert:
+            print(message)
+        return "dry-run"
+
+    if should_alert:
+        if not message:
+            raise DeliveryError("alert decision has an empty message")
+        post_feishu(message, webhook_url=webhook_url, signing_secret=signing_secret)
+
+    _atomic_write(key_file, key + "\n")
+    return "delivered" if should_alert else "unchanged"
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--target", required=True)
-    parser.add_argument("--outcome", required=True)
-    parser.add_argument("--receipt", type=pathlib.Path, required=True)
-    parser.add_argument("--prev-key-file", type=pathlib.Path, required=True)
-    parser.add_argument("--run-url", required=True)
+    parser.add_argument("--deliver", action="store_true")
+    parser.add_argument("--decision", type=pathlib.Path)
+    parser.add_argument("--key-file", type=pathlib.Path)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--target")
+    parser.add_argument("--outcome")
+    parser.add_argument("--receipt", type=pathlib.Path)
+    parser.add_argument("--prev-key-file", type=pathlib.Path)
+    parser.add_argument("--run-url")
     args = parser.parse_args(argv)
+
+    if args.deliver:
+        if args.decision is None or args.key_file is None:
+            parser.error("--deliver requires --decision and --key-file")
+        try:
+            decision = json.loads(args.decision.read_text(encoding="utf-8"))
+            result = apply_key_decision(
+                decision,
+                key_file=args.key_file,
+                dry_run=args.dry_run,
+                webhook_url=os.environ.get("FEISHU_WEBHOOK_URL", ""),
+                signing_secret=os.environ.get("FEISHU_SIGNING_SECRET", ""),
+            )
+        except (OSError, json.JSONDecodeError, DeliveryError) as exc:
+            print(f"restore-canary delivery failed: {exc}", file=sys.stderr)
+            return 1
+        print(f"restore-canary delivery: {result}")
+        return 0
+
+    missing = [
+        name
+        for name, value in (
+            ("--target", args.target),
+            ("--outcome", args.outcome),
+            ("--receipt", args.receipt),
+            ("--prev-key-file", args.prev_key_file),
+            ("--run-url", args.run_url),
+        )
+        if value is None
+    ]
+    if missing:
+        parser.error("decide mode requires " + ", ".join(missing))
 
     receipt: object = None
     if args.receipt.is_file():

--- a/ops/observability/test_pgdump_restore_canary_alert.py
+++ b/ops/observability/test_pgdump_restore_canary_alert.py
@@ -9,7 +9,7 @@ import sys
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
-from ops.observability.pgdump_restore_canary_alert import build_decision
+from ops.observability.pgdump_restore_canary_alert import apply_key_decision, build_decision
 
 
 def valid_receipt(target: str = "edge:us3") -> dict:
@@ -59,6 +59,37 @@ class PgdumpRestoreCanaryAlertTest(unittest.TestCase):
         )
         self.assertEqual(completed.returncode, 0, completed.stderr)
         self.assertNotIn("ModuleNotFoundError", completed.stderr)
+        self.assertIn("--deliver", completed.stdout)
+
+    def test_deliver_cli_writes_key_file(self) -> None:
+        import json
+        import tempfile
+
+        decision = build_decision("prod", "failure", None, "", "https://run/9")
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            decision_path = root / "decision.json"
+            key_file = root / "key"
+            decision_path.write_text(json.dumps(decision), encoding="utf-8")
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "ops/observability/pgdump_restore_canary_alert.py"),
+                    "--deliver",
+                    "--decision",
+                    str(decision_path),
+                    "--key-file",
+                    str(key_file),
+                    "--dry-run",
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertIn("dry-run", completed.stdout)
+            self.assertFalse(key_file.exists())
 
     def test_first_failure_fires(self) -> None:
         decision = build_decision("edge:us3", "failure", None, "", "https://run/1")
@@ -125,6 +156,42 @@ class PgdumpRestoreCanaryAlertTest(unittest.TestCase):
         decision = build_decision("edge:us3", "success", None, "", "https://run/1")
         self.assertTrue(decision["should_alert"])
         self.assertIn(":firing:missing-receipt", decision["key"])
+
+    def test_deliver_persists_canary_key_without_edge_health_state(self) -> None:
+        import tempfile
+
+        decision = build_decision("edge:us3", "failure", None, "", "https://run/1")
+        with tempfile.TemporaryDirectory() as raw:
+            key_file = pathlib.Path(raw) / "key"
+            result = apply_key_decision(
+                decision,
+                key_file=key_file,
+                dry_run=True,
+            )
+            self.assertEqual(result, "dry-run")
+            self.assertFalse(key_file.exists())
+            result = apply_key_decision(
+                {**decision, "should_alert": False},
+                key_file=key_file,
+            )
+            self.assertEqual(result, "unchanged")
+            self.assertEqual(key_file.read_text(encoding="utf-8"), decision["key"] + "\n")
+
+    def test_deliver_rejects_edge_health_state_shape(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as raw:
+            key_file = pathlib.Path(raw) / "key"
+            with self.assertRaisesRegex(Exception, "key"):
+                apply_key_decision(
+                    {
+                        "schema_version": 1,
+                        "should_alert": False,
+                        "state": {"schema_version": 1},
+                        "message": "",
+                    },
+                    key_file=key_file,
+                )
 
 
 if __name__ == "__main__":

--- a/ops/stage0/pgdump_restore_canary.py
+++ b/ops/stage0/pgdump_restore_canary.py
@@ -30,6 +30,8 @@ OBJECT_RE = re.compile(r"tokenkey-\d{8}T\d{6}Z\.sql\.gz")
 LIVE_POSTGRES = "tokenkey-postgres"
 FRESHNESS = dt.timedelta(hours=3)
 CAPACITY_HEADROOM_BYTES = 1024**3
+POSTGRES_READY_ATTEMPTS = 180
+POSTGRES_READY_SLEEP_SECONDS = 1
 RunCommand = Callable[..., subprocess.CompletedProcess[str]]
 
 
@@ -62,6 +64,46 @@ def _run(run: RunCommand, args: list[str], *, timeout: int = 120) -> str:
         detail = (completed.stderr or completed.stdout or "command failed").strip()
         raise CanaryError(f"command failed: {args[0]} {args[1]}: {detail[:400]}")
     return completed.stdout.strip()
+
+
+def _container_ready_diagnostics(run: RunCommand, container: str) -> str:
+    inspect = _raw_run(
+        run,
+        [
+            "docker",
+            "inspect",
+            "--format",
+            "status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}}",
+            container,
+        ],
+        timeout=10,
+    )
+    logs = _raw_run(run, ["docker", "logs", "--tail", "40", container], timeout=15)
+    inspect_text = (inspect.stdout or inspect.stderr or "inspect-unavailable").strip()
+    log_text = (logs.stderr or logs.stdout or "logs-unavailable").strip()
+    return f"{inspect_text}; logs={log_text[-400:]}"
+
+
+def _wait_temporary_postgres(
+    run: RunCommand,
+    container: str,
+    sleep: Callable[[float], None],
+) -> None:
+    last_error = "pg_isready failed"
+    for attempt in range(POSTGRES_READY_ATTEMPTS):
+        try:
+            # Wait for postmaster listen only. Requiring -d tokenkey races CREATE DATABASE
+            # on 0.5–1 CPU ARM hosts and made the first fleet run fail in 60s.
+            _run(run, ["docker", "exec", container, "pg_isready"], timeout=10)
+            return
+        except CanaryError as exc:
+            last_error = str(exc)
+            if attempt == POSTGRES_READY_ATTEMPTS - 1:
+                raise CanaryError(
+                    "temporary PostgreSQL did not become ready: "
+                    f"{_container_ready_diagnostics(run, container)}; last={last_error[:200]}"
+                ) from exc
+            sleep(POSTGRES_READY_SLEEP_SECONDS)
 
 
 def _count_sql() -> str:
@@ -360,20 +402,13 @@ def run_canary(
                 run,
                 [
                     "docker", "run", "--detach", "--name", container, "--pull=never",
-                    "--network=none", "--cpus=0.50", "--memory=640m",
-                    "--memory-swap=1024m", "--env", "POSTGRES_HOST_AUTH_METHOD=trust",
+                    "--network=none", "--cpus=1.00", "--memory=1024m",
+                    "--memory-swap=1536m", "--env", "POSTGRES_HOST_AUTH_METHOD=trust",
                     "--env", "POSTGRES_USER=tokenkey", "--env", "POSTGRES_DB=tokenkey",
                     "--volume", f"{data_dir}:/var/lib/postgresql/data", image,
                 ],
             )
-            for attempt in range(60):
-                try:
-                    _run(run, ["docker", "exec", container, "pg_isready", "-U", "tokenkey", "-d", "tokenkey"], timeout=10)
-                    break
-                except CanaryError:
-                    if attempt == 59:
-                        raise CanaryError("temporary PostgreSQL did not become ready")
-                    sleep(1)
+            _wait_temporary_postgres(run, container, sleep)
 
             pipeline = (
                 f"gunzip -c -- {shlex.quote(str(dump_path))} | "

--- a/ops/stage0/test_pgdump_restore_canary.py
+++ b/ops/stage0/test_pgdump_restore_canary.py
@@ -48,6 +48,7 @@ class FakeCommands:
         dump_bytes: bytes | None = None,
         rm_fails: bool = False,
         run_times_out: bool = False,
+        pg_isready_fails: bool = False,
     ) -> None:
         self.calls: list[list[str]] = []
         self.objects = objects if objects is not None else [
@@ -65,6 +66,7 @@ class FakeCommands:
             self.objects[0]["Size"] = len(self.downloaded)
         self.rm_fails = rm_fails
         self.run_times_out = run_times_out
+        self.pg_isready_fails = pg_isready_fails
         self.container_present = False
 
     def __call__(self, args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
@@ -87,6 +89,8 @@ class FakeCommands:
             stdout = "true\n"
         elif args[:2] == ["docker", "inspect"] and "{{.Config.Image}}" in args:
             stdout = "postgres:18-alpine\n"
+        elif args[:2] == ["docker", "inspect"] and "{{.State.Status}}" in " ".join(args):
+            stdout = "status=exited exit=1 oom=false\n"
         elif args[:2] == ["docker", "inspect"]:
             returncode = 0 if self.container_present else 1
             stderr = "present" if self.container_present else "No such container"
@@ -95,8 +99,14 @@ class FakeCommands:
             if self.run_times_out:
                 raise subprocess.TimeoutExpired(args, 120)
             stdout = "canary-container-id\n"
+        elif args[:2] == ["docker", "logs"]:
+            stderr = "initdb: error: could not create directory\n"
         elif args[:3] == ["docker", "exec", args[2]] and "pg_isready" in args:
-            stdout = "accepting connections\n"
+            if self.pg_isready_fails:
+                returncode = 1
+                stderr = "no response"
+            else:
+                stdout = "accepting connections\n"
         elif args[:3] == ["docker", "exec", "tokenkey-postgres"] and "json_build_object" in joined:
             stdout = json.dumps(LIVE_COUNTS) + "\n"
         elif args[:2] == ["bash", "-o"] and "gunzip -c" in joined:
@@ -176,6 +186,9 @@ class PgdumpRestoreCanaryTest(unittest.TestCase):
         self.assertTrue(any("s3api list-objects-v2" in call for call in joined))
         self.assertTrue(any("s3 cp s3://tokenkey-prod-pgdump-123/edge/us3/pgdump/tokenkey-20260818T070000Z.sql.gz" in call for call in joined))
         self.assertTrue(any("gunzip -c" in call and "docker exec -i" in call and "ON_ERROR_STOP=1" in call for call in joined))
+        self.assertTrue(any("--cpus=1.00" in call and "--memory=1024m" in call for call in joined))
+        self.assertTrue(any(call.endswith("pg_isready") for call in joined))
+        self.assertFalse(any("pg_isready -U tokenkey -d tokenkey" in call for call in joined))
         self.assertFalse(any("pg_dump" in call for call in joined))
 
     def test_receipt_completion_time_is_sampled_after_cleanup(self) -> None:
@@ -289,6 +302,21 @@ class PgdumpRestoreCanaryTest(unittest.TestCase):
                     disk_usage=lambda _: shutil._ntuple_diskusage(10**10, 0, 10**10),
                 )
             self.assertEqual(receipt.read_text(encoding="utf-8"), '{"previous":true}\n')
+
+    def test_postgres_ready_timeout_includes_container_diagnostics(self) -> None:
+        fake = FakeCommands(pg_isready_fails=True)
+        with self.assertRaisesRegex(canary.CanaryError, "did not become ready.*initdb"):
+            self.run_case(fake)
+        self.assertTrue(any(call[:2] == ["docker", "logs"] for call in fake.calls))
+        self.assertTrue(
+            any(
+                call[:2] == ["docker", "inspect"] and "{{.State.Status}}" in " ".join(call)
+                for call in fake.calls
+            )
+        )
+        pg_isready_calls = [call for call in fake.calls if "pg_isready" in call]
+        self.assertEqual(len(pg_isready_calls), canary.POSTGRES_READY_ATTEMPTS)
+        self.assertEqual(pg_isready_calls[0][-1], "pg_isready")
 
     def test_docker_run_timeout_removes_container_created_before_timeout(self) -> None:
         fake = FakeCommands(run_times_out=True)

--- a/ops/stage0/test_pgdump_restore_canary_workflow.py
+++ b/ops/stage0/test_pgdump_restore_canary_workflow.py
@@ -65,7 +65,10 @@ class PgdumpRestoreCanaryWorkflowTest(unittest.TestCase):
         self.assertIn("pgdump_restore_canary_alert.py", decision_step["run"])
         delivery_step = restore["steps"][deliver]
         self.assertEqual(delivery_step["if"], "always()")
-        self.assertIn("edge_health_delivery.py", delivery_step["run"])
+        self.assertIn("pgdump_restore_canary_alert.py", delivery_step["run"])
+        self.assertIn("--deliver", delivery_step["run"])
+        self.assertIn("--key-file", delivery_step["run"])
+        self.assertNotIn("edge_health_delivery.py", delivery_step["run"])
         self.assertIn("TK_FEISHU_WEBHOOK_URL", str(delivery_step["env"]))
         self.assertNotIn("TK_FEISHU_WEBHOOK_URL", command)
 


### PR DESCRIPTION
## 摘要

- 首次 fleet dispatch（[run 32221625120](https://github.com/youxuanxue/sub2api/actions/runs/32221625120)）在 prod / us3 / us4 / us5 / us6 全部失败：`temporary PostgreSQL did not become ready`。
- 根因是临时库用 0.5 CPU / 640MB，还要在 60s 内 `pg_isready -d tokenkey`，和 initdb + CREATE DATABASE 抢时间。
- 现在改为等 postmaster listen（180s）、提高隔离配额，失败时带上 container status / logs。
- 顺带修掉 workflow 误把 canary key 交给 `edge_health_delivery.py --key-file`（该脚本只认 `--state-file` 且要 edge-health state）。

关联：#1724 #1725 #1726 #1727 #1728。合入后需再 dispatch 一次 canary，收据落地后 daily diagnostics 才会自动关单。

## 风险

常规风险。只改 ops canary 与告警投递，不碰网关/Web。`no-web-impact`。

## 验证

- `python3 ops/stage0/test_pgdump_restore_canary.py`
- `python3 ops/stage0/test_pgdump_restore_canary_workflow.py`
- `python3 ops/observability/test_pgdump_restore_canary_alert.py`
- `./scripts/preflight.sh` PASS

合入后：`gh workflow run ops-pgdump-restore-canary.yml -f target_selector=all`

## 提交

- `782621ddb` fix(ops): give restore canary enough time and a matching delivery path
- 最新提交：`782621ddb`

Made with [Cursor](https://cursor.com)