### PR TITLE
fix(ops): 自定义时间超窗时截到 30 天并继续出数

### DIFF
--- a/backend/internal/handler/admin/admin_helpers_test.go
+++ b/backend/internal/handler/admin/admin_helpers_test.go
@@ -172,6 +172,27 @@ func TestParseOpsTimeRange(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestParseOpsTimeRangeRejectsWindowOver30Days(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	end := time.Date(2026, 8, 20, 5, 37, 0, 0, time.UTC)
+	overLimit := end.Add(-30*24*time.Hour - time.Millisecond)
+	exactLimit := end.Add(-30 * 24 * time.Hour)
+
+	cOver, _ := gin.CreateTestContext(w)
+	cOver.Request = httptest.NewRequest(http.MethodGet, "/?start_time="+overLimit.Format(time.RFC3339Nano)+"&end_time="+end.Format(time.RFC3339Nano), nil)
+	_, _, err := parseOpsTimeRange(cOver, "1h")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "max window is 30 days")
+
+	cExact, _ := gin.CreateTestContext(w)
+	cExact.Request = httptest.NewRequest(http.MethodGet, "/?start_time="+exactLimit.Format(time.RFC3339Nano)+"&end_time="+end.Format(time.RFC3339Nano), nil)
+	start, gotEnd, err := parseOpsTimeRange(cExact, "1h")
+	require.NoError(t, err)
+	require.True(t, start.Equal(exactLimit))
+	require.True(t, gotEnd.Equal(end))
+}
+
 func TestParseOpsRealtimeWindow(t *testing.T) {
 	dur, label, ok := parseOpsRealtimeWindow("5m")
 	require.True(t, ok)

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 703,
-  "hash": "c567d0362b1a206ec3ba6d43bf1e1e36ec89df1ed0db1d025198af11067a2ea7",
+  "hash": "b22bf2a33cac8759927f4616ebe89f01bd926d009344382dab5f44c6ab681eab",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 702,
-  "hash": "3d5aec88172bab91974ff044217f968875cae7c1106271a1c508b65a50a0ef9d",
+  "file_count": 703,
+  "hash": "c567d0362b1a206ec3ba6d43bf1e1e36ec89df1ed0db1d025198af11067a2ea7",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 702,
-  "hash": "06ae5537c208c9018ef1fad87175aa90e984fb707cb048b2cb2dd3e7687756fd",
+  "hash": "3d5aec88172bab91974ff044217f968875cae7c1106271a1c508b65a50a0ef9d",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/i18n/__tests__/opsLocaleKeys.spec.ts
+++ b/frontend/src/i18n/__tests__/opsLocaleKeys.spec.ts
@@ -21,6 +21,10 @@ describe('ops locale key completeness', () => {
     'admin.ops.timeRange.custom',
     'admin.ops.customTimeRange.startTime',
     'admin.ops.customTimeRange.endTime',
+    'admin.ops.customTimeRange.hint',
+    'admin.ops.customTimeRange.invalid',
+    'admin.ops.customTimeRange.inverted',
+    'admin.ops.customTimeRange.clamped',
   ]
 
   for (const key of requiredKeys) {

--- a/frontend/src/i18n/locales/en/admin/ops.ts
+++ b/frontend/src/i18n/locales/en/admin/ops.ts
@@ -151,7 +151,11 @@ export default {
       },
       customTimeRange: {
         startTime: 'Start Time',
-        endTime: 'End Time'
+        endTime: 'End Time',
+        hint: 'Maximum 30 days; longer ranges query the latest 30 days',
+        invalid: 'Invalid time',
+        inverted: 'Start time must be earlier than end time',
+        clamped: 'The selected range exceeds the 30-day maximum. Showing the latest 30 days.'
       },
       openaiTokenStats: {
         title: 'OpenAI Token Request Stats',

--- a/frontend/src/i18n/locales/zh/admin/ops.ts
+++ b/frontend/src/i18n/locales/zh/admin/ops.ts
@@ -171,7 +171,11 @@ export default {
       },
       customTimeRange: {
         startTime: '开始时间',
-        endTime: '结束时间'
+        endTime: '结束时间',
+        hint: '最长 30 天，超出将自动按最近 30 天查询',
+        invalid: '时间无效',
+        inverted: '开始时间必须早于结束时间',
+        clamped: '所选时间超过平台最大窗口（30 天），已按最近 30 天查询。'
       },
       fullscreen: {
         enter: '进入全屏'

--- a/frontend/src/views/admin/ops/OpsDashboard.vue
+++ b/frontend/src/views/admin/ops/OpsDashboard.vue
@@ -7,6 +7,12 @@
       >
         {{ errorMessage }}
       </div>
+      <div
+        v-else-if="timeRangeHint"
+        class="rounded-2xl bg-amber-50 p-4 text-sm text-amber-800 dark:bg-amber-900/20 dark:text-amber-200"
+      >
+        {{ timeRangeHint }}
+      </div>
 
       <OpsDashboardSkeleton v-if="loading && !hasLoadedOnce" :fullscreen="isFullscreen" />
 
@@ -163,6 +169,7 @@ import {
   type OpsMetricThresholds
 } from '@/api/admin/ops'
 import { useAdminSettingsStore, useAppStore } from '@/stores'
+import { resolveOpsCustomTimeRange } from './utils/opsTimeRange'
 import OpsDashboardHeader from './components/OpsDashboardHeader.vue'
 import OpsDashboardSkeleton from './components/OpsDashboardSkeleton.vue'
 import OpsConcurrencyCard from './components/OpsConcurrencyCard.vue'
@@ -198,6 +205,7 @@ const allowedQueryModes = new Set<QueryMode>(['auto', 'raw', 'preagg'])
 const loading = ref(true)
 const hasLoadedOnce = ref(false)
 const errorMessage = ref('')
+const timeRangeHint = ref('')
 const lastUpdated = ref<Date | null>(new Date())
 
 const timeRange = ref<TimeRange>('1h')
@@ -480,11 +488,16 @@ function onTimeRangeChange(v: string | number | boolean | null) {
   if (typeof v !== 'string') return
   if (!allowedTimeRanges.has(v as TimeRange)) return
   timeRange.value = v as TimeRange
+  if (v !== 'custom') timeRangeHint.value = ''
 }
 
-function onCustomTimeRangeChange(startTime: string, endTime: string) {
+function onCustomTimeRangeChange(startTime: string, endTime: string, clamped = false) {
   customStartTime.value = startTime
   customEndTime.value = endTime
+  timeRangeHint.value = clamped ? t('admin.ops.customTimeRange.clamped') : ''
+  if (clamped) {
+    appStore.showInfo(t('admin.ops.customTimeRange.clamped'))
+  }
 }
 
 async function onSettingsSaved() {
@@ -535,8 +548,13 @@ function buildApiParams() {
 
   if (timeRange.value === 'custom') {
     if (customStartTime.value && customEndTime.value) {
-      params.start_time = customStartTime.value
-      params.end_time = customEndTime.value
+      const resolved = resolveOpsCustomTimeRange(customStartTime.value, customEndTime.value)
+      if (resolved.ok) {
+        params.start_time = resolved.startISO
+        params.end_time = resolved.endISO
+      } else {
+        params.time_range = '1h'
+      }
     } else {
       // Safety fallback: avoid sending time_range=custom (backend may not support it)
       params.time_range = '1h'
@@ -711,6 +729,21 @@ function isOpsDisabledError(err: unknown): boolean {
 async function fetchData() {
   if (!opsEnabled.value) return
 
+  if (timeRange.value === 'custom' && customStartTime.value && customEndTime.value) {
+    const resolved = resolveOpsCustomTimeRange(customStartTime.value, customEndTime.value)
+    if (!resolved.ok) {
+      abortDashboardFetch()
+      errorMessage.value = t(`admin.ops.customTimeRange.${resolved.error}`)
+      timeRangeHint.value = ''
+      loading.value = false
+      hasLoadedOnce.value = true
+      return
+    }
+    if (resolved.clamped) {
+      timeRangeHint.value = t('admin.ops.customTimeRange.clamped')
+    }
+  }
+
   abortDashboardFetch()
   dashboardFetchSeq += 1
   const fetchSeq = dashboardFetchSeq
@@ -751,7 +784,7 @@ async function fetchData() {
 }
 
 watch(
-  () => [timeRange.value, platform.value, groupId.value, queryMode.value] as const,
+  () => [timeRange.value, platform.value, groupId.value, queryMode.value, customStartTime.value, customEndTime.value] as const,
   () => {
     if (isApplyingRouteQuery.value) return
     if (opsEnabled.value) {

--- a/frontend/src/views/admin/ops/components/OpsDashboardHeader.vue
+++ b/frontend/src/views/admin/ops/components/OpsDashboardHeader.vue
@@ -12,6 +12,7 @@ import type { OpsRequestDetailsPreset } from './OpsRequestDetailsModal.vue'
 import { useAdminSettingsStore } from '@/stores'
 import { formatNumber } from '@/utils/format'
 import { formatMemorySizeMB } from '../utils/opsFormatters'
+import { datetimeLocalToISO, resolveOpsCustomTimeRange, toDatetimeLocalValue } from '../utils/opsTimeRange'
 
 type RealtimeWindow = '1min' | '5min' | '30min' | '1h'
 
@@ -36,7 +37,7 @@ interface Emits {
   (e: 'update:group', value: number | null): void
   (e: 'update:timeRange', value: string): void
   (e: 'update:queryMode', value: string): void
-  (e: 'update:customTimeRange', startTime: string, endTime: string): void
+  (e: 'update:customTimeRange', startTime: string, endTime: string, clamped?: boolean): void
   (e: 'refresh'): void
   (e: 'openRequestDetails', preset?: OpsRequestDetailsPreset): void
   (e: 'openErrorDetails', kind: 'request' | 'upstream'): void
@@ -92,6 +93,7 @@ watch(
 const showCustomTimeRangeDialog = ref(false)
 const customStartTimeInput = ref('')
 const customEndTimeInput = ref('')
+const customRangeError = ref('')
 
 function formatCustomTimeRangeLabel(startTime: string, endTime: string): string {
   const start = new Date(startTime)
@@ -176,11 +178,13 @@ function handleGroupChange(val: string | number | boolean | null) {
 function handleTimeRangeChange(val: string | number | boolean | null) {
   const newValue = String(val || '1h')
   if (newValue === 'custom') {
-    // 初始化为最近1小时
     const now = new Date()
     const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000)
-    customStartTimeInput.value = oneHourAgo.toISOString().slice(0, 16)
-    customEndTimeInput.value = now.toISOString().slice(0, 16)
+    const start = props.customStartTime ? new Date(props.customStartTime) : oneHourAgo
+    const end = props.customEndTime ? new Date(props.customEndTime) : now
+    customStartTimeInput.value = toDatetimeLocalValue(Number.isNaN(start.getTime()) ? oneHourAgo : start)
+    customEndTimeInput.value = toDatetimeLocalValue(Number.isNaN(end.getTime()) ? now : end)
+    customRangeError.value = ''
     showCustomTimeRangeDialog.value = true
   } else {
     emit('update:timeRange', newValue)
@@ -189,11 +193,17 @@ function handleTimeRangeChange(val: string | number | boolean | null) {
 
 function handleCustomTimeRangeConfirm() {
   if (!customStartTimeInput.value || !customEndTimeInput.value) return
-  const startTime = new Date(customStartTimeInput.value).toISOString()
-  const endTime = new Date(customEndTimeInput.value).toISOString()
-  // Emit custom time range first so the parent can build correct API params
-  // when it reacts to timeRange switching to "custom".
-  emit('update:customTimeRange', startTime, endTime)
+  const startTime = datetimeLocalToISO(customStartTimeInput.value)
+  const endTime = datetimeLocalToISO(customEndTimeInput.value)
+  const resolved = resolveOpsCustomTimeRange(startTime, endTime)
+  if (!resolved.ok) {
+    customRangeError.value = t(`admin.ops.customTimeRange.${resolved.error}`)
+    return
+  }
+  customRangeError.value = ''
+  // Emit the resolved window (possibly clamped to 30d) so the parent queries
+  // the platform max instead of sending a range the backend will reject.
+  emit('update:customTimeRange', resolved.startISO, resolved.endISO, resolved.clamped)
   emit('update:timeRange', 'custom')
   showCustomTimeRangeDialog.value = false
 }
@@ -1607,6 +1617,8 @@ function handleToolbarRefresh() {
             class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-dark-600 dark:bg-dark-800 dark:text-white"
           />
         </div>
+        <p class="text-xs text-gray-500 dark:text-gray-400">{{ t('admin.ops.customTimeRange.hint') }}</p>
+        <p v-if="customRangeError" class="text-sm text-rose-600 dark:text-rose-400">{{ customRangeError }}</p>
         <div class="flex justify-end gap-3 pt-2">
           <button
             type="button"

--- a/frontend/src/views/admin/ops/components/OpsErrorDetailsModal.vue
+++ b/frontend/src/views/admin/ops/components/OpsErrorDetailsModal.vue
@@ -112,17 +112,6 @@ async function fetchErrorLogs() {
     }
     Object.assign(params, buildOpsErrorTimeParams(props.timeRange, props.customStartTime, props.customEndTime))
 
-    if (props.timeRange === 'custom') {
-      if (props.customStartTime && props.customEndTime) {
-        params.start_time = props.customStartTime
-        params.end_time = props.customEndTime
-        delete params.time_range
-      } else {
-        // Safety fallback: avoid sending time_range=custom (backend doesn't support it)
-        params.time_range = '1h'
-      }
-    }
-
     const platform = String(props.platform || '').trim()
     if (platform) params.platform = platform
     if (typeof props.groupId === 'number' && props.groupId > 0) params.group_id = props.groupId

--- a/frontend/src/views/admin/ops/components/__tests__/OpsErrorDetailsModal.spec.ts
+++ b/frontend/src/views/admin/ops/components/__tests__/OpsErrorDetailsModal.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import OpsErrorDetailsModal from '../OpsErrorDetailsModal.vue'
+import { OPS_MAX_WINDOW_MS } from '../../utils/opsTimeRange'
+
+const mockListRequestErrors = vi.fn()
+const mockListUpstreamErrors = vi.fn()
+
+vi.mock('@/api/admin/ops', () => ({
+  opsAPI: {
+    listRequestErrors: (...args: any[]) => mockListRequestErrors(...args),
+    listUpstreamErrors: (...args: any[]) => mockListUpstreamErrors(...args)
+  }
+}))
+
+vi.mock('vue-i18n', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-i18n')>()
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key
+    })
+  }
+})
+
+const stubs = {
+  BaseDialog: { template: '<div><slot /></div>' },
+  Select: true,
+  OpsErrorLogTable: true
+}
+
+async function openModal(props: Record<string, unknown>) {
+  const wrapper = mount(OpsErrorDetailsModal, {
+    props: {
+      show: false,
+      timeRange: '1h',
+      errorType: 'request',
+      ...props
+    },
+    global: { stubs }
+  })
+  await wrapper.setProps({ show: true })
+  await flushPromises()
+  return wrapper
+}
+
+describe('OpsErrorDetailsModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListRequestErrors.mockResolvedValue({ items: [], total: 0 })
+    mockListUpstreamErrors.mockResolvedValue({ items: [], total: 0 })
+  })
+
+  it('sends the clamped 30-day window instead of oversized custom props', async () => {
+    const end = '2026-08-20T13:37:00.000+08:00'
+    const start = '2026-07-21T00:00:00.000+08:00'
+
+    await openModal({
+      timeRange: 'custom',
+      customStartTime: start,
+      customEndTime: end,
+      errorType: 'request'
+    })
+
+    expect(mockListRequestErrors).toHaveBeenCalled()
+    const params = mockListRequestErrors.mock.calls[0][0]
+    expect(params.start_time).toBe(new Date(Date.parse(end) - OPS_MAX_WINDOW_MS).toISOString())
+    expect(params.end_time).toBe(new Date(end).toISOString())
+    expect(params.start_time).not.toBe(start)
+    expect(params.time_range).toBeUndefined()
+  })
+
+  it('falls back to 1h when a custom range is incomplete', async () => {
+    await openModal({
+      timeRange: 'custom',
+      customStartTime: null,
+      customEndTime: null,
+      errorType: 'request'
+    })
+
+    const params = mockListRequestErrors.mock.calls[0][0]
+    expect(params.time_range).toBe('1h')
+    expect(params.start_time).toBeUndefined()
+    expect(params.end_time).toBeUndefined()
+  })
+})

--- a/frontend/src/views/admin/ops/utils/__tests__/opsErrorParams.spec.ts
+++ b/frontend/src/views/admin/ops/utils/__tests__/opsErrorParams.spec.ts
@@ -4,8 +4,17 @@ import { buildOpsErrorTimeParams } from '../opsErrorParams'
 describe('buildOpsErrorTimeParams', () => {
   it('uses explicit timestamps for a complete custom range', () => {
     expect(buildOpsErrorTimeParams('custom', '2026-08-01T00:00:00Z', '2026-08-02T00:00:00Z')).toEqual({
-      start_time: '2026-08-01T00:00:00Z',
-      end_time: '2026-08-02T00:00:00Z'
+      start_time: '2026-08-01T00:00:00.000Z',
+      end_time: '2026-08-02T00:00:00.000Z'
+    })
+  })
+
+  it('clamps an oversized custom range to the max 30-day window', () => {
+    expect(
+      buildOpsErrorTimeParams('custom', '2026-07-21T00:00:00.000+08:00', '2026-08-20T13:37:00.000+08:00')
+    ).toEqual({
+      start_time: new Date(Date.parse('2026-08-20T13:37:00.000+08:00') - 30 * 24 * 60 * 60 * 1000).toISOString(),
+      end_time: new Date('2026-08-20T13:37:00.000+08:00').toISOString()
     })
   })
 

--- a/frontend/src/views/admin/ops/utils/__tests__/opsTimeRange.spec.ts
+++ b/frontend/src/views/admin/ops/utils/__tests__/opsTimeRange.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  OPS_MAX_WINDOW_MS,
+  datetimeLocalToISO,
+  resolveOpsCustomTimeRange,
+  toDatetimeLocalValue
+} from '../opsTimeRange'
+
+describe('resolveOpsCustomTimeRange', () => {
+  it('keeps an exact 30-day window unchanged', () => {
+    const end = Date.parse('2026-08-20T05:37:00.000Z')
+    const start = end - OPS_MAX_WINDOW_MS
+    const startISO = new Date(start).toISOString()
+    const endISO = new Date(end).toISOString()
+    expect(resolveOpsCustomTimeRange(startISO, endISO)).toEqual({
+      ok: true,
+      startISO,
+      endISO,
+      clamped: false
+    })
+  })
+
+  it('clamps a window one millisecond over 30 days to the max window ending at end', () => {
+    const end = Date.parse('2026-08-20T05:37:00.000Z')
+    const start = end - OPS_MAX_WINDOW_MS - 1
+    const resolved = resolveOpsCustomTimeRange(new Date(start).toISOString(), new Date(end).toISOString())
+    expect(resolved).toEqual({
+      ok: true,
+      startISO: new Date(end - OPS_MAX_WINDOW_MS).toISOString(),
+      endISO: new Date(end).toISOString(),
+      clamped: true
+    })
+  })
+
+  it('clamps a late-July calendar pick that exceeds 30 days by afternoon on Aug 20', () => {
+    const resolved = resolveOpsCustomTimeRange(
+      '2026-07-21T00:00:00.000+08:00',
+      '2026-08-20T13:37:00.000+08:00'
+    )
+    expect(resolved.ok).toBe(true)
+    if (!resolved.ok) return
+    expect(resolved.clamped).toBe(true)
+    expect(resolved.endISO).toBe(new Date('2026-08-20T13:37:00.000+08:00').toISOString())
+    expect(Date.parse(resolved.endISO) - Date.parse(resolved.startISO)).toBe(OPS_MAX_WINDOW_MS)
+  })
+
+  it('rejects inverted ranges', () => {
+    expect(resolveOpsCustomTimeRange('2026-08-20T01:00:00.000Z', '2026-08-20T00:00:00.000Z')).toEqual({
+      ok: false,
+      error: 'inverted'
+    })
+  })
+
+  it('rejects invalid timestamps', () => {
+    expect(resolveOpsCustomTimeRange('not-a-date', '2026-08-20T00:00:00.000Z')).toEqual({
+      ok: false,
+      error: 'invalid'
+    })
+    expect(resolveOpsCustomTimeRange('2026-08-20T00:00:00.000Z', '')).toEqual({
+      ok: false,
+      error: 'invalid'
+    })
+  })
+})
+
+describe('datetime-local conversion', () => {
+  it('round-trips a local Date through the datetime-local input value', () => {
+    const local = new Date(2026, 7, 20, 13, 37)
+    const value = toDatetimeLocalValue(local)
+    expect(value).toBe('2026-08-20T13:37')
+    expect(datetimeLocalToISO(value)).toBe(local.toISOString())
+  })
+})

--- a/frontend/src/views/admin/ops/utils/opsErrorParams.ts
+++ b/frontend/src/views/admin/ops/utils/opsErrorParams.ts
@@ -1,10 +1,15 @@
+import { resolveOpsCustomTimeRange } from './opsTimeRange'
+
 export function buildOpsErrorTimeParams(
   timeRange: string,
   customStartTime?: string | null,
   customEndTime?: string | null
 ): Record<string, string> {
   if (timeRange === 'custom' && customStartTime && customEndTime) {
-    return { start_time: customStartTime, end_time: customEndTime }
+    const resolved = resolveOpsCustomTimeRange(customStartTime, customEndTime)
+    if (resolved.ok) {
+      return { start_time: resolved.startISO, end_time: resolved.endISO }
+    }
   }
 
   return { time_range: timeRange === 'custom' ? '1h' : timeRange }

--- a/frontend/src/views/admin/ops/utils/opsTimeRange.ts
+++ b/frontend/src/views/admin/ops/utils/opsTimeRange.ts
@@ -1,0 +1,46 @@
+/** Matches backend parseOpsTimeRange: end.Sub(start) > 30*24*time.Hour. */
+export const OPS_MAX_WINDOW_MS = 30 * 24 * 60 * 60 * 1000
+
+export type OpsCustomTimeRangeError = 'invalid' | 'inverted'
+
+export type OpsResolvedCustomTimeRange =
+  | { ok: false; error: OpsCustomTimeRangeError }
+  | { ok: true; startISO: string; endISO: string; clamped: boolean }
+
+export function resolveOpsCustomTimeRange(
+  startISO: string | null | undefined,
+  endISO: string | null | undefined
+): OpsResolvedCustomTimeRange {
+  const start = Date.parse(String(startISO || ''))
+  const end = Date.parse(String(endISO || ''))
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return { ok: false, error: 'invalid' }
+  if (start > end) return { ok: false, error: 'inverted' }
+  if (end - start > OPS_MAX_WINDOW_MS) {
+    return {
+      ok: true,
+      startISO: new Date(end - OPS_MAX_WINDOW_MS).toISOString(),
+      endISO: new Date(end).toISOString(),
+      clamped: true
+    }
+  }
+  return {
+    ok: true,
+    startISO: new Date(start).toISOString(),
+    endISO: new Date(end).toISOString(),
+    clamped: false
+  }
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+/** Format a Date as a `datetime-local` value in the viewer's local timezone. */
+export function toDatetimeLocalValue(date: Date): string {
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}T${pad2(date.getHours())}:${pad2(date.getMinutes())}`
+}
+
+/** Parse a `datetime-local` value as local time and return UTC ISO-8601. */
+export function datetimeLocalToISO(value: string): string {
+  return new Date(value).toISOString()
+}


### PR DESCRIPTION
## 摘要

运维监控自定义时间超过后端 30 天上限时，原先每个图表各自报错、页面被打空。现在自动截到平台最大窗口（保留结束时间，起点收到最近 30 天），继续出数，并用提示说明已截断。错误详情弹窗也只走同一条截断入口，不再用原始时间覆盖。

upstream-touch-trivial

## 风险

常规。只改运维监控自定义时间窗的前端解析与提示；后端 30 天硬限制不变。无效/倒置时间仍拦截。

## 验证

- `./scripts/preflight.sh` 通过
- `vitest run` opsTimeRange / opsErrorParams / OpsErrorDetailsModal：11 项通过
- `go test -tags=unit ./internal/handler/admin/ -run TestParseOpsTimeRange`：通过（刚好 30 天允许，多 1ms 拒绝）

## 提交

- `efc2ef91e` fix(ops): clamp oversized custom ranges so the dashboard still loads
- `ac6159cb7` chore(ops): refresh embedded frontend source hash
- `e517c81b2` fix(ops): address R-001 — keep error details on the clamped window
- 最新提交：`e517c81b2`