### PR TITLE
fix(ops): chat 烟测软跳过 Kiro not-supported

### DIFF
--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -705,6 +705,7 @@ bash scripts/release-rollout-summary.sh --mode release
 | 发版后 tick 报 `No such container: tokenkey` | 先确认在用新版 `ops/observability/probe-post-release-tick.sh`；它默认 `CONTAINER=auto` 会解析 prod blue/green active container。不要手工猜 `tokenkey-green`；若仍失败，看 tick stdout 的 `container_resolution`。 |
 | `TK_SMOKE_GITHUB_ENV=prod` 报 `unexpected gh variables response` | 旧版 `load_smoke_github_env.py` 对单页 gh api 响应断言成 list 的 bug，已修；若复现先 `gh api repos/{owner}/{repo}/environments/prod/variables` 看原始形状。 |
 | prod `Deploy via SSM Run-Command` 报 `AccessDenied(ssm:SendCommand)` | 先核对 `tokenkey-cicd-oidc` 的 `TargetInstanceId` 是否等于 `tokenkey-prod-stage0` 当前 `InstanceId`；不一致先更新 OIDC 栈参数再重跑 deploy。 |
+| prod smoke `/v1/chat/completions` **400** + `not supported by Kiro` | universal key 打到 Kiro stub、上游 entitlement 拒 Claude；烟测应 soft-skip 并 defer 到 `/v1/messages`。**不要 rollback**。Kiro catalog 无 Claude 是上游问题，不是镜像回归。 |
 | prod smoke Gemini tools **429** + soft-skip + **`tk_post_deploy_smoke: OK`** | 运行时资源/cooldown，**不是** passthrough 路由回归；verdict green/yellow，不 rollback。若要 200 证据，cooldown 后重跑 deploy-stage0 smoke。 |
 | prod smoke Gemini tools **400** + Codex 账号文案 | 路由回归（#1168 类）；**red**，rollback `previous_tag` 并停 edge rollout。 |
 | prod smoke 报 configured smoke model not listed in GET /v1/models | 不是代码回归，改 **`prod`** Environment 对应的 **`TK_SMOKE_ANTHROPIC_MODELS` / `TK_SMOKE_GEMINI_MODELS` / `TK_SMOKE_OPENAI_OAUTH_MODELS`** 为 `TK_SMOKE_API_KEY` 可见模型后重跑。 |

--- a/ops/stage0/smoke_lib.sh
+++ b/ops/stage0/smoke_lib.sh
@@ -192,6 +192,26 @@ if [[ -z "${_TK_SMOKE_LIB_LOADED:-}" ]]; then
             echo "tk_post_deploy_smoke: ${label} section soft-skipped (universal_no_entitled_group; /v1/messages probe is the canonical signal)"
             return 1
             ;;
+          *"not supported by Kiro"*)
+            # Universal key /v1/chat/completions is expected to hit Kiro
+            # mirror stubs first. When the selected Kiro profile has dropped
+            # Claude (ListAvailableModels has no Claude; INVALID_MODEL_ID),
+            # the gateway rewrites that into a terminal 400. That is upstream
+            # entitlement, not a control-plane shape regression. Defer to
+            # /v1/messages, which remains the canonical Anthropic probe.
+            if [[ "${label}" == "/v1/messages" ]]; then
+              echo "tk_post_deploy_smoke: ${label} failed" >&2
+              jq . "${resp_file}" >&2 2>/dev/null || cat "${resp_file}" >&2
+              exit 1
+            fi
+            echo "::warning::tk_post_deploy_smoke: ${label} returned HTTP ${http} — Kiro rejected the model (upstream entitlement); deferring to /v1/messages probe." >&2
+            if [[ -n "${err_msg}" ]]; then
+              echo "  gateway message: ${err_msg}" >&2
+            fi
+            jq . "${resp_file}" >&2 2>/dev/null || cat "${resp_file}" >&2
+            echo "tk_post_deploy_smoke: ${label} section soft-skipped (kiro_invalid_model; /v1/messages probe is the canonical signal)"
+            return 1
+            ;;
           *"restricted to Claude Code clients"*|*"/v1/messages only"*)
             # claude_code_only group policy: the configured Anthropic key is
             # bound to a group that allows /v1/messages with a Claude Code UA

--- a/scripts/test_smoke_suite.py
+++ b/scripts/test_smoke_suite.py
@@ -168,6 +168,27 @@ class SoftDegradeOrExitTest(unittest.TestCase):
         self.assertEqual(rc, 1, out)
         self.assertNotIn("MARKER=continue", out)
 
+    def test_full_chat_400_kiro_not_supported_soft_skips(self) -> None:
+        rc, out = self._run(
+            "full",
+            "400",
+            {"error": {"message": "model claude-sonnet-4-6 is not supported by Kiro", "type": "server_error"}},
+            label="/v1/chat/completions",
+        )
+        self.assertEqual(rc, 0, out)
+        self.assertIn("MARKER=softskip", out)
+        self.assertIn("kiro_invalid_model", out)
+
+    def test_full_messages_400_kiro_not_supported_hard_fails(self) -> None:
+        rc, out = self._run(
+            "full",
+            "400",
+            {"error": {"message": "model claude-sonnet-4-6 is not supported by Kiro"}},
+            label="/v1/messages",
+        )
+        self.assertEqual(rc, 1, out)
+        self.assertNotIn("MARKER=continue", out)
+
     def test_full_messages_400_unsupported_model_hard_fails(self) -> None:
         rc, out = self._run(
             "full",


### PR DESCRIPTION
## 摘要
- prod `/v1/chat/completions` 打到 Kiro stub 后，上游拒 Claude（`not supported by Kiro`）不再硬失败
- 与空池 / universal_no_entitled 一样 defer 到 `/v1/messages`
- `/v1/messages` 同文案仍硬失败，避免把 Anthropic 探针也吞掉

## 风险
常规。只改 CI 烟测判定，不改网关行为、不 bump VERSION。用来重跑已构建的 1.8.164。

## 验证
- `python3 -m unittest scripts.test_smoke_suite.SoftDegradeOrExitTest` 全绿
- 正向：chat 400 + `not supported by Kiro` → soft-skip
- 负向：messages 400 同文案、chat 400 `Unsupported model` 仍硬失败

## 提交
- `731166ce8` fix(ops): soft-skip Kiro not-supported on chat smoke
- 最新提交：`731166ce8`


Made with [Cursor](https://cursor.com)