### PR TITLE
fix(gateway): GPT 专线 overloaded 400 换号到 tokensea

### DIFF
--- a/backend/internal/service/openai_gateway_messages_failed_response_test.go
+++ b/backend/internal/service/openai_gateway_messages_failed_response_test.go
@@ -155,6 +155,35 @@ func TestForwardAsAnthropic_StreamingBareErrorBeforeOutputFailsOver(t *testing.T
 	require.Empty(t, rec.Body.String(), "failover path must not commit downstream output")
 }
 
+func TestForwardAsAnthropic_StreamingResponseFailed_OverloadedFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.6","max_tokens":32,"messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	ssePayload := buildResponsesFailedSSEStream("invalid_request_error", "Our servers are currently overloaded. Please try again later.")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(ssePayload)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+
+	account := rawChatCompletionsTestAccount()
+	_, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "")
+
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr), "stream capacity overloaded must failover even when typed invalid_request_error: %T: %v", err, err)
+	require.Empty(t, rec.Body.String(), "failover path must not commit downstream output")
+}
+
 func TestForwardAsAnthropic_BufferedResponseFailed_Failover(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
@@ -282,6 +282,16 @@ func TestIsOpenAITransientProcessingError(t *testing.T) {
 	))
 
 	require.True(t, isOpenAITransientProcessingError(
+		http.StatusBadRequest,
+		"Our servers are currently overloaded. Please try again later.",
+		[]byte(`{"type":"response.failed","response":{"error":{"code":"invalid_request_error","type":"invalid_request_error","message":"Our servers are currently overloaded. Please try again later."}}}`),
+	))
+	require.True(t, openAIStreamFailedEventShouldFailover(
+		[]byte(`{"type":"response.failed","response":{"error":{"code":"invalid_request_error","type":"invalid_request_error","message":"Our servers are currently overloaded. Please try again later."}}}`),
+		"Our servers are currently overloaded. Please try again later.",
+	))
+
+	require.True(t, isOpenAITransientProcessingError(
 		http.StatusServiceUnavailable,
 		"",
 		[]byte(`{"error":{"code":"slow_down","message":"Please retry later."}}`),

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -204,17 +204,17 @@ func TestFailoverOpenAIUpstreamHTTPError_NilContextSkipsTempUnschedulablePolicy(
 			"temp_unschedulable_enabled": true,
 			"temp_unschedulable_rules": []any{map[string]any{
 				"error_code":       float64(http.StatusBadRequest),
-				"keywords":         []any{"servers are currently overloaded"},
+				"keywords":         []any{"custom account cooldown phrase"},
 				"duration_minutes": float64(1),
 			}},
 		},
 	}
-	body := []byte(`{"error":{"message":"Our servers are currently overloaded."}}`)
+	body := []byte(`{"error":{"message":"custom account cooldown phrase"}}`)
 	resp := &http.Response{StatusCode: http.StatusBadRequest, Header: http.Header{}}
 
 	got := svc.failoverOpenAIUpstreamHTTPError(
 		context.Background(), nil, account, resp, body,
-		"Our servers are currently overloaded.", "gpt-5.4",
+		"custom account cooldown phrase", "gpt-5.4",
 	)
 
 	require.Nil(t, got)

--- a/backend/internal/service/openai_gateway_service_tk_buffered_failover_test.go
+++ b/backend/internal/service/openai_gateway_service_tk_buffered_failover_test.go
@@ -229,6 +229,41 @@ func TestForwardAsChatCompletions_BufferedResponseFailedNonRetryableNoFailover(t
 	require.Contains(t, rec.Body.String(), "not allowed")
 }
 
+func TestForwardAsAnthropic_BufferedResponseFailedOverloadedFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.6","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	// Prod GPT 专线 / Codex edge 把容量 400 写成 invalid_request_error，而不是
+	// server_is_overloaded。这条必须换号，否则同组 tokensea 永远接不到。
+	upstreamBody := strings.Join([]string{
+		`event: response.failed`,
+		`data: {"type":"response.failed","response":{"id":"resp_failed","object":"response","model":"gpt-5.6","status":"failed","output":[],"error":{"code":"invalid_request_error","type":"invalid_request_error","message":"Our servers are currently overloaded. Please try again later."}}}`,
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "X-Request-Id": []string{"rid_messages_failed_overloaded"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := openAICompatTestOAuthAccount(63, "openai-us6")
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.6")
+	require.Error(t, err)
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr), "capacity overloaded must failover even when wrapped as invalid_request_error: %T: %v", err, err)
+	require.True(t, failoverErr.ShouldRetryNextAccount())
+	require.False(t, c.Writer.Written(), "failover path must not commit a client 400")
+	require.Empty(t, rec.Body.String())
+}
+
 func TestForwardAsAnthropic_BufferedResponseFailedNonRetryableNoFailover(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/openai_gateway_upstream_errors.go
+++ b/backend/internal/service/openai_gateway_upstream_errors.go
@@ -147,6 +147,13 @@ func isOpenAITransientProcessingError(upstreamStatusCode int, upstreamMsg string
 		if strings.Contains(lower, "selected model is at capacity") {
 			return true
 		}
+		// Codex / ChatGPT often wrap capacity 400 as invalid_request_error with
+		// this message and no server_is_overloaded code. Treat it as transient so
+		// GPT 专线 can leave a saturated edge OAuth account for a sibling APIKey
+		// (e.g. tokensea) instead of returning a terminal client 400.
+		if strings.Contains(lower, "servers are currently overloaded") {
+			return true
+		}
 		return strings.Contains(lower, "you can retry your request") &&
 			strings.Contains(lower, "help.openai.com") &&
 			strings.Contains(lower, "request id")


### PR DESCRIPTION
## 摘要

GPT 专线 `/v1/messages` 打到已满的 edge Codex 时，上游把容量错误包成 `invalid_request_error` + `Our servers are currently overloaded. Please try again later.`，没有 `server_is_overloaded`。网关把这条当成终态 400，不再换号，同组 tokensea 接不到请求。

本 PR 把这句容量 overloaded 识别为可换号瞬时错误：首 token 前必须 `UpstreamFailoverError`，确定性 invalid_request（policy / not allowed）仍不换号。

## 风险

常规。只改 OpenAI 瞬时错误识别，不改公共契约、鉴权或 schema。误伤面：带 “servers are currently overloaded” 的 400 会换号；确定性 policy/invalid 路径有回归测试守住。

no-web-impact
Web impact: none
sentinel-registry-reviewed
upstream-conflict-surface-accepted

## 验证

- `./scripts/preflight.sh` 通过
- `go test -tags=unit -count=1 -run 'TestForwardAsAnthropic_|TestForwardAsChatCompletions_Buffered|TestIsOpenAITransientProcessingError|TestFailoverOpenAIUpstreamHTTPError|TestOpenAIStreamingResponseFailed' ./internal/service/` 通过

## 提交

- `805e63576` fix(gateway): failover Codex overloaded 400 so GPT 专线 can use tokensea
- `37329cf4b` merge(main): restore ancestry after #1744 landed on main
- 最新提交：`37329cf4b`