### PR TITLE
fix(ops): base Feishu rollout notes on live tag

### DIFF
--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -230,6 +230,17 @@ jobs:
           echo "qa_cfn_service_role_arn=$SERVICE_ROLE_ARN" >> "$GITHUB_OUTPUT"
           echo "deploying ${INPUT_TAG} to instance=$ID api=$API_URL (env=prod stack=$STACK_NAME)"
 
+      - name: Resolve previous prod runtime tag
+        id: previous_runtime
+        env:
+          INSTANCE_ID: ${{ steps.instance.outputs.id }}
+        run: |
+          set -euo pipefail
+          PREVIOUS_TAG="$(bash ops/stage0/resolve-prod-running-tag-via-ssm.sh --instance-id "$INSTANCE_ID")"
+          test -n "$PREVIOUS_TAG"
+          echo "tag=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
+          echo "prod runtime baseline: $PREVIOUS_TAG"
+
       - name: Checkout target-tag QA contract and host artifacts
         uses: actions/checkout@v6
         with:
@@ -519,16 +530,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -uo pipefail
-          # changelog 的唯一源是 tag 注解正文(release-tag.sh 自动生成,release.yml
-          # 也读它喂给 GitHub Release header)。直接读 tag body 而非渲染后的
-          # `gh release view` —— 后者还含 goreleaser 的 README 标语 header + 安装
-          # footer,会被 clean_changelog 倒进「其他」桶污染卡片。runner 默认浅克隆
-          # 无 tag,先 fetch。取不到 → NOTES 空 → 卡片降级为只留链接(best-effort,
-          # 无 set -e,失败不影响通知本身)。
-          git fetch origin "refs/tags/v${INPUT_TAG}:refs/tags/v${INPUT_TAG}" --force 2>/dev/null || true
-          NOTES="$(git tag -l --format='%(contents:body)' "v$INPUT_TAG" 2>/dev/null)"
+          # Feishu rollout notes describe what changed since the tag that was
+          # actually serving before this deploy. This intentionally differs from
+          # the tag-to-tag GitHub Release changelog when an image build failed
+          # before reaching prod.
+          PREVIOUS_TAG="${{ steps.previous_runtime.outputs.tag }}"
+          git fetch origin "refs/tags/v${INPUT_TAG}:refs/tags/v${INPUT_TAG}" \
+            "refs/tags/v${PREVIOUS_TAG}:refs/tags/v${PREVIOUS_TAG}" --force 2>/dev/null || true  # preflight-allow: swallow -- notification remains best-effort
+          NOTES="$(git log --first-parent --pretty=format='- %s' "v$PREVIOUS_TAG..v$INPUT_TAG" \
+            | grep -viE 'bump VERSION|sync.version.file' || true)"  # preflight-allow: swallow -- no matching noise commits is valid
           bash ops/stage0/notify-feishu-release.sh "$INPUT_TAG" "$API_URL" \
-            --run-url "$RUN_URL" --notes "$NOTES"
+            --previous-tag "$PREVIOUS_TAG" --run-url "$RUN_URL" --notes "$NOTES"
 
       - name: Job summary
         if: always()

--- a/ops/stage0/notify-feishu-release.sh
+++ b/ops/stage0/notify-feishu-release.sh
@@ -25,10 +25,12 @@ set -euo pipefail
 # Usage:
 #   TK_FEISHU_WEBHOOK_URL=... [TK_FEISHU_SIGNING_SECRET=...] \
 #     bash ops/stage0/notify-feishu-release.sh <tag> <api_url> \
-#       [--run-url URL] [--notes TEXT] [--dry-run]
+#       --previous-tag TAG [--run-url URL] [--notes TEXT] [--dry-run]
 #
 #   <tag>      released image tag WITHOUT leading v (e.g. 1.7.83). A leading v is
 #              tolerated and stripped.
+#   --previous-tag  tag that was serving on prod immediately before this rollout;
+#                   required so the card's changelog has a trusted live baseline.
 #   <api_url>  prod gateway URL (e.g. https://api.tokenkey.dev).
 #   --run-url  link to the deploy workflow run (optional).
 #   --notes    release changelog (e.g. `gh release view` body) to inline under a
@@ -44,12 +46,13 @@ usage() {
 Usage:
   TK_FEISHU_WEBHOOK_URL=... [TK_FEISHU_SIGNING_SECRET=...] \
     bash ops/stage0/notify-feishu-release.sh <tag> <api_url> \
-      [--run-url URL] [--notes TEXT] [--dry-run]
+      --previous-tag TAG [--run-url URL] [--notes TEXT] [--dry-run]
 EOF
 }
 
 TAG=""
 API_URL=""
+PREVIOUS_TAG=""
 RUN_URL=""
 NOTES=""
 DRY_RUN=0
@@ -60,6 +63,8 @@ need_val() { [ "$2" -ge 2 ] || { echo "[error] $1 needs a value" >&2; usage; exi
 
 while [ $# -gt 0 ]; do
   case "$1" in
+    --previous-tag) need_val "$1" "$#"; PREVIOUS_TAG="$2"; shift 2 ;;
+    --previous-tag=*) PREVIOUS_TAG="${1#*=}"; shift ;;
     --run-url) need_val "$1" "$#"; RUN_URL="$2"; shift 2 ;;
     --run-url=*) RUN_URL="${1#*=}"; shift ;;
     --notes) need_val "$1" "$#"; NOTES="$2"; shift 2 ;;
@@ -84,9 +89,15 @@ if [ -z "$TAG" ] || [ -z "$API_URL" ]; then
   usage
   exit 2
 fi
+if [[ ! "$PREVIOUS_TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+|-beta\.[0-9]+)?$ ]]; then
+  echo "[error] --previous-tag must be a Stage0 release tag" >&2
+  usage
+  exit 2
+fi
 
 # deploy-stage0 passes a bare tag, but tolerate a leading v just in case.
 TAG="${TAG#v}"
+PREVIOUS_TAG="${PREVIOUS_TAG#v}"
 
 WEBHOOK="${TK_FEISHU_WEBHOOK_URL:-}"
 SECRET="${TK_FEISHU_SIGNING_SECRET:-}"
@@ -102,6 +113,7 @@ fi
 # payload to stdout (sanitized when NF_DRY_RUN=1).
 PAYLOAD_JSON="$(
   NF_TAG="$TAG" \
+  NF_PREVIOUS_TAG="$PREVIOUS_TAG" \
   NF_API_URL="$API_URL" \
   NF_RUN_URL="$RUN_URL" \
   NF_NOTES="$NOTES" \
@@ -117,6 +129,7 @@ import os
 import time
 
 tag = os.environ["NF_TAG"]
+previous_tag = os.environ["NF_PREVIOUS_TAG"]
 api_url = os.environ["NF_API_URL"]
 run_url = os.environ.get("NF_RUN_URL", "").strip()
 notes = os.environ.get("NF_NOTES", "").strip()
@@ -131,6 +144,7 @@ when = f"{utc:%Y-%m-%d %H:%M} UTC · {cst:%Y-%m-%d %H:%M} CST"
 
 lines = [
     f"**版本**  v{tag}",
+    f"**线上基线**  v{previous_tag}",
     "**环境**  prod",
     f"**API**  {api_url}",
     f"**上线时间**  {when}",

--- a/ops/stage0/test_deploy_stage0_workflow.py
+++ b/ops/stage0/test_deploy_stage0_workflow.py
@@ -85,6 +85,26 @@ class DeployStage0WorkflowTest(unittest.TestCase):
             deploy,
         )
 
+    def test_feishu_rollout_uses_pre_mutation_runtime_baseline(self) -> None:
+        deploy = job_block("deploy")
+        baseline = deploy.index("name: Resolve previous prod runtime tag")
+        image_mutation = deploy.index("name: Deploy via SSM Run-Command")
+        notification = deploy.index("name: Notify Feishu (release rollout)")
+        smoke = deploy.index("name: Post-deploy gateway smoke (API + Claude paths)")
+
+        self.assertLess(baseline, image_mutation)
+        self.assertLess(smoke, notification)
+        block = deploy[baseline:image_mutation]
+        self.assertIn("resolve-prod-running-tag-via-ssm.sh", block)
+        self.assertIn('INSTANCE_ID: ${{ steps.instance.outputs.id }}', block)
+        self.assertIn('--instance-id "$INSTANCE_ID"', block)
+        self.assertIn("id: previous_runtime", block)
+        notice = deploy[notification:]
+        self.assertIn("steps.previous_runtime.outputs.tag", notice)
+        self.assertIn("--previous-tag", notice)
+        self.assertIn("v$PREVIOUS_TAG..v$INPUT_TAG", notice)
+        self.assertNotIn("git tag -l --format", notice)
+
     def test_target_release_contract_is_bound_before_prod_mutation(self) -> None:
         deploy = job_block("deploy")
         target_checkout = deploy.index("name: Checkout target-tag QA contract and host artifacts")

--- a/ops/stage0/test_notify_feishu_release.py
+++ b/ops/stage0/test_notify_feishu_release.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Contract tests for Feishu prod rollout changelog baselines."""
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).with_name("notify-feishu-release.sh")
+
+
+class NotifyFeishuReleaseTest(unittest.TestCase):
+    def run_script(self, *args: str) -> subprocess.CompletedProcess[str]:
+        env = {**os.environ, "GITHUB_REPOSITORY": "youxuanxue/sub2api"}
+        return subprocess.run(
+            ["bash", str(SCRIPT), *args],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_dry_run_shows_explicit_live_baseline(self) -> None:
+        proc = self.run_script(
+            "1.8.163",
+            "https://api.tokenkey.dev",
+            "--previous-tag",
+            "v1.8.161",
+            "--notes",
+            "- fix: timezone worker startup\n- feat: example",
+            "--dry-run",
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertIn("线上基线", proc.stdout)
+        self.assertIn("v1.8.161", proc.stdout)
+        self.assertIn("timezone worker startup", proc.stdout)
+
+    def test_previous_tag_is_required_for_rollout_notes(self) -> None:
+        proc = self.run_script(
+            "1.8.163",
+            "https://api.tokenkey.dev",
+            "--notes",
+            "- fix: missing baseline",
+            "--dry-run",
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("--previous-tag", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

- 在 prod 镜像变更前解析实际运行中的线上版本。
- Feishu 上线通知按线上基线到目标版本生成变更摘要。
- 通知卡片明确展示线上基线版本。

## 风险

仅影响 Stage0 部署完成后的 Feishu/线上成功通知，不改变镜像构建、GitHub Release、tag 或 Telegram 构建通知。通知仍为 best-effort；基线解析失败会在镜像变更前阻断部署。

Web impact: none
No-web-impact: deployment notification only.
sentinel-registry-reviewed

## 验证

- `python3 -m unittest ops.stage0.test_deploy_stage0_workflow ops.stage0.test_notify_feishu_release ops.stage0.test_resolve_prod_running_tag_via_ssm`：22 项通过
- `bash scripts/preflight.sh`：通过
- PR CI：`preflight`、`test-unit`、`test-integration`、`shell`、`frontend`、`golangci-lint`、安全检查均通过
- `bash -n ops/stage0/notify-feishu-release.sh`：通过
- `git diff --check`：通过

## 提交

- `aeee02d5c fix(ops): base Feishu rollout notes on live tag`
- 最新提交：`aeee02d5c`
