### PR TITLE
fix(ops): edge 上游错误率飞书告警降为 P1

### DIFF
--- a/backend/internal/service/ops_alert_evaluator_service.go
+++ b/backend/internal/service/ops_alert_evaluator_service.go
@@ -325,11 +325,12 @@ func (s *OpsAlertEvaluatorService) evaluateOnce(interval time.Duration) {
 				}
 			}
 
+			pageSeverity := effectiveOpsAlertPageSeverity(rule, s.isEdgeNode())
 			firedEvent := &OpsAlertEvent{
 				RuleID:         rule.ID,
-				Severity:       strings.TrimSpace(rule.Severity),
+				Severity:       pageSeverity,
 				Status:         OpsAlertStatusFiring,
-				Title:          fmt.Sprintf("%s: %s", strings.TrimSpace(rule.Severity), strings.TrimSpace(rule.Name)),
+				Title:          fmt.Sprintf("%s: %s", pageSeverity, strings.TrimSpace(rule.Name)),
 				Description:    buildOpsAlertDescription(rule, metricValue, windowMinutes, scopePlatform, scopeGroupID),
 				MetricValue:    float64Ptr(metricValue),
 				ThresholdValue: float64Ptr(rule.Threshold),

--- a/backend/internal/service/ops_alert_evaluator_service_test.go
+++ b/backend/internal/service/ops_alert_evaluator_service_test.go
@@ -610,7 +610,8 @@ func TestIsEdgeNode(t *testing.T) {
 // TestIsEdgeSuppressedAlertRule pins WHICH rules are silenced on a mirror-relay
 // edge. The retired routing-capacity rule stays defensively suppressed, and both
 // real-user experience rules (P0 user-visible + P1 client-visible) are prod-only.
-// Capacity/error signals that ARE meaningful on an edge must still page.
+// Capacity/error signals that ARE meaningful on an edge must still page;
+// upstream_error_rate is demoted to P1 rather than suppressed.
 func TestIsEdgeSuppressedAlertRule(t *testing.T) {
 	t.Parallel()
 	require.True(t, isEdgeSuppressedAlertRule(&OpsAlertRule{MetricType: "routing_capacity_rejection_count"}))
@@ -621,6 +622,31 @@ func TestIsEdgeSuppressedAlertRule(t *testing.T) {
 	require.False(t, isEdgeSuppressedAlertRule(&OpsAlertRule{MetricType: "upstream_error_rate"}))
 	require.False(t, isEdgeSuppressedAlertRule(&OpsAlertRule{MetricType: "group_available_accounts"}))
 	require.False(t, isEdgeSuppressedAlertRule(nil))
+}
+
+// TestEffectiveOpsAlertPageSeverity pins the us4-class demotion: an edge-local
+// P0 upstream_error_rate is not end-user visible (prod failovers to another
+// edge), so the stored/paged severity must be P1. Prod keeps P0 because it is
+// the user-facing terminus. The 8% early-warning P1 rule stays P1; other P0
+// rules on an edge are unchanged.
+func TestEffectiveOpsAlertPageSeverity(t *testing.T) {
+	t.Parallel()
+
+	p0Upstream := &OpsAlertRule{Name: "上游错误率极高", MetricType: "upstream_error_rate", Severity: "P0"}
+	p1Upstream := &OpsAlertRule{Name: "上游错误率偏高", MetricType: "upstream_error_rate", Severity: "P1"}
+	p0Pool := &OpsAlertRule{MetricType: "pool_load_rate", Severity: "P0"}
+
+	require.Equal(t, "P1", effectiveOpsAlertPageSeverity(p0Upstream, true))
+	require.Equal(t, "P0", effectiveOpsAlertPageSeverity(p0Upstream, false))
+	require.Equal(t, "P1", effectiveOpsAlertPageSeverity(p1Upstream, true))
+	require.Equal(t, "P1", effectiveOpsAlertPageSeverity(p1Upstream, false))
+	require.Equal(t, "P0", effectiveOpsAlertPageSeverity(p0Pool, true))
+	require.Equal(t, "P0", effectiveOpsAlertPageSeverity(p0Pool, false))
+	require.Equal(t, "", effectiveOpsAlertPageSeverity(nil, true))
+	require.True(t, isEdgeNonUserFacingAlertRule(p0Upstream))
+	require.False(t, isEdgeNonUserFacingAlertRule(p1Upstream))
+	require.False(t, isEdgeNonUserFacingAlertRule(p0Pool))
+	require.False(t, isEdgeNonUserFacingAlertRule(nil))
 }
 
 func TestShouldEvaluateAlertRuleOnNode(t *testing.T) {

--- a/backend/internal/service/ops_alert_notifications_tk_feishu.go
+++ b/backend/internal/service/ops_alert_notifications_tk_feishu.go
@@ -83,6 +83,33 @@ func isEdgeSuppressedAlertRule(rule *OpsAlertRule) bool {
 	}
 }
 
+// isEdgeNonUserFacingAlertRule reports whether a P0 rule is local provider-health
+// noise on a mirror-relay edge: the edge recorded a final upstream failure, but
+// prod typically failovers to another edge and the end user still gets 200
+// (us4 2026-08-19 gpt-5.6-sol 502 → prod recovered-200). These still page, but
+// as P1 rather than paging-as-outage P0. The 8% early-warning P1 rule is not
+// this class — it is already P1 and stays off Feishu.
+func isEdgeNonUserFacingAlertRule(rule *OpsAlertRule) bool {
+	if rule == nil {
+		return false
+	}
+	return strings.TrimSpace(rule.MetricType) == "upstream_error_rate" &&
+		strings.EqualFold(strings.TrimSpace(rule.Severity), "P0")
+}
+
+// effectiveOpsAlertPageSeverity is the severity stored on the event and shown
+// on Feishu cards. Prod keeps the rule's configured severity. Edges demote
+// local-only provider-health P0s so they do not look like user-visible outages.
+func effectiveOpsAlertPageSeverity(rule *OpsAlertRule, isEdge bool) string {
+	if rule == nil {
+		return ""
+	}
+	if isEdge && isEdgeNonUserFacingAlertRule(rule) {
+		return "P1"
+	}
+	return strings.TrimSpace(rule.Severity)
+}
+
 // isEdgeNode reports whether this node is a prod→edge mirror-relay edge
 // (api-<id>.<domain>), derived from the configured frontend URL — the SAME source
 // the alert card's node label uses (deriveOpsNodeIdentity / siteFromFrontendURL),
@@ -271,6 +298,11 @@ func opsAlertFeishuSeverityAllowed(rule *OpsAlertRule, event *OpsAlertEvent) boo
 	ruleSeverity := strings.ToUpper(strings.TrimSpace(rule.Severity))
 	eventSeverity := strings.ToUpper(strings.TrimSpace(event.Severity))
 	if ruleSeverity == "P0" && eventSeverity == "P0" {
+		return true
+	}
+	// Edge remaps the 20% upstream_error_rate P0 to a P1 event so Feishu still
+	// delivers, but as orange P1. The 8% P1 early-warning rule stays excluded.
+	if ruleSeverity == "P0" && eventSeverity == "P1" && isEdgeNonUserFacingAlertRule(rule) {
 		return true
 	}
 	return ruleSeverity == "P1" &&

--- a/backend/internal/service/ops_feishu_alerts_tk_test.go
+++ b/backend/internal/service/ops_feishu_alerts_tk_test.go
@@ -274,6 +274,42 @@ func TestMaybeSendAlertFeishuP0AndClientVisibleP1Only(t *testing.T) {
 	}
 }
 
+func TestOpsAlertFeishuSeverityAllowedEdgeUpstreamErrorRateP1(t *testing.T) {
+	t.Parallel()
+
+	p0Upstream := &OpsAlertRule{Name: "上游错误率极高", MetricType: "upstream_error_rate", Severity: "P0", NotifyEmail: true}
+	p1Upstream := &OpsAlertRule{Name: "上游错误率偏高", MetricType: "upstream_error_rate", Severity: "P1", NotifyEmail: true}
+	p0Event := &OpsAlertEvent{Severity: "P0", Status: OpsAlertStatusFiring}
+	p1Event := &OpsAlertEvent{Severity: "P1", Status: OpsAlertStatusFiring}
+
+	require.True(t, opsAlertFeishuSeverityAllowed(p0Upstream, p0Event), "prod still pages the 20% rule as P0")
+	require.True(t, opsAlertFeishuSeverityAllowed(p0Upstream, p1Event), "edge-demoted 20% rule must still reach Feishu as P1")
+	require.False(t, opsAlertFeishuSeverityAllowed(p1Upstream, p1Event), "8% early-warning P1 must stay off Feishu")
+	require.False(t, opsAlertFeishuSeverityAllowed(p1Upstream, p0Event))
+}
+
+func TestMaybeSendAlertFeishuAllowsEdgeDemotedUpstreamErrorRateP1(t *testing.T) {
+	t.Parallel()
+
+	doer := &recordingFeishuHTTPDoer{body: `{"code":0}`}
+	svc := newOpsFeishuAlertEvaluatorForTest(t, OpsFeishuAlertConfig{Enabled: true, WebhookURL: "https://open.feishu.cn/open-apis/bot/v2/hook/token", RateLimitPerHour: 3, CooldownSeconds: 3600}, doer)
+	rule := testOpsFeishuRule()
+	rule.Name = "上游错误率极高"
+	rule.Severity = "P0"
+	rule.MetricType = "upstream_error_rate"
+	rule.Operator = ">"
+	rule.Threshold = 20
+	event := testOpsFeishuEvent(1)
+	event.Severity = "P1"
+	event.Dimensions = map[string]any{"top_cause": "gpt-5.6-sol ×28（upstream 502 / provider）"}
+
+	require.True(t, svc.maybeSendAlertFeishu(context.Background(), nil, rule, event))
+	require.Equal(t, 1, doer.calls)
+	require.Contains(t, doer.bodies[0], "TokenKey P1 告警")
+	require.Contains(t, doer.bodies[0], "orange")
+	require.NotContains(t, doer.bodies[0], "TokenKey P0 告警")
+}
+
 func TestMaybeSendAlertFeishuAllowsClientVisibleP1(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -369,6 +369,7 @@
       "must_contain": [
         "maybeSendAlertNotifications",
         "feishu_sent",
+        "effectiveOpsAlertPageSeverity",
         "\"anthropic_cooldown_tier_escalation_count\"",
         "SetAnthropicUpstreamErrorCounterCache",
         "GetAnthropicCooldownTierEscalations",
@@ -384,6 +385,8 @@
         "markFiringDelivered",
         "opsAlertFeishuSeverityAllowed",
         "ruleSeverity == \"P0\" && eventSeverity == \"P0\"",
+        "isEdgeNonUserFacingAlertRule",
+        "effectiveOpsAlertPageSeverity",
         "OpsAlertMetricClientVisibleFailureCount",
         "rule.NotifyEmail",
         "opsFeishuDedupeKey",
@@ -392,7 +395,7 @@
         "s.limiter.SetLimit(cfg.RateLimitPerHour)",
         "s.cfg.Server.FrontendURL"
       ],
-      "rationale": "TK companion that keeps Feishu alerting limited to P0 plus the explicit P1 client_visible_failure_count real-user failure exception on prod only (edge nodes suppress both user-visible P0 and client-visible P1 via isEdgeSuppressedAlertRule / isProdOnlyAlertRule), tied to the existing external-notification opt-in, and protected by per-rule/dimension cooldown plus global hourly rate limiting. Paired green recovery cards must fire only after a delivered firing card (firedFeishuEventIDs) and use a separate recovery dedupe key so resolve notifications are not blocked by the firing cooldown. Dropping any anchor turns a low-noise OPC pager into either silence or chat noise. FrontendURL threads the per-node public base URL into the card so prod vs each edge is distinguishable; losing it silently regresses every card back to an unattributable 'overall'."
+      "rationale": "TK companion that keeps Feishu alerting limited to P0 plus two explicit P1 exceptions: client_visible_failure_count on prod, and edge-demoted upstream_error_rate (P0 rule + P1 event) so a local provider 502 that prod failovers away from does not page as a user-visible P0 (us4 2026-08-19). Edge nodes suppress both user-visible P0 and client-visible P1 via isEdgeSuppressedAlertRule / isProdOnlyAlertRule. Tied to the existing external-notification opt-in, and protected by per-rule/dimension cooldown plus global hourly rate limiting. Paired green recovery cards must fire only after a delivered firing card (firedFeishuEventIDs) and use a separate recovery dedupe key so resolve notifications are not blocked by the firing cooldown. Dropping any anchor turns a low-noise OPC pager into either silence or chat noise. FrontendURL threads the per-node public base URL into the card so prod vs each edge is distinguishable; losing it silently regresses every card back to an unattributable 'overall'."
     },
     {
       "path": "backend/internal/repository/ops_repo_alerts.go",


### PR DESCRIPTION
## 摘要
- edge 上的 `上游错误率极高`（`upstream_error_rate` > 20%）不再按 P0 打飞书。边上的最终 502 通常会被 prod failover 成 200，终端用户看不到失败（us4 2026-08-19 `gpt-5.6-sol` 即此形态）。
- 飞书卡片改为橙色 P1；prod 仍是 P0，因为 prod 终态失败等于用户可见失败。
- 8% 的 `上游错误率偏高` 预警仍不发飞书，避免和 20% 规则叠卡。

## 风险
- 常规风险：只改 ops 告警分页级别，不改网关转发、计费或公共 API。
- Web impact: none。Admin 规则表仍显示种子 P0，变化只在 edge 写入的事件严重级别和飞书卡片。
- 未改已 firing 的历史事件；需等恢复后再触发才会以 P1 发出。

## 验证
- `./scripts/preflight.sh`：PASS
- `go test -tags=unit ./internal/service/ -run 'TestEffectiveOpsAlertPageSeverity|TestOpsAlertFeishuSeverityAllowedEdgeUpstreamErrorRateP1|TestMaybeSendAlertFeishuAllowsEdgeDemotedUpstreamErrorRateP1|TestMaybeSendAlertFeishuP0AndClientVisibleP1Only|TestMaybeSendAlertFeishuAllowsClientVisibleP1|TestIsEdgeSuppressedAlertRule'`：ok

## 提交
- `b3cbd08dd` fix(ops): page edge-only upstream_error_rate as P1 on Feishu
- 最新提交：`b3cbd08dd`

Made with [Cursor](https://cursor.com)