### PR TITLE
fix(gateway): keep previous-response sticky and /v1/models on TokenKey SSOT

### DIFF
--- a/backend/internal/service/gateway_hotpath_optimization_test.go
+++ b/backend/internal/service/gateway_hotpath_optimization_test.go
@@ -381,7 +381,7 @@ func TestGetAvailableModels_OpenAIPassthroughUsesDefaultFallback(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "passthrough wins over ordinary account mapping",
+			name: "mixed mapped account keeps whitelist when sibling is passthrough",
 			accounts: []Account{
 				{
 					ID:          2,
@@ -395,7 +395,7 @@ func TestGetAvailableModels_OpenAIPassthroughUsesDefaultFallback(t *testing.T) {
 					Extra:       map[string]any{"openai_passthrough": true},
 				},
 			},
-			want: nil,
+			want: []string{"configured-model"},
 		},
 		{
 			name: "ordinary accounts preserve mapped whitelist",

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -1459,15 +1459,12 @@ func (s *GatewayService) GetAvailableModels(ctx context.Context, groupID *int64,
 	hasAnyMapping := false
 
 	for _, acc := range accounts {
-		// Passthrough routing accepts models independently of model_mapping. A stale
-		// mapping on any eligible passthrough account therefore cannot define the
-		// public whitelist; return nil so the handler uses its default model set.
+		// Passthrough accounts accept models independently of model_mapping, so
+		// their (often stale) mapping must not define the public whitelist.
+		// Skip them while collecting; sibling mapped accounts still own the
+		// curated set. Passthrough-only groups fall through to nil / default.
 		if platform == PlatformOpenAI && acc.IsOpenAIPassthroughEnabled() {
-			if s.modelsListCache != nil {
-				s.modelsListCache.Set(cacheKey, []string(nil), s.modelsListCacheTTL)
-				modelsListCacheStoreTotal.Add(1)
-			}
-			return nil
+			continue
 		}
 
 		mapping := acc.GetModelMapping()

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -378,7 +378,10 @@ func (s *defaultOpenAIAccountScheduler) Select(
 	}
 
 	previousResponseID := strings.TrimSpace(req.PreviousResponseID)
-	if previousResponseID != "" && NormalizeOpenAICompatiblePlatform(req.Platform) == PlatformOpenAI &&
+	// Production Select() only sets GroupPlatform. Empty req.Platform normalizes
+	// to openai, so the gate must use schedulePlatform() — the same SSOT as
+	// sticky/load-balance — or newapi/grok/CN groups inherit OpenAI response sticky.
+	if previousResponseID != "" && req.schedulePlatform() == PlatformOpenAI &&
 		(!req.StickyWeighted || !req.PreviousResponseCanMove) {
 		selection, err := s.service.selectAccountByPreviousResponseIDForCapability(
 			ctx,

--- a/backend/internal/service/openai_account_scheduler_tk_newapi_test.go
+++ b/backend/internal/service/openai_account_scheduler_tk_newapi_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/stretchr/testify/require"
@@ -333,4 +334,44 @@ func TestAdvancedSchedulerVideoSkipsUnsupportedStickyAccount(t *testing.T) {
 	require.NotNil(t, selection.Account)
 	require.Equal(t, int64(81102), selection.Account.ID, "sticky video routing must not reuse a non-video account")
 	require.Equal(t, openAIAccountScheduleLayerLoadBalance, decision.Layer)
+}
+
+// Production Select() leaves Platform empty and only fills GroupPlatform.
+// Empty Platform normalizes to openai, so previous_response_id sticky must
+// key off schedulePlatform() or a leftover OpenAI WS binding can pin an
+// OpenAI account into a newapi group.
+func TestSelect_NewAPIGroupIgnoresOpenAIPreviousResponseSticky(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(80021)
+	const prevResp = "resp_should_not_pin_newapi"
+	newapi := newAPIAccount(82101, 14)
+	openaiBound := openAIAccount(82102, 0)
+	openaiBound.Type = AccountTypeAPIKey
+	openaiBound.Extra = map[string]any{
+		"openai_apikey_responses_websockets_v2_enabled": true,
+	}
+
+	svc, sched := newAPISchedFixture(t, groupID, PlatformNewAPI, []*Account{newapi, openaiBound})
+	svc.cfg.Gateway.OpenAIWS.Enabled = true
+	svc.cfg.Gateway.OpenAIWS.APIKeyEnabled = true
+	svc.cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	svc.cfg.Gateway.OpenAIWS.StickyResponseIDTTLSeconds = 3600
+	svc.cache = &schedulerTestGatewayCache{}
+
+	store := svc.getOpenAIWSStateStore()
+	require.NoError(t, store.BindResponseAccount(ctx, groupID, prevResp, openaiBound.ID, time.Hour))
+
+	selection, decision, err := sched.Select(ctx, OpenAIAccountScheduleRequest{
+		GroupID:            &groupID,
+		GroupPlatform:      PlatformNewAPI,
+		PreviousResponseID: prevResp,
+		RequestedModel:     "qwen-max",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, newapi.ID, selection.Account.ID, "newapi group must not inherit OpenAI previous_response_id sticky")
+	require.Equal(t, PlatformNewAPI, selection.Account.Platform)
+	require.NotEqual(t, openAIAccountScheduleLayerPreviousResponse, decision.Layer)
+	require.False(t, decision.StickyPreviousHit)
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3122,6 +3122,35 @@
       "rationale": "Regression anchor for duplicate Claude Code environment blocks: every block must receive the outbound timezone rewrite, so an upstream merge cannot retain only the first block's TZ while silently dropping later blocks."
     },
     {
+      "path": "backend/internal/service/openai_account_scheduler.go",
+      "must_contain": [
+        "req.schedulePlatform() == PlatformOpenAI"
+      ],
+      "rationale": "previous_response_id sticky must key off schedulePlatform() (GroupPlatform first). Production Select() never sets req.Platform; empty Platform normalizes to openai and would let leftover OpenAI WS bindings pin an OpenAI account into newapi/grok/CN groups."
+    },
+    {
+      "path": "backend/internal/service/openai_account_scheduler_tk_newapi_test.go",
+      "must_contain": [
+        "TestSelect_NewAPIGroupIgnoresOpenAIPreviousResponseSticky"
+      ],
+      "rationale": "Focused regression: a newapi group with an empty Platform field and a leftover OpenAI previous_response_id binding must stay on the newapi pool, not the OpenAI sticky layer."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "if platform == PlatformOpenAI && acc.IsOpenAIPassthroughEnabled() {",
+        "Skip them while collecting; sibling mapped accounts still own the"
+      ],
+      "rationale": "OpenAI passthrough accounts must be skipped while collecting /v1/models mappings. Returning nil on the first passthrough account wipes TokenKey curated model_mapping from sibling accounts and collapses mixed Codex-passthrough + mapped groups onto the default catalog."
+    },
+    {
+      "path": "backend/internal/service/gateway_hotpath_optimization_test.go",
+      "must_contain": [
+        "mixed mapped account keeps whitelist when sibling is passthrough"
+      ],
+      "rationale": "GetAvailableModels mixed-group contract: a leftover openai_passthrough sibling cannot erase the curated mapping whitelist. Upstream #5581 returned nil for the whole group; TokenKey serving SSOT keeps the non-passthrough union."
+    },
+    {
       "path": "backend/internal/service/gateway_anthropic_request_normalize_tk.go",
       "must_contain": [
         "func tkApplyAnthropicCCPromptSurfaceNormalize"


### PR DESCRIPTION
## 摘要
- 这是 #1715 合入后的 follow-up：复审发现的两处 TokenKey 回归当时没赶上合并提交 `3b1fec723`。
- `previous_response_id` 粘性改回 `schedulePlatform()`。生产路径只填 `GroupPlatform`，空 `Platform` 不能把 newapi/grok/国产组送进 OpenAI previous-response 粘性。
- `GetAvailableModels` 只跳过 OpenAI passthrough 账号，不再因一个透传账号丢掉兄弟账号的 curated `model_mapping`。

## 风险
- 常规风险：调度粘性与 `/v1/models` 白名单，无 schema / 鉴权 / 公共 API 字段变更。
- Web impact: none

## 验证
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh` 通过。
- `go -C backend test -tags=unit ./internal/service -run 'TestSelect_NewAPIGroupIgnoresOpenAIPreviousResponseSticky|TestGetAvailableModels_OpenAIPassthroughUsesDefaultFallback|TestGetAvailableModels_GlobalListPreservesMappedModelsWithOpenAIPassthrough|TestUS008_'` 通过。

## 提交
最新提交：ffedc04be

```
ffedc04be fix(gateway): keep previous-response sticky and /v1/models on TokenKey SSOT
```

Made with [Cursor](https://cursor.com)