### PR TITLE
fix(ops): 30 天线查询不再因峰值 SQL 取消而 500

### DIFF
--- a/backend/internal/repository/ops_repo_dashboard.go
+++ b/backend/internal/repository/ops_repo_dashboard.go
@@ -15,10 +15,9 @@ import (
 const (
 	opsRawLatencyQueryTimeout = 2 * time.Second
 	opsRawPeakQueryTimeout    = 1500 * time.Millisecond
-	// Minute-bucket peak over a multi-hour window is too expensive on raw
-	// usage_logs and trips the local timeout (then 500'd before timeout
-	// classification recognized lib/pq's cancel). Skip the raw scan.
-	opsRawPeakMaxWindow = 2 * time.Hour
+	// Toolbar presets top out at 24h. Longer custom windows (e.g. 30d) make
+	// the minute-bucket peak scan miss the local timeout; skip those only.
+	opsRawPeakMaxWindow = 24 * time.Hour
 )
 
 func (r *opsRepository) GetDashboardOverview(ctx context.Context, filter *service.OpsDashboardFilter) (*service.OpsDashboardOverview, error) {

--- a/backend/internal/repository/ops_repo_dashboard.go
+++ b/backend/internal/repository/ops_repo_dashboard.go
@@ -15,6 +15,10 @@ import (
 const (
 	opsRawLatencyQueryTimeout = 2 * time.Second
 	opsRawPeakQueryTimeout    = 1500 * time.Millisecond
+	// Minute-bucket peak over a multi-hour window is too expensive on raw
+	// usage_logs and trips the local timeout (then 500'd before timeout
+	// classification recognized lib/pq's cancel). Skip the raw scan.
+	opsRawPeakMaxWindow = 2 * time.Hour
 )
 
 func (r *opsRepository) GetDashboardOverview(ctx context.Context, filter *service.OpsDashboardFilter) (*service.OpsDashboardOverview, error) {
@@ -901,6 +905,9 @@ func (r *opsRepository) queryCurrentRates(ctx context.Context, filter *service.O
 }
 
 func (r *opsRepository) queryPeakRates(ctx context.Context, filter *service.OpsDashboardFilter, start, end time.Time) (qpsPeak float64, tpsPeak float64, err error) {
+	if skipRawPeakScan(start, end) {
+		return 0, 0, context.DeadlineExceeded
+	}
 	usageJoin, usageWhere, usageArgs, next := buildUsageWhere(filter, start, end, 1)
 	errorWhere, errorArgs, _ := buildErrorWhere(filter, start, end, next)
 
@@ -949,8 +956,24 @@ FROM combined`
 	return qpsPeak, tpsPeak, nil
 }
 
+func skipRawPeakScan(start, end time.Time) bool {
+	if start.IsZero() || end.IsZero() {
+		return false
+	}
+	return end.Sub(start) > opsRawPeakMaxWindow
+}
+
 func isQueryTimeoutErr(err error) bool {
-	return errors.Is(err, context.DeadlineExceeded)
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	// lib/pq reports a canceled query as PostgreSQL 57014 instead of wrapping
+	// context.DeadlineExceeded. The local peak/latency timeouts then look like
+	// a fatal error and the ops dashboard returns 500 "internal error".
+	return strings.Contains(strings.ToLower(err.Error()), "canceling statement due to user request")
 }
 
 func buildUsageWhere(filter *service.OpsDashboardFilter, start, end time.Time, startIndex int) (join string, where string, args []any, nextIndex int) {

--- a/backend/internal/repository/ops_repo_dashboard.go
+++ b/backend/internal/repository/ops_repo_dashboard.go
@@ -97,15 +97,12 @@ func (r *opsRepository) getDashboardOverviewRaw(ctx context.Context, filter *ser
 		}
 	}
 
-	peakCtx, cancelPeak := context.WithTimeout(ctx, opsRawPeakQueryTimeout)
-	qpsPeak, tpsPeak, err := r.queryPeakRates(peakCtx, filter, start, end)
-	cancelPeak()
+	qpsPeak, tpsPeak, peakDegraded, err := r.queryPeakRatesAllowSkip(ctx, filter, start, end)
 	if err != nil {
-		if isQueryTimeoutErr(err) {
-			degraded = true
-		} else {
-			return nil, err
-		}
+		return nil, err
+	}
+	if peakDegraded {
+		degraded = true
 	}
 
 	qpsAvg := roundTo1DP(float64(requestCountTotal) / windowSeconds)
@@ -273,15 +270,12 @@ func (r *opsRepository) getDashboardOverviewPreaggregated(ctx context.Context, f
 		}
 	}
 
-	peakCtx, cancelPeak := context.WithTimeout(ctx, opsRawPeakQueryTimeout)
-	qpsPeak, tpsPeak, err := r.queryPeakRates(peakCtx, filter, start, end)
-	cancelPeak()
+	qpsPeak, tpsPeak, peakDegraded, err := r.queryPeakRatesAllowSkip(ctx, filter, start, end)
 	if err != nil {
-		if isQueryTimeoutErr(err) {
-			degraded = true
-		} else {
-			return nil, err
-		}
+		return nil, err
+	}
+	if peakDegraded {
+		degraded = true
 	}
 
 	qpsAvg := roundTo1DP(float64(requestCountTotal) / windowSeconds)
@@ -904,10 +898,23 @@ func (r *opsRepository) queryCurrentRates(ctx context.Context, filter *service.O
 	return qpsCurrent, tpsCurrent, nil
 }
 
-func (r *opsRepository) queryPeakRates(ctx context.Context, filter *service.OpsDashboardFilter, start, end time.Time) (qpsPeak float64, tpsPeak float64, err error) {
+func (r *opsRepository) queryPeakRatesAllowSkip(ctx context.Context, filter *service.OpsDashboardFilter, start, end time.Time) (qpsPeak float64, tpsPeak float64, degraded bool, err error) {
 	if skipRawPeakScan(start, end) {
-		return 0, 0, context.DeadlineExceeded
+		return 0, 0, true, nil
 	}
+	peakCtx, cancelPeak := context.WithTimeout(ctx, opsRawPeakQueryTimeout)
+	defer cancelPeak()
+	qpsPeak, tpsPeak, err = r.queryPeakRates(peakCtx, filter, start, end)
+	if err != nil {
+		if isQueryTimeoutErr(err) {
+			return 0, 0, true, nil
+		}
+		return 0, 0, false, err
+	}
+	return qpsPeak, tpsPeak, false, nil
+}
+
+func (r *opsRepository) queryPeakRates(ctx context.Context, filter *service.OpsDashboardFilter, start, end time.Time) (qpsPeak float64, tpsPeak float64, err error) {
 	usageJoin, usageWhere, usageArgs, next := buildUsageWhere(filter, start, end, 1)
 	errorWhere, errorArgs, _ := buildErrorWhere(filter, start, end, next)
 

--- a/backend/internal/repository/ops_repo_dashboard_timeout_test.go
+++ b/backend/internal/repository/ops_repo_dashboard_timeout_test.go
@@ -44,3 +44,18 @@ func TestSkipRawPeakScan(t *testing.T) {
 		t.Fatalf("30d custom window must skip the raw peak scan")
 	}
 }
+
+func TestQueryPeakRatesAllowSkip_WideWindowDoesNotFakeDeadline(t *testing.T) {
+	end := time.Date(2026, 8, 20, 15, 31, 0, 0, time.UTC)
+	r := &opsRepository{}
+	qps, tps, degraded, err := r.queryPeakRatesAllowSkip(context.Background(), nil, end.Add(-30*24*time.Hour), end)
+	if err != nil {
+		t.Fatalf("wide window should skip without error, got %v", err)
+	}
+	if !degraded {
+		t.Fatalf("wide window should mark peak as degraded")
+	}
+	if qps != 0 || tps != 0 {
+		t.Fatalf("skipped peak should be zero so caller can fill from avg/current, got qps=%v tps=%v", qps, tps)
+	}
+}

--- a/backend/internal/repository/ops_repo_dashboard_timeout_test.go
+++ b/backend/internal/repository/ops_repo_dashboard_timeout_test.go
@@ -2,8 +2,10 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
+	"time"
 )
 
 func TestIsQueryTimeoutErr(t *testing.T) {
@@ -13,10 +15,32 @@ func TestIsQueryTimeoutErr(t *testing.T) {
 	if !isQueryTimeoutErr(fmt.Errorf("wrapped: %w", context.DeadlineExceeded)) {
 		t.Fatalf("wrapped context.DeadlineExceeded should be treated as query timeout")
 	}
+	if !isQueryTimeoutErr(errors.New("pq: canceling statement due to user request")) {
+		t.Fatalf("lib/pq cancel-after-deadline should be treated as query timeout")
+	}
+	if isQueryTimeoutErr(errors.New("pq: canceling statement due to statement timeout")) {
+		t.Fatalf("Postgres statement timeout is not the local peak/latency deadline")
+	}
 	if isQueryTimeoutErr(context.Canceled) {
 		t.Fatalf("context.Canceled should not be treated as query timeout")
 	}
 	if isQueryTimeoutErr(fmt.Errorf("wrapped: %w", context.Canceled)) {
 		t.Fatalf("wrapped context.Canceled should not be treated as query timeout")
+	}
+	if isQueryTimeoutErr(nil) {
+		t.Fatalf("nil should not be treated as query timeout")
+	}
+}
+
+func TestSkipRawPeakScan(t *testing.T) {
+	end := time.Date(2026, 8, 20, 15, 31, 0, 0, time.UTC)
+	if skipRawPeakScan(end.Add(-time.Hour), end) {
+		t.Fatalf("1h window should still use the raw minute-bucket peak scan")
+	}
+	if skipRawPeakScan(end.Add(-2*time.Hour), end) {
+		t.Fatalf("exactly 2h should still use the raw minute-bucket peak scan")
+	}
+	if !skipRawPeakScan(end.Add(-30*24*time.Hour), end) {
+		t.Fatalf("30d custom window must skip the raw peak scan")
 	}
 }

--- a/backend/internal/repository/ops_repo_dashboard_timeout_test.go
+++ b/backend/internal/repository/ops_repo_dashboard_timeout_test.go
@@ -37,8 +37,11 @@ func TestSkipRawPeakScan(t *testing.T) {
 	if skipRawPeakScan(end.Add(-time.Hour), end) {
 		t.Fatalf("1h window should still use the raw minute-bucket peak scan")
 	}
-	if skipRawPeakScan(end.Add(-2*time.Hour), end) {
-		t.Fatalf("exactly 2h should still use the raw minute-bucket peak scan")
+	if skipRawPeakScan(end.Add(-6*time.Hour), end) {
+		t.Fatalf("6h toolbar preset should still use the raw minute-bucket peak scan")
+	}
+	if skipRawPeakScan(end.Add(-24*time.Hour), end) {
+		t.Fatalf("exactly 24h toolbar preset should still use the raw minute-bucket peak scan")
 	}
 	if !skipRawPeakScan(end.Add(-30*24*time.Hour), end) {
 		t.Fatalf("30d custom window must skip the raw peak scan")

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 703,
-  "hash": "b22bf2a33cac8759927f4616ebe89f01bd926d009344382dab5f44c6ab681eab",
+  "file_count": 704,
+  "hash": "9208fc43628a4c499b9dba1323b3fd3a8d86f9b87dc4b6cd80d44299ec2f0dee",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/views/admin/ops/OpsDashboard.vue
+++ b/frontend/src/views/admin/ops/OpsDashboard.vue
@@ -170,6 +170,7 @@ import {
 } from '@/api/admin/ops'
 import { useAdminSettingsStore, useAppStore } from '@/stores'
 import { resolveOpsCustomTimeRange } from './utils/opsTimeRange'
+import { shouldFillHeaderOverview } from './utils/opsSla'
 import OpsDashboardHeader from './components/OpsDashboardHeader.vue'
 import OpsDashboardSkeleton from './components/OpsDashboardSkeleton.vue'
 import OpsConcurrencyCard from './components/OpsConcurrencyCard.vue'
@@ -579,15 +580,21 @@ function buildSwitchTrendParams() {
   return params
 }
 
-async function refreshOverviewWithCancel(fetchSeq: number, signal: AbortSignal) {
+const OPS_HEADER_FILL_MS = 800
+
+async function refreshOverviewWithCancel(
+  fetchSeq: number,
+  signal: AbortSignal,
+  onApplied?: () => void
+) {
   if (!opsEnabled.value) return
   try {
     const data = await opsAPI.getDashboardOverview(buildApiParams(), { signal })
     if (fetchSeq !== dashboardFetchSeq) return
     overview.value = data
+    onApplied?.()
   } catch (err: any) {
     if (fetchSeq !== dashboardFetchSeq || isCanceledRequest(err)) return
-    overview.value = null
     appStore.showError(err?.message || t('admin.ops.failedToLoadOverview'))
   }
 }
@@ -628,7 +635,11 @@ async function refreshThroughputTrendWithCancel(fetchSeq: number, signal: AbortS
   }
 }
 
-async function refreshCoreSnapshotWithCancel(fetchSeq: number, signal: AbortSignal) {
+async function refreshCoreSnapshotWithCancel(
+  fetchSeq: number,
+  signal: AbortSignal,
+  onOverviewApplied?: () => void
+) {
   if (!opsEnabled.value) return
   loadingTrend.value = true
   loadingErrorTrend.value = true
@@ -636,13 +647,13 @@ async function refreshCoreSnapshotWithCancel(fetchSeq: number, signal: AbortSign
     const data = await opsAPI.getDashboardSnapshotV2(buildApiParams(), { signal })
     if (fetchSeq !== dashboardFetchSeq) return
     overview.value = data.overview
+    onOverviewApplied?.()
     throughputTrend.value = data.throughput_trend
     errorTrend.value = data.error_trend
   } catch (err: any) {
     if (fetchSeq !== dashboardFetchSeq || isCanceledRequest(err)) return
-    // Fallback to legacy split endpoints when snapshot endpoint is unavailable.
     await Promise.all([
-      refreshOverviewWithCancel(fetchSeq, signal),
+      refreshOverviewWithCancel(fetchSeq, signal, onOverviewApplied),
       refreshThroughputTrendWithCancel(fetchSeq, signal),
       refreshErrorTrendWithCancel(fetchSeq, signal)
     ])
@@ -752,9 +763,34 @@ async function fetchData() {
   loading.value = true
   errorMessage.value = ''
   try {
+    const signal = dashboardFetchController.signal
+    let snapshotDone = false
+    let overviewApplied = false
+    const markOverviewApplied = () => {
+      overviewApplied = true
+    }
+    const snapshotP = refreshCoreSnapshotWithCancel(fetchSeq, signal, markOverviewApplied).finally(() => {
+      snapshotDone = true
+    })
+    const headerFillP = (async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, OPS_HEADER_FILL_MS))
+      if (fetchSeq !== dashboardFetchSeq) return
+      if (!shouldFillHeaderOverview(snapshotDone, overviewApplied)) return
+      await refreshOverviewWithCancel(fetchSeq, signal, markOverviewApplied)
+    })()
+
+    await Promise.race([snapshotP, headerFillP])
+    if (fetchSeq !== dashboardFetchSeq) return
+    if (overview.value != null || snapshotDone) {
+      loading.value = false
+      hasLoadedOnce.value = true
+      lastUpdated.value = new Date()
+    }
+
     await Promise.all([
-      refreshCoreSnapshotWithCancel(fetchSeq, dashboardFetchController.signal),
-      refreshSwitchTrendWithCancel(fetchSeq, dashboardFetchController.signal),
+      snapshotP,
+      headerFillP,
+      refreshSwitchTrendWithCancel(fetchSeq, signal),
     ])
     if (fetchSeq !== dashboardFetchSeq) return
 
@@ -769,7 +805,7 @@ async function fetchData() {
     }
 
     // Defer non-core visual panels to reduce initial blocking.
-    void refreshDeferredPanels(fetchSeq, dashboardFetchController.signal)
+    void refreshDeferredPanels(fetchSeq, signal)
   } catch (err) {
     if (!isOpsDisabledError(err)) {
       console.error('[ops] failed to fetch dashboard data', err)

--- a/frontend/src/views/admin/ops/components/OpsDashboardHeader.vue
+++ b/frontend/src/views/admin/ops/components/OpsDashboardHeader.vue
@@ -13,6 +13,7 @@ import { useAdminSettingsStore } from '@/stores'
 import { formatNumber } from '@/utils/format'
 import { formatMemorySizeMB } from '../utils/opsFormatters'
 import { datetimeLocalToISO, resolveOpsCustomTimeRange, toDatetimeLocalValue } from '../utils/opsTimeRange'
+import { resolveOpsSlaPercent } from '../utils/opsSla'
 
 type RealtimeWindow = '1min' | '5min' | '30min' | '1h'
 
@@ -399,12 +400,7 @@ const tpsAvgLabel = computed(() => {
   return v.toFixed(1)
 })
 
-const slaPercent = computed(() => {
-  const v = overview.value?.sla
-  if (typeof v !== 'number') return null
-  if ((overview.value?.request_count_sla ?? 0) <= 0) return null
-  return v * 100
-})
+const slaPercent = computed(() => resolveOpsSlaPercent(overview.value))
 
 const errorRatePercent = computed(() => {
   const v = overview.value?.error_rate
@@ -942,7 +938,6 @@ function handleToolbarRefresh() {
           v-if="!props.fullscreen"
           type="button"
           class="flex h-8 w-8 items-center justify-center rounded-lg bg-gray-100 text-gray-500 transition-colors hover:bg-gray-200 dark:bg-dark-700 dark:text-gray-400 dark:hover:bg-dark-600"
-          :disabled="loading"
           :title="t('common.refresh')"
           @click="handleToolbarRefresh"
         >
@@ -1282,7 +1277,7 @@ function handleToolbarRefresh() {
             <div class="flex justify-between">
               <span class="text-gray-500">{{ t('admin.ops.exceptions') }}:</span>
               <span class="font-bold text-red-600 dark:text-red-400">{{ formatNumber(overview.error_count_sla ?? 0) }}</span>
-              <span class="font-bold text-gray-900 dark:text-white">{{ formatNumber((overview.request_count_sla ?? 0) - (overview.success_count ?? 0)) }}</span>
+              <span class="font-bold text-gray-900 dark:text-white">{{ formatNumber((overview.request_count_total ?? 0) - (overview.success_count ?? 0)) }}</span>
             </div>
           </div>
         </div>

--- a/frontend/src/views/admin/ops/utils/__tests__/opsSla.spec.ts
+++ b/frontend/src/views/admin/ops/utils/__tests__/opsSla.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveOpsSlaPercent, shouldFillHeaderOverview } from '../opsSla'
+
+describe('resolveOpsSlaPercent', () => {
+  it('returns sla percent when the window has requests', () => {
+    expect(resolveOpsSlaPercent({ sla: 0.9966, request_count_total: 1178 })).toBeCloseTo(99.66)
+  })
+
+  it('hides sla when request_count_total is missing or zero', () => {
+    expect(resolveOpsSlaPercent({ sla: 0.9966 })).toBeNull()
+    expect(resolveOpsSlaPercent({ sla: 1, request_count_total: 0 })).toBeNull()
+  })
+
+  it('does not use a backend field that is never sent', () => {
+    const overview = { sla: 0.9818, request_count_total: 110, request_count_sla: undefined }
+    expect(resolveOpsSlaPercent(overview)).toBeCloseTo(98.18)
+  })
+})
+
+describe('shouldFillHeaderOverview', () => {
+  it('fills the header from overview when snapshot is still pending', () => {
+    expect(shouldFillHeaderOverview(false, false)).toBe(true)
+  })
+
+  it('does not start a second overview after snapshot or header already applied', () => {
+    expect(shouldFillHeaderOverview(true, false)).toBe(false)
+    expect(shouldFillHeaderOverview(false, true)).toBe(false)
+  })
+})

--- a/frontend/src/views/admin/ops/utils/opsSla.ts
+++ b/frontend/src/views/admin/ops/utils/opsSla.ts
@@ -1,0 +1,17 @@
+export type OpsSlaOverview = {
+  sla?: number
+  request_count_total?: number
+}
+
+/** Hide SLA when the window has no requests. Backend never sends request_count_sla. */
+export function resolveOpsSlaPercent(overview: OpsSlaOverview | null | undefined): number | null {
+  if (overview == null || typeof overview.sla !== 'number' || !Number.isFinite(overview.sla)) {
+    return null
+  }
+  if ((overview.request_count_total ?? 0) <= 0) return null
+  return overview.sla * 100
+}
+
+export function shouldFillHeaderOverview(snapshotDone: boolean, overviewApplied: boolean): boolean {
+  return !snapshotDone && !overviewApplied
+}


### PR DESCRIPTION
## 摘要

1.8.167 上自定义 30 天线查询时，`/dashboard/snapshot-v2` 和 `/dashboard/overview` 返回 500 internal error。现网日志是 `pq: canceling statement due to user request`：分钟级峰值扫描在本地 1.5s 超时后被 lib/pq 取消，却没被当成可降级超时。现在把这类取消按超时处理；只有超过工具栏最大预设 24h 的自定义窗口才跳过原始峰值扫描。SLA 卡片改为看 `request_count_total`；snapshot 慢或失败时先补请求数/SLA，加载中也可以刷新。

sentinel-registry-reviewed
upstream-touch-trivial

## 风险

常规。运维监控 overview 超时分类、超长窗口峰值跳过，以及 SLA/刷新前端行为。5m/30m/1h/6h/24h 现网实测 200；只有自定义 30 天在未发版前仍 500。超过 24h 的峰值回退到 avg/current。OpsDashboard.vue / OpsDashboardHeader.vue 是 TokenKey 运维页，不是 Wei-Shaw 上游面，后续 upstream merge 不会静默覆盖这次 SLA/刷新改动。

## 验证

- 现网窗口矩阵：5m/30m/1h/6h/24h snapshot-v2+overview 均为 200；custom 30d 仍 500（`internal error`，snapshot 5.0s / overview 1.6s）
- `go test -tags=unit ./internal/repository/ -run 'TestIsQueryTimeoutErr|TestSkipRawPeakScan|TestQueryPeakRatesAllowSkip'` 通过
- `vitest run src/views/admin/ops/utils/__tests__/opsSla.spec.ts` 通过
- `./scripts/preflight.sh` 通过

## 提交

- `a092f999e` fix(ops): treat pq cancel as dashboard timeout instead of 500
- `9e72b1119` fix(ops): address R-001 — skip peak scan without fake DeadlineExceeded
- `7d9e9a066` fix(ops): address R-001 — keep 6h/24h real peak, skip only beyond 24h
- `d51c1c672` fix(ops): show SLA from request_count_total and keep header refreshing
- `c537572f7` chore(ops): refresh frontend-source stamp after SLA header fix
- 最新提交：`c537572f7`