### PR TITLE
fix(gateway): tokensea OpenAI Claude messages 不再误走 Responses

### DIFF
--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -46,6 +46,16 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	if account.IsAnthropicProtocol() {
 		return s.forwardAnthropicViaNativeAnthropicEndpoint(ctx, c, account, body, defaultMappedModel)
 	}
+	// Tokensea OpenAI relay (#92): extra.openai_native_messages_supported can
+	// be a false-negative. The probe uses selectResponsesProbeModel (first
+	// mapping id, often GPT); live 2026-08-20 GPT /v1/messages timed out so
+	// extra.native_messages=false while extra.responses=true. Direct Claude
+	// /v1/messages is 200; Claude /v1/responses returns "not implemented".
+	// Route Claude here without waiting for the extra flag. GPT stays on
+	// Responses below.
+	if account.IsOpenAITokenseaRelay() && shouldForwardNativeAnthropicMessagesForModel(body) {
+		return s.forwardAnthropicViaNativeMessages(ctx, c, account, body, defaultMappedModel)
+	}
 	if account.Type == AccountTypeAPIKey && openai_compat.ShouldUseNativeAnthropicMessagesAPI(account.Extra) {
 		if shouldForwardNativeAnthropicMessagesForModel(body) {
 			return s.forwardAnthropicViaNativeMessages(ctx, c, account, body, defaultMappedModel)

--- a/backend/internal/service/openai_gateway_messages_native_test.go
+++ b/backend/internal/service/openai_gateway_messages_native_test.go
@@ -86,3 +86,77 @@ func TestForwardAsAnthropic_NativeMessagesPreferredOverChatFallback(t *testing.T
 	require.NotContains(t, upstream.lastReq.URL.String(), "chat/completions")
 	require.Contains(t, upstream.lastReq.URL.String(), "/v1/messages")
 }
+
+func tokenseaOpenAIRelayWithStaleNativeFlag() *Account {
+	account := rawChatCompletionsTestAccount()
+	account.Credentials["base_url"] = "https://agent.tokensea.ai"
+	account.Extra = map[string]any{
+		// Live 2026-08-20 account 92: GPT /v1/messages probe timed out, so
+		// extra.openai_native_messages_supported=false while
+		// openai_responses_supported=true. Direct upstream Claude
+		// /v1/messages still returned 200.
+		openai_compat.ExtraKeyResponsesSupported:      true,
+		openai_compat.ExtraKeyNativeMessagesSupported: false,
+	}
+	return account
+}
+
+func TestForwardAsAnthropic_TokenseaClaudeUsesNativeMessagesEvenWhenExtraFlagFalse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"claude-sonnet-4-6","max_tokens":8,"messages":[{"role":"user","content":"Reply OK only."}]}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(strings.NewReader(
+			`{"type":"message","model":"claude-sonnet-4-6","role":"assistant","content":[{"type":"text","text":"OK"}],"usage":{"input_tokens":7,"output_tokens":1}}`,
+		)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, tokenseaOpenAIRelayWithStaleNativeFlag(), body, "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "https://agent.tokensea.ai/v1/messages", upstream.lastReq.URL.String(),
+		"92 Claude /v1/messages must passthrough even when extra.native_messages=false")
+	require.NotContains(t, upstream.lastReq.URL.String(), "/responses")
+	require.Contains(t, rec.Body.String(), "OK")
+}
+
+func TestForwardAsAnthropic_TokenseaGPTKeepsResponsesWhenFlagTrue(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+
+	upstreamBody := strings.Join([]string{
+		`data: {"type":"response.completed","response":{"id":"resp_native","object":"response","model":"gpt-5.4","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":5,"output_tokens":2,"total_tokens":7}}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, tokenseaOpenAIRelayWithStaleNativeFlag(), body, "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, strings.HasSuffix(upstream.lastReq.URL.Path, "/responses"),
+		"92 GPT /v1/messages must stay on Responses when extra.responses=true, got %s", upstream.lastReq.URL.String())
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1132,11 +1132,12 @@
         "Wei-Shaw/sub2api#1322",
         "\"response.cancelled\", \"response.canceled\"",
         "ShouldUseNativeAnthropicMessagesAPI",
-        "shouldForwardNativeAnthropicMessagesForModel",
+        "if shouldForwardNativeAnthropicMessagesForModel(body)",
         "forwardAnthropicViaNativeMessages",
-        "forwardAnthropicViaRawChatCompletions"
+        "forwardAnthropicViaRawChatCompletions",
+        "IsOpenAITokenseaRelay() && shouldForwardNativeAnthropicMessagesForModel"
       ],
-      "rationale": "Non-stream /v1/messages uses the same buffered Responses SSE -> JSON conversion root cause as /v1/chat/completions; it must also override Content-Type after WriteFilteredHeaders so JSON bodies are not labeled text/event-stream. The buffered terminal reader must use openAICompatSSEFrameParser to recognise typed completion events when the stream closes without a standalone [DONE] (upstream PR #2530). isOpenAICompatResponsesTerminalEvent — used by both the Messages and Chat Completions streaming handlers — must keep response.cancelled / response.canceled in its terminal set so legitimate upstream cancellations close the stream cleanly instead of degenerating to 'stream usage incomplete: missing terminal event' (upstream #1322). OpenAI APIKey dual-stack relays (tokensea/cloudwise) branch to native /v1/messages passthrough only for claude-* models when extra.openai_native_messages_supported is true; non-Claude models (MiniMax-M3, glm-5) must fall back to raw chat completions like /v1/responses."
+      "rationale": "Non-stream /v1/messages uses the same buffered Responses SSE -> JSON conversion root cause as /v1/chat/completions; it must also override Content-Type after WriteFilteredHeaders so JSON bodies are not labeled text/event-stream. The buffered terminal reader must use openAICompatSSEFrameParser to recognise typed completion events when the stream closes without a standalone [DONE] (upstream PR #2530). isOpenAICompatResponsesTerminalEvent — used by both the Messages and Chat Completions streaming handlers — must keep response.cancelled / response.canceled in its terminal set so legitimate upstream cancellations close the stream cleanly instead of degenerating to 'stream usage incomplete: missing terminal event' (upstream #1322). OpenAI APIKey dual-stack relays (tokensea/cloudwise) branch to native /v1/messages passthrough for claude-* models; tokensea #92 must do this even when extra.openai_native_messages_supported is a false-negative (GPT probe timeout). Non-Claude models (MiniMax-M3, glm-5) must fall back to raw chat completions like /v1/responses."
     },
     {
       "path": "backend/internal/service/openai_gateway_messages_native.go",
@@ -1148,6 +1149,15 @@
         "tkIsForwardableAnthropicModelName"
       ],
       "rationale": "Native Anthropic Messages passthrough for OpenAI-platform dual-stack relays (agent.tokensea.ai, cloudwise). Must forward claude-* /v1/messages directly with API key Bearer auth; non-Claude models stay on chat fallback."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_messages_native_test.go",
+      "must_contain": [
+        "TestForwardAsAnthropic_TokenseaClaudeUsesNativeMessagesEvenWhenExtraFlagFalse",
+        "TestForwardAsAnthropic_TokenseaGPTKeepsResponsesWhenFlagTrue",
+        "https://agent.tokensea.ai/v1/messages"
+      ],
+      "rationale": "Live 2026-08-20 account 92: extra.native_messages=false and extra.responses=true because the GPT /v1/messages probe timed out. Claude /v1/messages must still passthrough; GPT /v1/messages must stay on Responses. Losing these regressions restores 502 not implemented on 92 Claude messages."
     },
     {
       "path": "backend/internal/service/openai_cloudwise_relay_tk.go",


### PR DESCRIPTION
## 摘要

tokensea OpenAI 账号（prod #92）打 Claude `/v1/messages` 会 502 `not implemented`。直连上游 Claude `/v1/messages` 是 200；探测用 GPT id 超时后把 `extra.openai_native_messages_supported` 写成 false，网关误把 Claude 转成 `/v1/responses`。本 PR 让 tokensea OpenAI 的 Claude 请求直接走 native messages，不看 extra 旗标；GPT 仍走 Responses。

qwen/kimi leftover mapping 不在本 PR：已对 #92 `apply-accounts` 对齐编译期 floor，不另加 hard gate。

Web impact: none

## 风险

常规风险。只改 `ForwardAsAnthropic` 的 tokensea OpenAI + Claude 分流，不改公共契约、schema、鉴权。GPT Responses 路径保持原样。

## 验证

- `go test -tags=unit -count=1 -run 'TestForwardAsAnthropic_TokenseaClaudeUsesNativeMessagesEvenWhenExtraFlagFalse|TestForwardAsAnthropic_TokenseaGPTKeepsResponsesWhenFlagTrue' ./internal/service/` 通过
- `./scripts/preflight.sh` 通过
- 直连实测：#92 Claude `/v1/messages` 200；Claude `/v1/responses` `not implemented`
- 现网 1.8.167 尚未带此修复，发版后才能复测网关 92 Claude messages

## 提交

- `aed391be5` fix(gateway): tokensea OpenAI Claude messages 不再误走 Responses
- 最新提交：`aed391be5`

Made with [Cursor](https://cursor.com)