### PR TITLE
fix(ops): 删除 8% 上游错误率偏高，20% 仅 edge 飞书 P1

### DIFF
--- a/backend/internal/repository/ops_alert_rules_seed_state_integration_test.go
+++ b/backend/internal/repository/ops_alert_rules_seed_state_integration_test.go
@@ -12,7 +12,8 @@ import (
 // TestSeededAlertRuleStateAfterMigrations pins the enabled-alert-rule contract
 // after all migrations apply: tk_060 seeds user-visible failure P0/P1, tk_061
 // retires routing_capacity_rejection_count (replaced by user_visible_failure_count),
-// and tk_036 latency rules ship disabled — every enabled rule has a working path.
+// tk_087 disables the leftover 20% upstream_error_rate Feishu P0, and tk_036
+// latency rules ship disabled — every enabled rule has a working path.
 func TestSeededAlertRuleStateAfterMigrations(t *testing.T) {
 	ctx := context.Background()
 
@@ -60,6 +61,32 @@ func TestSeededAlertRuleStateAfterMigrations(t *testing.T) {
 		"prod P0 user-visible threshold is evaluated over 5 minutes")
 	require.True(t, enabledFor("client_visible_failure_count"),
 		"tk_060 client_visible_failure_count rule must be enabled")
+
+	// tk_087: the 20% upstream_error_rate Feishu P0 is retired. It double-paged
+	// the same provider terminal failures as user_visible_failure_count. The 8%
+	// P1 early-warning rule stays on; it does not send Feishu.
+	type namedRule struct {
+		enabled    bool
+		severity   string
+		metricType string
+	}
+	ruleByName := func(name string) namedRule {
+		var rule namedRule
+		err := integrationDB.QueryRowContext(ctx,
+			`SELECT enabled, severity, metric_type FROM ops_alert_rules WHERE name = $1`,
+			name,
+		).Scan(&rule.enabled, &rule.severity, &rule.metricType)
+		require.NoError(t, err, "alert rule %q should be seeded", name)
+		return rule
+	}
+	retiredUpstreamP0 := ruleByName("上游错误率极高")
+	require.False(t, retiredUpstreamP0.enabled,
+		"tk_087 disables 上游错误率极高; user_visible_failure_count is the only prod UX P0")
+	require.Equal(t, "upstream_error_rate", retiredUpstreamP0.metricType)
+	elevatedUpstream := ruleByName("上游错误率偏高")
+	require.True(t, elevatedUpstream.enabled,
+		"8% upstream_error_rate P1 early warning stays enabled")
+	require.Equal(t, "P1", elevatedUpstream.severity)
 
 	// tk_061: routing-capacity P0 retired to avoid double-paging the same incident.
 	absentFor("routing_capacity_rejection_count")

--- a/backend/internal/repository/ops_alert_rules_seed_state_integration_test.go
+++ b/backend/internal/repository/ops_alert_rules_seed_state_integration_test.go
@@ -12,8 +12,9 @@ import (
 // TestSeededAlertRuleStateAfterMigrations pins the enabled-alert-rule contract
 // after all migrations apply: tk_060 seeds user-visible failure P0/P1, tk_061
 // retires routing_capacity_rejection_count (replaced by user_visible_failure_count),
-// tk_087 disables the leftover 20% upstream_error_rate Feishu P0, and tk_036
-// latency rules ship disabled — every enabled rule has a working path.
+// tk_087 deletes the 8% upstream_error_rate P1 and keeps the 20% rule as an
+// edge-only Feishu P1, and tk_036 latency rules ship disabled — every enabled
+// rule has a working path.
 func TestSeededAlertRuleStateAfterMigrations(t *testing.T) {
 	ctx := context.Background()
 
@@ -62,31 +63,38 @@ func TestSeededAlertRuleStateAfterMigrations(t *testing.T) {
 	require.True(t, enabledFor("client_visible_failure_count"),
 		"tk_060 client_visible_failure_count rule must be enabled")
 
-	// tk_087: the 20% upstream_error_rate Feishu P0 is retired. It double-paged
-	// the same provider terminal failures as user_visible_failure_count. The 8%
-	// P1 early-warning rule stays on; it does not send Feishu.
+	// tk_087: delete the 8% early-warning rate rule. Keep the 20% rule enabled
+	// as P1; the evaluator skips it on prod and pages it on edges.
 	type namedRule struct {
 		enabled    bool
 		severity   string
 		metricType string
+		threshold  float64
 	}
 	ruleByName := func(name string) namedRule {
 		var rule namedRule
 		err := integrationDB.QueryRowContext(ctx,
-			`SELECT enabled, severity, metric_type FROM ops_alert_rules WHERE name = $1`,
+			`SELECT enabled, severity, metric_type, threshold FROM ops_alert_rules WHERE name = $1`,
 			name,
-		).Scan(&rule.enabled, &rule.severity, &rule.metricType)
+		).Scan(&rule.enabled, &rule.severity, &rule.metricType, &rule.threshold)
 		require.NoError(t, err, "alert rule %q should be seeded", name)
 		return rule
 	}
-	retiredUpstreamP0 := ruleByName("上游错误率极高")
-	require.False(t, retiredUpstreamP0.enabled,
-		"tk_087 disables 上游错误率极高; user_visible_failure_count is the only prod UX P0")
-	require.Equal(t, "upstream_error_rate", retiredUpstreamP0.metricType)
-	elevatedUpstream := ruleByName("上游错误率偏高")
-	require.True(t, elevatedUpstream.enabled,
-		"8% upstream_error_rate P1 early warning stays enabled")
-	require.Equal(t, "P1", elevatedUpstream.severity)
+	absentByName := func(name string) {
+		var id int64
+		err := integrationDB.QueryRowContext(ctx,
+			`SELECT id FROM ops_alert_rules WHERE name = $1`,
+			name,
+		).Scan(&id)
+		require.Error(t, err, "alert rule %q should be removed", name)
+	}
+	absentByName("上游错误率偏高")
+	edgeUpstream := ruleByName("上游错误率极高")
+	require.True(t, edgeUpstream.enabled,
+		"tk_087 keeps 上游错误率极高 enabled for edge P1 paging")
+	require.Equal(t, "P1", edgeUpstream.severity)
+	require.Equal(t, "upstream_error_rate", edgeUpstream.metricType)
+	require.Equal(t, 20.0, edgeUpstream.threshold)
 
 	// tk_061: routing-capacity P0 retired to avoid double-paging the same incident.
 	absentFor("routing_capacity_rejection_count")

--- a/backend/internal/service/ops_alert_evaluator_service.go
+++ b/backend/internal/service/ops_alert_evaluator_service.go
@@ -383,7 +383,10 @@ func (s *OpsAlertEvaluatorService) shouldEvaluateAlertRuleOnNode(rule *OpsAlertR
 	if s == nil || rule == nil {
 		return true
 	}
-	return !s.isEdgeNode() || !isProdOnlyAlertRule(rule)
+	if s.isEdgeNode() {
+		return !isProdOnlyAlertRule(rule)
+	}
+	return !isEdgeOnlyAlertRule(rule)
 }
 
 func isProdOnlyAlertRule(rule *OpsAlertRule) bool {
@@ -396,6 +399,17 @@ func isProdOnlyAlertRule(rule *OpsAlertRule) bool {
 	default:
 		return false
 	}
+}
+
+// isEdgeOnlyAlertRule reports whether a rule is local provider-health noise on
+// prod (the user-facing terminus already pages via user_visible_failure_count).
+// After tk_087 the only remaining upstream_error_rate default is the 20% edge
+// P1; prod must not evaluate it.
+func isEdgeOnlyAlertRule(rule *OpsAlertRule) bool {
+	if rule == nil {
+		return false
+	}
+	return strings.TrimSpace(rule.MetricType) == "upstream_error_rate"
 }
 
 func (s *OpsAlertEvaluatorService) resolveActiveSkippedRule(ctx context.Context, rule *OpsAlertRule, now time.Time) bool {

--- a/backend/internal/service/ops_alert_evaluator_service_test.go
+++ b/backend/internal/service/ops_alert_evaluator_service_test.go
@@ -624,11 +624,12 @@ func TestIsEdgeSuppressedAlertRule(t *testing.T) {
 	require.False(t, isEdgeSuppressedAlertRule(nil))
 }
 
-// TestEffectiveOpsAlertPageSeverity pins the us4-class demotion: an edge-local
-// P0 upstream_error_rate is not end-user visible (prod failovers to another
-// edge), so the stored/paged severity must be P1. Prod keeps P0 because it is
-// the user-facing terminus. The 8% early-warning P1 rule stays P1; other P0
-// rules on an edge are unchanged.
+// TestEffectiveOpsAlertPageSeverity pins the leftover us4-class demotion if an
+// operator re-enables the retired 20% P0: an edge-local upstream_error_rate is
+// not end-user visible (prod failovers to another edge), so the stored/paged
+// severity must be P1. The seeded 20% rule is disabled by tk_087; this helper
+// only matters for a re-enabled copy. The 8% P1 stays P1; other P0 rules on an
+// edge are unchanged.
 func TestEffectiveOpsAlertPageSeverity(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/service/ops_alert_evaluator_service_test.go
+++ b/backend/internal/service/ops_alert_evaluator_service_test.go
@@ -624,12 +624,11 @@ func TestIsEdgeSuppressedAlertRule(t *testing.T) {
 	require.False(t, isEdgeSuppressedAlertRule(nil))
 }
 
-// TestEffectiveOpsAlertPageSeverity pins the leftover us4-class demotion if an
-// operator re-enables the retired 20% P0: an edge-local upstream_error_rate is
-// not end-user visible (prod failovers to another edge), so the stored/paged
-// severity must be P1. The seeded 20% rule is disabled by tk_087; this helper
-// only matters for a re-enabled copy. The 8% P1 stays P1; other P0 rules on an
-// edge are unchanged.
+// TestEffectiveOpsAlertPageSeverity pins the us4-class demotion: an edge-local
+// leftover P0 upstream_error_rate is not end-user visible (prod failovers to
+// another edge), so the stored/paged severity must be P1. tk_087 stores the
+// 20% rule as P1 already; a leftover P0 copy still remaps. Other P0 rules on
+// an edge are unchanged.
 func TestEffectiveOpsAlertPageSeverity(t *testing.T) {
 	t.Parallel()
 
@@ -656,15 +655,21 @@ func TestShouldEvaluateAlertRuleOnNode(t *testing.T) {
 	userVisibleRule := &OpsAlertRule{MetricType: OpsAlertMetricUserVisibleFailureCount}
 	clientVisibleRule := &OpsAlertRule{MetricType: OpsAlertMetricClientVisibleFailureCount}
 	routingRule := &OpsAlertRule{MetricType: OpsAlertMetricRoutingCapacityRejectionCount}
+	upstreamRate := &OpsAlertRule{Name: "上游错误率极高", MetricType: "upstream_error_rate", Severity: "P1", Threshold: 20}
 
 	edge := &OpsAlertEvaluatorService{cfg: &config.Config{Server: config.ServerConfig{FrontendURL: "https://api-us6.tokenkey.dev"}}}
 	require.False(t, edge.shouldEvaluateAlertRuleOnNode(userVisibleRule), "user-visible P0 is prod-only")
 	require.False(t, edge.shouldEvaluateAlertRuleOnNode(clientVisibleRule), "client-visible P1 is prod-only")
 	require.True(t, edge.shouldEvaluateAlertRuleOnNode(routingRule), "retired routing rule is not changed at evaluator level")
+	require.True(t, edge.shouldEvaluateAlertRuleOnNode(upstreamRate), "20% upstream_error_rate is edge-only P1")
 
 	prod := &OpsAlertEvaluatorService{cfg: &config.Config{Server: config.ServerConfig{FrontendURL: "https://api.tokenkey.dev"}}}
 	require.True(t, prod.shouldEvaluateAlertRuleOnNode(userVisibleRule))
 	require.True(t, prod.shouldEvaluateAlertRuleOnNode(clientVisibleRule))
+	require.False(t, prod.shouldEvaluateAlertRuleOnNode(upstreamRate), "prod must not evaluate upstream_error_rate")
+	require.True(t, isEdgeOnlyAlertRule(upstreamRate))
+	require.False(t, isEdgeOnlyAlertRule(userVisibleRule))
+	require.False(t, isEdgeOnlyAlertRule(nil))
 }
 
 // TestMaybeSendAlertNotificationsEdgeSuppression verifies the composed gate: on an
@@ -678,6 +683,11 @@ func TestMaybeSendAlertNotificationsEdgeSuppression(t *testing.T) {
 	edge := &OpsAlertEvaluatorService{cfg: &config.Config{Server: config.ServerConfig{FrontendURL: "https://api-us6.tokenkey.dev"}}}
 	prod := &OpsAlertEvaluatorService{cfg: &config.Config{Server: config.ServerConfig{FrontendURL: "https://api.tokenkey.dev"}}}
 	require.True(t, edge.isEdgeNode())
+
+	upstreamRate := &OpsAlertRule{MetricType: "upstream_error_rate", Severity: "P1", Threshold: 20}
+	prodUpstream := prod.maybeSendAlertNotifications(context.Background(), nil, upstreamRate, &OpsAlertEvent{})
+	require.False(t, prodUpstream.EmailSent)
+	require.False(t, prodUpstream.FeishuSent, "prod must not page leftover upstream_error_rate events")
 
 	for _, metricType := range []string{
 		"routing_capacity_rejection_count",

--- a/backend/internal/service/ops_alert_notifications_tk_feishu.go
+++ b/backend/internal/service/ops_alert_notifications_tk_feishu.go
@@ -54,6 +54,9 @@ func (s *OpsAlertEvaluatorService) maybeSendAlertNotifications(ctx context.Conte
 	if s.isEdgeNode() && isEdgeSuppressedAlertRule(rule) {
 		return result
 	}
+	if !s.isEdgeNode() && isEdgeOnlyAlertRule(rule) {
+		return result
+	}
 	if s.maybeSendAlertEmail(ctx, runtimeCfg, rule, event) {
 		result.EmailSent = true
 	}
@@ -83,18 +86,29 @@ func isEdgeSuppressedAlertRule(rule *OpsAlertRule) bool {
 	}
 }
 
-// isEdgeNonUserFacingAlertRule reports whether a P0 rule is local provider-health
-// noise on a mirror-relay edge: the edge recorded a final upstream failure, but
-// prod typically failovers to another edge and the end user still gets 200
-// (us4 2026-08-19 gpt-5.6-sol 502 → prod recovered-200). These still page, but
-// as P1 rather than paging-as-outage P0. The 8% early-warning P1 rule is not
-// this class — it is already P1 and stays off Feishu.
+// isEdgeNonUserFacingAlertRule reports whether a leftover P0 upstream_error_rate
+// copy is local provider-health noise on a mirror-relay edge: the edge recorded
+// a final upstream failure, but prod typically failovers to another edge and
+// the end user still gets 200 (us4 2026-08-19 gpt-5.6-sol 502 → prod
+// recovered-200). tk_087 stores the 20% rule as P1; this still remaps any
+// remaining P0 copy so it does not page as a user-visible outage.
 func isEdgeNonUserFacingAlertRule(rule *OpsAlertRule) bool {
 	if rule == nil {
 		return false
 	}
 	return strings.TrimSpace(rule.MetricType) == "upstream_error_rate" &&
 		strings.EqualFold(strings.TrimSpace(rule.Severity), "P0")
+}
+
+// isEdgeUpstreamRatePageRule is the 20% upstream_error_rate rule that may
+// reach Feishu as P1 on an edge. The deleted 8% early-warning rule (threshold
+// 8) must stay excluded even if an operator recreates it.
+func isEdgeUpstreamRatePageRule(rule *OpsAlertRule) bool {
+	if rule == nil {
+		return false
+	}
+	return strings.TrimSpace(rule.MetricType) == "upstream_error_rate" &&
+		rule.Threshold >= 20
 }
 
 // effectiveOpsAlertPageSeverity is the severity stored on the event and shown
@@ -194,6 +208,10 @@ func (s *OpsAlertEvaluatorService) maybeSendAlertFeishuRecovery(ctx context.Cont
 		return false
 	}
 	if s.isEdgeNode() && isEdgeSuppressedAlertRule(rule) {
+		s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseRecovery, false, "skip_severity_or_status", "", nil)
+		return false
+	}
+	if !s.isEdgeNode() && isEdgeOnlyAlertRule(rule) {
 		s.recordAlertFeishuDelivery(ctx, event, OpsAlertFeishuPhaseRecovery, false, "skip_severity_or_status", "", nil)
 		return false
 	}
@@ -300,9 +318,10 @@ func opsAlertFeishuSeverityAllowed(rule *OpsAlertRule, event *OpsAlertEvent) boo
 	if ruleSeverity == "P0" && eventSeverity == "P0" {
 		return true
 	}
-	// Edge remaps the 20% upstream_error_rate P0 to a P1 event so Feishu still
-	// delivers, but as orange P1. The 8% P1 early-warning rule stays excluded.
-	if ruleSeverity == "P0" && eventSeverity == "P1" && isEdgeNonUserFacingAlertRule(rule) {
+	// Edge 20% upstream_error_rate pages as P1 (seeded severity after tk_087,
+	// or a leftover P0 copy remapped by effectiveOpsAlertPageSeverity). The
+	// deleted 8% early-warning rule stays excluded (threshold < 20).
+	if eventSeverity == "P1" && isEdgeUpstreamRatePageRule(rule) {
 		return true
 	}
 	return ruleSeverity == "P1" &&

--- a/backend/internal/service/ops_feishu_alerts_tk_test.go
+++ b/backend/internal/service/ops_feishu_alerts_tk_test.go
@@ -282,8 +282,8 @@ func TestOpsAlertFeishuSeverityAllowedEdgeUpstreamErrorRateP1(t *testing.T) {
 	p0Event := &OpsAlertEvent{Severity: "P0", Status: OpsAlertStatusFiring}
 	p1Event := &OpsAlertEvent{Severity: "P1", Status: OpsAlertStatusFiring}
 
-	require.True(t, opsAlertFeishuSeverityAllowed(p0Upstream, p0Event), "prod still pages the 20% rule as P0")
-	require.True(t, opsAlertFeishuSeverityAllowed(p0Upstream, p1Event), "edge-demoted 20% rule must still reach Feishu as P1")
+	require.True(t, opsAlertFeishuSeverityAllowed(p0Upstream, p0Event), "if an operator re-enables the retired 20% P0, Feishu still accepts P0+P0")
+	require.True(t, opsAlertFeishuSeverityAllowed(p0Upstream, p1Event), "if the retired 20% rule is re-enabled on an edge, demoted P1 still reaches Feishu")
 	require.False(t, opsAlertFeishuSeverityAllowed(p1Upstream, p1Event), "8% early-warning P1 must stay off Feishu")
 	require.False(t, opsAlertFeishuSeverityAllowed(p1Upstream, p0Event))
 }

--- a/backend/internal/service/ops_feishu_alerts_tk_test.go
+++ b/backend/internal/service/ops_feishu_alerts_tk_test.go
@@ -277,15 +277,19 @@ func TestMaybeSendAlertFeishuP0AndClientVisibleP1Only(t *testing.T) {
 func TestOpsAlertFeishuSeverityAllowedEdgeUpstreamErrorRateP1(t *testing.T) {
 	t.Parallel()
 
-	p0Upstream := &OpsAlertRule{Name: "上游错误率极高", MetricType: "upstream_error_rate", Severity: "P0", NotifyEmail: true}
-	p1Upstream := &OpsAlertRule{Name: "上游错误率偏高", MetricType: "upstream_error_rate", Severity: "P1", NotifyEmail: true}
+	p0Upstream := &OpsAlertRule{Name: "上游错误率极高", MetricType: "upstream_error_rate", Severity: "P0", Threshold: 20, NotifyEmail: true}
+	p1Upstream20 := &OpsAlertRule{Name: "上游错误率极高", MetricType: "upstream_error_rate", Severity: "P1", Threshold: 20, NotifyEmail: true}
+	p1Upstream8 := &OpsAlertRule{Name: "上游错误率偏高", MetricType: "upstream_error_rate", Severity: "P1", Threshold: 8, NotifyEmail: true}
 	p0Event := &OpsAlertEvent{Severity: "P0", Status: OpsAlertStatusFiring}
 	p1Event := &OpsAlertEvent{Severity: "P1", Status: OpsAlertStatusFiring}
 
-	require.True(t, opsAlertFeishuSeverityAllowed(p0Upstream, p0Event), "if an operator re-enables the retired 20% P0, Feishu still accepts P0+P0")
-	require.True(t, opsAlertFeishuSeverityAllowed(p0Upstream, p1Event), "if the retired 20% rule is re-enabled on an edge, demoted P1 still reaches Feishu")
-	require.False(t, opsAlertFeishuSeverityAllowed(p1Upstream, p1Event), "8% early-warning P1 must stay off Feishu")
-	require.False(t, opsAlertFeishuSeverityAllowed(p1Upstream, p0Event))
+	require.True(t, opsAlertFeishuSeverityAllowed(p1Upstream20, p1Event), "tk_087 20% rule pages Feishu as P1")
+	require.True(t, opsAlertFeishuSeverityAllowed(p0Upstream, p1Event), "leftover P0 20% copy remapped to P1 still reaches Feishu")
+	require.True(t, opsAlertFeishuSeverityAllowed(p0Upstream, p0Event), "generic P0+P0 still allowed")
+	require.False(t, opsAlertFeishuSeverityAllowed(p1Upstream8, p1Event), "deleted 8% early-warning P1 must stay off Feishu")
+	require.False(t, opsAlertFeishuSeverityAllowed(p1Upstream8, p0Event))
+	require.True(t, isEdgeUpstreamRatePageRule(p1Upstream20))
+	require.False(t, isEdgeUpstreamRatePageRule(p1Upstream8))
 }
 
 func TestMaybeSendAlertFeishuAllowsEdgeDemotedUpstreamErrorRateP1(t *testing.T) {
@@ -308,6 +312,26 @@ func TestMaybeSendAlertFeishuAllowsEdgeDemotedUpstreamErrorRateP1(t *testing.T) 
 	require.Contains(t, doer.bodies[0], "TokenKey P1 告警")
 	require.Contains(t, doer.bodies[0], "orange")
 	require.NotContains(t, doer.bodies[0], "TokenKey P0 告警")
+}
+
+func TestMaybeSendAlertFeishuAllowsSeededUpstreamErrorRateP1(t *testing.T) {
+	t.Parallel()
+
+	doer := &recordingFeishuHTTPDoer{body: `{"code":0}`}
+	svc := newOpsFeishuAlertEvaluatorForTest(t, OpsFeishuAlertConfig{Enabled: true, WebhookURL: "https://open.feishu.cn/open-apis/bot/v2/hook/token", RateLimitPerHour: 3, CooldownSeconds: 3600}, doer)
+	rule := testOpsFeishuRule()
+	rule.Name = "上游错误率极高"
+	rule.Severity = "P1"
+	rule.MetricType = "upstream_error_rate"
+	rule.Operator = ">"
+	rule.Threshold = 20
+	event := testOpsFeishuEvent(1)
+	event.Severity = "P1"
+	event.Dimensions = map[string]any{"top_cause": "gpt-5.6-sol ×28（upstream 502 / provider）"}
+
+	require.True(t, svc.maybeSendAlertFeishu(context.Background(), nil, rule, event))
+	require.Equal(t, 1, doer.calls)
+	require.Contains(t, doer.bodies[0], "TokenKey P1 告警")
 }
 
 func TestMaybeSendAlertFeishuAllowsClientVisibleP1(t *testing.T) {

--- a/backend/migrations/tk_087_disable_upstream_error_rate_p0.sql
+++ b/backend/migrations/tk_087_disable_upstream_error_rate_p0.sql
@@ -1,0 +1,45 @@
+-- tk_087_disable_upstream_error_rate_p0.sql
+--
+-- Retire the Feishu P0 "上游错误率极高" (upstream_error_rate > 20%).
+--
+-- After tk_060/tk_064, prod already pages real user-visible provider/platform
+-- terminal failures via user_visible_failure_count ("真实用户体验受损", ≥50 / 5m).
+-- The 20% rate rule double-pages the same provider 5xx class on busy windows,
+-- and on quiet windows it can still P0 on a handful of failures (rateSampleFloor
+-- is 20 requests). That leftover P0 is from tk_014, before the UX count rule
+-- existed.
+--
+-- Keep the 8% P1 "上游错误率偏高" rule as the single upstream-rate early warning.
+-- It does not send Feishu (opsAlertFeishuSeverityAllowed only allows P0 plus
+-- client_visible_failure_count).
+--
+-- Disable rather than delete: historical events keep their rule_id, and the
+-- admin rule list shows the retired default. Idempotent: 0 rows on re-run.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+UPDATE ops_alert_events
+   SET status = 'resolved',
+       resolved_at = NOW()
+ WHERE status = 'firing'
+   AND rule_id IN (
+       SELECT id
+         FROM ops_alert_rules
+        WHERE name = '上游错误率极高'
+          AND metric_type = 'upstream_error_rate'
+   );
+
+UPDATE ops_alert_rules
+   SET enabled = false,
+       description = '已停用：与 prod「真实用户体验受损」(user_visible_failure_count) 飞书 P0 重复。用户侧终态失败只由该计数规则分页；上游比例预警保留「上游错误率偏高」(8%, P1, 不发飞书)。',
+       updated_at = NOW()
+ WHERE name = '上游错误率极高'
+   AND metric_type = 'upstream_error_rate'
+   AND enabled = true;
+
+UPDATE ops_alert_rules
+   SET description = '上游错误率（provider 端非 429/529 限流错误，已排除客户端/网关侧失败与限流）超过 8% 且持续 5 分钟触发。仅作早期预警，不发飞书；用户侧事故由「真实用户体验受损」P0 覆盖。',
+       updated_at = NOW()
+ WHERE name = '上游错误率偏高'
+   AND metric_type = 'upstream_error_rate';

--- a/backend/migrations/tk_087_disable_upstream_error_rate_p0.sql
+++ b/backend/migrations/tk_087_disable_upstream_error_rate_p0.sql
@@ -1,20 +1,20 @@
 -- tk_087_disable_upstream_error_rate_p0.sql
 --
--- Retire the Feishu P0 "上游错误率极高" (upstream_error_rate > 20%).
+-- Delete the 8% P1 "上游错误率偏高" rule on every node. It never sent Feishu
+-- and is leftover early-warning next to the 20% rule.
 --
--- After tk_060/tk_064, prod already pages real user-visible provider/platform
--- terminal failures via user_visible_failure_count ("真实用户体验受损", ≥50 / 5m).
--- The 20% rate rule double-pages the same provider 5xx class on busy windows,
--- and on quiet windows it can still P0 on a handful of failures (rateSampleFloor
--- is 20 requests). That leftover P0 is from tk_014, before the UX count rule
--- existed.
+-- Keep "上游错误率极高" (upstream_error_rate > 20%). Prod already pages real
+-- user-visible terminal failures via user_visible_failure_count, so the
+-- evaluator skips this rate rule on prod. Edges still evaluate it and page
+-- Feishu as P1 (rule severity is flipped here; leftover P0 copies are also
+-- demoted at runtime).
 --
--- Keep the 8% P1 "上游错误率偏高" rule as the single upstream-rate early warning.
--- It does not send Feishu (opsAlertFeishuSeverityAllowed only allows P0 plus
--- client_visible_failure_count).
+-- Remove the 8% default instead of leaving a second unused rate rule.
+-- Firing events are resolved first; silences are cleaned. Historical
+-- ops_alert_events stay; rule_id has no foreign key.
 --
--- Disable rather than delete: historical events keep their rule_id, and the
--- admin rule list shows the retired default. Idempotent: 0 rows on re-run.
+-- Idempotent: once the 8% row is gone each delete matches 0 rows; the 20%
+-- UPDATE is a no-op after the first apply.
 
 SET LOCAL lock_timeout = '5s';
 SET LOCAL statement_timeout = '5min';
@@ -26,20 +26,41 @@ UPDATE ops_alert_events
    AND rule_id IN (
        SELECT id
          FROM ops_alert_rules
+        WHERE name = '上游错误率偏高'
+          AND metric_type = 'upstream_error_rate'
+   );
+
+DO $$
+BEGIN
+    IF to_regclass('public.ops_alert_silences') IS NOT NULL THEN
+        DELETE FROM ops_alert_silences
+         WHERE rule_id IN (
+               SELECT id
+                 FROM ops_alert_rules
+                WHERE name = '上游错误率偏高'
+                  AND metric_type = 'upstream_error_rate'
+           );
+    END IF;
+END $$;
+
+DELETE FROM ops_alert_rules
+ WHERE name = '上游错误率偏高'
+   AND metric_type = 'upstream_error_rate';
+
+UPDATE ops_alert_events
+   SET severity = 'P1'
+ WHERE status = 'firing'
+   AND rule_id IN (
+       SELECT id
+         FROM ops_alert_rules
         WHERE name = '上游错误率极高'
           AND metric_type = 'upstream_error_rate'
    );
 
 UPDATE ops_alert_rules
-   SET enabled = false,
-       description = '已停用：与 prod「真实用户体验受损」(user_visible_failure_count) 飞书 P0 重复。用户侧终态失败只由该计数规则分页；上游比例预警保留「上游错误率偏高」(8%, P1, 不发飞书)。',
+   SET enabled = true,
+       severity = 'P1',
+       description = '仅 edge 评估：上游错误率（provider 端非 429/529 限流错误）超过 20% 且持续 5 分钟触发，飞书 P1。prod 不评估；用户侧终态失败由「真实用户体验受损」(user_visible_failure_count) 飞书 P0 覆盖。',
        updated_at = NOW()
  WHERE name = '上游错误率极高'
-   AND metric_type = 'upstream_error_rate'
-   AND enabled = true;
-
-UPDATE ops_alert_rules
-   SET description = '上游错误率（provider 端非 429/529 限流错误，已排除客户端/网关侧失败与限流）超过 8% 且持续 5 分钟触发。仅作早期预警，不发飞书；用户侧事故由「真实用户体验受损」P0 覆盖。',
-       updated_at = NOW()
- WHERE name = '上游错误率偏高'
    AND metric_type = 'upstream_error_rate';

--- a/backend/migrations/tk_087_disable_upstream_error_rate_p0_test.go
+++ b/backend/migrations/tk_087_disable_upstream_error_rate_p0_test.go
@@ -1,0 +1,23 @@
+package migrations
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTK087DisablesUpstreamErrorRateP0WithoutDeleting(t *testing.T) {
+	content, err := FS.ReadFile("tk_087_disable_upstream_error_rate_p0.sql")
+	require.NoError(t, err)
+
+	sql := strings.Join(strings.Fields(string(content)), " ")
+	require.Contains(t, sql, "name = '上游错误率极高'")
+	require.Contains(t, sql, "metric_type = 'upstream_error_rate'")
+	require.Contains(t, sql, "enabled = false")
+	require.Contains(t, sql, "AND enabled = true")
+	require.Contains(t, sql, "status = 'resolved'")
+	require.Contains(t, sql, "name = '上游错误率偏高'")
+	require.NotContains(t, sql, "DELETE FROM ops_alert_rules")
+	require.Contains(t, sql, "user_visible_failure_count")
+}

--- a/backend/migrations/tk_087_disable_upstream_error_rate_p0_test.go
+++ b/backend/migrations/tk_087_disable_upstream_error_rate_p0_test.go
@@ -7,17 +7,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTK087DisablesUpstreamErrorRateP0WithoutDeleting(t *testing.T) {
+func TestTK087RemovesElevatedUpstreamRateAndKeepsEdgeP1(t *testing.T) {
 	content, err := FS.ReadFile("tk_087_disable_upstream_error_rate_p0.sql")
 	require.NoError(t, err)
 
 	sql := strings.Join(strings.Fields(string(content)), " ")
+	require.Contains(t, sql, "DELETE FROM ops_alert_rules")
+	require.Contains(t, sql, "name = '上游错误率偏高'")
 	require.Contains(t, sql, "name = '上游错误率极高'")
 	require.Contains(t, sql, "metric_type = 'upstream_error_rate'")
-	require.Contains(t, sql, "enabled = false")
-	require.Contains(t, sql, "AND enabled = true")
-	require.Contains(t, sql, "status = 'resolved'")
-	require.Contains(t, sql, "name = '上游错误率偏高'")
-	require.NotContains(t, sql, "DELETE FROM ops_alert_rules")
+	require.Contains(t, sql, "severity = 'P1'")
+	require.Contains(t, sql, "enabled = true")
 	require.Contains(t, sql, "user_visible_failure_count")
+	require.NotContains(t, sql, "enabled = false")
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -370,6 +370,7 @@
         "maybeSendAlertNotifications",
         "feishu_sent",
         "effectiveOpsAlertPageSeverity",
+        "isEdgeOnlyAlertRule",
         "\"anthropic_cooldown_tier_escalation_count\"",
         "SetAnthropicUpstreamErrorCounterCache",
         "GetAnthropicCooldownTierEscalations",
@@ -386,6 +387,7 @@
         "opsAlertFeishuSeverityAllowed",
         "ruleSeverity == \"P0\" && eventSeverity == \"P0\"",
         "isEdgeNonUserFacingAlertRule",
+        "isEdgeUpstreamRatePageRule",
         "effectiveOpsAlertPageSeverity",
         "OpsAlertMetricClientVisibleFailureCount",
         "rule.NotifyEmail",
@@ -395,7 +397,7 @@
         "s.limiter.SetLimit(cfg.RateLimitPerHour)",
         "s.cfg.Server.FrontendURL"
       ],
-      "rationale": "TK companion that keeps Feishu alerting limited to P0 plus two explicit P1 exceptions: client_visible_failure_count on prod, and edge-demoted upstream_error_rate (P0 rule + P1 event) so a local provider 502 that prod failovers away from does not page as a user-visible P0 (us4 2026-08-19). Edge nodes suppress both user-visible P0 and client-visible P1 via isEdgeSuppressedAlertRule / isProdOnlyAlertRule. Tied to the existing external-notification opt-in, and protected by per-rule/dimension cooldown plus global hourly rate limiting. Paired green recovery cards must fire only after a delivered firing card (firedFeishuEventIDs) and use a separate recovery dedupe key so resolve notifications are not blocked by the firing cooldown. Dropping any anchor turns a low-noise OPC pager into either silence or chat noise. FrontendURL threads the per-node public base URL into the card so prod vs each edge is distinguishable; losing it silently regresses every card back to an unattributable 'overall'."
+      "rationale": "TK companion that keeps Feishu alerting limited to P0 plus two explicit P1 exceptions: client_visible_failure_count on prod, and the 20% upstream_error_rate edge page (isEdgeUpstreamRatePageRule, threshold >= 20) so a local provider 502 that prod failovers away from does not page as a user-visible P0 (us4 2026-08-19). The deleted 8% early-warning rule stays excluded. Edge nodes suppress both user-visible P0 and client-visible P1 via isEdgeSuppressedAlertRule / isProdOnlyAlertRule; prod suppresses leftover upstream_error_rate via isEdgeOnlyAlertRule. Tied to the existing external-notification opt-in, and protected by per-rule/dimension cooldown plus global hourly rate limiting. Paired green recovery cards must fire only after a delivered firing card (firedFeishuEventIDs) and use a separate recovery dedupe key so resolve notifications are not blocked by the firing cooldown. Dropping any anchor turns a low-noise OPC pager into either silence or chat noise. FrontendURL threads the per-node public base URL into the card so prod vs each edge is distinguishable; losing it silently regresses every card back to an unattributable 'overall'."
     },
     {
       "path": "backend/internal/repository/ops_repo_alerts.go",


### PR DESCRIPTION
## 摘要

删除 seeded 规则「上游错误率偏高」（8%, P1），prod 与 edge 都不再保留。

「上游错误率极高」（20%）保留为 **仅 edge 评估** 的飞书 P1：prod 不评估、不发飞书；用户侧终态失败仍只由「真实用户体验受损」（`user_visible_failure_count`）发 P0。

Web impact: none
no-web-impact
sentinel-registry-reviewed
high-risk-anchor: user approved ops alert rule migration in this session

## 风险

常规。`backend/migrations/` 被项目 high-risk 路径覆盖，因此带了锚点；行为上只改 ops 告警默认规则与节点评估，不改公共 API / WebUI / 鉴权。

## 验证

- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh` 通过
- `go test ./migrations/ -count=1 -run TestTK087` 通过
- `go test -tags=unit ./internal/service/ -count=1 -run 'TestOpsAlertFeishuSeverityAllowedEdgeUpstreamErrorRateP1|TestEffectiveOpsAlertPageSeverity|TestMaybeSendAlertFeishuAllowsEdgeDemotedUpstreamErrorRateP1|TestMaybeSendAlertFeishuAllowsSeededUpstreamErrorRateP1|TestShouldEvaluateAlertRuleOnNode|TestMaybeSendAlertNotificationsEdgeSuppression'` 通过
- `TestSeededAlertRuleStateAfterMigrations` 本地未验证（本机无 Docker/testcontainers）；依赖 CI `test-integration`

## 提交

- `d48c16ea2` fix(ops): retire leftover 20% upstream_error_rate Feishu P0
- `4709172d9` fix(ops): keep 20% upstream_error_rate as edge-only Feishu P1
- 最新提交：`4709172d9`