### PR TITLE
fix(gateway): GPT overloaded 400 从单一 SSOT failover

### DIFF
--- a/backend/internal/service/openai_gateway_failover_ssot_test.go
+++ b/backend/internal/service/openai_gateway_failover_ssot_test.go
@@ -41,6 +41,14 @@ func TestShouldFailoverOpenAIUpstreamError_HTTPAndSSEShareDecision(t *testing.T)
 			want:       false,
 		},
 		{
+			name:       "context-window 400 with echoed overloaded text stays terminal",
+			status:     http.StatusBadRequest,
+			message:    contextWindowMsg,
+			body:       []byte(`{"type":"response.failed","response":{"output":[{"type":"message","content":[{"type":"output_text","text":"Our servers are currently overloaded. Please try again later."}]}],"error":{"message":"Your input exceeds the context window of this model. Please adjust your input and try again."}}}`),
+			ssePayload: []byte(`{"type":"response.failed","response":{"output":[{"type":"message","content":[{"type":"output_text","text":"Our servers are currently overloaded. Please try again later."}]}],"error":{"message":"Your input exceeds the context window of this model. Please adjust your input and try again."}}}`),
+			want:       false,
+		},
+		{
 			name:       "content_policy is caller-fault",
 			status:     http.StatusBadRequest,
 			message:    "request blocked by policy",

--- a/backend/internal/service/openai_gateway_failover_ssot_test.go
+++ b/backend/internal/service/openai_gateway_failover_ssot_test.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldFailoverOpenAIUpstreamError_HTTPAndSSEShareDecision(t *testing.T) {
+	overloadedEchoedContext := []byte(`{"type":"response.failed","response":{"id":"resp_failed","object":"response","model":"gpt-5.6","status":"failed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"isOpenAIContextWindowError reports whether the caller exceeded the context window"}]}],"error":{"code":"invalid_request_error","type":"invalid_request_error","message":"Our servers are currently overloaded. Please try again later."}}}`)
+	overloadedMsg := "Our servers are currently overloaded. Please try again later."
+	contextWindowBody := []byte(`{"error":{"message":"Your input exceeds the context window of this model. Please adjust your input and try again.","type":"upstream_error","code":null}}`)
+	contextWindowMsg := "Your input exceeds the context window of this model. Please adjust your input and try again."
+	contentPolicy := []byte(`{"type":"response.failed","error":{"code":"content_policy","message":"request blocked by policy"}}`)
+	rateLimit := []byte(`{"type":"response.failed","response":{"error":{"type":"rate_limit_error","code":"rate_limit_exceeded","message":"Rate limit reached"}}}`)
+	serverError := []byte(`{"type":"response.failed","error":{"code":"server_error","message":"upstream processing failed"}}`)
+
+	tests := []struct {
+		name       string
+		status     int
+		message    string
+		body       []byte
+		ssePayload []byte
+		want       bool
+	}{
+		{
+			name:       "overloaded 400 with echoed context-window text failovers",
+			status:     http.StatusBadRequest,
+			message:    overloadedMsg,
+			body:       overloadedEchoedContext,
+			ssePayload: overloadedEchoedContext,
+			want:       true,
+		},
+		{
+			name:       "real context-window 400 is terminal",
+			status:     http.StatusBadRequest,
+			message:    contextWindowMsg,
+			body:       contextWindowBody,
+			ssePayload: contextWindowBody,
+			want:       false,
+		},
+		{
+			name:       "content_policy is caller-fault",
+			status:     http.StatusBadRequest,
+			message:    "request blocked by policy",
+			body:       contentPolicy,
+			ssePayload: contentPolicy,
+			want:       false,
+		},
+		{
+			name:       "rate_limit failovers",
+			status:     http.StatusTooManyRequests,
+			message:    "Rate limit reached",
+			body:       rateLimit,
+			ssePayload: rateLimit,
+			want:       true,
+		},
+		{
+			name:       "unknown server_error failovers",
+			status:     http.StatusBadGateway,
+			message:    "upstream processing failed",
+			body:       serverError,
+			ssePayload: serverError,
+			want:       true,
+		},
+		{
+			name:    "generic HTTP 400 without transient signal stays terminal",
+			status:  http.StatusBadRequest,
+			message: "Missing required parameter: 'instructions'",
+			body:    []byte(`{"error":{"message":"Missing required parameter: 'instructions'"}}`),
+			want:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, shouldFailoverOpenAIUpstreamError(tc.status, tc.message, tc.body))
+			require.Equal(t, tc.want, (&OpenAIGatewayService{}).shouldFailoverOpenAIUpstreamResponse(tc.status, tc.message, tc.body))
+			if len(tc.ssePayload) == 0 {
+				return
+			}
+			sseWant := openAIStreamFailedEventShouldFailover(tc.ssePayload, tc.message)
+			require.Equal(t, tc.want, sseWant, "SSE adapter must match the HTTP SSOT for this payload")
+			require.Equal(t, shouldFailoverOpenAIUpstreamError(
+				openAIStreamFailedEventSemanticStatus(tc.ssePayload, tc.message),
+				tc.message,
+				tc.ssePayload,
+			), sseWant, "SSE wrapper must be semantic-status + SSOT only")
+		})
+	}
+}

--- a/backend/internal/service/openai_gateway_messages_failed_response_test.go
+++ b/backend/internal/service/openai_gateway_messages_failed_response_test.go
@@ -47,7 +47,7 @@ func TestForwardAsAnthropic_BufferedResponseFailed_ReturnsError(t *testing.T) {
 
 	require.Error(t, err, "non-cyber response.failed must return an error, not swallow as 200")
 	require.Contains(t, err.Error(), "upstream response failed")
-	require.Equal(t, http.StatusBadGateway, rec.Code, "should write 502 for non-failover failed response")
+	require.Equal(t, http.StatusBadRequest, rec.Code, "caller-fault content policy must be 400 so clients do not retry a 502")
 }
 
 func TestForwardAsAnthropic_StreamingResponseFailed_ReturnsError(t *testing.T) {

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -1042,6 +1042,11 @@ func openAIStreamFailedEventSemanticStatus(payload []byte, message string) int {
 		return http.StatusForbidden
 	case code == "server_is_overloaded" || code == "slow_down":
 		return http.StatusServiceUnavailable
+	case isOpenAINonRetryableClientError(message, payload):
+		// Policy / safety / "not allowed" events are caller-fault. Map them to
+		// 400 so the shared failover SSOT will not treat the transport 200/502
+		// as a retryable upstream outage.
+		return http.StatusBadRequest
 	default:
 		return http.StatusBadGateway
 	}
@@ -1133,45 +1138,14 @@ func applyOpenAIStreamFailedErrorPassthroughRule(
 }
 
 func openAIStreamFailedEventShouldFailover(payload []byte, message string) bool {
-	if isOpenAIContextWindowError(message, payload) {
-		return false
-	}
-	// A response.failed event is transported over HTTP 200. Prefer its semantic
-	// rate-limit status over a generic/invalid_request error type so it can enter
-	// the same 429 retry policy as a regular upstream HTTP response.
-	if openAIStreamFailureStatus(payload, message) == http.StatusTooManyRequests {
-		return true
-	}
-	if isOpenAITransientProcessingError(http.StatusBadRequest, message, payload) {
-		return true
-	}
-	code := strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "response.error.code").String()))
-	if code == "" {
-		code = strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "error.code").String()))
-	}
-	errType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "response.error.type").String()))
-	if errType == "" {
-		errType = strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "error.type").String()))
-	}
-	combined := strings.ToLower(strings.TrimSpace(message + " " + code + " " + errType))
-	if combined == "" {
-		return true
-	}
-	nonRetryableMarkers := []string{
-		"invalid_request",
-		"content_policy",
-		"policy",
-		"safety",
-		"high-risk cyber",
-		"not allowed",
-		"violat",
-	}
-	for _, marker := range nonRetryableMarkers {
-		if strings.Contains(combined, marker) {
-			return false
-		}
-	}
-	return true
+	// Transport adapter only: response.failed arrives over HTTP 200, so map the
+	// event to a semantic status and reuse the HTTP failover SSOT. Do not add
+	// a second decision tree here.
+	return shouldFailoverOpenAIUpstreamError(
+		openAIStreamFailedEventSemanticStatus(payload, message),
+		message,
+		payload,
+	)
 }
 
 func openAIStreamFailedEventRetryableOnSameAccount(account *Account, payload []byte, message string) bool {

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -1034,8 +1034,6 @@ func openAIStreamFailedEventSemanticStatus(payload []byte, message string) int {
 		return http.StatusBadRequest
 	case strings.Contains(combined, "rate_limit"):
 		return http.StatusTooManyRequests
-	case strings.Contains(errType, "invalid_request"):
-		return http.StatusBadRequest
 	case strings.Contains(combined, "authentication") || strings.Contains(combined, "unauthorized") || strings.Contains(combined, "invalid_api_key"):
 		return http.StatusUnauthorized
 	case strings.Contains(combined, "permission") || strings.Contains(combined, "forbidden") || strings.Contains(combined, "access denied"):

--- a/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
@@ -323,6 +323,14 @@ func TestIsOpenAIContextWindowError(t *testing.T) {
 		"context canceled",
 		nil,
 	))
+	require.True(t, isOpenAIContextWindowError(
+		"",
+		[]byte("Your input exceeds the context window of this model."),
+	), "plain-text upstream bodies still classify as context-window")
+	require.False(t, isOpenAIContextWindowError(
+		"Our servers are currently overloaded. Please try again later.",
+		[]byte(`{"type":"response.failed","response":{"output":[{"type":"message","content":[{"type":"output_text","text":"exceeded the context window"}]}],"error":{"message":"Our servers are currently overloaded. Please try again later."}}}`),
+	), "JSON Responses bodies must not classify on echoed output text")
 }
 
 func TestShouldFailoverOpenAIUpstreamResponseContextWindow502(t *testing.T) {

--- a/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
@@ -308,6 +308,18 @@ func TestIsOpenAITransientProcessingError(t *testing.T) {
 		"Missing required parameter: 'instructions'",
 		[]byte(`{"error":{"message":"Missing required parameter: 'instructions'"}}`),
 	))
+
+	require.True(t, isOpenAITransientProcessingError(
+		http.StatusBadRequest,
+		"",
+		[]byte(`{"type":"response.failed","response":{"error":{"message":"Our servers are currently overloaded. Please try again later."}}}`),
+	), "Responses JSON must classify overloaded from response.error.message without a separate extracted message")
+
+	require.False(t, isOpenAITransientProcessingError(
+		http.StatusBadRequest,
+		"Your input exceeds the context window of this model. Please adjust your input and try again.",
+		[]byte(`{"type":"response.failed","response":{"output":[{"type":"message","content":[{"type":"output_text","text":"Our servers are currently overloaded. Please try again later."}]}],"error":{"message":"Your input exceeds the context window of this model. Please adjust your input and try again."}}}`),
+	), "JSON Responses bodies must not classify on echoed output text")
 }
 
 func TestIsOpenAIContextWindowError(t *testing.T) {

--- a/backend/internal/service/openai_gateway_service_tk_buffered_failover.go
+++ b/backend/internal/service/openai_gateway_service_tk_buffered_failover.go
@@ -46,11 +46,10 @@ func (s *OpenAIGatewayService) openAICompatBufferedMissingTerminalResult(
 }
 
 // openAICompatBufferedFailedResponseResult mirrors the streaming response.failed
-// policy. The streaming path only fails over when openAIStreamFailedEventShouldFailover
-// agrees (transient / capacity errors); a non-retryable failure (content_policy,
-// safety, invalid_request, …) is forwarded to the client instead of replayed on a
-// sibling account. The buffered path applies the same gate: retryable → failover,
-// non-retryable → surface the upstream message as a client error with no failover.
+// policy. Both paths call openAIStreamFailedEventShouldFailover, which is only a
+// semantic-status adapter over shouldFailoverOpenAIUpstreamError. Retryable
+// (transient / capacity) → failover; non-retryable (content_policy, safety,
+// invalid_request, …) → surface the upstream message with no sibling replay.
 // cyber_policy is handled by the caller before reaching here.
 func (s *OpenAIGatewayService) openAICompatBufferedFailedResponseResult(
 	c *gin.Context,

--- a/backend/internal/service/openai_gateway_service_tk_buffered_failover_test.go
+++ b/backend/internal/service/openai_gateway_service_tk_buffered_failover_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
@@ -313,4 +314,79 @@ func openAICompatTestOAuthAccount(id int64, name string) *Account {
 			"chatgpt_account_id": "chatgpt-acc",
 		},
 	}
+}
+
+func openAICompatTestEdgeStubAccount(id int64, name string) *Account {
+	return &Account{
+		ID:          id,
+		Name:        name,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-edge-stub",
+			"base_url": "http://upstream.example",
+		},
+		Extra: map[string]any{
+			"openai_responses_supported": true,
+		},
+	}
+}
+
+func TestOpenAIStreamFailedEventShouldFailover_OverloadedNotMaskedByEchoedContextWindowText(t *testing.T) {
+	// Prod 2026-08-19: Claude CLI stream=false /v1/messages on GPT 专线 wrote a
+	// terminal 400 (buffered_response_failed) instead of failing over to tokensea.
+	// The failed Responses object can echo earlier output/input that mentions
+	// "context window" / "exceed"; matching the entire JSON blob then classifies
+	// a capacity 400 as a caller-fault context-window error.
+	payload := []byte(`{"type":"response.failed","response":{"id":"resp_failed","object":"response","model":"gpt-5.6","status":"failed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"isOpenAIContextWindowError reports whether the caller exceeded the context window"}]}],"error":{"code":"invalid_request_error","type":"invalid_request_error","message":"Our servers are currently overloaded. Please try again later."}}}`)
+	message := "Our servers are currently overloaded. Please try again later."
+
+	require.False(t, isOpenAIContextWindowError(message, payload),
+		"capacity overloaded must not be treated as a context-window rejection just because the echoed body mentions those words")
+	require.True(t, shouldFailoverOpenAIUpstreamError(http.StatusBadRequest, message, payload),
+		"HTTP SSOT must failover capacity overloaded even when the failed response echoes context-window text")
+	require.True(t, openAIStreamFailedEventShouldFailover(payload, message),
+		"SSE adapter must reuse the HTTP SSOT for the same payload")
+}
+
+func TestForwardAsAnthropic_BufferedOverloadedOnEdgeStubFailsOver(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.6","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	// Same shape as prod account 64 (openai-us3 stub): API key + Responses.
+	// Partial assistant output mentions context-window helpers from this repo;
+	// that text must not pin the request to a terminal client 400.
+	upstreamBody := strings.Join([]string{
+		`event: response.failed`,
+		`data: {"type":"response.failed","response":{"id":"resp_failed","object":"response","model":"gpt-5.6","status":"failed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"isOpenAIContextWindowError reports whether the caller exceeded the context window"}]}],"error":{"code":"invalid_request_error","type":"invalid_request_error","message":"Our servers are currently overloaded. Please try again later."}}}`,
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "X-Request-Id": []string{"rid_edge_stub_overloaded"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &OpenAIGatewayService{
+		cfg: &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{
+			Enabled: false, AllowInsecureHTTP: true,
+		}}},
+		httpUpstream: upstream,
+	}
+	account := openAICompatTestEdgeStubAccount(64, "openai-us3")
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.6")
+	require.Error(t, err)
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr), "edge-stub buffered overloaded must failover to sibling tokensea: %T: %v", err, err)
+	require.True(t, failoverErr.ShouldRetryNextAccount())
+	require.False(t, c.Writer.Written(), "failover path must not commit a client 400")
+	require.Empty(t, rec.Body.String())
 }

--- a/backend/internal/service/openai_gateway_upstream_errors.go
+++ b/backend/internal/service/openai_gateway_upstream_errors.go
@@ -220,10 +220,18 @@ func isOpenAIContextWindowError(upstreamMsg string, upstreamBody []byte) bool {
 			return true
 		}
 	}
+	// Plain-text upstream bodies still participate. A JSON Responses/SSE
+	// document must not: it can echo the caller's input or earlier model
+	// output, and a substring like "context window" + "exceed" would then
+	// pin a capacity 400 (servers are currently overloaded) as a terminal
+	// client error instead of failing over to a sibling account.
+	if gjson.ValidBytes(bytes.TrimSpace(upstreamBody)) {
+		return false
+	}
 	return match(string(upstreamBody))
 }
 
-func (s *OpenAIGatewayService) shouldFailoverUpstreamError(statusCode int) bool {
+func shouldFailoverOpenAIUpstreamStatus(statusCode int) bool {
 	switch statusCode {
 	case 401, 402, 403, 405, 429, 529:
 		return true
@@ -232,7 +240,21 @@ func (s *OpenAIGatewayService) shouldFailoverUpstreamError(statusCode int) bool 
 	}
 }
 
-func (s *OpenAIGatewayService) shouldFailoverOpenAIUpstreamResponse(statusCode int, upstreamMsg string, upstreamBody []byte) bool {
+func (s *OpenAIGatewayService) shouldFailoverUpstreamError(statusCode int) bool {
+	return shouldFailoverOpenAIUpstreamStatus(statusCode)
+}
+
+// shouldFailoverOpenAIUpstreamError is the single OpenAI failover decision.
+// HTTP callers pass the upstream status. SSE / buffered callers map the event
+// to a semantic status first (openAIStreamFailedEventSemanticStatus); they
+// must not re-implement transient / context-window / terminal-client rules.
+func shouldFailoverOpenAIUpstreamError(statusCode int, upstreamMsg string, upstreamBody []byte) bool {
+	// Capacity 400s are request-scoped and must leave the current account
+	// before the context-window heuristic can false-positive on echoed body
+	// text and pin a terminal client 400.
+	if isOpenAITransientProcessingError(statusCode, upstreamMsg, upstreamBody) {
+		return true
+	}
 	if isOpenAIContextWindowError(upstreamMsg, upstreamBody) {
 		return false
 	}
@@ -244,10 +266,43 @@ func (s *OpenAIGatewayService) shouldFailoverOpenAIUpstreamResponse(statusCode i
 	if tkIsGrokEntitlement403(statusCode, upstreamBody) {
 		return false
 	}
-	if s.shouldFailoverUpstreamError(statusCode) {
-		return true
+	return shouldFailoverOpenAIUpstreamStatus(statusCode)
+}
+
+func (s *OpenAIGatewayService) shouldFailoverOpenAIUpstreamResponse(statusCode int, upstreamMsg string, upstreamBody []byte) bool {
+	return shouldFailoverOpenAIUpstreamError(statusCode, upstreamMsg, upstreamBody)
+}
+
+// isOpenAINonRetryableClientError reports caller-fault / policy rejections that
+// must not be replayed on a sibling account. Owned here so SSE semantic-status
+// mapping cannot drift from the marker list.
+func isOpenAINonRetryableClientError(upstreamMsg string, upstreamBody []byte) bool {
+	code := strings.ToLower(strings.TrimSpace(gjson.GetBytes(upstreamBody, "response.error.code").String()))
+	if code == "" {
+		code = strings.ToLower(strings.TrimSpace(gjson.GetBytes(upstreamBody, "error.code").String()))
 	}
-	return isOpenAITransientProcessingError(statusCode, upstreamMsg, upstreamBody)
+	errType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(upstreamBody, "response.error.type").String()))
+	if errType == "" {
+		errType = strings.ToLower(strings.TrimSpace(gjson.GetBytes(upstreamBody, "error.type").String()))
+	}
+	combined := strings.ToLower(strings.TrimSpace(upstreamMsg + " " + code + " " + errType))
+	if combined == "" {
+		return false
+	}
+	for _, marker := range []string{
+		"invalid_request",
+		"content_policy",
+		"policy",
+		"safety",
+		"high-risk cyber",
+		"not allowed",
+		"violat",
+	} {
+		if strings.Contains(combined, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // OpenAIRequestBodyTooLargeClientMessage is the fixed downstream message used

--- a/backend/internal/service/openai_gateway_upstream_errors.go
+++ b/backend/internal/service/openai_gateway_upstream_errors.go
@@ -159,16 +159,7 @@ func isOpenAITransientProcessingError(upstreamStatusCode int, upstreamMsg string
 			strings.Contains(lower, "request id")
 	}
 
-	if match(upstreamMsg) {
-		return true
-	}
-	if len(upstreamBody) == 0 {
-		return false
-	}
-	if match(gjson.GetBytes(upstreamBody, "error.message").String()) {
-		return true
-	}
-	return match(string(upstreamBody))
+	return matchOpenAIUpstreamErrorFields(upstreamMsg, upstreamBody, match)
 }
 
 // IsOpenAIContextWindowError reports whether upstream text indicates the caller
@@ -202,6 +193,14 @@ func isOpenAIContextWindowError(upstreamMsg string, upstreamBody []byte) bool {
 			hasExceeded
 	}
 
+	return matchOpenAIUpstreamErrorFields(upstreamMsg, upstreamBody, match)
+}
+
+// matchOpenAIUpstreamErrorFields applies match to the extracted message and the
+// JSON error message/code fields only. A Responses/SSE document can echo the
+// caller's input or earlier model output; scanning the whole blob would let
+// those substrings flip capacity ↔ context-window classification.
+func matchOpenAIUpstreamErrorFields(upstreamMsg string, upstreamBody []byte, match func(string) bool) bool {
 	if match(upstreamMsg) {
 		return true
 	}
@@ -220,11 +219,6 @@ func isOpenAIContextWindowError(upstreamMsg string, upstreamBody []byte) bool {
 			return true
 		}
 	}
-	// Plain-text upstream bodies still participate. A JSON Responses/SSE
-	// document must not: it can echo the caller's input or earlier model
-	// output, and a substring like "context window" + "exceed" would then
-	// pin a capacity 400 (servers are currently overloaded) as a terminal
-	// client error instead of failing over to a sibling account.
 	if gjson.ValidBytes(bytes.TrimSpace(upstreamBody)) {
 		return false
 	}


### PR DESCRIPTION
## 摘要

生产 GPT 专线（Claude CLI `stream=false` `/v1/messages`）再次把 `Our servers are currently overloaded` 写成终态 HTTP 400（`buffered_response_failed`），没有换到同组 tokensea。根因不是 #1745 漏了文案，而是 `isOpenAIContextWindowError` 对整段 JSON 做子串匹配：`response.failed` 回显的 output 里只要同时出现 `context window` 和 `exceed`，容量 400 就会被钉成调用方撑爆 context。

本次把 JSON 匹配收窄到 `error.message` / `error.code`（及 Responses 对应路径），并把 HTTP / SSE / buffered 的「要不要换号」收成 `shouldFailoverOpenAIUpstreamError`。SSE 只负责把 `response.failed` 映射成语义状态码；已经写出给客户端的流仍在调用点拦截。内容策略类 caller-fault 现在走 400，避免客户端对着 502 死重试。transient 与 context-window 共用同一字段匹配器，避免回显文本朝任一方向误判。

sentinel-registry-reviewed

## 风险

常规风险。改的是 OpenAI gateway 换号判定，不是 WebUI / API 契约字段。HTTP 5xx 仍按状态码换号；SSE 的 policy / safety / not allowed 经语义状态落到 400 后不再换号，与旧 SSE marker 行为一致。`no-web-impact`

## 验证

- `./scripts/preflight.sh` 通过
- `go test -tags=unit -count=1 -timeout 120s -run 'TestShouldFailoverOpenAIUpstreamError_HTTPAndSSEShareDecision|TestOpenAIStreamFailedEventShouldFailover|TestIsOpenAIContextWindowError|TestIsOpenAITransientProcessingError|TestForwardAsAnthropic_BufferedResponseFailed|TestForwardAsAnthropic_BufferedOverloaded|TestShouldFailoverOpenAIUpstreamResponseContextWindow' ./internal/service/` 通过
- HTTP/SSE 共用决策表含正向（overloaded 回显 context-window 要换号）与反向（context-window 回显 overloaded 不换号）

## 提交

- `c2e4fa515` fix(gateway): fail over GPT overloaded 400 from one SSOT
- `d23ed0419` fix(gateway): address R-001..R-002 — scope transient JSON match

最新提交：d23ed0419