### PR TITLE
fix(db): 跳过上游 224 收窄配额 CHECK，避免 newapi/kiro 存量行阻断启动

### DIFF
--- a/backend/internal/repository/migrations_runner.go
+++ b/backend/internal/repository/migrations_runner.go
@@ -60,6 +60,7 @@ const opsSystemLogsAPIKeyIDIndexMigration = "155_add_ops_system_logs_api_key_id_
 const opsSystemLogsAPIKeyIDIndex = "idx_ops_system_logs_api_key_id_created_at"
 const opsSystemLogsAPIKeyIDIndexDDL = `CREATE INDEX IF NOT EXISTS idx_ops_system_logs_api_key_id_created_at ON ops_system_logs (api_key_id, created_at DESC)`
 const opsMonthlyPartitionsMigration = "tk_041_provision_ops_monthly_partitions.sql"
+const userPlatformQuotasCNProvidersMigration = "224_user_platform_quotas_add_cn_providers.sql"
 const latestAPIKeyIPIndexMigration = "174_add_usage_logs_api_key_latest_ip_index_notx.sql"
 const latestAPIKeyIPIndex = "idx_usage_logs_api_key_latest_ip"
 
@@ -336,6 +337,13 @@ func applyMigrationsSession(ctx context.Context, db migrationDB, fsys fs.FS) (re
 }
 
 func shouldRecordMigrationWithoutExecution(ctx context.Context, db migrationDB, name string) (bool, error) {
+	// Upstream 224 replaces the CHECK with a set that omits newapi/kiro.
+	// TK live rows already include those platforms (tk_083). Executing 224
+	// fails ADD CONSTRAINT and blocks startup before tk_087 can restore the
+	// full AllowedQuotaPlatforms set. Record 224 without executing it.
+	if name == userPlatformQuotasCNProvidersMigration {
+		return true, nil
+	}
 	if name != opsMonthlyPartitionsMigration {
 		return false, nil
 	}

--- a/backend/internal/repository/migrations_runner_cn_providers_test.go
+++ b/backend/internal/repository/migrations_runner_cn_providers_test.go
@@ -1,0 +1,21 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldRecordMigrationWithoutExecution_SkipsUpstreamCNProviderConstraint(t *testing.T) {
+	ctx := context.Background()
+
+	skip, err := shouldRecordMigrationWithoutExecution(ctx, nil, userPlatformQuotasCNProvidersMigration)
+	require.NoError(t, err)
+	require.True(t, skip,
+		"upstream 224's CHECK omits live TK platforms newapi/kiro; executing it blocks startup before tk_087")
+
+	skip, err = shouldRecordMigrationWithoutExecution(ctx, nil, "157_user_platform_quotas_add_grok.sql")
+	require.NoError(t, err)
+	require.False(t, skip, "unrelated quota migrations must still execute")
+}

--- a/backend/internal/repository/user_platform_quota_cn_providers_migration_integration_test.go
+++ b/backend/internal/repository/user_platform_quota_cn_providers_migration_integration_test.go
@@ -1,0 +1,73 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplyMigrations_Upstream224DoesNotBreakLiveNewAPIKiroRows reproduces the
+// 1.8.166 us4 canary failure: tk_083 already stored newapi/kiro quota rows, then
+// upstream 224 tried to install a narrower CHECK and aborted startup.
+func TestApplyMigrations_Upstream224DoesNotBreakLiveNewAPIKiroRows(t *testing.T) {
+	ctx := context.Background()
+	db := openMigrationIntegrationDatabase(t, "migration_224_live_newapi_kiro")
+
+	_, err := db.ExecContext(ctx, `
+		CREATE TABLE user_platform_quotas (
+			id BIGSERIAL PRIMARY KEY,
+			user_id BIGINT NOT NULL,
+			platform VARCHAR(32) NOT NULL,
+			daily_usage_usd DECIMAL(20,10) NOT NULL DEFAULT 0,
+			weekly_usage_usd DECIMAL(20,10) NOT NULL DEFAULT 0,
+			monthly_usage_usd DECIMAL(20,10) NOT NULL DEFAULT 0,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		);
+		ALTER TABLE user_platform_quotas
+			ADD CONSTRAINT user_platform_quotas_platform_check
+			CHECK (platform IN ('anthropic', 'openai', 'gemini', 'antigravity', 'newapi', 'kiro', 'grok'));
+		INSERT INTO user_platform_quotas (user_id, platform) VALUES (1, 'newapi'), (1, 'kiro');
+	`)
+	require.NoError(t, err)
+
+	t.Run("upstream 224 SQL is unsafe on this fixture", func(t *testing.T) {
+		tx, txErr := db.BeginTx(ctx, nil)
+		require.NoError(t, txErr)
+		t.Cleanup(func() { _ = tx.Rollback() })
+
+		content := string(migrationFilesFS(t, userPlatformQuotasCNProvidersMigration)[userPlatformQuotasCNProvidersMigration].Data)
+		_, execErr := tx.ExecContext(ctx, content)
+		require.Error(t, execErr)
+		require.Contains(t, execErr.Error(), "user_platform_quotas_platform_check")
+	})
+
+	require.NoError(t, applyMigrationsFS(ctx, db, migrationFilesFS(t,
+		userPlatformQuotasCNProvidersMigration,
+		"tk_087_user_platform_quotas_allow_all_served_platforms.sql",
+	)))
+
+	assertMigrationsRecorded(t, db,
+		userPlatformQuotasCNProvidersMigration,
+		"tk_087_user_platform_quotas_allow_all_served_platforms.sql",
+	)
+
+	var constraintDef string
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT pg_get_constraintdef(oid)
+		FROM pg_constraint
+		WHERE conname = 'user_platform_quotas_platform_check'
+	`).Scan(&constraintDef))
+	for _, platform := range []string{"newapi", "kiro", "kimi", "zhipu", "deepseek"} {
+		require.Contains(t, constraintDef, platform, "canonical CHECK must keep %s", platform)
+	}
+
+	var liveRows int
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT count(*) FROM user_platform_quotas WHERE platform IN ('newapi', 'kiro')
+	`).Scan(&liveRows))
+	require.Equal(t, 2, liveRows, "live newapi/kiro quota rows must survive the 224/tk_087 sequence")
+}


### PR DESCRIPTION
## 摘要
- `v1.8.166` us4 canary 启动失败：上游 `224_user_platform_quotas_add_cn_providers.sql` 把 `user_platform_quotas.platform` CHECK 收成不含 `newapi`/`kiro` 的 8 平台，撞上 `tk_083` 已写入的存量行。
- 不改已入库的 224 文件（避免 checksum / immutability 门禁）。runner 对 224 **只记账、不执行**，让后续 `tk_087` 装上完整 10 平台约束。
- 合入后需再发 **1.8.167**，不要重试 1.8.166。

## 风险
常规。不改 schema 文件，不改公共契约。错误跳过 224 只会让约束仍由 `tk_087` 对齐 `AllowedQuotaPlatforms`；224 本身在含 `newapi`/`kiro` 行的库上本来就无法执行。

Web impact: none
no-web-impact

## 验证
- `go test -tags=unit -count=1 -run TestShouldRecordMigrationWithoutExecution_SkipsUpstreamCNProviderConstraint ./internal/repository/` 通过
- `TESTCONTAINERS_RYUK_DISABLED=true DOCKER_HOST=unix:///Users/feng/.colima/default/docker.sock go test -tags=integration -count=1 -run 'TestApplyMigrations_Upstream224DoesNotBreakLiveNewAPIKiroRows|TestUserPlatformQuotaRepository_BulkInsertInitial_CNProvidersAllowed|TestUserPlatformQuotaRepository_BulkInsertInitial_GrokAllowed' ./internal/repository/` 通过
- `./scripts/preflight.sh` 通过

## 提交
- `5dc67b186` fix(db): skip upstream 224 quota CHECK so live newapi/kiro rows can boot
- 最新提交：`5dc67b186`

Made with [Cursor](https://cursor.com)