### PR TITLE
fix(openai): 补齐 HTTP /responses 的 QA encrypted_reasoning

### DIFF
--- a/backend/internal/service/openai_encrypted_reasoning_qa.go
+++ b/backend/internal/service/openai_encrypted_reasoning_qa.go
@@ -10,8 +10,29 @@ import (
 
 const openaiEncryptedReasoningGinKey = "ops_openai_encrypted_reasoning"
 
+// observeOpenAIResponsesEvent 是 QA encrypted_reasoning 的唯一生产入口。
+// 所有会把 OpenAI Responses JSON 事件写给客户端的路径都必须走这里，
+// 禁止在各转发循环里再手写 stash。
+func observeOpenAIResponsesEvent(c *gin.Context, data []byte) {
+	stashOpenAIEncryptedReasoningFromSSE(c, data)
+}
+
+func observeOpenAIResponsesSSEBody(c *gin.Context, body string) {
+	if strings.TrimSpace(body) == "" {
+		return
+	}
+	if bodyHasSSEFraming([]byte(body)) {
+		forEachOpenAISSEDataPayload(body, func(data []byte) {
+			observeOpenAIResponsesEvent(c, data)
+		})
+		return
+	}
+	observeOpenAIResponsesEvent(c, []byte(body))
+}
+
 // stashOpenAIEncryptedReasoningFromSSE 从 Responses SSE/JSON 抽出 reasoning.encrypted_content，
 // 写入 gin context 供 QA blob response.encrypted_reasoning 记录。
+// 生产代码必须走 observeOpenAIResponsesEvent，不要直接调用。
 func stashOpenAIEncryptedReasoningFromSSE(c *gin.Context, data []byte) {
 	if c == nil || len(data) == 0 || !gjson.ValidBytes(data) {
 		return

--- a/backend/internal/service/openai_encrypted_reasoning_qa_test.go
+++ b/backend/internal/service/openai_encrypted_reasoning_qa_test.go
@@ -2,9 +2,12 @@ package service
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/gin-gonic/gin"
@@ -161,6 +164,94 @@ func TestStashOpenAIEncryptedReasoningFromSSE_IgnoresEmptyAndNonReasoning(t *tes
 
 	stashOpenAIEncryptedReasoningFromSSE(c, []byte(`{"type":"response.output_item.done","item":{"id":"msg_1","type":"message","encrypted_content":""}}`))
 	stashOpenAIEncryptedReasoningFromSSE(c, nil)
+	_, ok := c.Get(openaiEncryptedReasoningGinKey)
+	require.False(t, ok)
+}
+
+func TestHandleStreamingResponse_StashesEncryptedReasoning(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &OpenAIGatewayService{
+		cfg: &config.Config{
+			Gateway: config.GatewayConfig{
+				MaxLineSize: defaultMaxLineSize,
+			},
+		},
+		toolCorrector: NewCodexToolCorrector(),
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			`data: {"type":"response.output_item.done","item":{"id":"rs_http_1","type":"reasoning","encrypted_content":"gAAAA-HTTP-STREAM"}}`,
+			"",
+			`data: {"type":"response.completed","response":{"id":"resp_http_enc","output":[{"id":"rs_http_1","type":"reasoning","summary":[{"type":"summary_text","text":"plan"}]}],"usage":{"input_tokens":2,"output_tokens":1}}}`,
+			"",
+		}, "\n"))),
+		Header: http.Header{"X-Request-Id": []string{"rid-http-enc"}},
+	}
+
+	result, err := svc.handleStreamingResponse(
+		c.Request.Context(),
+		resp,
+		c,
+		&Account{ID: 1, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Name: "acc"},
+		time.Now(),
+		"gpt-5.6-sol",
+		"gpt-5.6-sol",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Contains(t, rec.Body.String(), "gAAAA-HTTP-STREAM")
+
+	got, ok := c.Get(openaiEncryptedReasoningGinKey)
+	require.True(t, ok, "HTTP 非 passthrough 流式路径应把 item.encrypted_content 写入 QA gin key")
+	blocks, ok := got.([]string)
+	require.True(t, ok)
+	require.Len(t, blocks, 1)
+	require.Contains(t, blocks[0], `"item_id":"rs_http_1"`)
+	require.Contains(t, blocks[0], "gAAAA-HTTP-STREAM")
+}
+
+func TestHandleStreamingResponse_DoesNotStashWithoutCiphertext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &OpenAIGatewayService{
+		cfg: &config.Config{
+			Gateway: config.GatewayConfig{
+				MaxLineSize: defaultMaxLineSize,
+			},
+		},
+		toolCorrector: NewCodexToolCorrector(),
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			`data: {"type":"response.output_item.done","item":{"id":"rs_http_2","type":"reasoning","summary":[{"type":"summary_text","text":"plan"}]}}`,
+			"",
+			`data: {"type":"response.completed","response":{"id":"resp_http_plain","usage":{"input_tokens":1,"output_tokens":1}}}`,
+			"",
+		}, "\n"))),
+	}
+
+	result, err := svc.handleStreamingResponse(
+		c.Request.Context(),
+		resp,
+		c,
+		&Account{ID: 1, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Name: "acc"},
+		time.Now(),
+		"gpt-5.6-sol",
+		"gpt-5.6-sol",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
 	_, ok := c.Get(openaiEncryptedReasoningGinKey)
 	require.False(t, ok)
 }

--- a/backend/internal/service/openai_encrypted_reasoning_ssot_test.go
+++ b/backend/internal/service/openai_encrypted_reasoning_ssot_test.go
@@ -1,0 +1,159 @@
+package service
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const observeOpenAIResponsesEventName = "observeOpenAIResponsesEvent"
+const stashOpenAIEncryptedReasoningName = "stashOpenAIEncryptedReasoningFromSSE"
+
+func TestEncryptedReasoningStashHasSingleProductionCaller(t *testing.T) {
+	callers := collectIdentCallers(t, stashOpenAIEncryptedReasoningName)
+	if len(callers) != 1 || callers[0] != observeOpenAIResponsesEventName {
+		t.Fatalf("stashOpenAIEncryptedReasoningFromSSE 只能被 %s 调用，实际生产调用方=%v", observeOpenAIResponsesEventName, callers)
+	}
+}
+
+func TestOpenAIResponsesClientEventLoopsMustObserveEncryptedReasoning(t *testing.T) {
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var missing []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		if name == "openai_encrypted_reasoning_qa.go" {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(".", name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			calls := collectCallNames(fn.Body)
+			if !callsObserver(calls) && callsParser(calls) && callsClientSink(fn.Body) {
+				missing = append(missing, name+":"+fn.Name.Name)
+			}
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("这些会把 OpenAI Responses 事件写给客户端的函数没有调用 %s: %s", observeOpenAIResponsesEventName, strings.Join(missing, ", "))
+	}
+}
+
+func collectIdentCallers(t *testing.T, target string) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]struct{}{}
+	var callers []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(".", name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				ident, ok := call.Fun.(*ast.Ident)
+				if !ok || ident.Name != target {
+					return true
+				}
+				if _, exists := seen[fn.Name.Name]; exists {
+					return true
+				}
+				seen[fn.Name.Name] = struct{}{}
+				callers = append(callers, fn.Name.Name)
+				return true
+			})
+		}
+	}
+	return callers
+}
+
+func collectCallNames(body *ast.BlockStmt) map[string]bool {
+	out := map[string]bool{}
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch fun := call.Fun.(type) {
+		case *ast.Ident:
+			out[fun.Name] = true
+		case *ast.SelectorExpr:
+			out[fun.Sel.Name] = true
+		}
+		return true
+	})
+	return out
+}
+
+func callsObserver(calls map[string]bool) bool {
+	return calls[observeOpenAIResponsesEventName] || calls["observeOpenAIResponsesSSEBody"]
+}
+
+func callsParser(calls map[string]bool) bool {
+	return calls["extractOpenAISSEDataLine"] ||
+		calls["parseOpenAIWSEventEnvelope"] ||
+		calls["forEachOpenAISSEDataPayload"] ||
+		calls["ObserveOpenAI"]
+}
+
+func callsClientSink(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch fun := call.Fun.(type) {
+		case *ast.Ident:
+			switch fun.Name {
+			case "writePendingString", "emitStreamMessage", "writeClientMessage", "writeOpenAICompactSSEBridge":
+				found = true
+			}
+		case *ast.SelectorExpr:
+			if fun.Sel.Name == "Data" {
+				found = true
+				return true
+			}
+			if fun.Sel.Name == "Write" || fun.Sel.Name == "WriteString" {
+				if x, ok := fun.X.(*ast.SelectorExpr); ok && x.Sel.Name == "Writer" {
+					found = true
+				}
+			}
+		}
+		return true
+	})
+	return found
+}

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -586,7 +586,7 @@ func (s *OpenAIGatewayService) handleChatStreamingResponse(
 			return false
 		}
 		observer.ObserveOpenAI([]byte(payload), event.Type)
-		stashOpenAIEncryptedReasoningFromSSE(c, []byte(payload))
+		observeOpenAIResponsesEvent(c, []byte(payload))
 		refusalDetector.ObservePayload([]byte(payload))
 
 		// Nested evt.Response.Usage takes precedence over top-level evt.Usage:

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -340,6 +340,7 @@ func (s *OpenAIGatewayService) streamRawChatCompletions(
 			}
 			trimmedPayload := strings.TrimSpace(payload)
 			if trimmedPayload != "[DONE]" {
+				observeOpenAIResponsesEvent(c, []byte(payload))
 				observer.ObserveOpenAI([]byte(payload), strings.TrimSpace(gjson.Get(payload, "type").String()))
 				usageOnlyChunk := isOpenAIChatUsageOnlyStreamChunk(payload)
 				if u := extractCCStreamUsage(payload); u != nil {
@@ -481,6 +482,7 @@ func (s *OpenAIGatewayService) bufferRawChatCompletions(
 	if observer == nil {
 		observer = beginUpstreamResponseModelObservation(c)
 	}
+	observeOpenAIResponsesEvent(c, respBody)
 	observer.ObserveOpenAI(respBody, strings.TrimSpace(gjson.GetBytes(respBody, "type").String()))
 
 	var usage OpenAIUsage

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -1053,7 +1053,7 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 			return false
 		}
 		observer.ObserveOpenAI([]byte(payload), event.Type)
-		stashOpenAIEncryptedReasoningFromSSE(c, []byte(payload))
+		observeOpenAIResponsesEvent(c, []byte(payload))
 
 		// 仅按兼容转换器支持的终止事件提取 usage，避免无意扩大事件语义。
 		switch event.Type {

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -1430,7 +1430,7 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 				}
 			}
 			eventType := strings.TrimSpace(gjson.Get(trimmedData, "type").String())
-			stashOpenAIEncryptedReasoningFromSSE(c, dataBytes)
+			observeOpenAIResponsesEvent(c, dataBytes)
 			if eventType == "response.failed" {
 				failedMessage = extractOpenAISSEErrorMessage(dataBytes)
 				// response.failed 自带上游已消耗的 usage（input token 通常已扣）；必须先解析
@@ -1651,6 +1651,7 @@ func (s *OpenAIGatewayService) handleNonStreamingResponsePassthrough(
 	if err != nil {
 		return nil, fmt.Errorf("restore OpenAI passthrough namespace response: %w", err)
 	}
+	observeOpenAIResponsesSSEBody(c, string(body))
 	if !writeOpenAICompactSSEBridge(c, resp.StatusCode, body) {
 		c.Data(resp.StatusCode, contentType, body)
 	}
@@ -1669,6 +1670,7 @@ func (s *OpenAIGatewayService) handleNonStreamingResponsePassthrough(
 // rewrite model fields back to the original requested model.
 func (s *OpenAIGatewayService) handlePassthroughSSEToJSON(resp *http.Response, c *gin.Context, body []byte, originalModel string, mappedModel string) (*openaiNonStreamingResultPassthrough, error) {
 	bodyText := string(body)
+	observeOpenAIResponsesSSEBody(c, bodyText)
 	finalResponse, ok := extractCodexFinalResponse(bodyText)
 
 	usage := &OpenAIUsage{}

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -560,6 +560,7 @@ func (s *OpenAIGatewayService) handleStreamingResponseWithReasoning(ctx context.
 				data = string(sanitizedData)
 				line = "data: " + data
 			}
+			observeOpenAIResponsesEvent(c, dataBytes)
 			// Replace model in response if needed.
 			// Fast path: most events do not contain model field values.
 			if needModelReplace && mappedModel != "" && strings.Contains(line, mappedModel) {
@@ -1227,13 +1228,10 @@ func (s *OpenAIGatewayService) handleNonStreamingResponse(ctx context.Context, r
 	}
 	if bodyHasSSEFraming(body) {
 		observeOpenAISSEBody(observer, string(body))
-		forEachOpenAISSEDataPayload(string(body), func(data []byte) {
-			stashOpenAIEncryptedReasoningFromSSE(c, data)
-		})
 	} else {
 		observer.ObserveOpenAI(body, strings.TrimSpace(gjson.GetBytes(body, "type").String()))
-		stashOpenAIEncryptedReasoningFromSSE(c, body)
 	}
+	observeOpenAIResponsesSSEBody(c, string(body))
 
 	// Detect SSE responses for ALL account types via Content-Type header.
 	// Some OpenAI-compatible upstreams (including other sub2api instances)
@@ -1334,9 +1332,7 @@ func bodyHasSSEFraming(body []byte) bool {
 
 func (s *OpenAIGatewayService) handleSSEToJSON(resp *http.Response, c *gin.Context, account *Account, body []byte, originalModel, mappedModel string) (*openaiNonStreamingResult, error) {
 	bodyText := string(body)
-	forEachOpenAISSEDataPayload(bodyText, func(data []byte) {
-		stashOpenAIEncryptedReasoningFromSSE(c, data)
-	})
+	observeOpenAIResponsesSSEBody(c, bodyText)
 	finalResponse, ok := extractCodexFinalResponse(bodyText)
 
 	usage := &OpenAIUsage{}

--- a/backend/internal/service/openai_images.go
+++ b/backend/internal/service/openai_images.go
@@ -945,6 +945,7 @@ func (s *OpenAIGatewayService) handleOpenAIImagesStreamingResponse(
 		seenSSEData = true
 		fallbackBody.Reset()
 		fallbackBytes = 0
+		observeOpenAIResponsesEvent(c, dataBytes)
 		mergeOpenAIUsage(&usage, dataBytes)
 		imageCounter.AddSSEData(dataBytes)
 	}

--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -1106,6 +1106,7 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthNonStreamingResponse(
 	}
 
 	var usage OpenAIUsage
+	observeOpenAIResponsesSSEBody(c, string(body))
 	forEachOpenAISSEDataPayload(string(body), func(data []byte) {
 		s.parseSSEUsageBytes(data, &usage)
 	})

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -976,6 +976,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 					}
 				}
 				replayCollector.AddEvent(eventType, upstreamMessage)
+				observeOpenAIResponsesEvent(c, upstreamMessage)
 				if err := writeClientMessage(upstreamMessage); err != nil {
 					if isOpenAIWSClientDisconnectError(err) {
 						clientDisconnected = true

--- a/backend/internal/service/openai_ws_forwarder_v2.go
+++ b/backend/internal/service/openai_ws_forwarder_v2.go
@@ -500,7 +500,7 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 		if eventType == "" {
 			continue
 		}
-		stashOpenAIEncryptedReasoningFromSSE(c, message)
+		observeOpenAIResponsesEvent(c, message)
 		responseModelObserver.ObserveOpenAI(message, eventType)
 		eventCount++
 		if firstEventType == "" {

--- a/backend/internal/service/openai_ws_http_bridge.go
+++ b/backend/internal/service/openai_ws_http_bridge.go
@@ -393,6 +393,7 @@ func (s *OpenAIGatewayService) proxyOpenAIWSHTTPBridgeTurn(
 			}
 		}
 		if !clientDisconnected {
+			observeOpenAIResponsesEvent(c, clientMessage)
 			if err := writeClientMessage(clientMessage); err != nil {
 				if isOpenAIWSClientDisconnectError(err) {
 					clientDisconnected = true


### PR DESCRIPTION
## 摘要
- 1.8.163 只修了 WS emit 路径；线上 native apikey HTTP `/responses` 已把 `encrypted_content` 写给客户端 stream，但从不写入 gin key，所以 QA `response.encrypted_reasoning` 仍空。
- 所有面向客户端的 Responses 事件统一走 `observeOpenAIResponsesEvent` / `observeOpenAIResponsesSSEBody`，生产路径禁止再直调 stash。
- AST 门禁锁住「解析并写出 Responses 事件」必须调用 observe，避免下次再只改一处。
- sentinel-registry-reviewed：改动的是既有 gateway 热路径上的观察调用，不是新 TK companion / 新注入面，无需新增 sentinel 锚点。

## 风险
- 常规风险：只改 backend 观察侧，不改对外 API 字段语义、鉴权或 schema。
- QA 字段仍只读 gin key；漏 observe 会被 SSOT 测试拦住，而不是 silently 空字段。
- Web impact: none

## 验证
- `go test -tags=unit -count=1 -timeout 90s -run 'EncryptedReasoning|HandleStreamingResponse_Stash|HandleStreamingResponse_DoesNotStash|TestEncryptedReasoningStashHasSingleProductionCaller|TestOpenAIResponsesClientEventLoopsMustObserveEncryptedReasoning' ./internal/service`（backend）通过
- `./scripts/preflight.sh` 通过
- 线上 1.8.163 复现：apikey HTTP `/responses` stream 有密文、QA 字段空；本 PR 针对该路径补 observe，发版后才能再核线上

## 提交
- `6cc770b8e` fix(openai): stash HTTP /responses encrypted_reasoning for QA
- 最新提交：`6cc770b8e`

Made with [Cursor](https://cursor.com)