### PR TITLE
fix(qa): configure bundle worker timezone

### DIFF
--- a/deploy/aws/cloudformation/stage0-qa-raw-archive.yaml
+++ b/deploy/aws/cloudformation/stage0-qa-raw-archive.yaml
@@ -599,6 +599,8 @@ Resources:
             - --qa-bundle-worker
           Essential: true
           Environment:
+            - Name: TZ
+              Value: UTC
             - Name: QA_BUNDLE_ENABLED
               Value: 'true'
             - Name: QA_BUNDLE_QUEUE_URL

--- a/deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py
+++ b/deploy/aws/cloudformation/test_stage0_qa_bundle_contract.py
@@ -96,7 +96,10 @@ class Stage0QABundleContractTest(unittest.TestCase):
         self.assertEqual(policy["DenyLightsailEdgeRole"], {
             "Sid": "DenyLightsailEdgeRole", "Effect": "Deny", "Principal": "*", "Action": "s3:*",
             "Resource": ["QaBundleBucket.Arn", "${QaBundleBucket.Arn}/*"],
-            "Condition": {"ArnEquals": {"aws:PrincipalArn": EDGE_ROLE_ARN}},
+            "Condition": {"ArnLike": {"aws:PrincipalArn": [
+                EDGE_ROLE_ARN,
+                "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/tokenkey-lightsail-ssm-hybrid-*",
+            ]}},
         })
         create = policy["AllowAppInstanceRoleCreateScopedBundleJobs"]
         self.assertEqual(create["Action"], "s3:PutObject")
@@ -248,6 +251,7 @@ class Stage0QABundleContractTest(unittest.TestCase):
         self.assertEqual(container["Command"], ["--qa-bundle-worker"])
         environment = {item["Name"]: item["Value"] for item in container["Environment"]}
         self.assertEqual(environment, {
+            "TZ": "UTC",
             "QA_BUNDLE_ENABLED": "true",
             "QA_BUNDLE_QUEUE_URL": "QaBundleQueue",
             "QA_BUNDLE_STORAGE_DRIVER": "s3",


### PR DESCRIPTION
## Summary
- set `TZ=UTC` on the Stage0 QA Bundle ECS worker
- keep the CloudFormation contract test aligned with the existing Lightsail role ARN policy

## Root cause
The worker image now fails closed when no timezone is configured. The QA Bundle task definition omitted `TZ`, so the worker exited before rollout verification.

## Validation
- `python3 -m unittest deploy.aws.cloudformation.test_stage0_qa_bundle_contract`
- `bash scripts/preflight.sh`
- reviewer: no findings

Web impact: none
No-web-impact: ops-only QA worker configuration.