### PR TITLE
fix(gateway): tokensea anthropic 账号放行公开 SSOT 模型

### DIFF
--- a/backend/internal/handler/gateway_handler_tk_unsupported_model_test.go
+++ b/backend/internal/handler/gateway_handler_tk_unsupported_model_test.go
@@ -47,3 +47,13 @@ func TestTkWriteUnsupportedAnthropicModelAtIngress_AllowsCloudwiseWhitelistModel
 		require.False(t, h.tkWriteUnsupportedAnthropicModelAtIngress(c, model, false, nil), model)
 	}
 }
+
+func TestTkWriteUnsupportedAnthropicModelAtIngress_AllowsTokenseaPublicSSOTModels(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &GatewayHandler{}
+	// Boundary samples from the tokensea public SSOT floor, not a copied catalog.
+	for _, model := range []string{"gpt-5.4", "qwen3.7-max"} {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		require.False(t, h.tkWriteUnsupportedAnthropicModelAtIngress(c, model, false, nil), model)
+	}
+}

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -775,6 +775,9 @@ func (a *Account) IsModelSupported(requestedModel string) bool {
 	if isCloudwiseRelayAccount(a) && !openAICloudwiseRelaySupportsRequestedModel(requestedModel) {
 		return false
 	}
+	if a.IsAnthropicTokenseaRelay() && !tokenseaRelayAccountSupportsRequestedModel(requestedModel) {
+		return false
+	}
 	// 透传模式仅替换认证、模型语义完全交由上游决定，因此放行所有模型。
 	// 该短路必须在 model_mapping 判定之前：账号从"白名单模式"切换到透传后，
 	// credentials 里常残留旧的非空 model_mapping，若不在此放行，透传账号会被

--- a/backend/internal/service/account_model_mapping_ssot_tk.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk.go
@@ -351,6 +351,12 @@ func accountModelMappingForbiddenKeysByScope() map[string][]string {
 			domain.AntigravityStructuralDeadModelMappingKeys(),
 			domain.AntigravityUnpricedModelMappingKeys()...,
 		),
+		accountModelMappingPlatformOpenAITokenseaRelay: tokenseaRelayForbiddenUpstreamIDs(
+			supportedOpenAITokenseaRelayCatalogModels,
+		),
+		accountModelMappingPlatformAnthropicTokenseaRelay: tokenseaRelayForbiddenUpstreamIDs(
+			supportedAnthropicTokenseaRelayCatalogModels,
+		),
 	}
 }
 
@@ -439,7 +445,10 @@ func openAIAinzyRelayAccountModelMappingFloor(ctx context.Context, pricing *Pric
 }
 
 func openAITokenseaRelayAccountModelMappingFloor(ctx context.Context, pricing *PricingCatalogService, availability MePricingAvailability) map[string]string {
-	ids := supportedCatalogModelIDsFromMap(supportedOpenAITokenseaRelayCatalogModels)
+	_ = ctx
+	_ = pricing
+	_ = availability
+	ids := tokenseaRelayCorePublicFloorIDs()
 	if len(ids) == 0 {
 		return nil
 	}
@@ -454,31 +463,138 @@ func openAICloudwiseRelayAccountModelMappingFloor(ctx context.Context, pricing *
 }
 
 func anthropicTokenseaRelayModelMappingFloor() map[string]string {
-	ids := supportedCatalogModelIDsFromMap(supportedAnthropicTokenseaRelayCatalogModels)
+	ids := tokenseaRelayPublicSSOTIDs(append(
+		append([]string{}, tokenseaRelayCorePublicFloorIDs()...),
+		supportedCatalogModelIDsFromMap(supportedAnthropicTokenseaRelayCatalogModels)...,
+	))
 	if len(ids) == 0 {
 		return nil
 	}
 	out := make(map[string]string, len(ids))
 	for _, id := range ids {
-		wire, ok := anthropicTokenseaRelayWireModelMapping[id]
-		if !ok {
+		if wire, ok := anthropicTokenseaRelayWireModelMapping[id]; ok {
+			out[id] = wire
 			continue
 		}
-		out[id] = wire
+		out[id] = id
 	}
 	return out
 }
 
+// tokenseaRelaySharedExtraSSOTIDs are public priced+displayable models already
+// served on prod account 92 but absent from the 47-id upstream snapshot.
+var tokenseaRelaySharedExtraSSOTIDs = []string{
+	"codex-auto-review",
+	"gpt-5.3-codex-spark",
+	"gpt-5.6",
+}
+
+func tokenseaRelaySupportsRequestedModel(requestedModel string) bool {
+	normalized := strings.TrimSpace(requestedModel)
+	if normalized == "" {
+		return false
+	}
+	for _, id := range tokenseaRelayCorePublicFloorIDs() {
+		if strings.EqualFold(id, normalized) {
+			return true
+		}
+	}
+	return false
+}
+
+// tokenseaRelayCorePublicFloorIDs is the shared 92/93 live floor: upstream 47
+// intersect public SSOT, plus the extras 92 already serves.
+func tokenseaRelayCorePublicFloorIDs() []string {
+	return tokenseaRelayPublicSSOTIDs(append(
+		supportedCatalogModelIDsFromMap(supportedOpenAITokenseaRelayCatalogModels),
+		tokenseaRelaySharedExtraSSOTIDs...,
+	))
+}
+
+// tokenseaRelayPublicSSOTIDs keeps only upstream-listed IDs that already satisfy
+// the public serving triple: displayable catalog/menu, priced, and servable.
+func tokenseaRelayPublicSSOTIDs(ids []string) []string {
+	seen := make(map[string]struct{}, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if !tokenseaRelayMeetsPublicSSOT(id) {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func tokenseaRelayMeetsPublicSSOT(id string) bool {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return false
+	}
+	if tokenseaRelayIsClientFacing(id) && tokenseaRelayIsPriced(id) {
+		return true
+	}
+	// Official dated wire IDs stay first-class when they alias a client-facing SSOT row.
+	for short, wire := range anthropicTokenseaRelayWireModelMapping {
+		if wire == id && tokenseaRelayIsClientFacing(short) && tokenseaRelayIsPriced(short) {
+			return true
+		}
+	}
+	return false
+}
+
+func tokenseaRelayIsClientFacing(id string) bool {
+	if _, ok := supportedOpenAICatalogModels[id]; ok {
+		return true
+	}
+	if _, ok := supportedClaudeCatalogModels[id]; ok {
+		return true
+	}
+	if _, ok := supportedGeminiCatalogModels[id]; ok {
+		return true
+	}
+	if _, ok := supportedAntigravityCatalogModels[id]; ok {
+		return true
+	}
+	return isTkCuratedNewAPIModelDisplayed(id)
+}
+
+func tokenseaRelayIsPriced(id string) bool {
+	if snap := loadTKPricingOverlaySnapshot(); snap != nil {
+		if pricing := snap.Models[id]; pricing != nil {
+			return true
+		}
+	}
+	return isTkCuratedNewAPIModelListed(id)
+}
+
+func tokenseaRelayForbiddenUpstreamIDs(upstream map[string]struct{}) []string {
+	out := make([]string, 0)
+	for id := range upstream {
+		if !tokenseaRelayMeetsPublicSSOT(id) {
+			out = append(out, id)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
 var anthropicTokenseaRelayWireModelMapping = map[string]string{
-	"claude-fable-5":    "claude-fable-5",
-	"claude-haiku-4-5":  "claude-haiku-4-5-20251001",
-	"claude-opus-4-5":   "claude-opus-4-5-20251101",
-	"claude-opus-4-6":   "claude-opus-4-6",
-	"claude-opus-4-7":   "claude-opus-4-7",
-	"claude-opus-4-8":   "claude-opus-4-8",
-	"claude-opus-5":     "claude-opus-5",
-	"claude-sonnet-4-6": "claude-sonnet-4-6",
-	"claude-sonnet-5":   "claude-sonnet-5",
+	"claude-fable-5":            "claude-fable-5",
+	"claude-haiku-4-5":          "claude-haiku-4-5-20251001",
+	"claude-haiku-4-5-20251001": "claude-haiku-4-5-20251001",
+	"claude-opus-4-5":           "claude-opus-4-5-20251101",
+	"claude-opus-4-5-20251101":  "claude-opus-4-5-20251101",
+	"claude-opus-4-6":           "claude-opus-4-6",
+	"claude-opus-4-7":           "claude-opus-4-7",
+	"claude-opus-4-8":           "claude-opus-4-8",
+	"claude-opus-5":             "claude-opus-5",
+	"claude-sonnet-4-6":         "claude-sonnet-4-6",
+	"claude-sonnet-5":           "claude-sonnet-5",
 }
 
 func supportedCatalogModelIDsFromMap(src map[string]struct{}) []string {

--- a/backend/internal/service/account_model_mapping_ssot_tk.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk.go
@@ -502,6 +502,11 @@ func tokenseaRelaySupportsRequestedModel(requestedModel string) bool {
 	return false
 }
 
+func tokenseaRelayAccountSupportsRequestedModel(requestedModel string) bool {
+	return tokenseaRelaySupportsRequestedModel(requestedModel) ||
+		tkIsForwardableAnthropicModelName(requestedModel)
+}
+
 // tokenseaRelayCorePublicFloorIDs is the shared 92/93 live floor: upstream 47
 // intersect public SSOT, plus the extras 92 already serves.
 func tokenseaRelayCorePublicFloorIDs() []string {

--- a/backend/internal/service/account_model_mapping_ssot_tk_test.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk_test.go
@@ -87,7 +87,24 @@ func TestAccount_IsAnthropicTokenseaRelay(t *testing.T) {
 func TestOpenAITokenseaRelayFloorIsProbeCuratedOnly(t *testing.T) {
 	t.Parallel()
 	mapping := openAITokenseaRelayAccountModelMappingFloor(context.Background(), nil, nil)
-	requireIdentityMappingForIDs(t, mapping, supportedCatalogModelIDsFromMap(supportedOpenAITokenseaRelayCatalogModels))
+	requireIdentityMappingForIDs(t, mapping, tokenseaRelayCorePublicFloorIDs())
+	require.NotEmpty(t, mapping)
+	require.Contains(t, mapping, "gpt-5.4")
+	require.Contains(t, mapping, "claude-sonnet-4-6")
+	require.Contains(t, mapping, "gpt-5.6")
+	require.NotContains(t, mapping, "byteplus/dreamina-seedance-2-0-260128", "non-SSOT upstream id is a boundary sample, not an owner copy")
+}
+
+func TestAnthropicTokenseaRelayFloorCoversSharedOpenAILiveKeys(t *testing.T) {
+	t.Parallel()
+	openaiFloor := openAITokenseaRelayAccountModelMappingFloor(context.Background(), nil, nil)
+	anthropicFloor := anthropicTokenseaRelayModelMappingFloor()
+	require.NotEmpty(t, openaiFloor)
+	for id := range openaiFloor {
+		require.Contains(t, anthropicFloor, id, "account 93 floor must include every account 92 live key")
+	}
+	require.Contains(t, anthropicFloor, "claude-haiku-4-5")
+	require.Equal(t, "claude-haiku-4-5-20251001", anthropicFloor["claude-haiku-4-5"])
 }
 
 func TestOpenAIAinzyRelayFloorIsProbeCuratedOnly(t *testing.T) {
@@ -136,7 +153,7 @@ func TestAccountModelMappingFloorForOps_ExportsAinzyRelayScope(t *testing.T) {
 	requireIdentityMappingForIDs(t, ainzy, supportedCatalogModelIDsFromMap(supportedOpenAIAinzyRelayCatalogModels))
 	tokensea, ok := doc.Platforms[accountModelMappingPlatformOpenAITokenseaRelay]
 	require.True(t, ok)
-	requireIdentityMappingForIDs(t, tokensea, supportedCatalogModelIDsFromMap(supportedOpenAITokenseaRelayCatalogModels))
+	requireIdentityMappingForIDs(t, tokensea, tokenseaRelayCorePublicFloorIDs())
 	cloudwise, ok := doc.Platforms[accountModelMappingPlatformOpenAICloudwiseRelay]
 	require.True(t, ok)
 	require.Equal(t, openAICloudwiseRelayWildcardModelMappingFloor(), cloudwise)
@@ -176,6 +193,17 @@ func TestAccountModelMappingFloorForOps_ExportsPolicyMetadata(t *testing.T) {
 	require.ElementsMatch(t, kiroExclusiveModelIDs(), doc.ForbiddenModelMappingKeys[PlatformAnthropic])
 	require.Contains(t, doc.ForbiddenModelMappingKeys[PlatformAnthropic], "claude-opus-5")
 	require.Contains(t, doc.ForbiddenModelMappingPrefixes[PlatformAntigravity], "gpt-oss-")
+	require.ElementsMatch(
+		t,
+		tokenseaRelayForbiddenUpstreamIDs(supportedOpenAITokenseaRelayCatalogModels),
+		doc.ForbiddenModelMappingKeys[accountModelMappingPlatformOpenAITokenseaRelay],
+	)
+	require.Contains(
+		t,
+		doc.ForbiddenModelMappingKeys[accountModelMappingPlatformOpenAITokenseaRelay],
+		"byteplus/dreamina-seedance-2-0-260128",
+		"non-SSOT upstream id is a boundary sample, not an owner copy",
+	)
 }
 
 func TestAccountModelMappingFloorForOps_ExportsAccountOverrides(t *testing.T) {

--- a/backend/internal/service/gateway_scheduling.go
+++ b/backend/internal/service/gateway_scheduling.go
@@ -2282,10 +2282,12 @@ func (s *GatewayService) isModelSupportedByAccountWithContext(ctx context.Contex
 
 // isModelSupportedByAccount 根据账户平台检查模型支持（无 context，用于非 Antigravity 平台）
 func (s *GatewayService) isModelSupportedByAccount(account *Account, requestedModel string) bool {
-	// CloudWise dual-stack relays must not use the OpenAI passthrough
-	// namespace filter: empty mapping + passthrough would allow gpt-* via
-	// tkIsForwardableOpenAIModelName and reject claude-/glm-.
+	// CloudWise / tokensea dual-stack relays must not use the Anthropic
+	// claude-* namespace filter: their mapping is the allowlist.
 	if isCloudwiseRelayAccount(account) {
+		return account.IsModelSupported(requestedModel)
+	}
+	if account.IsAnthropicTokenseaRelay() {
 		return account.IsModelSupported(requestedModel)
 	}
 	if account.Platform == PlatformAntigravity {

--- a/backend/internal/service/gateway_service_tk_unsupported_model.go
+++ b/backend/internal/service/gateway_service_tk_unsupported_model.go
@@ -115,6 +115,14 @@ func tkAnthropicCrossVendorSelectionFailure(requestedModel string) error {
 	if openAICloudwiseRelaySupportsRequestedModel(requestedModel) {
 		return nil
 	}
+	// Dual-stack tokensea anthropic accounts (#93) advertise the public
+	// priced+servable subset of agent.tokensea.ai via model_mapping. Ingress
+	// must not 400 those exact IDs before selection; official Anthropic
+	// OAuth/APIKey still cannot claim them because isModelSupportedByAccount
+	// keeps the claude-* namespace guard unless IsAnthropicTokenseaRelay.
+	if tokenseaRelaySupportsRequestedModel(requestedModel) {
+		return nil
+	}
 	if normalized := claude.NormalizeModelID(requestedModel); normalized != "" && normalized != requestedModel {
 		if tkIsForwardableAnthropicModelName(normalized) {
 			return nil

--- a/backend/internal/service/gateway_service_tk_unsupported_model_test.go
+++ b/backend/internal/service/gateway_service_tk_unsupported_model_test.go
@@ -144,6 +144,20 @@ func TestTkWrapSelectionFailure(t *testing.T) {
 		}
 	})
 
+	t.Run("tokensea public SSOT does not beat capacity 429", func(t *testing.T) {
+		err := tkWrapSelectionFailure(PlatformAnthropic, "gpt-5.4", selectionFailureStats{
+			Total:            5,
+			ModelUnsupported: 4,
+			Unschedulable:    1,
+		})
+		if !errors.Is(err, ErrNoAvailableAccounts) {
+			t.Fatalf("want capacity ErrNoAvailableAccounts for tokensea SSOT id, got %v", err)
+		}
+		if errors.Is(err, ErrUnsupportedModel) {
+			t.Fatalf("tokensea public SSOT must not be classified as cross-vendor: %v", err)
+		}
+	})
+
 	t.Run("cross-vendor model beats mixed stats routing 429", func(t *testing.T) {
 		stats := selectionFailureStats{
 			Total:            5,
@@ -428,5 +442,67 @@ func TestIsModelSupportedByAccount_MappedCloudwisePrefixDoesNotLeakToOfficialAnt
 	}
 	if !svc.isModelSupportedByAccount(claudeToWire, "claude-3-5-sonnet-20241022") {
 		t.Error("claude request remapped to a vendor wire ID must still be selectable")
+	}
+}
+
+func tokenseaRelayNonClaudePublicIDs(t *testing.T) []string {
+	t.Helper()
+	out := make([]string, 0)
+	for _, id := range tokenseaRelayCorePublicFloorIDs() {
+		if !tkIsForwardableAnthropicModelName(id) {
+			out = append(out, id)
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("tokensea public floor must include at least one non-claude id")
+	}
+	return out
+}
+
+func TestTkAnthropicCrossVendorSelectionFailure_AllowsTokenseaPublicSSOT(t *testing.T) {
+	for _, id := range tokenseaRelayNonClaudePublicIDs(t) {
+		if err := tkAnthropicCrossVendorSelectionFailure(id); err != nil {
+			t.Fatalf("tokensea public SSOT id %q must pass Anthropic ingress, got %v", id, err)
+		}
+		if TkIsAnthropicCrossVendorModelName(id) {
+			t.Fatalf("TkIsAnthropicCrossVendorModelName(%q) = true, want false", id)
+		}
+	}
+}
+
+func TestTkAnthropicCrossVendorSelectionFailure_StillRejectsBareAndUnknownGPT(t *testing.T) {
+	for _, id := range []string{"gpt", "gpt-not-in-tokensea-ssot"} {
+		if err := tkAnthropicCrossVendorSelectionFailure(id); err == nil {
+			t.Fatalf("%q must stay an Anthropic cross-vendor reject", id)
+		}
+		if !TkIsAnthropicCrossVendorModelName(id) {
+			t.Fatalf("TkIsAnthropicCrossVendorModelName(%q) = false, want true", id)
+		}
+	}
+}
+
+func TestIsModelSupportedByAccount_MappedTokenseaGPTDoesNotLeakToOfficialAnthropic(t *testing.T) {
+	svc := &GatewayService{}
+	sample := tokenseaRelayNonClaudePublicIDs(t)[0]
+	leaked := &Account{
+		ID:       13,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://api.anthropic.com",
+			"model_mapping": map[string]any{
+				sample:              sample,
+				"claude-sonnet-4-6": "claude-sonnet-4-6",
+			},
+		},
+	}
+	if leaked.IsAnthropicTokenseaRelay() {
+		t.Fatal("official Anthropic base_url must not be classified as tokensea")
+	}
+	if svc.isModelSupportedByAccount(leaked, sample) {
+		t.Fatalf("non-tokensea mapped anthropic must not claim %s after tokensea ingress allow", sample)
+	}
+	if !svc.isModelSupportedByAccount(leaked, "claude-sonnet-4-6") {
+		t.Fatal("non-tokensea mapped anthropic must still serve its claude-* mapping")
 	}
 }

--- a/backend/internal/service/gateway_tokensea_anthropic_relay_test.go
+++ b/backend/internal/service/gateway_tokensea_anthropic_relay_test.go
@@ -119,6 +119,40 @@ func TestIsModelSupportedByAccount_AnthropicTokenseaUsesMapping(t *testing.T) {
 	require.False(t, svc.isModelSupportedByAccount(account, "gpt"))
 }
 
+func TestIsModelSupportedByAccount_AnthropicTokenseaEmptyMappingUsesSSOTGate(t *testing.T) {
+	t.Parallel()
+	svc := &GatewayService{}
+	account := &Account{
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://agent.tokensea.ai",
+		},
+	}
+	require.True(t, account.IsAnthropicTokenseaRelay())
+	require.Empty(t, account.GetModelMapping())
+
+	for _, id := range tokenseaRelayNonClaudePublicIDs(t) {
+		require.True(t, account.IsModelSupported(id), id)
+		require.True(t, svc.isModelSupportedByAccount(account, id), id)
+	}
+	require.True(t, svc.isModelSupportedByAccount(account, "claude-haiku-4-5"))
+	require.False(t, account.IsModelSupported("gpt-not-in-tokensea-ssot"))
+	require.False(t, svc.isModelSupportedByAccount(account, "gpt-not-in-tokensea-ssot"))
+	require.False(t, svc.isModelSupportedByAccount(account, "gpt"))
+}
+
+func TestIsModelSupported_AnthropicTokenseaGateOverridesExplicitForbiddenMapping(t *testing.T) {
+	t.Parallel()
+	account := tokenseaAnthropicRelayAccount()
+	account.Credentials["model_mapping"] = map[string]any{
+		"gpt-5.4":                  "gpt-5.4",
+		"gpt-not-in-tokensea-ssot": "gpt-not-in-tokensea-ssot",
+	}
+	require.True(t, account.IsModelSupported("gpt-5.4"))
+	require.False(t, account.IsModelSupported("gpt-not-in-tokensea-ssot"))
+}
+
 func TestBuildAnthropicCompatUpstreamRequest_OAuthPassthroughUsesBearerAuth(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)

--- a/backend/internal/service/gateway_tokensea_anthropic_relay_test.go
+++ b/backend/internal/service/gateway_tokensea_anthropic_relay_test.go
@@ -27,9 +27,19 @@ func TestAnthropicTokenseaRelayFloorMapsShortNamesToWireIDs(t *testing.T) {
 	t.Parallel()
 	mapping := anthropicTokenseaRelayModelMappingFloor()
 	require.Equal(t, "claude-haiku-4-5-20251001", mapping["claude-haiku-4-5"])
+	require.Equal(t, "claude-haiku-4-5-20251001", mapping["claude-haiku-4-5-20251001"])
 	require.Equal(t, "claude-opus-4-5-20251101", mapping["claude-opus-4-5"])
-	require.Equal(t, "claude-opus-5", mapping["claude-opus-5"])
-	require.Len(t, mapping, len(supportedAnthropicTokenseaRelayCatalogModels))
+	require.Equal(t, "claude-opus-4-5-20251101", mapping["claude-opus-4-5-20251101"])
+	require.Equal(t, "claude-sonnet-4-6", mapping["claude-sonnet-4-6"])
+	require.Equal(t, "gpt-5.4", mapping["gpt-5.4"])
+	require.Equal(t, "qwen3.7-max", mapping["qwen3.7-max"])
+	for _, id := range tokenseaRelayCorePublicFloorIDs() {
+		require.Contains(t, mapping, id, "93 floor must include every 92 live SSOT key")
+	}
+	require.GreaterOrEqual(t, len(mapping), len(tokenseaRelayCorePublicFloorIDs()))
+	if !tokenseaRelayMeetsPublicSSOT("claude-opus-5") {
+		require.NotContains(t, mapping, "claude-opus-5")
+	}
 }
 
 func TestBuildAnthropicCompatUpstreamRequest_PassthroughUsesTokenseaMessagesURL(t *testing.T) {
@@ -93,6 +103,20 @@ func TestForwardAsChatCompletions_AnthropicTokenseaPassthroughMapsHaikuWireID(t 
 	require.NoError(t, err)
 	require.Equal(t, "claude-haiku-4-5-20251001", gjson.GetBytes(upstream.lastBody, "model").String())
 	require.Equal(t, "https://agent.tokensea.ai/v1/messages?beta=true", upstream.lastReq.URL.String())
+}
+
+func TestIsModelSupportedByAccount_AnthropicTokenseaUsesMapping(t *testing.T) {
+	t.Parallel()
+	svc := &GatewayService{}
+	account := tokenseaAnthropicRelayAccount()
+	require.True(t, account.IsAnthropicTokenseaRelay())
+
+	for _, id := range tokenseaRelayCorePublicFloorIDs() {
+		require.True(t, svc.isModelSupportedByAccount(account, id), id)
+	}
+	require.True(t, svc.isModelSupportedByAccount(account, "claude-haiku-4-5"))
+	require.False(t, svc.isModelSupportedByAccount(account, "gpt-not-in-tokensea-ssot"))
+	require.False(t, svc.isModelSupportedByAccount(account, "gpt"))
 }
 
 func TestBuildAnthropicCompatUpstreamRequest_OAuthPassthroughUsesBearerAuth(t *testing.T) {

--- a/backend/internal/service/pricing_catalog_supported_models_tk.go
+++ b/backend/internal/service/pricing_catalog_supported_models_tk.go
@@ -154,13 +154,69 @@ var supportedOpenAIAinzyRelayCatalogModels = map[string]struct{}{
 	"gpt-5.5":      {},
 }
 
-// supportedOpenAITokenseaRelayCatalogModels — Claude IDs kept in the compiled
-// model_mapping floor for prod account 92 (agent.tokensea.ai). Derived from
-// upstream GET /v1/models on 2026-08-12; claude-opus-4-5-20251101 is listed but
-// may return model_not_found when the upstream channel pool is empty.
+// supportedOpenAITokenseaRelayCatalogModels — upstream GET /v1/models owner for
+// prod account 92 (agent.tokensea.ai OpenAI relay) on 2026-08-20. The compiled
+// account floor is this set intersected with public priced+displayable+servable
+// SSOT; listing here does not add public catalog/menu rows.
 var supportedOpenAITokenseaRelayCatalogModels = map[string]struct{}{
+	"byteplus/dreamina-seedance-2-0-260128":      {},
+	"byteplus/dreamina-seedance-2-0-fast-260128": {},
+	"byteplus/dreamina-seedance-2-0-mini-260615": {},
+	"claude-fable-5":                 {},
+	"claude-haiku-4-5-20251001":      {},
+	"claude-opus-4-5-20251101":       {},
+	"claude-opus-4-6":                {},
+	"claude-opus-4-7":                {},
+	"claude-opus-4-8":                {},
+	"claude-opus-5":                  {},
+	"claude-sonnet-4-6":              {},
+	"claude-sonnet-5":                {},
+	"deepseek-v3.2":                  {},
+	"deepseek-v4-flash":              {},
+	"deepseek-v4-pro":                {},
+	"doubao-seedance-2-0-250428":     {},
+	"doubao-seedance-2.0":            {},
+	"gemini-3-pro-image":             {},
+	"gemini-3-pro-image-preview":     {},
+	"gemini-3.1-flash-image":         {},
+	"gemini-3.1-flash-image-preview": {},
+	"gemini-omni-flash-preview":      {},
+	"generate_video_seedance_v2_0":   {},
+	"glm-5":                          {},
+	"glm-5.1":                        {},
+	"glm-5.2":                        {},
+	"gpt-4o-2024-05-13":              {},
+	"gpt-5.4":                        {},
+	"gpt-5.4-mini":                   {},
+	"gpt-5.5":                        {},
+	"gpt-5.6-luna":                   {},
+	"gpt-5.6-sol":                    {},
+	"gpt-5.6-terra":                  {},
+	"gpt-image-2":                    {},
+	"kimi-k2.5":                      {},
+	"kimi-k2.6":                      {},
+	"kimi-k2.7-code":                 {},
+	"kimi-k3":                        {},
+	"kimi/kimi-k3":                   {},
+	"minimax-m2.7":                   {},
+	"qwen3.6-plus":                   {},
+	"qwen3.7-max":                    {},
+	"qwen3.7-plus":                   {},
+	"us.anthropic.claude-opus-4-7":   {},
+	"us.anthropic.claude-opus-5":     {},
+	"us.anthropic.claude-sonnet-4-6": {},
+	"us.anthropic.claude-sonnet-5":   {},
+}
+
+// supportedAnthropicTokenseaRelayCatalogModels — Claude short-name aliases for
+// prod account 93. The live floor is tokenseaRelayCorePublicFloorIDs (same
+// SSOT set as account 92) plus these shorts; wire IDs stay in
+// anthropicTokenseaRelayModelMappingFloor.
+var supportedAnthropicTokenseaRelayCatalogModels = map[string]struct{}{
 	"claude-fable-5":            {},
+	"claude-haiku-4-5":          {},
 	"claude-haiku-4-5-20251001": {},
+	"claude-opus-4-5":           {},
 	"claude-opus-4-5-20251101":  {},
 	"claude-opus-4-6":           {},
 	"claude-opus-4-7":           {},
@@ -168,22 +224,6 @@ var supportedOpenAITokenseaRelayCatalogModels = map[string]struct{}{
 	"claude-opus-5":             {},
 	"claude-sonnet-4-6":         {},
 	"claude-sonnet-5":           {},
-}
-
-// supportedAnthropicTokenseaRelayCatalogModels — client-facing Claude IDs for
-// prod account 93 (agent.tokensea.ai Anthropic relay). Wire IDs are mapped in
-// anthropicTokenseaRelayModelMappingFloor; claude-opus-4-5 may 503 when the
-// upstream channel pool is empty.
-var supportedAnthropicTokenseaRelayCatalogModels = map[string]struct{}{
-	"claude-fable-5":    {},
-	"claude-haiku-4-5":  {},
-	"claude-opus-4-5":   {},
-	"claude-opus-4-6":   {},
-	"claude-opus-4-7":   {},
-	"claude-opus-4-8":   {},
-	"claude-opus-5":     {},
-	"claude-sonnet-4-6": {},
-	"claude-sonnet-5":   {},
 }
 
 // CloudWise relay model families: openai_cloudwise_relay_tk.go (openAICloudwiseRelayAllowedModelPrefixes).

--- a/ops/pricing/model-surface-bundle.json
+++ b/ops/pricing/model-surface-bundle.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 4,
-  "floor_sha256": "9bf2140bc735a76864ea08812438a094c67f76f1d093b7d39d8dbf2770025ba1",
+  "floor_sha256": "eda3ce2d107230e44efc6917159b35fc2b84362b2eef57075aeb6c760be2064c",
   "account_model_mapping": {
     "platforms": {
       "anthropic": {
@@ -18,13 +18,40 @@
       "anthropic_tokensea_relay": {
         "claude-fable-5": "claude-fable-5",
         "claude-haiku-4-5": "claude-haiku-4-5-20251001",
+        "claude-haiku-4-5-20251001": "claude-haiku-4-5-20251001",
         "claude-opus-4-5": "claude-opus-4-5-20251101",
+        "claude-opus-4-5-20251101": "claude-opus-4-5-20251101",
         "claude-opus-4-6": "claude-opus-4-6",
         "claude-opus-4-7": "claude-opus-4-7",
         "claude-opus-4-8": "claude-opus-4-8",
         "claude-opus-5": "claude-opus-5",
         "claude-sonnet-4-6": "claude-sonnet-4-6",
-        "claude-sonnet-5": "claude-sonnet-5"
+        "claude-sonnet-5": "claude-sonnet-5",
+        "codex-auto-review": "codex-auto-review",
+        "deepseek-v3.2": "deepseek-v3.2",
+        "deepseek-v4-flash": "deepseek-v4-flash",
+        "deepseek-v4-pro": "deepseek-v4-pro",
+        "gemini-3-pro-image": "gemini-3-pro-image",
+        "gemini-3.1-flash-image": "gemini-3.1-flash-image",
+        "gemini-3.1-flash-image-preview": "gemini-3.1-flash-image-preview",
+        "glm-5": "glm-5",
+        "glm-5.1": "glm-5.1",
+        "glm-5.2": "glm-5.2",
+        "gpt-5.3-codex-spark": "gpt-5.3-codex-spark",
+        "gpt-5.4": "gpt-5.4",
+        "gpt-5.4-mini": "gpt-5.4-mini",
+        "gpt-5.5": "gpt-5.5",
+        "gpt-5.6": "gpt-5.6",
+        "gpt-5.6-luna": "gpt-5.6-luna",
+        "gpt-5.6-sol": "gpt-5.6-sol",
+        "gpt-5.6-terra": "gpt-5.6-terra",
+        "kimi-k2.5": "kimi-k2.5",
+        "kimi-k2.6": "kimi-k2.6",
+        "kimi-k2.7-code": "kimi-k2.7-code",
+        "kimi-k3": "kimi-k3",
+        "minimax-m2.7": "minimax-m2.7",
+        "qwen3.7-max": "qwen3.7-max",
+        "qwen3.7-plus": "qwen3.7-plus"
       },
       "antigravity": {
         "claude-opus-4-6": "claude-opus-4-6-thinking",
@@ -221,7 +248,32 @@
         "claude-opus-4-8": "claude-opus-4-8",
         "claude-opus-5": "claude-opus-5",
         "claude-sonnet-4-6": "claude-sonnet-4-6",
-        "claude-sonnet-5": "claude-sonnet-5"
+        "claude-sonnet-5": "claude-sonnet-5",
+        "codex-auto-review": "codex-auto-review",
+        "deepseek-v3.2": "deepseek-v3.2",
+        "deepseek-v4-flash": "deepseek-v4-flash",
+        "deepseek-v4-pro": "deepseek-v4-pro",
+        "gemini-3-pro-image": "gemini-3-pro-image",
+        "gemini-3.1-flash-image": "gemini-3.1-flash-image",
+        "gemini-3.1-flash-image-preview": "gemini-3.1-flash-image-preview",
+        "glm-5": "glm-5",
+        "glm-5.1": "glm-5.1",
+        "glm-5.2": "glm-5.2",
+        "gpt-5.3-codex-spark": "gpt-5.3-codex-spark",
+        "gpt-5.4": "gpt-5.4",
+        "gpt-5.4-mini": "gpt-5.4-mini",
+        "gpt-5.5": "gpt-5.5",
+        "gpt-5.6": "gpt-5.6",
+        "gpt-5.6-luna": "gpt-5.6-luna",
+        "gpt-5.6-sol": "gpt-5.6-sol",
+        "gpt-5.6-terra": "gpt-5.6-terra",
+        "kimi-k2.5": "kimi-k2.5",
+        "kimi-k2.6": "kimi-k2.6",
+        "kimi-k2.7-code": "kimi-k2.7-code",
+        "kimi-k3": "kimi-k3",
+        "minimax-m2.7": "minimax-m2.7",
+        "qwen3.7-max": "qwen3.7-max",
+        "qwen3.7-plus": "qwen3.7-plus"
       }
     },
     "newapi_channel_types": {
@@ -440,6 +492,7 @@
       "anthropic": [
         "claude-opus-5"
       ],
+      "anthropic_tokensea_relay": [],
       "antigravity": [
         "gemini-2.5-flash-image-preview",
         "gemini-3-flash-preview",
@@ -450,6 +503,24 @@
         "gemini-3.1-pro-high",
         "gemini-3.1-pro-preview",
         "tab_flash_lite_preview"
+      ],
+      "openai_tokensea_relay": [
+        "byteplus/dreamina-seedance-2-0-260128",
+        "byteplus/dreamina-seedance-2-0-fast-260128",
+        "byteplus/dreamina-seedance-2-0-mini-260615",
+        "doubao-seedance-2-0-250428",
+        "doubao-seedance-2.0",
+        "gemini-3-pro-image-preview",
+        "gemini-omni-flash-preview",
+        "generate_video_seedance_v2_0",
+        "gpt-4o-2024-05-13",
+        "gpt-image-2",
+        "kimi/kimi-k3",
+        "qwen3.6-plus",
+        "us.anthropic.claude-opus-4-7",
+        "us.anthropic.claude-opus-5",
+        "us.anthropic.claude-sonnet-4-6",
+        "us.anthropic.claude-sonnet-5"
       ]
     },
     "forbidden_model_mapping_prefixes": {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1177,6 +1177,30 @@
       "rationale": "GatewayService.isModelSupportedByAccount must route CloudWise accounts through Account.IsModelSupported before the OpenAI passthrough namespace filter. Empty mapping + passthrough otherwise calls tkIsForwardableOpenAIModelName, which allows gpt-* and rejects claude-/glm- — the opposite of the CloudWise floor. Pin the early return so an upstream merge cannot restore that leak while Account.IsModelSupported tests stay green."
     },
     {
+      "path": "backend/internal/service/gateway_scheduling.go",
+      "must_contain": [
+        "if account.IsAnthropicTokenseaRelay() {",
+        "return account.IsModelSupported(requestedModel)"
+      ],
+      "rationale": "GatewayService.isModelSupportedByAccount must route tokensea anthropic #93 through Account.IsModelSupported before the claude-* namespace guard. Without this early return, gpt/qwen public SSOT IDs that now pass Anthropic ingress still cannot select #93. Pin the short-circuit so an upstream merge cannot restore the 400-before-selection leak."
+    },
+    {
+      "path": "backend/internal/service/account.go",
+      "must_contain": [
+        "a.IsAnthropicTokenseaRelay() && !tokenseaRelayAccountSupportsRequestedModel(requestedModel)"
+      ],
+      "rationale": "Tokensea anthropic hard gate must stay at the top of upstream-shaped Account.IsModelSupported. Empty model_mapping would otherwise allow any model onto #93 after the scheduling short-circuit. The helper body lives in account_model_mapping_ssot_tk.go; this pins the injection so an upstream merge cannot drop the call while leaving the companion compile-clean."
+    },
+    {
+      "path": "backend/internal/service/account_model_mapping_ssot_tk.go",
+      "must_contain": [
+        "func tokenseaRelaySupportsRequestedModel(",
+        "func tokenseaRelayAccountSupportsRequestedModel(",
+        "func tokenseaRelayCorePublicFloorIDs("
+      ],
+      "rationale": "Exact-ID public SSOT allowlist for tokensea anthropic ingress and #93 selection. Prefix gpt-* is forbidden; official Anthropic accounts stay on the claude-* guard. Losing these helpers silently reopens Unsupported model 400 on group 1 GPT or lets empty-mapping #93 claim arbitrary names."
+    },
+    {
       "path": "backend/internal/service/openai_cloudwise_relay_tk_test.go",
       "must_contain": [
         "TestCloudwiseRelayEmptyMappingStillRejectsForeignFamilies",
@@ -1235,7 +1259,10 @@
         "TestAnthropicTokenseaRelayFloorMapsShortNamesToWireIDs",
         "TestBuildAnthropicCompatUpstreamRequest_PassthroughUsesTokenseaMessagesURL",
         "TestBuildAnthropicCompatUpstreamRequest_OAuthPassthroughUsesBearerAuth",
-        "TestForwardAsChatCompletions_AnthropicTokenseaPassthroughMapsHaikuWireID"
+        "TestForwardAsChatCompletions_AnthropicTokenseaPassthroughMapsHaikuWireID",
+        "TestIsModelSupportedByAccount_AnthropicTokenseaUsesMapping",
+        "TestIsModelSupportedByAccount_AnthropicTokenseaEmptyMappingUsesSSOTGate",
+        "TestIsModelSupported_AnthropicTokenseaGateOverridesExplicitForbiddenMapping"
       ],
       "rationale": "Focused regressions for tokensea-cc model_mapping floor (short name→dated wire id) and buildAnthropicCompatUpstreamRequest passthrough auth for API Key and OAuth accounts."
     },
@@ -4682,7 +4709,8 @@
       "path": "backend/internal/service/gateway_service_tk_unsupported_model.go",
       "must_contain": [
         "func tkIsForwardableAnthropicModelName(model string) bool {",
-        "return strings.HasPrefix(m, \"claude-\")"
+        "return strings.HasPrefix(m, \"claude-\")",
+        "tokenseaRelaySupportsRequestedModel(requestedModel)"
       ],
       "rationale": "TK fix (PR #806): tkIsForwardableAnthropicModelName is the namespace-prefix predicate that keeps cross-vendor model names (deepseek-/gpt-/gemini- …) from being forwarded to api.anthropic.com on a passthrough anthropic account — they 404 upstream AND are an abuse-detection fingerprint anomaly (prod 2026-06-16 edge us3 oh1-ls-b ID 4 was OAuth-revoked; it had sent deepseek-v4-flash). must_contain pins both the function and the claude- prefix rule so an upstream merge or refactor that deletes the predicate (re-opening the leak) fails the sentinel check."
     },
@@ -4697,6 +4725,8 @@
       "path": "backend/internal/service/gateway_service_tk_unsupported_model_test.go",
       "must_contain": [
         "TestIsModelSupportedByAccount_MappedCloudwisePrefixDoesNotLeakToOfficialAnthropic",
+        "TestIsModelSupportedByAccount_MappedTokenseaGPTDoesNotLeakToOfficialAnthropic",
+        "TestTkAnthropicCrossVendorSelectionFailure_AllowsTokenseaPublicSSOT",
         "https://api.anthropic.com"
       ],
       "rationale": "Regression for PR #1743 R-001: a non-CloudWise anthropic APIKey that copies the CloudWise prefix floor must not be selected for glm/kimi/minimax/deepseek after ingress allows those names."


### PR DESCRIPTION
## 摘要

- group 1 打 GPT（如 `gpt-5.4`）被 Anthropic 入口直接 400 `Unsupported model`，请求到不了账号 93。
- 93 上游已能访问可访问模型，现网 mapping 也已有公开 SSOT key；卡的是入口只认 `claude-*`（CloudWise 前缀例外不含 gpt/qwen），以及选号要求 request/mapped 都是 `claude-*`。
- 本 PR 对标 #1743：入口放行 tokensea 公开 SSOT 的精确模型 ID；`IsAnthropicTokenseaRelay`（93）按 mapping 选号。官方 Claude 账号即使 mapping 写了 GPT 也选不上。
- 同步把 92/93 编译期 floor 收成「上游 47 ∩ 公开 SSOT + 92 已有 extras」，避免以后 apply 把 93 收窄回只有 Claude。
- Review R-001：空 mapping 的 93 不得认领任意模型；`IsModelSupported` 顶部加 public SSOT / `claude-*` hard gate。
- Review R-002：入口放行、选号短路、hard gate 与 focused 测试写入 `gateway-tk` sentinel。
- 不建新账号，不改 93 凭证。非 Claude 的 chat fallback 等发版后独占探测再决定。

sentinel-registry-reviewed
no-web-impact
Web impact: none

## 风险

常规风险。不改公共路由、字段或鉴权；官方 Anthropic 账号的 `claude-*` 守卫保持。入口只放行精确 SSOT ID，不开放 `gpt-*` 前缀。线上 93 要等本修复发版后才会生效。

## 验证

```bash
cd backend
go test -tags=unit -count=1 -run 'TestTkAnthropicCrossVendorSelectionFailure_|TestTkWrapSelectionFailure|TestTkWriteUnsupportedAnthropicModelAtIngress|TestIsModelSupportedByAccount_MappedTokenseaGPTDoesNotLeakToOfficialAnthropic|TestIsModelSupportedByAccount_AnthropicTokenseaUsesMapping|TestIsModelSupportedByAccount_AnthropicTokenseaEmptyMappingUsesSSOTGate|TestIsModelSupported_AnthropicTokenseaGateOverridesExplicitForbiddenMapping|TestIsModelSupportedByAccount_MappedCloudwisePrefixDoesNotLeakToOfficialAnthropic|TestAnthropicTokenseaRelayFloor' ./internal/service/ ./internal/handler/
```

已跑过，通过。`./scripts/preflight.sh` 全绿。发版后需独占探测 93 的 messages/chat（`gpt-5.4` + `claude-sonnet-4-6`）；若 GPT messages 被上游拒，再补 chat fallback。

## 提交

- `5889e542f` fix(gateway): let tokensea anthropic accounts serve public SSOT models
- `2c3f280f1` fix(gateway): address R-001..R-002 — tokensea empty-mapping gate and sentinels
- 最新提交：`2c3f280f1`