### PR TITLE
fix(frontend): 空 site_logo 时统一回退 TokenKey logo

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 694,
-  "hash": "65c66110e1ac4e51b6c5e550b30e49264160c34e335fdf9538b95fc75b5cc441",
+  "hash": "713aeaf796bbe7fb5d2a957851d75ec5031e81b03e8aa9bbd04b6f5fe1f45752",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+    <link rel="icon" type="image/png" href="/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="TokenKey - AI API Gateway. 每一次调用，都是官方品质。文本、图像、视频，一个 Key 全搞定。Official quality AI API access.">
     <meta property="og:type" content="website">

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -11,7 +11,7 @@ import { useAppStore, useAuthStore, useSubscriptionStore, useAnnouncementStore, 
 import { getSetupStatus } from '@/api/setup'
 import { isNetworkError } from '@/api/client.tk'
 
-import { updateFavicon } from '@/utils/branding'
+import { DEFAULT_SITE_LOGO, updateFavicon } from '@/utils/branding'
 
 const router = useRouter()
 const route = useRoute()
@@ -34,7 +34,7 @@ function updateDocumentTitle() {
 watch(
   () => appStore.siteLogo,
   (newLogo) => {
-    updateFavicon(newLogo || '/favicon.ico')
+    updateFavicon(newLogo || DEFAULT_SITE_LOGO)
   },
   { immediate: true }
 )

--- a/frontend/src/components/home/HomeTkLanding.tk.vue
+++ b/frontend/src/components/home/HomeTkLanding.tk.vue
@@ -33,7 +33,7 @@
         <!-- Logo -->
         <div class="flex items-center">
           <div class="h-10 w-10 overflow-hidden rounded-xl shadow-md">
-            <img :src="siteLogo || '/logo.png'" alt="Logo" class="h-full w-full object-contain" />
+            <img :src="siteLogo" alt="Logo" class="h-full w-full object-contain" />
           </div>
         </div>
 
@@ -499,6 +499,7 @@
 import { ref, reactive, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore, useAppStore } from '@/stores'
+import { resolveSiteLogo } from '@/utils/branding'
 import LocaleSwitcher from '@/components/common/LocaleSwitcher.vue'
 import Icon from '@/components/icons/Icon.vue'
 import {
@@ -605,7 +606,9 @@ const appStore = useAppStore()
 
 // Site settings - directly from appStore (already initialized from injected config)
 const siteName = computed(() => appStore.cachedPublicSettings?.site_name || appStore.siteName || 'TokenKey')
-const siteLogo = computed(() => appStore.cachedPublicSettings?.site_logo || appStore.siteLogo || '')
+const siteLogo = computed(() =>
+  resolveSiteLogo(appStore.cachedPublicSettings?.site_logo || appStore.siteLogo),
+)
 const docUrl = computed(() => appStore.cachedPublicSettings?.doc_url || appStore.docUrl || '')
 
 // Theme

--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -14,7 +14,7 @@
         class="sidebar-logo flex h-9 w-9 items-center justify-center overflow-hidden rounded-xl shadow-glow transition-opacity hover:opacity-80"
         @click="handleMenuItemClick(homePath)"
       >
-        <img v-if="settingsLoaded" :src="siteLogo || '/logo.svg'" alt="Logo" class="h-full w-full object-contain" />
+        <img v-if="settingsLoaded" :src="siteLogo" alt="Logo" class="h-full w-full object-contain" />
       </router-link>
       <div class="sidebar-brand" :class="{ 'sidebar-brand-collapsed': sidebarCollapsed }" :aria-hidden="sidebarCollapsed ? 'true' : 'false'">
         <router-link
@@ -194,7 +194,7 @@ import { useI18n } from 'vue-i18n'
 import { useAdminSettingsStore, useAppStore, useAuthStore, useOnboardingStore } from '@/stores'
 import VersionBadge from '@/components/common/VersionBadge.vue'
 import { sanitizeSvg } from '@/utils/sanitize'
-import { sanitizeUrl } from '@/utils/url'
+import { resolveSiteLogo } from '@/utils/branding'
 import { FeatureFlags, makeSidebarFlag } from '@/utils/featureFlags'
 import { TK_SIDEBAR_WIDTH_CLASS } from '@/constants/layout'
 import { useBatchImageAccess } from '@/composables/useBatchImageAccess'
@@ -258,7 +258,7 @@ const expandedGroups = ref<Set<string>>(new Set())
 
 // Site settings from appStore (cached, no flicker)
 const siteName = computed(() => appStore.siteName)
-const siteLogo = computed(() => sanitizeUrl(appStore.siteLogo || '', { allowRelative: true, allowDataUrl: true }))
+const siteLogo = computed(() => resolveSiteLogo(appStore.siteLogo))
 const siteVersion = computed(() => appStore.siteVersion)
 const settingsLoaded = computed(() => appStore.publicSettingsLoaded)
 

--- a/frontend/src/components/layout/AuthLayout.vue
+++ b/frontend/src/components/layout/AuthLayout.vue
@@ -33,7 +33,7 @@
           <div
             class="mb-4 inline-flex h-16 w-16 items-center justify-center overflow-hidden rounded-2xl shadow-lg shadow-primary-500/30"
           >
-            <img :src="siteLogo || '/logo.svg'" alt="Logo" class="h-full w-full object-contain" />
+            <img :src="siteLogo" alt="Logo" class="h-full w-full object-contain" />
           </div>
           <h1 class="text-gradient mb-2 text-3xl font-bold">
             {{ siteName }}
@@ -65,12 +65,12 @@
 <script setup lang="ts">
 import { computed, onMounted } from 'vue'
 import { useAppStore } from '@/stores'
-import { sanitizeUrl } from '@/utils/url'
+import { resolveSiteLogo } from '@/utils/branding'
 
 const appStore = useAppStore()
 
 const siteName = computed(() => appStore.siteName || 'TokenKey')
-const siteLogo = computed(() => sanitizeUrl(appStore.siteLogo || '', { allowRelative: true, allowDataUrl: true }))
+const siteLogo = computed(() => resolveSiteLogo(appStore.siteLogo))
 const siteSubtitle = computed(() => appStore.cachedPublicSettings?.site_subtitle || 'AI API Gateway Platform')
 const settingsLoaded = computed(() => appStore.publicSettingsLoaded)
 

--- a/frontend/src/components/layout/__tests__/siteLogoSanitization.spec.ts
+++ b/frontend/src/components/layout/__tests__/siteLogoSanitization.spec.ts
@@ -5,28 +5,31 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
 const dir = dirname(fileURLToPath(import.meta.url))
+const brandingSource = readFileSync(resolve(dir, '../../../utils/branding.ts'), 'utf8')
 const sidebarSource = readFileSync(resolve(dir, '../AppSidebar.vue'), 'utf8')
-const homeViewSource = readFileSync(resolve(dir, '../../../views/HomeView.vue'), 'utf8')
 const keyUsageViewSource = readFileSync(resolve(dir, '../../../views/KeyUsageView.vue'), 'utf8')
+const homeLandingSource = readFileSync(resolve(dir, '../../../components/home/HomeTkLanding.tk.vue'), 'utf8')
 
 describe('site_logo sanitization', () => {
-  it('AppSidebar imports sanitizeUrl and applies it to siteLogo', () => {
-    expect(sidebarSource).toContain("import { sanitizeUrl } from '@/utils/url'")
-    expect(sidebarSource).toContain('sanitizeUrl(appStore.siteLogo')
+  it('resolveSiteLogo is the single sanitizing fallback', () => {
+    expect(brandingSource).toContain("import { sanitizeUrl } from '@/utils/url'")
+    expect(brandingSource).toContain('allowRelative: true')
+    expect(brandingSource).toContain('allowDataUrl: true')
+    expect(brandingSource).toContain('DEFAULT_SITE_LOGO')
   })
 
-  it('HomeView applies sanitizeUrl to siteLogo', () => {
-    expect(homeViewSource).toContain('sanitizeUrl(appStore.cachedPublicSettings?.site_logo || appStore.siteLogo')
+  it('AppSidebar resolves site logos through resolveSiteLogo', () => {
+    expect(sidebarSource).toContain("import { resolveSiteLogo } from '@/utils/branding'")
+    expect(sidebarSource).toContain('resolveSiteLogo(appStore.siteLogo')
   })
 
-  it('KeyUsageView applies sanitizeUrl to siteLogo', () => {
-    expect(keyUsageViewSource).toContain('sanitizeUrl(appStore.cachedPublicSettings?.site_logo || appStore.siteLogo')
+  it('KeyUsageView resolves site logos through resolveSiteLogo', () => {
+    expect(keyUsageViewSource).toContain("import { resolveSiteLogo } from '@/utils/branding'")
+    expect(keyUsageViewSource).toContain('resolveSiteLogo(appStore.cachedPublicSettings?.site_logo || appStore.siteLogo')
   })
 
-  it('all three pass allowRelative and allowDataUrl options', () => {
-    for (const src of [sidebarSource, homeViewSource, keyUsageViewSource]) {
-      expect(src).toContain('allowRelative: true')
-      expect(src).toContain('allowDataUrl: true')
-    }
+  it('HomeTkLanding resolves site logos through resolveSiteLogo', () => {
+    expect(homeLandingSource).toContain("import { resolveSiteLogo } from '@/utils/branding'")
+    expect(homeLandingSource).toContain('resolveSiteLogo(appStore.cachedPublicSettings?.site_logo || appStore.siteLogo')
   })
 })

--- a/frontend/src/components/modelPlaza/PlazaNavBar.vue
+++ b/frontend/src/components/modelPlaza/PlazaNavBar.vue
@@ -9,7 +9,7 @@
           <span
             class="flex h-9 w-9 flex-shrink-0 items-center justify-center overflow-hidden rounded-xl bg-white shadow-sm ring-1 ring-gray-200 dark:bg-dark-800 dark:ring-dark-700"
           >
-            <img :src="siteLogo || '/logo.svg'" alt="Logo" class="h-full w-full object-contain" />
+            <img :src="siteLogo" alt="Logo" class="h-full w-full object-contain" />
           </span>
           <span class="truncate text-base font-semibold text-gray-950 dark:text-white">
             {{ siteName }}
@@ -43,7 +43,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { sanitizeUrl } from '@/utils/url'
+import { resolveSiteLogo } from '@/utils/branding'
 import { useAppStore } from '@/stores/app'
 import { useAuthStore } from '@/stores/auth'
 
@@ -52,10 +52,8 @@ const appStore = useAppStore()
 const authStore = useAuthStore()
 
 const settings = computed(() => appStore.cachedPublicSettings)
-const siteName = computed(() => settings.value?.site_name || 'Sub2API')
-const siteLogo = computed(() =>
-  sanitizeUrl(settings.value?.site_logo || '', { allowRelative: true, allowDataUrl: true })
-)
+const siteName = computed(() => settings.value?.site_name || 'TokenKey')
+const siteLogo = computed(() => resolveSiteLogo(settings.value?.site_logo))
 const isAuthenticated = computed(() => authStore.isAuthenticated)
 const backTarget = computed(() => (authStore.isAdmin ? '/admin/dashboard' : '/dashboard'))
 </script>

--- a/frontend/src/utils/__tests__/branding.spec.ts
+++ b/frontend/src/utils/__tests__/branding.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { updateFavicon } from '@/utils/branding'
+import { DEFAULT_SITE_LOGO, updateFavicon } from '@/utils/branding'
 
 describe('updateFavicon', () => {
   beforeEach(() => {
@@ -13,10 +13,11 @@ describe('updateFavicon', () => {
     expect(link?.href).toBe('https://example.com/custom-logo.png')
   })
 
-  it('ignores unsafe logo URLs', () => {
+  it('falls back to the TokenKey logo when the URL is empty or unsafe', () => {
     updateFavicon('javascript:alert(1)')
 
     const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]')
-    expect(link?.getAttribute('href')).toBe('/logo.svg')
+    expect(link?.getAttribute('href')).toBe(DEFAULT_SITE_LOGO)
+    expect(link?.getAttribute('href')).not.toBe('/logo.svg')
   })
 })

--- a/frontend/src/utils/__tests__/defaultSiteLogo.spec.ts
+++ b/frontend/src/utils/__tests__/defaultSiteLogo.spec.ts
@@ -1,0 +1,73 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_SITE_LOGO, resolveSiteLogo } from '@/utils/branding'
+
+const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+
+const BRAND_SURFACES = [
+  'src/components/layout/AppSidebar.vue',
+  'src/components/layout/AuthLayout.vue',
+  'src/components/modelPlaza/PlazaNavBar.vue',
+  'src/views/public/LegalDocumentView.vue',
+  'src/views/KeyUsageView.vue',
+  'src/components/home/HomeTkLanding.tk.vue',
+] as const
+
+const UPSTREAM_LOGO_FALLBACK = /(?:\|\|\s*['"]\/logo\.svg['"]|href=["']\/logo\.svg["'])/
+
+function walkSourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    if (name === 'node_modules' || name === 'dist' || name === '__tests__') {
+      continue
+    }
+    const full = join(dir, name)
+    const stat = statSync(full)
+    if (stat.isDirectory()) {
+      walkSourceFiles(full, acc)
+      continue
+    }
+    if (name.endsWith('.vue') || name.endsWith('.html') || name === 'App.vue' || name === 'main.ts') {
+      acc.push(full)
+    }
+  }
+  return acc
+}
+
+describe('resolveSiteLogo', () => {
+  it('falls back to the TokenKey logo when no site_logo is configured', () => {
+    expect(resolveSiteLogo('')).toBe('/logo.png')
+    expect(resolveSiteLogo('')).toBe(DEFAULT_SITE_LOGO)
+    expect(resolveSiteLogo('')).not.toBe('/logo.svg')
+  })
+
+  it('rejects an unsafe URL and still uses the TokenKey logo', () => {
+    expect(resolveSiteLogo('javascript:alert(1)')).toBe(DEFAULT_SITE_LOGO)
+  })
+
+  it('keeps a sanitized custom logo', () => {
+    expect(resolveSiteLogo('/uploads/custom.png')).toBe('/uploads/custom.png')
+  })
+})
+
+describe('TokenKey default logo surfaces', () => {
+  it('known brand surfaces resolve through resolveSiteLogo', () => {
+    for (const rel of BRAND_SURFACES) {
+      const src = readFileSync(join(frontendRoot, rel), 'utf8')
+      expect(src, rel).toContain('resolveSiteLogo')
+      expect(src, rel).not.toMatch(UPSTREAM_LOGO_FALLBACK)
+    }
+  })
+
+  it('no Vue/HTML brand surface falls back to the upstream Sub2API logo', () => {
+    const files = [
+      ...walkSourceFiles(join(frontendRoot, 'src')),
+      join(frontendRoot, 'index.html'),
+    ]
+    const offenders = files.filter((file) => UPSTREAM_LOGO_FALLBACK.test(readFileSync(file, 'utf8')))
+    expect(offenders.map((file) => file.slice(frontendRoot.length + 1))).toEqual([])
+  })
+})

--- a/frontend/src/utils/branding.ts
+++ b/frontend/src/utils/branding.ts
@@ -1,13 +1,19 @@
 import { sanitizeUrl } from '@/utils/url'
 
+/** TokenKey product mark. `/logo.svg` remains the upstream Sub2API asset. */
+export const DEFAULT_SITE_LOGO = '/logo.png'
+
+export function resolveSiteLogo(logoUrl: string | undefined | null): string {
+  return (
+    sanitizeUrl(logoUrl || '', {
+      allowRelative: true,
+      allowDataUrl: true,
+    }) || DEFAULT_SITE_LOGO
+  )
+}
+
 export function updateFavicon(logoUrl: string): void {
-  const sanitizedLogoUrl = sanitizeUrl(logoUrl, {
-    allowRelative: true,
-    allowDataUrl: true,
-  })
-  if (!sanitizedLogoUrl) {
-    return
-  }
+  const sanitizedLogoUrl = resolveSiteLogo(logoUrl)
 
   let link = document.querySelector<HTMLLinkElement>('link[rel="icon"]')
   if (!link) {
@@ -16,6 +22,6 @@ export function updateFavicon(logoUrl: string): void {
     document.head.appendChild(link)
   }
 
-  link.type = sanitizedLogoUrl.endsWith('.svg') ? 'image/svg+xml' : 'image/x-icon'
+  link.type = sanitizedLogoUrl.endsWith('.svg') ? 'image/svg+xml' : 'image/png'
   link.href = sanitizedLogoUrl
 }

--- a/frontend/src/views/KeyUsageView.vue
+++ b/frontend/src/views/KeyUsageView.vue
@@ -421,6 +421,7 @@ import Icon from '@/components/icons/Icon.vue'
 import { buildGatewayUrl } from '@/api/client'
 import { STATUS_ACTIVE } from '@/constants/channel'
 import { formatDateLocalInput } from '@/utils/format'
+import { resolveSiteLogo } from '@/utils/branding'
 import { sanitizeUrl } from '@/utils/url'
 
 const { t, locale } = useI18n()
@@ -430,10 +431,7 @@ const appStore = useAppStore()
 
 const siteName = computed(() => appStore.cachedPublicSettings?.site_name || appStore.siteName || 'TokenKey')
 const siteLogo = computed(() =>
-  sanitizeUrl(appStore.cachedPublicSettings?.site_logo || appStore.siteLogo || '', {
-    allowRelative: true,
-    allowDataUrl: true,
-  }) || '/logo.png',
+  resolveSiteLogo(appStore.cachedPublicSettings?.site_logo || appStore.siteLogo),
 )
 const docUrl = computed(() =>
   sanitizeUrl(appStore.cachedPublicSettings?.doc_url || appStore.docUrl || '', {

--- a/frontend/src/views/public/LegalDocumentView.vue
+++ b/frontend/src/views/public/LegalDocumentView.vue
@@ -5,7 +5,7 @@
         <RouterLink to="/home" class="flex min-w-0 items-center gap-3">
           <template v-if="settings">
             <span class="flex h-10 w-10 flex-shrink-0 items-center justify-center overflow-hidden rounded-xl bg-white shadow-sm ring-1 ring-gray-200 dark:bg-dark-800 dark:ring-dark-700">
-              <img :src="siteLogo || '/logo.svg'" alt="Logo" class="h-full w-full object-contain" />
+              <img :src="siteLogo" alt="Logo" class="h-full w-full object-contain" />
             </span>
             <span class="truncate text-base font-semibold text-gray-950 dark:text-white">
               {{ siteName }}
@@ -97,7 +97,7 @@ import DOMPurify from 'dompurify'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/icons/Icon.vue'
 import { getLocale } from '@/i18n'
-import { sanitizeUrl } from '@/utils/url'
+import { resolveSiteLogo } from '@/utils/branding'
 import { useAppStore } from '@/stores/app'
 import type { LoginAgreementDocument } from '@/types'
 import zhAdminCompliance from '../../../../docs/legal/admin-compliance.zh.md?raw'
@@ -120,11 +120,8 @@ marked.setOptions({
 const documentId = computed(() => String(route.params.documentId || ''))
 const isAdminComplianceDocument = computed(() => documentId.value === 'admin-compliance')
 const documents = computed(() => settings.value?.login_agreement_documents ?? [])
-const siteName = computed(() => settings.value?.site_name || 'Sub2API')
-const siteLogo = computed(() => sanitizeUrl(settings.value?.site_logo || '', {
-  allowRelative: true,
-  allowDataUrl: true,
-}))
+const siteName = computed(() => settings.value?.site_name || 'TokenKey')
+const siteLogo = computed(() => resolveSiteLogo(settings.value?.site_logo))
 const updatedAt = computed(() =>
   isAdminComplianceDocument.value ? '' : settings.value?.login_agreement_updated_at || ''
 )

--- a/scripts/sentinels/brand.json
+++ b/scripts/sentinels/brand.json
@@ -7,9 +7,10 @@
       "must_contain": [
         "<title>TokenKey",
         "href=\"https://tokenkey.dev/\"",
-        "content=\"https://tokenkey.dev\""
+        "content=\"https://tokenkey.dev\"",
+        "href=\"/logo.png\""
       ],
-      "rationale": "Default embedded SPA browser tab title before JS runs; regressing to Sub2API breaks the single-product narrative for every fresh load. Canonical/og:url must stay on the human apex host after apex-domain phase 2."
+      "rationale": "Default embedded SPA browser tab title before JS runs; regressing to Sub2API breaks the single-product narrative for every fresh load. Canonical/og:url must stay on the human apex host after apex-domain phase 2. The PNG favicon must stay on /logo.png (TokenKey mark); /logo.svg is the upstream Sub2API asset and must not become the default tab icon."
     },
     {
       "path": "frontend/src/router/title.ts",

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -72,6 +72,27 @@
     {
       "path": "frontend/src/components/layout/AppSidebar.vue",
       "must_contain": [
+        "resolveSiteLogo"
+      ],
+      "must_not_contain": [
+        "/logo.svg"
+      ],
+      "rationale": "Logged-in pages including /dashboard render the sidebar logo from AppSidebar. Production site_logo is empty, so the fallback is the visible brand mark. resolveSiteLogo must keep the TokenKey PNG; an upstream merge that restores `|| '/logo.svg'` silently puts the Sub2API interlocking-S back on every console page."
+    },
+    {
+      "path": "frontend/src/utils/branding.ts",
+      "must_contain": [
+        "export const DEFAULT_SITE_LOGO = '/logo.png'",
+        "export function resolveSiteLogo"
+      ],
+      "must_not_contain": [
+        "DEFAULT_SITE_LOGO = '/logo.svg'"
+      ],
+      "rationale": "Single default-logo owner for every SPA surface. `/logo.png` is the TokenKey mark; `/logo.svg` is the upstream Sub2API asset left on disk to keep README/upstream merge surface small. Losing this helper lets page-local fallbacks drift back to /logo.svg."
+    },
+    {
+      "path": "frontend/src/components/layout/AppSidebar.vue",
+      "must_contain": [
         "t('nav.studio')"
       ],
       "rationale": "The Media Studio (/studio) user-nav entry. Without this anchor an upstream merge to the nav builder could silently drop the Studio link, hiding the image/video generation surface from users while everything still compiles."


### PR DESCRIPTION
## 摘要
生产 `tokenkey.dev/dashboard` 的侧栏 logo 仍是上游 Sub2API 标。线上 `site_logo` 为空，`AppSidebar` 等页面回退到 `/logo.svg`（文件标题仍是 Sub2API），而 TokenKey 标是 `/logo.png`。

本次把默认标收敛到单一 `resolveSiteLogo()`：空值或不安全 URL 一律回退 `/logo.png`，覆盖 dashboard 侧栏、登录页、模型广场、法律页、落地页、key-usage，以及 favicon。

## 风险
常规风险。只改前端品牌回退路径，不改 API / 鉴权 / schema。`/logo.svg` 仍留在仓库以免扩大上游 merge 冲突面，但不再作为任何页面的默认标。

## 验证
- 线上取证：`GET /api/v1/settings/public` 的 `site_logo=""`；`/logo.svg` 标题为 Sub2API，`/logo.png` 为 TK 标。
- `pnpm exec vitest run src/utils/__tests__/defaultSiteLogo.spec.ts src/utils/__tests__/branding.spec.ts src/components/layout/__tests__/siteLogoSanitization.spec.ts src/views/__tests__/KeyUsageView.spec.ts`：14 passed
- `./scripts/preflight.sh`：PASS

## 提交
- `2183e19d8` fix(frontend): 空 site_logo 时统一回退 TokenKey logo
- 最新提交：`2183e19d8`

Made with [Cursor](https://cursor.com)