### PR TITLE
fix(gateway): Claude 中继空池时回退到组内 dispatch GPT 映射

### DIFF
--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -194,12 +194,13 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 			return
 		}
 		reqLog.Debug("openai_chat_completions.account_selecting", zap.Int("excluded_account_count", len(failedAccountIDs)))
+		currentRoutingModel := routingModel
 		selection, scheduleDecision, err := h.gatewayService.SelectAccountWithSchedulerForCapability(
 			c.Request.Context(),
 			apiKey.GroupID,
 			"",
 			sessionHash,
-			routingModel,
+			currentRoutingModel,
 			failedAccountIDs,
 			service.OpenAIUpstreamTransportAny,
 			service.OpenAIEndpointCapabilityChatCompletions,
@@ -208,6 +209,27 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 			true,
 			requestPlatform,
 		)
+		if fallbackModel, ok := tkOpenAIDispatchSelectionFallbackModel(dispatchMappedModel, currentRoutingModel, err); ok {
+			reqLog.Info("openai_chat_completions.dispatch_selection_fallback",
+				zap.String("from_model", currentRoutingModel),
+				zap.String("to_model", fallbackModel),
+				zap.Error(err),
+			)
+			selection, scheduleDecision, err = h.gatewayService.SelectAccountWithSchedulerForCapability(
+				c.Request.Context(),
+				apiKey.GroupID,
+				"",
+				sessionHash,
+				fallbackModel,
+				failedAccountIDs,
+				service.OpenAIUpstreamTransportAny,
+				service.OpenAIEndpointCapabilityChatCompletions,
+				false,
+				false,
+				true,
+				requestPlatform,
+			)
+		}
 		if err != nil {
 			if failoverClientGone(c) {
 				reqLog.Info("openai_chat_completions.account_select_aborted_client_disconnected", zap.Error(err))

--- a/backend/internal/handler/openai_gateway_count_tokens.go
+++ b/backend/internal/handler/openai_gateway_count_tokens.go
@@ -165,6 +165,30 @@ func (h *OpenAIGatewayHandler) CountTokens(c *gin.Context) {
 		false,
 		openAICompatibleRequestPlatform(c.Request.Context(), apiKey),
 	)
+	if fallbackModel, ok := tkOpenAIDispatchSelectionFallbackModel(preferredMappedModel, currentRoutingModel, err); ok {
+		reqLog.Info("openai_count_tokens.dispatch_selection_fallback",
+			zap.String("from_model", currentRoutingModel),
+			zap.String("to_model", fallbackModel),
+			zap.Error(err),
+		)
+		selection, _, err = h.gatewayService.SelectAccountWithSchedulerForCapability(
+			c.Request.Context(),
+			apiKey.GroupID,
+			"",
+			sessionHash,
+			fallbackModel,
+			nil,
+			service.OpenAIUpstreamTransportAny,
+			service.OpenAIEndpointCapabilityChatCompletions,
+			false,
+			false,
+			false,
+			openAICompatibleRequestPlatform(c.Request.Context(), apiKey),
+		)
+		if err == nil {
+			currentRoutingModel = fallbackModel
+		}
+	}
 	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
 	if err != nil {
 		requestPlatform := openAICompatibleRequestPlatform(c.Request.Context(), apiKey)

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -484,9 +484,11 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	var oauth429FailoverState service.OpenAIOAuth429FailoverState
 	var passthroughFailoverState openAIPassthroughFailoverState
 
-	// TK: account selection routes on the client-requested model (canonicalized),
-	// matching /v1/chat/completions. Group dispatch mapping applies per-account at
-	// forward time for OAuth/Codex paths; tokensea relays keep Claude wire IDs.
+	// TK: first-pass account selection uses the client-requested model
+	// (canonicalized) so tokensea relays stay selectable. Group dispatch
+	// mapping still applies per-account at forward time. After the native
+	// Claude pool is empty, retry selection with dispatchMappedModel — same
+	// helper as /v1/messages — so GPT OAuth accounts are not model_unsupported.
 	selectionModel := service.CanonicalizeOpenAICompatRoutingModel(reqModel)
 	// 生图意图的 /v1/responses 请求必须调度到确实支持 Responses API 的账号，否则
 	// 会在 forward 阶段被静默降级为无法生图的 Chat Completions 直转（#4417）。
@@ -515,12 +517,13 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		}
 		// Select account supporting the requested model
 		reqLog.Debug("openai.account_selecting", zap.Int("excluded_account_count", len(failedAccountIDs)))
+		currentRoutingModel := selectionModel
 		selection, scheduleDecision, err := h.gatewayService.SelectAccountWithSchedulerForCapability(
 			c.Request.Context(),
 			apiKey.GroupID,
 			previousResponseID,
 			sessionHash,
-			selectionModel,
+			currentRoutingModel,
 			failedAccountIDs,
 			service.OpenAIUpstreamTransportAny,
 			requiredCapability,
@@ -529,6 +532,27 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			!imageIntent,
 			requestPlatform,
 		)
+		if fallbackModel, ok := tkOpenAIDispatchSelectionFallbackModel(dispatchMappedModel, currentRoutingModel, err); ok {
+			reqLog.Info("openai_responses.dispatch_selection_fallback",
+				zap.String("from_model", currentRoutingModel),
+				zap.String("to_model", fallbackModel),
+				zap.Error(err),
+			)
+			selection, scheduleDecision, err = h.gatewayService.SelectAccountWithSchedulerForCapability(
+				c.Request.Context(),
+				apiKey.GroupID,
+				previousResponseID,
+				sessionHash,
+				fallbackModel,
+				failedAccountIDs,
+				service.OpenAIUpstreamTransportAny,
+				requiredCapability,
+				requireCompact,
+				false,
+				!imageIntent,
+				requestPlatform,
+			)
+		}
 		if err != nil {
 			if failoverClientGone(c) {
 				reqLog.Info("openai.account_select_aborted_client_disconnected", zap.Error(err))

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1148,6 +1148,30 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 			true,
 			requestPlatform,
 		)
+		if fallbackModel, ok := tkOpenAIDispatchSelectionFallbackModel(preferredMappedModel, currentRoutingModel, err); ok {
+			reqLog.Info("openai_messages.dispatch_selection_fallback",
+				zap.String("from_model", currentRoutingModel),
+				zap.String("to_model", fallbackModel),
+				zap.Error(err),
+			)
+			selection, scheduleDecision, err = h.gatewayService.SelectAccountWithSchedulerForCapability(
+				c.Request.Context(),
+				apiKey.GroupID,
+				"",
+				sessionHash,
+				fallbackModel,
+				failedAccountIDs,
+				service.OpenAIUpstreamTransportAny,
+				service.OpenAIEndpointCapabilityChatCompletions,
+				false,
+				false,
+				true,
+				requestPlatform,
+			)
+			if err == nil {
+				currentRoutingModel = fallbackModel
+			}
+		}
 		if err != nil {
 			if failoverClientGone(c) {
 				reqLog.Info("openai_messages.account_select_aborted_client_disconnected", zap.Error(err))

--- a/backend/internal/handler/openai_gateway_handler_tk_dispatch_select.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_dispatch_select.go
@@ -1,0 +1,50 @@
+package handler
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+// tkOpenAIDispatchSelectionFallbackModel returns the group-level
+// messages-dispatch mapped model when the first account selection failed
+// solely because the client-requested Claude name had no eligible account
+// left in the OpenAI-compat pool.
+//
+// Prod 2026-08-20 (user_id=6, group GPT专线, model=claude-opus-4-8):
+// cloudwise (native Claude relay) went status=error on 402 insufficient
+// balance; tokensea advertises claude-opus-4-8 but /v1/messages returns
+// "not implemented". Selection kept using the client model name, so the
+// three native OpenAI accounts that can serve opus_mapped_model=gpt-5.6-sol
+// were counted as model_unsupported and the user saw routing 429s. The
+// mapped id is already applied at forward time; this helper makes selection
+// use the same fallback after the native-Claude pool is empty.
+func tkOpenAIDispatchSelectionFallbackModel(mappedModel, primaryModel string, selectErr error) (string, bool) {
+	if selectErr == nil {
+		return "", false
+	}
+	mappedModel = strings.TrimSpace(mappedModel)
+	primaryModel = strings.TrimSpace(primaryModel)
+	if mappedModel == "" || mappedModel == primaryModel {
+		return "", false
+	}
+	if !tkOpenAIDispatchSelectionAllowsFallback(selectErr) {
+		return "", false
+	}
+	return mappedModel, true
+}
+
+func tkOpenAIDispatchSelectionAllowsFallback(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Compact-only exhaustion must not fall back to a non-compact GPT account.
+	if errors.Is(err, service.ErrNoAvailableCompactAccounts) {
+		return false
+	}
+	if errors.Is(err, service.ErrUnsupportedModel) {
+		return true
+	}
+	return isOpsNoAvailableAccountError(err)
+}

--- a/backend/internal/handler/openai_gateway_handler_tk_dispatch_select_test.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_dispatch_select_test.go
@@ -1,0 +1,81 @@
+//go:build unit
+
+package handler
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+func TestTkOpenAIDispatchSelectionFallbackModel(t *testing.T) {
+	emptyPool := fmt.Errorf("%w supporting model: claude-opus-4-8 (total=4 eligible=0 excluded=1 model_unsupported=3)", service.ErrNoAvailableAccounts)
+	unsupported := fmt.Errorf("%w: claude-opus-4-8 (total=3 eligible=0 model_unsupported=3)", service.ErrUnsupportedModel)
+
+	cases := []struct {
+		name         string
+		mapped       string
+		primary      string
+		err          error
+		wantModel    string
+		wantFallback bool
+	}{
+		{
+			name:         "empty pool after excluding claude relay falls back to opus mapped model",
+			mapped:       "gpt-5.6-sol",
+			primary:      "claude-opus-4-8",
+			err:          emptyPool,
+			wantModel:    "gpt-5.6-sol",
+			wantFallback: true,
+		},
+		{
+			name:         "unsupported original name still falls back when group has dispatch mapping",
+			mapped:       "gpt-5.6-sol",
+			primary:      "claude-opus-4-8",
+			err:          unsupported,
+			wantModel:    "gpt-5.6-sol",
+			wantFallback: true,
+		},
+		{
+			name:    "success does not fall back",
+			mapped:  "gpt-5.6-sol",
+			primary: "claude-opus-4-8",
+			err:     nil,
+		},
+		{
+			name:    "blank mapped model does not fall back",
+			primary: "claude-opus-4-8",
+			err:     emptyPool,
+		},
+		{
+			name:    "same mapped and primary does not fall back",
+			mapped:  "gpt-5.6-sol",
+			primary: "gpt-5.6-sol",
+			err:     emptyPool,
+		},
+		{
+			name:    "compact-only exhaustion does not fall back",
+			mapped:  "gpt-5.6-sol",
+			primary: "claude-opus-4-8",
+			err:     service.ErrNoAvailableCompactAccounts,
+		},
+		{
+			name:    "unrelated scheduler error does not fall back",
+			mapped:  "gpt-5.6-sol",
+			primary: "claude-opus-4-8",
+			err:     errors.New("database unavailable"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := tkOpenAIDispatchSelectionFallbackModel(tc.mapped, tc.primary, tc.err)
+			if ok != tc.wantFallback || got != tc.wantModel {
+				t.Fatalf("fallback(%q,%q,%v) = (%q,%v), want (%q,%v)",
+					tc.mapped, tc.primary, tc.err, got, ok, tc.wantModel, tc.wantFallback)
+			}
+		})
+	}
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -4897,6 +4897,48 @@
       "rationale": "TK tokensea relay guard: skips group messages-dispatch claude→gpt body rewrite for API-key accounts with native /v1/messages and/or CC-only upstream (openai_responses_supported=false). Without this companion, /v1/responses would rewrite Claude wire IDs to gpt dispatch models before forwardResponsesViaRawChatCompletions, breaking agent.tokensea.ai relays. Pairs with openai_gateway_handler.go per-account dispatch injection sentinel."
     },
     {
+      "path": "backend/internal/handler/openai_gateway_handler_tk_dispatch_select.go",
+      "must_contain": [
+        "func tkOpenAIDispatchSelectionFallbackModel(",
+        "func tkOpenAIDispatchSelectionAllowsFallback(",
+        "ErrNoAvailableCompactAccounts"
+      ],
+      "rationale": "TK companion for GPT专线-style messages-dispatch: after native Claude relays empty the pool, selection retries the group opus/sonnet/haiku mapped GPT id. Prod 2026-08-20 user 6 hit routing 429s on claude-opus-4-8 because selection kept the client model name after cloudwise 402 and tokensea 'not implemented'. Dropping this helper silently restores empty-pool 429s. Pairs with Messages/ChatCompletions/CountTokens injection sentinels."
+    },
+    {
+      "path": "backend/internal/handler/openai_gateway_handler_tk_dispatch_select_test.go",
+      "must_contain": [
+        "TestTkOpenAIDispatchSelectionFallbackModel",
+        "empty pool after excluding claude relay falls back to opus mapped model",
+        "compact-only exhaustion does not fall back"
+      ],
+      "rationale": "Positive and negative regressions for dispatch selection fallback: empty-pool and unsupported-model retry onto opus_mapped_model; success/blank/same-id/compact/unrelated errors must not fall back."
+    },
+    {
+      "path": "backend/internal/handler/openai_gateway_handler.go",
+      "must_contain": [
+        "if fallbackModel, ok := tkOpenAIDispatchSelectionFallbackModel(preferredMappedModel, currentRoutingModel, err); ok {",
+        "openai_messages.dispatch_selection_fallback"
+      ],
+      "rationale": "Injection that retries /v1/messages account selection with the group messages-dispatch mapped model after the client Claude name empties the OpenAI-compat pool. An upstream merge that restores select-on-client-model-only reopens the 2026-08-20 GPT专线 opus 429. Pairs with openai_gateway_handler_tk_dispatch_select.go."
+    },
+    {
+      "path": "backend/internal/handler/openai_chat_completions.go",
+      "must_contain": [
+        "if fallbackModel, ok := tkOpenAIDispatchSelectionFallbackModel(dispatchMappedModel, currentRoutingModel, err); ok {",
+        "openai_chat_completions.dispatch_selection_fallback"
+      ],
+      "rationale": "Same dispatch-selection fallback on /v1/chat/completions. Without this hook, chat-shaped Claude names on messages-dispatch groups 429 after native relays die even though opus_mapped_model is configured."
+    },
+    {
+      "path": "backend/internal/handler/openai_gateway_count_tokens.go",
+      "must_contain": [
+        "if fallbackModel, ok := tkOpenAIDispatchSelectionFallbackModel(preferredMappedModel, currentRoutingModel, err); ok {",
+        "openai_count_tokens.dispatch_selection_fallback"
+      ],
+      "rationale": "Same dispatch-selection fallback on count_tokens so token-count requests do not 429 independently of the messages path after Claude relays empty."
+    },
+    {
       "path": "backend/internal/service/gateway_service_tk_kiro_mirror_scheduling.go",
       "must_contain": [
         "func tkShouldClearStickyForKiroMirrorModelMismatch(",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -4903,7 +4903,7 @@
         "func tkOpenAIDispatchSelectionAllowsFallback(",
         "ErrNoAvailableCompactAccounts"
       ],
-      "rationale": "TK companion for GPT专线-style messages-dispatch: after native Claude relays empty the pool, selection retries the group opus/sonnet/haiku mapped GPT id. Prod 2026-08-20 user 6 hit routing 429s on claude-opus-4-8 because selection kept the client model name after cloudwise 402 and tokensea 'not implemented'. Dropping this helper silently restores empty-pool 429s. Pairs with Messages/ChatCompletions/CountTokens injection sentinels."
+      "rationale": "TK companion for GPT专线-style messages-dispatch: after native Claude relays empty the pool, selection retries the group opus/sonnet/haiku mapped GPT id. Prod 2026-08-20 user 6 hit routing 429s on claude-opus-4-8 because selection kept the client model name after cloudwise 402 and tokensea 'not implemented'. Dropping this helper silently restores empty-pool 429s. Pairs with Messages/ChatCompletions/CountTokens/Responses injection sentinels."
     },
     {
       "path": "backend/internal/handler/openai_gateway_handler_tk_dispatch_select_test.go",
@@ -4937,6 +4937,14 @@
         "openai_count_tokens.dispatch_selection_fallback"
       ],
       "rationale": "Same dispatch-selection fallback on count_tokens so token-count requests do not 429 independently of the messages path after Claude relays empty."
+    },
+    {
+      "path": "backend/internal/handler/openai_gateway_handler.go",
+      "must_contain": [
+        "if fallbackModel, ok := tkOpenAIDispatchSelectionFallbackModel(dispatchMappedModel, currentRoutingModel, err); ok {",
+        "openai_responses.dispatch_selection_fallback"
+      ],
+      "rationale": "Same dispatch-selection fallback on /v1/responses. The entry already rewrites Claude names at forward time via tkApplyResponsesDispatchModelMapping; without this hook, GPT/Codex accounts stay model_unsupported after native Claude relays empty and the request 429s before that rewrite can run."
     },
     {
       "path": "backend/internal/service/gateway_service_tk_kiro_mirror_scheduling.go",


### PR DESCRIPTION
## 摘要
GPT专线已配置 `opus → gpt-5.6-sol`，但选号一直用客户端模型名 `claude-opus-4-8`。cloudwise 402、tokensea `not implemented` 之后，原生 OpenAI 账号被当成 model_unsupported，浪潮万能 key 直接空池 429（2026-08-20 告警：5 分钟 55 次用户可见失败）。

本次在 Messages / ChatCompletions / count_tokens / Responses 选号失败后，按组内 messages-dispatch 映射重试选号；第一轮仍优先 Claude 中继（tokensea 可被选中），compact 耗尽与无关调度错误不回退。

Web impact: none

## 风险
常规风险。不改对外字段/状态码契约：Claude 中继仍优先；只有原模型空池时才落到组里已配置的 GPT 映射。用户要真 Claude 仍需开 claude 组或恢复 cloudwise，本 PR 只止血 429。

## 验证
- `go test -tags=unit ./internal/handler/ -run TestTkOpenAIDispatchSelectionFallbackModel` 通过（含空池回退、unsupported 回退、compact/无关错误不回退）
- `./scripts/preflight.sh` 通过
- prod 只读证据：user 6 仅授权 GPT专线等，无 claude 组；cloudwise #95 于 04:19Z 后 `402 Insufficient balance`；告警窗选号 `total=4 eligible=0 excluded=1 model_unsupported=3`

## 提交
- `766ecad2e` fix(gateway): fall back to dispatch-mapped GPT when Claude relays empty
- `5d8065375` fix(gateway): address R-001 — fall back dispatch select on /v1/responses
- 最新提交：`5d8065375`

Made with [Cursor](https://cursor.com)