### PR TITLE
fix(gateway): CloudWise anthropic 账号放行白名单模型

### DIFF
--- a/backend/internal/handler/gateway_handler_tk_unsupported_model_test.go
+++ b/backend/internal/handler/gateway_handler_tk_unsupported_model_test.go
@@ -38,3 +38,12 @@ func TestTkWriteUnsupportedAnthropicModelAtIngress_AllowsClaudeModel(t *testing.
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
 	require.False(t, h.tkWriteUnsupportedAnthropicModelAtIngress(c, "claude-opus-4-8", false, nil))
 }
+
+func TestTkWriteUnsupportedAnthropicModelAtIngress_AllowsCloudwiseWhitelistModels(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &GatewayHandler{}
+	for _, model := range []string{"glm-5.2", "glm-5.3", "kimi-k3", "MiniMax-M3", "deepseek-v4-pro"} {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		require.False(t, h.tkWriteUnsupportedAnthropicModelAtIngress(c, model, false, nil), model)
+	}
+}

--- a/backend/internal/service/gateway_cloudwise_anthropic_chat_fallback_tk.go
+++ b/backend/internal/service/gateway_cloudwise_anthropic_chat_fallback_tk.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+)
+
+// shouldForwardCloudwiseAnthropicViaChatCompletions reports whether an inbound
+// Anthropic /v1/messages request on a CloudWise dual-stack account must use
+// /v1/chat/completions. Claude stays on native messages; glm/kimi/minimax/
+// deepseek follow the same chat fallback as OpenAI-platform CloudWise (#95).
+func shouldForwardCloudwiseAnthropicViaChatCompletions(account *Account, parsed *ParsedRequest) bool {
+	if !isCloudwiseRelayAccount(account) || parsed == nil {
+		return false
+	}
+	if parsed.Body != nil && len(parsed.Body.Bytes()) > 0 {
+		return !shouldForwardNativeAnthropicMessagesForModel(parsed.Body.Bytes())
+	}
+	return !tkIsForwardableAnthropicModelName(parsed.Model)
+}
+
+func (s *GatewayService) forwardCloudwiseAnthropicViaChatCompletions(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	parsed *ParsedRequest,
+) (*ForwardResult, error) {
+	if parsed == nil || parsed.Body == nil {
+		return nil, fmt.Errorf("parse request: empty request")
+	}
+	openai := &OpenAIGatewayService{
+		cfg:                  s.cfg,
+		httpUpstream:         s.httpUpstream,
+		responseHeaderFilter: s.responseHeaderFilter,
+	}
+	defaultMapped := parsed.Model
+	if account != nil {
+		if mapped := account.GetMappedModel(parsed.Model); mapped != "" {
+			defaultMapped = mapped
+		}
+	}
+	out, err := openai.forwardAnthropicViaRawChatCompletions(ctx, c, account, parsed.Body.Bytes(), defaultMapped)
+	if out == nil {
+		return nil, err
+	}
+	return &ForwardResult{
+		RequestID:                     out.RequestID,
+		Usage:                         claudeUsageFromOpenAIUsage(out.Usage),
+		Model:                         out.Model,
+		UpstreamModel:                 out.UpstreamModel,
+		UpstreamResponseModel:         out.UpstreamResponseModel,
+		UpstreamResponseModelConflict: out.UpstreamResponseModelConflict,
+		Stream:                        out.Stream,
+		Duration:                      out.Duration,
+		FirstTokenMs:                  out.FirstTokenMs,
+		ClientDisconnect:              out.ClientDisconnect,
+		ReasoningEffort:               out.ReasoningEffort,
+	}, err
+}
+
+func claudeUsageFromOpenAIUsage(usage OpenAIUsage) ClaudeUsage {
+	return ClaudeUsage{
+		InputTokens:              usage.InputTokens,
+		OutputTokens:             usage.OutputTokens,
+		CacheCreationInputTokens: usage.CacheCreationInputTokens,
+		CacheReadInputTokens:     usage.CacheReadInputTokens,
+		ImageOutputTokens:        usage.ImageOutputTokens,
+	}
+}

--- a/backend/internal/service/gateway_cloudwise_relay_test.go
+++ b/backend/internal/service/gateway_cloudwise_relay_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
@@ -181,4 +182,123 @@ func TestShouldForwardOpenAIResponsesViaRawChatCompletions_DualStackRelaysIgnore
 	generic.Extra = map[string]any{openai_compat.ExtraKeyResponsesSupported: true}
 	require.False(t, shouldForwardOpenAIResponsesViaRawChatCompletions(generic),
 		"ordinary OpenAI APIKey with a real Responses probe must keep the Responses path")
+}
+
+func cloudwiseAnthropicRelayAccount() *Account {
+	return &Account{
+		ID:          94,
+		Name:        "cloudwise-anthropic",
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":       "upstream-cloudwise-key",
+			"base_url":      "https://api.cloudwise.ai/api",
+			"model_mapping": modelMappingToAny(openAICloudwiseRelayWildcardModelMappingFloor()),
+		},
+		Extra: map[string]any{
+			"anthropic_passthrough": true,
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+}
+
+func TestGatewayService_Forward_CloudwiseAnthropicNonClaudeUsesChatFallback(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	for _, model := range []string{"glm-5.2", "kimi-k3", "MiniMax-M3", "deepseek-v4-flash"} {
+		t.Run(model, func(t *testing.T) {
+			body := []byte(`{"model":"` + model + `","max_tokens":8,"messages":[{"role":"user","content":"Reply OK only."}]}`)
+			parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), PlatformAnthropic)
+			require.NoError(t, err)
+
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(
+					`{"id":"chatcmpl-test","object":"chat.completion","model":"` + model + `","choices":[{"index":0,"message":{"role":"assistant","content":"OK"},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":1,"total_tokens":8}}`,
+				)),
+			}}
+			svc := &GatewayService{
+				cfg:          &config.Config{},
+				httpUpstream: upstream,
+			}
+
+			result, err := svc.Forward(context.Background(), c, cloudwiseAnthropicRelayAccount(), parsed)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, "https://api.cloudwise.ai/api/v1/chat/completions", upstream.lastReq.URL.String(), model)
+			require.Equal(t, "Bearer upstream-cloudwise-key", getHeaderRaw(upstream.lastReq.Header, "authorization"), model)
+			require.Equal(t, model, gjson.GetBytes(upstream.lastBody, "model").String(), model)
+			require.True(t, gjson.GetBytes(upstream.lastBody, "messages").Exists(), model)
+			require.Contains(t, rec.Body.String(), "OK")
+			require.Equal(t, "message", gjson.GetBytes(rec.Body.Bytes(), "type").String(), model)
+		})
+	}
+}
+
+func TestGatewayService_Forward_CloudwiseAnthropicClaudeUsesNativeMessages(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"claude-sonnet-4-6","max_tokens":8,"messages":[{"role":"user","content":"Reply OK only."}]}`)
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), PlatformAnthropic)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(strings.NewReader(
+			`{"type":"message","model":"claude-sonnet-4-6","role":"assistant","content":[{"type":"text","text":"OK"}],"usage":{"input_tokens":7,"output_tokens":1}}`,
+		)),
+	}}
+	svc := &GatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+	}
+
+	result, err := svc.Forward(context.Background(), c, cloudwiseAnthropicRelayAccount(), parsed)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "https://api.cloudwise.ai/api/v1/messages?beta=true", upstream.lastReq.URL.String())
+	require.Equal(t, "claude-sonnet-4-6", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Contains(t, rec.Body.String(), "OK")
+}
+
+func TestGatewayService_Forward_CloudwiseAnthropicRewritesMiniMaxCase(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"minimax-m3","max_tokens":8,"messages":[{"role":"user","content":"Reply OK only."}]}`)
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), PlatformAnthropic)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(strings.NewReader(
+			`{"id":"chatcmpl-test","object":"chat.completion","model":"MiniMax-M3","choices":[{"index":0,"message":{"role":"assistant","content":"OK"},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":1,"total_tokens":8}}`,
+		)),
+	}}
+	svc := &GatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+	}
+
+	result, err := svc.Forward(context.Background(), c, cloudwiseAnthropicRelayAccount(), parsed)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "https://api.cloudwise.ai/api/v1/chat/completions", upstream.lastReq.URL.String())
+	require.Equal(t, "MiniMax-M3", gjson.GetBytes(upstream.lastBody, "model").String())
 }

--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -112,6 +112,10 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		return s.handleWebSearchEmulation(ctx, c, account, parsed)
 	}
 
+	if account != nil && shouldForwardCloudwiseAnthropicViaChatCompletions(account, parsed) {
+		return s.forwardCloudwiseAnthropicViaChatCompletions(ctx, c, account, parsed)
+	}
+
 	if account != nil && account.IsAnthropicAPIKeyPassthroughEnabled() {
 		passthroughBody := parsed.Body.Bytes()
 		passthroughModel := parsed.Model

--- a/backend/internal/service/gateway_scheduling.go
+++ b/backend/internal/service/gateway_scheduling.go
@@ -2299,11 +2299,13 @@ func (s *GatewayService) isModelSupportedByAccount(account *Account, requestedMo
 		return ok
 	}
 	if account.Platform == PlatformAnthropic && account.Type != AccountTypeServiceAccount {
-		// Judge the forwarded (mapped) name: empty mapping keeps the request
-		// name; gpt-4o→claude stays allowed; glm-*→glm-* identity copies on
-		// official Anthropic accounts must not claim CloudWise prefixes now
-		// that ingress lets those names through.
-		if !tkIsForwardableAnthropicModelName(account.GetMappedModel(requestedModel)) {
+		// Leak only when BOTH the request and the forwarded name are outside
+		// claude-*: empty mapping keeps the request name; gpt-4o→claude stays
+		// allowed; claude→vendor-wire-id stays allowed; glm-*→glm-* identity
+		// copies on official Anthropic accounts must not claim CloudWise
+		// prefixes now that ingress lets those names through.
+		mapped := account.GetMappedModel(requestedModel)
+		if !tkIsForwardableAnthropicModelName(requestedModel) && !tkIsForwardableAnthropicModelName(mapped) {
 			return false
 		}
 	}

--- a/backend/internal/service/gateway_scheduling.go
+++ b/backend/internal/service/gateway_scheduling.go
@@ -2298,8 +2298,12 @@ func (s *GatewayService) isModelSupportedByAccount(account *Account, requestedMo
 		_, ok := ResolveBedrockModelID(account, requestedModel)
 		return ok
 	}
-	if account.Platform == PlatformAnthropic && account.Type != AccountTypeServiceAccount && len(account.GetModelMapping()) == 0 {
-		if !tkIsForwardableAnthropicModelName(requestedModel) {
+	if account.Platform == PlatformAnthropic && account.Type != AccountTypeServiceAccount {
+		// Judge the forwarded (mapped) name: empty mapping keeps the request
+		// name; gpt-4o→claude stays allowed; glm-*→glm-* identity copies on
+		// official Anthropic accounts must not claim CloudWise prefixes now
+		// that ingress lets those names through.
+		if !tkIsForwardableAnthropicModelName(account.GetMappedModel(requestedModel)) {
 			return false
 		}
 	}

--- a/backend/internal/service/gateway_service_tk_unsupported_model.go
+++ b/backend/internal/service/gateway_service_tk_unsupported_model.go
@@ -108,6 +108,13 @@ func tkAnthropicCrossVendorSelectionFailure(requestedModel string) error {
 	if tkIsForwardableAnthropicModelName(requestedModel) {
 		return nil
 	}
+	// Dual-stack CloudWise anthropic accounts (#94) advertise glm/kimi/minimax/
+	// deepseek via model_mapping prefixes. Ingress must not 400 those names
+	// before selection; empty-mapping Anthropic OAuth still cannot claim them
+	// because isModelSupportedByAccount keeps the claude-* namespace guard.
+	if openAICloudwiseRelaySupportsRequestedModel(requestedModel) {
+		return nil
+	}
 	if normalized := claude.NormalizeModelID(requestedModel); normalized != "" && normalized != requestedModel {
 		if tkIsForwardableAnthropicModelName(normalized) {
 			return nil

--- a/backend/internal/service/gateway_service_tk_unsupported_model_test.go
+++ b/backend/internal/service/gateway_service_tk_unsupported_model_test.go
@@ -392,3 +392,27 @@ func TestIsModelSupportedByAccount_TkGuardWithExplicitMapping(t *testing.T) {
 		t.Error("mapped account should not support a cross-vendor model absent from its mapping")
 	}
 }
+
+func TestIsModelSupportedByAccount_MappedCloudwisePrefixDoesNotLeakToOfficialAnthropic(t *testing.T) {
+	svc := &GatewayService{}
+	leaked := &Account{
+		ID:       11,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url":      "https://api.anthropic.com",
+			"model_mapping": modelMappingToAny(openAICloudwiseRelayWildcardModelMappingFloor()),
+		},
+	}
+	if isCloudwiseRelayAccount(leaked) {
+		t.Fatal("official Anthropic base_url must not be classified as CloudWise")
+	}
+	for _, model := range []string{"glm-5.2", "kimi-k3", "MiniMax-M3", "deepseek-v4-flash"} {
+		if svc.isModelSupportedByAccount(leaked, model) {
+			t.Errorf("non-CloudWise mapped anthropic must not claim %s after CloudWise ingress allow", model)
+		}
+	}
+	if !svc.isModelSupportedByAccount(leaked, "claude-sonnet-4-6") {
+		t.Error("non-CloudWise mapped anthropic must still serve its claude-* mapping")
+	}
+}

--- a/backend/internal/service/gateway_service_tk_unsupported_model_test.go
+++ b/backend/internal/service/gateway_service_tk_unsupported_model_test.go
@@ -415,4 +415,18 @@ func TestIsModelSupportedByAccount_MappedCloudwisePrefixDoesNotLeakToOfficialAnt
 	if !svc.isModelSupportedByAccount(leaked, "claude-sonnet-4-6") {
 		t.Error("non-CloudWise mapped anthropic must still serve its claude-* mapping")
 	}
+
+	// Existing scheduling fixtures map a claude request to a dummy wire ID
+	// ("x"). That is not a CloudWise leak: the client already asked for claude.
+	claudeToWire := &Account{
+		ID:       12,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{"claude-3-5-sonnet-20241022": "x"},
+		},
+	}
+	if !svc.isModelSupportedByAccount(claudeToWire, "claude-3-5-sonnet-20241022") {
+		t.Error("claude request remapped to a vendor wire ID must still be selectable")
+	}
 }

--- a/backend/internal/service/gateway_service_tk_unsupported_model_test.go
+++ b/backend/internal/service/gateway_service_tk_unsupported_model_test.go
@@ -220,8 +220,20 @@ func TestTkIsAnthropicCrossVendorModelName(t *testing.T) {
 	if !TkIsAnthropicCrossVendorModelName("gpt") {
 		t.Fatal("gpt must be cross-vendor on anthropic ingress")
 	}
-	if !TkIsAnthropicCrossVendorModelName("deepseek-v4-flash") {
-		t.Fatal("deepseek must be cross-vendor on anthropic ingress")
+	if !TkIsAnthropicCrossVendorModelName("gemini-3-flash-preview") {
+		t.Fatal("gemini must stay cross-vendor; CloudWise whitelist does not include it")
+	}
+	if TkIsAnthropicCrossVendorModelName("deepseek-v4-flash") {
+		t.Fatal("CloudWise whitelist prefix deepseek-* must pass anthropic ingress")
+	}
+	if TkIsAnthropicCrossVendorModelName("glm-5.2") {
+		t.Fatal("CloudWise whitelist prefix glm-* must pass anthropic ingress")
+	}
+	if TkIsAnthropicCrossVendorModelName("kimi-k3") {
+		t.Fatal("CloudWise whitelist prefix kimi-* must pass anthropic ingress")
+	}
+	if TkIsAnthropicCrossVendorModelName("MiniMax-M3") {
+		t.Fatal("CloudWise whitelist prefix minimax-* must pass anthropic ingress")
 	}
 	if TkIsAnthropicCrossVendorModelName("claude-opus-4-8") {
 		t.Fatal("claude-opus-4-8 must not be cross-vendor")

--- a/backend/internal/service/openai_cloudwise_relay_tk.go
+++ b/backend/internal/service/openai_cloudwise_relay_tk.go
@@ -45,7 +45,7 @@ func openAICloudwiseRelayUpstreamModelID(modelID string) string {
 }
 
 func applyOpenAICloudwiseRelayUpstreamModelID(account *Account, modelID string) string {
-	if account == nil || !account.IsOpenAICloudwiseRelay() {
+	if account == nil || !isCloudwiseRelayAccount(account) {
 		return modelID
 	}
 	return openAICloudwiseRelayUpstreamModelID(modelID)

--- a/backend/internal/service/openai_cloudwise_relay_tk_test.go
+++ b/backend/internal/service/openai_cloudwise_relay_tk_test.go
@@ -98,6 +98,21 @@ func TestCloudwiseRelayEmptyMappingStillRejectsForeignFamilies(t *testing.T) {
 	}
 }
 
+func TestApplyOpenAICloudwiseRelayUpstreamModelID_AnthropicAccount(t *testing.T) {
+	anthropic := &Account{
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url":      "https://api.cloudwise.ai/api",
+			"model_mapping": modelMappingToAny(openAICloudwiseRelayWildcardModelMappingFloor()),
+		},
+	}
+	require.True(t, isCloudwiseRelayAccount(anthropic))
+	require.False(t, anthropic.IsOpenAICloudwiseRelay())
+	require.Equal(t, "MiniMax-M3", applyOpenAICloudwiseRelayUpstreamModelID(anthropic, "minimax-m3"))
+	require.Equal(t, "MiniMax-M3", anthropic.GetMappedModel("minimax-m3"))
+}
+
 func TestCloudwiseRelayPrefixGateOverridesExplicitGPTMapping(t *testing.T) {
 	account := &Account{
 		Platform: PlatformOpenAI,

--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -24,6 +24,9 @@ func nativeOpenAIBaseURLForAccount(account *Account) string {
 	if account == nil {
 		return ""
 	}
+	if isCloudwiseRelayAccount(account) {
+		return strings.TrimSpace(account.GetCredential("base_url"))
+	}
 	if isNewAPIVolcEngineAgentPlanAccount(account) {
 		return newapiintegration.NormalizeArkChannelBaseURL(account.ChannelType, account.GetBaseURL())
 	}
@@ -33,6 +36,9 @@ func nativeOpenAIBaseURLForAccount(account *Account) string {
 func nativeOpenAIApiKeyForAccount(account *Account) string {
 	if account == nil {
 		return ""
+	}
+	if isCloudwiseRelayAccount(account) {
+		return strings.TrimSpace(account.GetCredential("api_key"))
 	}
 	if isNewAPIVolcEngineAgentPlanAccount(account) {
 		return strings.TrimSpace(account.GetCredential("api_key"))

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -4651,9 +4651,9 @@
     {
       "path": "backend/internal/service/gateway_scheduling.go",
       "must_contain": [
-        "if !tkIsForwardableAnthropicModelName(account.GetMappedModel(requestedModel)) {"
+        "if !tkIsForwardableAnthropicModelName(requestedModel) && !tkIsForwardableAnthropicModelName(mapped) {"
       ],
-      "rationale": "TK fix (PR #806 / #1743): isModelSupportedByAccount must judge the forwarded (mapped) Anthropic model name, not only empty-mapping passthrough. After CloudWise prefixes pass anthropic ingress, a non-CloudWise account with glm-*/deepseek-* identity mapping would otherwise be selected and leak those names to api.anthropic.com. CloudWise accounts already return earlier via isCloudwiseRelayAccount. gpt-4o→claude mappings stay allowed because GetMappedModel is claude-*. Pairs with the predicate sentinel on gateway_service_tk_unsupported_model.go."
+      "rationale": "TK fix (PR #806 / #1743): isModelSupportedByAccount must reject official Anthropic only when BOTH the request and forwarded names are outside claude-*. After CloudWise prefixes pass anthropic ingress, glm-*→glm-* identity copies on official Anthropic must not be selected. gpt-4o→claude and claude→vendor-wire-id stay allowed (CI TestGatewayService_isModelSupportedByAccount maps claude to x). CloudWise accounts already return earlier via isCloudwiseRelayAccount. Pairs with the predicate sentinel on gateway_service_tk_unsupported_model.go."
     },
     {
       "path": "backend/internal/service/gateway_service_tk_unsupported_model_test.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -4651,10 +4651,17 @@
     {
       "path": "backend/internal/service/gateway_scheduling.go",
       "must_contain": [
-        "len(account.GetModelMapping()) == 0",
-        "if !tkIsForwardableAnthropicModelName(requestedModel) {"
+        "if !tkIsForwardableAnthropicModelName(account.GetMappedModel(requestedModel)) {"
       ],
-      "rationale": "TK fix (PR #806): the injection point in isModelSupportedByAccount that routes a cross-vendor model name on a passthrough (empty model_mapping) anthropic direct account to the local Path A 400 instead of forwarding it to api.anthropic.com. Pinning the full guard expression also anchors the passthrough-only scope (len(GetModelMapping())==0) so a refactor cannot silently widen it to over-block mapped accounts or narrow it to re-open the leak. Pairs with the predicate sentinel on gateway_service_tk_unsupported_model.go."
+      "rationale": "TK fix (PR #806 / #1743): isModelSupportedByAccount must judge the forwarded (mapped) Anthropic model name, not only empty-mapping passthrough. After CloudWise prefixes pass anthropic ingress, a non-CloudWise account with glm-*/deepseek-* identity mapping would otherwise be selected and leak those names to api.anthropic.com. CloudWise accounts already return earlier via isCloudwiseRelayAccount. gpt-4o→claude mappings stay allowed because GetMappedModel is claude-*. Pairs with the predicate sentinel on gateway_service_tk_unsupported_model.go."
+    },
+    {
+      "path": "backend/internal/service/gateway_service_tk_unsupported_model_test.go",
+      "must_contain": [
+        "TestIsModelSupportedByAccount_MappedCloudwisePrefixDoesNotLeakToOfficialAnthropic",
+        "https://api.anthropic.com"
+      ],
+      "rationale": "Regression for PR #1743 R-001: a non-CloudWise anthropic APIKey that copies the CloudWise prefix floor must not be selected for glm/kimi/minimax/deepseek after ingress allows those names."
     },
     {
       "path": "backend/internal/service/universal_routing_tk_serving.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1154,7 +1154,8 @@
         "openAICloudwiseRelayUpstreamModelID(",
         "openAICloudwiseRelayWildcardModelMappingFloor(",
         "func isCloudwiseRelayAccount(",
-        "func openAICloudwiseRelaySupportsRequestedModel("
+        "func openAICloudwiseRelaySupportsRequestedModel(",
+        "if account == nil || !isCloudwiseRelayAccount(account)"
       ],
       "rationale": "Single SSOT for CloudWise MaaS relay supported model families (kimi/claude/glm/minimax/deepseek prefix policy). Adjust only openAICloudwiseRelayAllowedModelPrefixes; wildcard model_mapping floor derives from it. isCloudwiseRelayAccount + openAICloudwiseRelaySupportsRequestedModel are the dual-stack prefix hard gate used before passthrough / empty-mapping allow-all."
     },
@@ -1178,7 +1179,8 @@
       "must_contain": [
         "TestCloudwiseRelayEmptyMappingStillRejectsForeignFamilies",
         "TestCloudwiseRelayPrefixGateOverridesExplicitGPTMapping",
-        "TestGatewayService_CloudwiseRelayPassthroughEmptyMappingUsesPrefixGate"
+        "TestGatewayService_CloudwiseRelayPassthroughEmptyMappingUsesPrefixGate",
+        "TestApplyOpenAICloudwiseRelayUpstreamModelID_AnthropicAccount"
       ],
       "rationale": "Focused regressions for the CloudWise prefix hard gate: empty mapping / leftover passthrough still reject gpt-* on both Account.IsModelSupported and GatewayService.isModelSupportedByAccount, and an explicit gpt mapping cannot override the family floor."
     },
@@ -1190,10 +1192,40 @@
         "TestForwardAsAnthropic_CloudwiseNativeMessagesPassthrough",
         "TestForwardAsAnthropic_CloudwiseNonClaudeUsesChatFallback",
         "TestForwardAsChatCompletions_CloudwiseNonClaudeUsesRawChatEvenWhenResponsesFlagTrue",
+        "TestGatewayService_Forward_CloudwiseAnthropicNonClaudeUsesChatFallback",
+        "TestGatewayService_Forward_CloudwiseAnthropicClaudeUsesNativeMessages",
+        "TestGatewayService_Forward_CloudwiseAnthropicRewritesMiniMaxCase",
         "https://api.cloudwise.ai/api/v1/messages",
         "https://api.cloudwise.ai/api/v1/chat/completions"
       ],
-      "rationale": "Focused regressions for CloudWise MaaS relay (prod account #95): prefix wildcard model_mapping floor, native /v1/messages passthrough for claude-*, chat fallback for MiniMax-M3, and inbound /v1/chat/completions staying on raw chat even when openai_responses_supported is a false-positive true."
+      "rationale": "Focused regressions for CloudWise MaaS relays (#94 anthropic / #95 openai): prefix wildcard model_mapping floor, native /v1/messages passthrough for claude-*, chat fallback for MiniMax/glm/kimi/deepseek, MiniMax wire-id rewrite on anthropic accounts, and inbound /v1/chat/completions staying on raw chat even when openai_responses_supported is a false-positive true."
+    },
+    {
+      "path": "backend/internal/service/gateway_cloudwise_anthropic_chat_fallback_tk.go",
+      "must_contain": [
+        "func shouldForwardCloudwiseAnthropicViaChatCompletions(",
+        "func (s *GatewayService) forwardCloudwiseAnthropicViaChatCompletions(",
+        "forwardAnthropicViaRawChatCompletions",
+        "isCloudwiseRelayAccount(account)",
+        "shouldForwardNativeAnthropicMessagesForModel"
+      ],
+      "rationale": "Anthropic-platform CloudWise account #94 must reuse the OpenAI CloudWise chat fallback for non-claude whitelist models. Without this hook, GatewayService.Forward always posts /v1/messages, which CloudWise rejects for kimi-k3 / deepseek-v4-flash."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_request_body.go",
+      "must_contain": [
+        "isCloudwiseRelayAccount(account) {\n\t\treturn strings.TrimSpace(account.GetCredential(\"base_url\"))",
+        "isCloudwiseRelayAccount(account) {\n\t\treturn strings.TrimSpace(account.GetCredential(\"api_key\"))"
+      ],
+      "rationale": "nativeOpenAIBaseURLForAccount / nativeOpenAIApiKeyForAccount must read CloudWise credentials for any platform. GetOpenAIBaseURL/GetOpenAIApiKey are OpenAI-only, so anthropic #94 would otherwise resolve an empty chat fallback target."
+    },
+    {
+      "path": "backend/internal/service/gateway_forward.go",
+      "must_contain": [
+        "shouldForwardCloudwiseAnthropicViaChatCompletions(account, parsed)",
+        "forwardCloudwiseAnthropicViaChatCompletions(ctx, c, account, parsed)"
+      ],
+      "rationale": "GatewayService.Forward must intercept CloudWise non-claude /v1/messages before anthropic APIKey passthrough, otherwise #94 glm/kimi/minimax/deepseek stay on native messages."
     },
     {
       "path": "backend/internal/service/gateway_tokensea_anthropic_relay_test.go",
@@ -3612,9 +3644,10 @@
         "tkDeprecatedAnthropicSelectionFailure(requestedModel)",
         "tkAnthropicCrossVendorSelectionFailure(requestedModel)",
         "platform == PlatformAnthropic",
-        "func TkIsAnthropicCrossVendorModelName"
+        "func TkIsAnthropicCrossVendorModelName",
+        "openAICloudwiseRelaySupportsRequestedModel(requestedModel)"
       ],
-      "rationale": "tkWrapSelectionFailure must short-circuit retired Anthropic model names to ErrDeprecatedAnthropicModel and, only when the resolved scheduling platform is anthropic, non-claude-* cross-vendor dirty names to ErrUnsupportedModel before empty-pool classification. The platform guard prevents an empty Gemini/Antigravity pool from misclassifying gemini-* as an Anthropic namespace error and populating the group unsupported-model negative cache; the Anthropic branch still prevents mixed model_unsupported + unschedulable stats or load-batch bare ErrNoAvailableAccounts from surfacing routing 429 for client-fault model names (prod 2026-07-07 user16 key121 model=gpt)."
+      "rationale": "tkWrapSelectionFailure must short-circuit retired Anthropic model names to ErrDeprecatedAnthropicModel and, only when the resolved scheduling platform is anthropic, non-claude-* cross-vendor dirty names to ErrUnsupportedModel before empty-pool classification. The platform guard prevents an empty Gemini/Antigravity pool from misclassifying gemini-* as an Anthropic namespace error and populating the group unsupported-model negative cache; the Anthropic branch still prevents mixed model_unsupported + unschedulable stats or load-batch bare ErrNoAvailableAccounts from surfacing routing 429 for client-fault model names (prod 2026-07-07 user16 key121 model=gpt). CloudWise prefix families (glm/kimi/minimax/deepseek) must pass this ingress check so anthropic-platform dual-stack account #94 can be selected; empty-mapping OAuth stays blocked by tkIsForwardableAnthropicModelName."
     },
     {
       "path": "backend/internal/service/ratelimit_service.go",


### PR DESCRIPTION
## 摘要

- CloudWise 实测能通的 glm/kimi/minimax/deepseek 在 TokenKey anthropic 账号 #94 上被入口直接 400 `Unsupported model`，请求到不了上游。
- 原因有两层：Anthropic 跨厂商入口把这些名字当成脏模型；即便过了入口，#94 也一律打 `/v1/messages`，而 kimi-k3 / deepseek-v4-flash 只认 chat。
- 本 PR 让 CloudWise 前缀白名单通过入口；#94 非 Claude 复用 #95 已有的 `/v1/chat/completions` 回退；MiniMax 大小写改写对 anthropic CloudWise 同样生效。空 mapping 的 Anthropic OAuth 仍只转发 claude-*。
- Review R-001：官方 Anthropic 选号不得认领 CloudWise 前缀身份通配，避免脏名字打到 `api.anthropic.com`。
- Review R-002：守卫改为「请求名和映射后名字都不是 claude-* 才拒绝」，避免把 `claude-* → 厂商 wire ID` 的既有映射误拦。

## 风险

常规风险。不改公共路由、字段或鉴权；空 mapping OAuth 的脏模型守卫保持 claude-* only。线上 #94 要等本修复发版后才会生效。

## 验证

```bash
cd backend
go test -tags=unit -count=1 -run 'TestTkIsAnthropicCrossVendorModelName|TestTkWriteUnsupportedAnthropicModelAtIngress|TestTkIsForwardableAnthropicModelName|TestIsModelSupportedByAccount_MappedCloudwisePrefixDoesNotLeakToOfficialAnthropic|TestIsModelSupportedByAccount_TkDirtyModelGuard|TestIsModelSupportedByAccount_TkGuardWithExplicitMapping|TestGatewayService_isModelSupportedByAccount|TestGatewayService_Forward_CloudwiseAnthropic|TestApplyOpenAICloudwiseRelayUpstreamModelID_AnthropicAccount|TestCloudwiseRelay|TestForwardAsAnthropic_Cloudwise' ./internal/service/ ./internal/handler/
```

已跑过，通过。`PREFLIGHT_BASE=origin/main ./scripts/preflight.sh` 全绿。线上独占绑复测需发版后执行。

## 提交

- `704e0be63` fix(gateway): let CloudWise anthropic accounts serve whitelist models
- `fea311886` fix(gateway): address R-001 — keep mapped CloudWise prefixes off official Anthropic
- `f273294c1` fix(gateway): address R-002 — allow claude→wire-id mapping on official Anthropic
- 最新提交：`f273294c1`