### PR TITLE
fix: 修复 OpenAI 401 整组假死、Antigravity Pro 429、账号级 400 与 Codex 额度缩水

### DIFF
--- a/backend/internal/pkg/antigravity/client.go
+++ b/backend/internal/pkg/antigravity/client.go
@@ -243,6 +243,17 @@ func TierIDToPlanType(tierID string) string {
 	}
 }
 
+// IsPaidPlanType 判断 plan_type 或 raw tier ID 是否为付费档（Pro / Ultra）。
+// 付费集合只在 TierIDToPlanType 维护：这里只看规范化后的套餐名。
+func IsPaidPlanType(planOrTier string) bool {
+	switch strings.ToLower(strings.TrimSpace(TierIDToPlanType(planOrTier))) {
+	case "pro", "ultra":
+		return true
+	default:
+		return false
+	}
+}
+
 // Client Antigravity API 客户端
 type Client struct {
 	httpClient *http.Client
@@ -842,7 +853,7 @@ func (c *Client) SetUserSettings(ctx context.Context, accessToken string) (*SetU
 	// 2026-06-13 真机 on-wire 抓包（IDE 2.0.11，setUserSettings/fetchUserInfo @ daily-cloudcode-pa）
 	// 确认真实客户端在这两个隐私端点上【不发】X-Goog-Api-Client(gl-node) 头——此前钉死的
 	// gl-node/22.21.1 是多发的指纹噪声，移除以对齐。
-	req.Host = "daily-cloudcode-pa.googleapis.com"
+	req.Host = DailyHost()
 
 	resp, err := servertiming.Do(c.httpClient, req)
 	if err != nil {
@@ -885,7 +896,7 @@ func (c *Client) FetchUserInfo(ctx context.Context, accessToken, projectID strin
 	req.Header.Set("Accept", "*/*")
 	req.Header.Set("User-Agent", GetUserAgentForContext(ctx))
 	// 2026-06-13 真机抓包确认 fetchUserInfo 不发 X-Goog-Api-Client(gl-node)，移除对齐（同 setUserSettings）。
-	req.Host = "daily-cloudcode-pa.googleapis.com"
+	req.Host = DailyHost()
 
 	resp, err := servertiming.Do(c.httpClient, req)
 	if err != nil {

--- a/backend/internal/pkg/antigravity/client_test.go
+++ b/backend/internal/pkg/antigravity/client_test.go
@@ -272,6 +272,16 @@ func TestTierIDToPlanType(t *testing.T) {
 	}
 }
 
+func TestIsPaidPlanType_DerivedFromTierIDToPlanType(t *testing.T) {
+	for _, id := range []string{"free-tier", "g1-pro-tier", "g1-ultra-tier", "", "unknown-tier", "Pro", "Ultra", "Free"} {
+		plan := TierIDToPlanType(id)
+		want := strings.EqualFold(plan, "Pro") || strings.EqualFold(plan, "Ultra")
+		if got := IsPaidPlanType(id); got != want {
+			t.Errorf("IsPaidPlanType(%q) = %v, want %v (via TierIDToPlanType=%q)", id, got, want, plan)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // NewClient
 // ---------------------------------------------------------------------------

--- a/backend/internal/pkg/antigravity/oauth.go
+++ b/backend/internal/pkg/antigravity/oauth.go
@@ -59,6 +59,19 @@ const (
 	antigravityDailyBaseURL = "https://daily-cloudcode-pa.googleapis.com"
 )
 
+// DailyBaseURL / ProdBaseURL 是网关与隐私请求共用的端点 owner。
+func DailyBaseURL() string { return antigravityDailyBaseURL }
+func ProdBaseURL() string  { return antigravityProdBaseURL }
+
+// DailyHost 从 DailyBaseURL 解析 Host，禁止第二份 hostname 字面量。
+func DailyHost() string {
+	parsed, err := url.Parse(antigravityDailyBaseURL)
+	if err != nil {
+		return ""
+	}
+	return parsed.Host
+}
+
 var userAgentVersionPattern = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
 
 // UserAgentVersionResolver 提供运行时 User-Agent 版本号覆盖能力。

--- a/backend/internal/pkg/antigravity/oauth.go
+++ b/backend/internal/pkg/antigravity/oauth.go
@@ -56,7 +56,7 @@ const (
 
 	// Antigravity API 端点
 	antigravityProdBaseURL  = "https://cloudcode-pa.googleapis.com"
-	antigravityDailyBaseURL = "https://daily-cloudcode-pa.sandbox.googleapis.com"
+	antigravityDailyBaseURL = "https://daily-cloudcode-pa.googleapis.com"
 )
 
 var userAgentVersionPattern = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
@@ -153,7 +153,7 @@ func getClientSecret() (string, error) {
 // BaseURLs 定义 Antigravity API 端点（与 Antigravity-Manager 保持一致）
 var BaseURLs = []string{
 	antigravityProdBaseURL,  // prod (优先)
-	antigravityDailyBaseURL, // daily sandbox (备用)
+	antigravityDailyBaseURL, // official daily（付费档网关转发）
 }
 
 // BaseURL 默认 URL（保持向后兼容）

--- a/backend/internal/pkg/antigravity/oauth_test.go
+++ b/backend/internal/pkg/antigravity/oauth_test.go
@@ -89,6 +89,16 @@ func TestGetClientSecret_环境变量有前后空格(t *testing.T) {
 // ForwardBaseURLs
 // ---------------------------------------------------------------------------
 
+func TestDailyHost_DerivedFromDailyBaseURL(t *testing.T) {
+	parsed, err := url.Parse(DailyBaseURL())
+	if err != nil {
+		t.Fatalf("DailyBaseURL 必须是合法 URL: %v", err)
+	}
+	if got := DailyHost(); got != parsed.Host {
+		t.Errorf("DailyHost() = %q, want %q from DailyBaseURL", got, parsed.Host)
+	}
+}
+
 func TestForwardBaseURLs_Daily优先(t *testing.T) {
 	urls := ForwardBaseURLs()
 	if len(urls) == 0 {

--- a/backend/internal/service/antigravity_gateway_retry.go
+++ b/backend/internal/service/antigravity_gateway_retry.go
@@ -87,16 +87,11 @@ func tkAntigravityPaidTierUsesDaily(account *Account) bool {
 	if account == nil {
 		return false
 	}
-	plan := strings.ToLower(strings.TrimSpace(account.GetCredential("plan_type")))
+	plan := strings.TrimSpace(account.GetCredential("plan_type"))
 	if plan == "" {
-		plan = strings.ToLower(strings.TrimSpace(account.GetExtraString("plan_type")))
+		plan = strings.TrimSpace(account.GetExtraString("plan_type"))
 	}
-	switch plan {
-	case "pro", "ultra", "g1-pro-tier", "g1-ultra-tier":
-		return true
-	default:
-		return false
-	}
+	return antigravity.IsPaidPlanType(plan)
 }
 
 // smartRetryAction 智能重试的处理结果

--- a/backend/internal/service/antigravity_gateway_retry.go
+++ b/backend/internal/service/antigravity_gateway_retry.go
@@ -54,26 +54,49 @@ type antigravityRetryLoopResult struct {
 
 // resolveAntigravityForwardBaseURL 解析转发用 base URL。
 //
-// 默认使用生产端点 cloudcode-pa.googleapis.com（antigravity.BaseURLs 的首个地址，
-// 与账号 OAuth 登录/测试连接所用的 antigravity.BaseURL 一致）。
+// 默认使用生产端点 cloudcode-pa.googleapis.com（antigravity.BaseURLs 的首个地址）。
+// Google AI Pro / Ultra（g1-pro-tier / g1-ultra-tier）走官方 daily 端点，
+// 与 Antigravity IDE 一致；免费档仍走 prod，避免再回归 #3611 / #2962
+// （生产 token 打 daily → Invalid bearer）。
 //
-// 历史上这里改用 ForwardBaseURLs()（把 daily/sandbox 排到首位）并默认取首个地址，
-// 导致网关把带生产 OAuth token 的请求发到 daily-cloudcode-pa.sandbox.googleapis.com，
-// 上游拒绝 → 账号被 401「Invalid bearer token」/502 打入临时不可调度且无法恢复
-// （见 #3611 / #2962）。后台「测试连接」用的是生产端点，所以「测试成功但网关 401」。
-//
-// daily/sandbox 端点仅供内部联调，需显式设置
-// GATEWAY_ANTIGRAVITY_FORWARD_BASE_URL=daily（或 sandbox）才启用。
-func resolveAntigravityForwardBaseURL() string {
+// GATEWAY_ANTIGRAVITY_FORWARD_BASE_URL=daily|sandbox|prod 可强制覆盖。
+func resolveAntigravityForwardBaseURL(account *Account) string {
 	baseURLs := antigravity.BaseURLs
 	if len(baseURLs) == 0 {
 		return ""
 	}
-	mode := strings.ToLower(strings.TrimSpace(os.Getenv(antigravityForwardBaseURLEnv)))
-	if (mode == "daily" || mode == "sandbox") && len(baseURLs) > 1 {
-		return baseURLs[1]
+	prod := baseURLs[0]
+	daily := prod
+	if len(baseURLs) > 1 {
+		daily = baseURLs[1]
 	}
-	return baseURLs[0]
+	mode := strings.ToLower(strings.TrimSpace(os.Getenv(antigravityForwardBaseURLEnv)))
+	switch mode {
+	case "daily", "sandbox":
+		return daily
+	case "prod":
+		return prod
+	}
+	if tkAntigravityPaidTierUsesDaily(account) {
+		return daily
+	}
+	return prod
+}
+
+func tkAntigravityPaidTierUsesDaily(account *Account) bool {
+	if account == nil {
+		return false
+	}
+	plan := strings.ToLower(strings.TrimSpace(account.GetCredential("plan_type")))
+	if plan == "" {
+		plan = strings.ToLower(strings.TrimSpace(account.GetExtraString("plan_type")))
+	}
+	switch plan {
+	case "pro", "ultra", "g1-pro-tier", "g1-ultra-tier":
+		return true
+	default:
+		return false
+	}
 }
 
 // smartRetryAction 智能重试的处理结果
@@ -494,7 +517,7 @@ func (s *AntigravityGatewayService) antigravityRetryLoop(p antigravityRetryLoopP
 		}
 	}
 
-	baseURL := resolveAntigravityForwardBaseURL()
+	baseURL := resolveAntigravityForwardBaseURL(p.account)
 	if baseURL == "" {
 		return nil, errors.New("no antigravity forward base url configured")
 	}

--- a/backend/internal/service/antigravity_gateway_retry.go
+++ b/backend/internal/service/antigravity_gateway_retry.go
@@ -54,22 +54,15 @@ type antigravityRetryLoopResult struct {
 
 // resolveAntigravityForwardBaseURL 解析转发用 base URL。
 //
-// 默认使用生产端点 cloudcode-pa.googleapis.com（antigravity.BaseURLs 的首个地址）。
-// Google AI Pro / Ultra（g1-pro-tier / g1-ultra-tier）走官方 daily 端点，
-// 与 Antigravity IDE 一致；免费档仍走 prod，避免再回归 #3611 / #2962
-// （生产 token 打 daily → Invalid bearer）。
+// 默认使用 ProdBaseURL()（cloudcode-pa.googleapis.com）。
+// Google AI Pro / Ultra 走 DailyBaseURL()，与 Antigravity IDE 一致；
+// 免费档仍走 prod，避免再回归 #3611 / #2962（生产 token 打 daily → Invalid bearer）。
+// 端点字符串只读这两个 owner，不从 BaseURLs 下标推断。
 //
 // GATEWAY_ANTIGRAVITY_FORWARD_BASE_URL=daily|sandbox|prod 可强制覆盖。
 func resolveAntigravityForwardBaseURL(account *Account) string {
-	baseURLs := antigravity.BaseURLs
-	if len(baseURLs) == 0 {
-		return ""
-	}
-	prod := baseURLs[0]
-	daily := prod
-	if len(baseURLs) > 1 {
-		daily = baseURLs[1]
-	}
+	prod := antigravity.ProdBaseURL()
+	daily := antigravity.DailyBaseURL()
 	mode := strings.ToLower(strings.TrimSpace(os.Getenv(antigravityForwardBaseURLEnv)))
 	switch mode {
 	case "daily", "sandbox":

--- a/backend/internal/service/antigravity_gateway_tk_daily_test.go
+++ b/backend/internal/service/antigravity_gateway_tk_daily_test.go
@@ -1,0 +1,74 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTkAntigravityPaidTierUsesDaily(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, tkAntigravityPaidTierUsesDaily(nil))
+	require.False(t, tkAntigravityPaidTierUsesDaily(&Account{Platform: PlatformAntigravity}))
+	require.False(t, tkAntigravityPaidTierUsesDaily(&Account{
+		Platform:    PlatformAntigravity,
+		Credentials: map[string]any{"plan_type": "Free"},
+	}))
+	require.False(t, tkAntigravityPaidTierUsesDaily(&Account{
+		Platform:    PlatformAntigravity,
+		Credentials: map[string]any{"plan_type": "free-tier"},
+	}))
+	require.True(t, tkAntigravityPaidTierUsesDaily(&Account{
+		Platform:    PlatformAntigravity,
+		Credentials: map[string]any{"plan_type": "Pro"},
+	}))
+	require.True(t, tkAntigravityPaidTierUsesDaily(&Account{
+		Platform:    PlatformAntigravity,
+		Credentials: map[string]any{"plan_type": "Ultra"},
+	}))
+	require.True(t, tkAntigravityPaidTierUsesDaily(&Account{
+		Platform:    PlatformAntigravity,
+		Credentials: map[string]any{"plan_type": "g1-pro-tier"},
+	}))
+	require.True(t, tkAntigravityPaidTierUsesDaily(&Account{
+		Platform: PlatformAntigravity,
+		Extra:    map[string]any{"plan_type": "g1-ultra-tier"},
+	}))
+}
+
+func TestResolveAntigravityForwardBaseURL_PaidTierUsesDaily(t *testing.T) {
+	t.Setenv(antigravityForwardBaseURLEnv, "")
+
+	const officialDaily = "https://daily-cloudcode-pa.googleapis.com"
+	prod := antigravity.BaseURLs[0]
+	require.Equal(t, "https://cloudcode-pa.googleapis.com", prod)
+	require.Equal(t, officialDaily, antigravity.BaseURLs[1])
+
+	require.Equal(t, prod, resolveAntigravityForwardBaseURL(nil))
+	require.Equal(t, prod, resolveAntigravityForwardBaseURL(&Account{
+		Platform:    PlatformAntigravity,
+		Credentials: map[string]any{"plan_type": "Free"},
+	}))
+	require.Equal(t, officialDaily, resolveAntigravityForwardBaseURL(&Account{
+		Platform:    PlatformAntigravity,
+		Credentials: map[string]any{"plan_type": "Pro"},
+	}))
+}
+
+func TestResolveAntigravityForwardBaseURL_EnvOverridesPaidTier(t *testing.T) {
+	t.Setenv(antigravityForwardBaseURLEnv, "daily")
+	require.Equal(t, "https://daily-cloudcode-pa.googleapis.com", resolveAntigravityForwardBaseURL(&Account{
+		Platform:    PlatformAntigravity,
+		Credentials: map[string]any{"plan_type": "Free"},
+	}))
+
+	t.Setenv(antigravityForwardBaseURLEnv, "prod")
+	require.Equal(t, antigravity.BaseURLs[0], resolveAntigravityForwardBaseURL(&Account{
+		Platform:    PlatformAntigravity,
+		Credentials: map[string]any{"plan_type": "Pro"},
+	}))
+}

--- a/backend/internal/service/antigravity_gateway_tk_daily_test.go
+++ b/backend/internal/service/antigravity_gateway_tk_daily_test.go
@@ -9,51 +9,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTkAntigravityPaidTierUsesDaily(t *testing.T) {
+func TestTkAntigravityPaidTierUsesDaily_DelegatesToPlanTypeOwner(t *testing.T) {
 	t.Parallel()
 
 	require.False(t, tkAntigravityPaidTierUsesDaily(nil))
 	require.False(t, tkAntigravityPaidTierUsesDaily(&Account{Platform: PlatformAntigravity}))
-	require.False(t, tkAntigravityPaidTierUsesDaily(&Account{
-		Platform:    PlatformAntigravity,
-		Credentials: map[string]any{"plan_type": "Free"},
-	}))
-	require.False(t, tkAntigravityPaidTierUsesDaily(&Account{
-		Platform:    PlatformAntigravity,
-		Credentials: map[string]any{"plan_type": "free-tier"},
-	}))
-	require.True(t, tkAntigravityPaidTierUsesDaily(&Account{
-		Platform:    PlatformAntigravity,
-		Credentials: map[string]any{"plan_type": "Pro"},
-	}))
-	require.True(t, tkAntigravityPaidTierUsesDaily(&Account{
-		Platform:    PlatformAntigravity,
-		Credentials: map[string]any{"plan_type": "Ultra"},
-	}))
-	require.True(t, tkAntigravityPaidTierUsesDaily(&Account{
-		Platform:    PlatformAntigravity,
-		Credentials: map[string]any{"plan_type": "g1-pro-tier"},
-	}))
-	require.True(t, tkAntigravityPaidTierUsesDaily(&Account{
-		Platform: PlatformAntigravity,
-		Extra:    map[string]any{"plan_type": "g1-ultra-tier"},
-	}))
+
+	for _, raw := range []string{"Free", "free-tier", "Pro", "Ultra", "g1-pro-tier", "g1-ultra-tier"} {
+		want := antigravity.IsPaidPlanType(raw)
+		require.Equal(t, want, tkAntigravityPaidTierUsesDaily(&Account{
+			Platform:    PlatformAntigravity,
+			Credentials: map[string]any{"plan_type": raw},
+		}), "credentials.plan_type=%s", raw)
+		require.Equal(t, want, tkAntigravityPaidTierUsesDaily(&Account{
+			Platform: PlatformAntigravity,
+			Extra:    map[string]any{"plan_type": raw},
+		}), "extra.plan_type=%s", raw)
+	}
 }
 
 func TestResolveAntigravityForwardBaseURL_PaidTierUsesDaily(t *testing.T) {
 	t.Setenv(antigravityForwardBaseURLEnv, "")
 
-	const officialDaily = "https://daily-cloudcode-pa.googleapis.com"
-	prod := antigravity.BaseURLs[0]
-	require.Equal(t, "https://cloudcode-pa.googleapis.com", prod)
-	require.Equal(t, officialDaily, antigravity.BaseURLs[1])
+	require.Equal(t, antigravity.ProdBaseURL(), antigravity.BaseURLs[0])
+	require.Equal(t, antigravity.DailyBaseURL(), antigravity.BaseURLs[1])
 
-	require.Equal(t, prod, resolveAntigravityForwardBaseURL(nil))
-	require.Equal(t, prod, resolveAntigravityForwardBaseURL(&Account{
+	require.Equal(t, antigravity.ProdBaseURL(), resolveAntigravityForwardBaseURL(nil))
+	require.Equal(t, antigravity.ProdBaseURL(), resolveAntigravityForwardBaseURL(&Account{
 		Platform:    PlatformAntigravity,
 		Credentials: map[string]any{"plan_type": "Free"},
 	}))
-	require.Equal(t, officialDaily, resolveAntigravityForwardBaseURL(&Account{
+	require.Equal(t, antigravity.DailyBaseURL(), resolveAntigravityForwardBaseURL(&Account{
 		Platform:    PlatformAntigravity,
 		Credentials: map[string]any{"plan_type": "Pro"},
 	}))
@@ -61,13 +47,13 @@ func TestResolveAntigravityForwardBaseURL_PaidTierUsesDaily(t *testing.T) {
 
 func TestResolveAntigravityForwardBaseURL_EnvOverridesPaidTier(t *testing.T) {
 	t.Setenv(antigravityForwardBaseURLEnv, "daily")
-	require.Equal(t, "https://daily-cloudcode-pa.googleapis.com", resolveAntigravityForwardBaseURL(&Account{
+	require.Equal(t, antigravity.DailyBaseURL(), resolveAntigravityForwardBaseURL(&Account{
 		Platform:    PlatformAntigravity,
 		Credentials: map[string]any{"plan_type": "Free"},
 	}))
 
 	t.Setenv(antigravityForwardBaseURLEnv, "prod")
-	require.Equal(t, antigravity.BaseURLs[0], resolveAntigravityForwardBaseURL(&Account{
+	require.Equal(t, antigravity.ProdBaseURL(), resolveAntigravityForwardBaseURL(&Account{
 		Platform:    PlatformAntigravity,
 		Credentials: map[string]any{"plan_type": "Pro"},
 	}))

--- a/backend/internal/service/antigravity_rate_limit_test.go
+++ b/backend/internal/service/antigravity_rate_limit_test.go
@@ -111,19 +111,16 @@ func (s *stubAntigravityAccountRepo) UpdateExtra(ctx context.Context, id int64, 
 func TestAntigravityRetryLoop_NoURLFallback_UsesConfiguredBaseURL(t *testing.T) {
 	t.Setenv(antigravityForwardBaseURLEnv, "")
 
-	oldBaseURLs := append([]string(nil), antigravity.BaseURLs...)
 	oldAvailability := antigravity.DefaultURLAvailability
 	defer func() {
-		antigravity.BaseURLs = oldBaseURLs
 		antigravity.DefaultURLAvailability = oldAvailability
 	}()
 
-	base1 := "https://ag-1.test"
-	base2 := "https://ag-2.test"
-	antigravity.BaseURLs = []string{base1, base2}
+	prod := antigravity.ProdBaseURL()
+	daily := antigravity.DailyBaseURL()
 	antigravity.DefaultURLAvailability = antigravity.NewURLAvailability(time.Minute)
 
-	upstream := &stubAntigravityUpstream{firstBase: base1, secondBase: base2}
+	upstream := &stubAntigravityUpstream{firstBase: prod, secondBase: daily}
 	account := &Account{
 		ID:          1,
 		Name:        "acc-1",
@@ -159,12 +156,12 @@ func TestAntigravityRetryLoop_NoURLFallback_UsesConfiguredBaseURL(t *testing.T) 
 	require.True(t, handleErrorCalled)
 	require.Len(t, upstream.calls, antigravityMaxRetries)
 	for _, callURL := range upstream.calls {
-		require.True(t, strings.HasPrefix(callURL, base1))
+		require.True(t, strings.HasPrefix(callURL, prod))
 	}
 
 	available := antigravity.DefaultURLAvailability.GetAvailableURLs()
 	require.NotEmpty(t, available)
-	require.Equal(t, base1, available[0])
+	require.Contains(t, available, prod)
 }
 
 // TestHandleUpstreamError_429_ModelRateLimit 测试 429 模型限流场景
@@ -1013,7 +1010,7 @@ func TestIsAntigravityAccountSwitchError(t *testing.T) {
 	}
 }
 
-func TestResolveAntigravityForwardBaseURL_DefaultDaily(t *testing.T) {
+func TestResolveAntigravityForwardBaseURL_IgnoresBaseURLsOrder(t *testing.T) {
 	t.Setenv(antigravityForwardBaseURLEnv, "")
 
 	oldBaseURLs := append([]string(nil), antigravity.BaseURLs...)
@@ -1021,12 +1018,9 @@ func TestResolveAntigravityForwardBaseURL_DefaultDaily(t *testing.T) {
 		antigravity.BaseURLs = oldBaseURLs
 	}()
 
-	prodURL := "https://prod.test"
-	dailyURL := "https://daily.test"
-	antigravity.BaseURLs = []string{dailyURL, prodURL}
-
-	resolved := resolveAntigravityForwardBaseURL(nil)
-	require.Equal(t, dailyURL, resolved)
+	antigravity.BaseURLs = []string{"https://daily.test", "https://prod.test"}
+	require.Equal(t, antigravity.ProdBaseURL(), resolveAntigravityForwardBaseURL(nil),
+		"打乱 BaseURLs 顺序不得把默认可调度端点改成 daily")
 }
 
 func TestAntigravityAccountSwitchError_Error(t *testing.T) {

--- a/backend/internal/service/antigravity_rate_limit_test.go
+++ b/backend/internal/service/antigravity_rate_limit_test.go
@@ -1025,7 +1025,7 @@ func TestResolveAntigravityForwardBaseURL_DefaultDaily(t *testing.T) {
 	dailyURL := "https://daily.test"
 	antigravity.BaseURLs = []string{dailyURL, prodURL}
 
-	resolved := resolveAntigravityForwardBaseURL()
+	resolved := resolveAntigravityForwardBaseURL(nil)
 	require.Equal(t, dailyURL, resolved)
 }
 

--- a/backend/internal/service/openai_account_runtime_block_fastpath.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath.go
@@ -78,6 +78,12 @@ func (s *OpenAIGatewayService) handleOpenAIAccountUpstreamError(ctx context.Cont
 		}
 		return false
 	}
+	if isOpenAIImageCapabilityLoss400(statusCode, responseBody) {
+		if s != nil && s.rateLimitService != nil {
+			_ = s.rateLimitService.HandleOpenAIImageCapabilityLoss400(stateCtx, account, statusCode, responseBody)
+		}
+		return false
+	}
 
 	if s == nil || account == nil {
 		return false

--- a/backend/internal/service/openai_codex_fingerprint.go
+++ b/backend/internal/service/openai_codex_fingerprint.go
@@ -67,9 +67,9 @@ const (
 	// codexFingerprintOff 不做任何收敛，原样透传客户端标识。
 	// 仅当 extra 显式写 off 时生效；缺省不再走这条路径。
 	codexFingerprintOff codexFingerprintMode = "off"
-	// codexFingerprintDevice 仅收敛 installation_id 为账号级恒定值。
-	// 上游看到 1 台设备 + 多会话（每用户各自的 session）。
-	// TokenKey 默认：把设备数压到 1，同时不把多个 API Key 收成同一 session。
+	// codexFingerprintDevice 收敛 installation_id。有客户端 session 时按
+	// (seed, session) 派生，避免多用户共享一台“设备”导致额度缩水（#5786）；
+	// 无 session 时仍回退账号级种子。session-id / thread 本身不折叠。
 	codexFingerprintDevice codexFingerprintMode = "device"
 	// codexFingerprintSession 收敛 installation_id + session_id，
 	// thread_id 按客户端原始 session-id 确定性派生（每个真实 Codex 会话一个独立线程）。
@@ -222,9 +222,10 @@ func deriveStableUUIDv4(seed string) string {
 		b[10:16])
 }
 
-// resolveConvergedInstallationID 返回账号级恒定的 installation_id。
-// 优先使用管理员配置的真实 device_id，无则从系统管理的账号随机种子确定性派生。
-func resolveConvergedInstallationID(account *Account, seed string) string {
+// resolveConvergedInstallationID 返回收敛后的 installation_id。
+// 优先使用管理员配置的真实 device_id；否则从账号随机种子派生。
+// 传入 clientSessionID 时按 (seed, session) 派生，保证同会话稳定、跨会话隔离。
+func resolveConvergedInstallationID(account *Account, seed string, clientSessionID ...string) string {
 	if account == nil {
 		return ""
 	}
@@ -233,6 +234,9 @@ func resolveConvergedInstallationID(account *Account, seed string) string {
 	}
 	if seed == "" {
 		return ""
+	}
+	if len(clientSessionID) > 0 && clientSessionID[0] != "" {
+		return deriveStableUUIDv4("sub2api:codex-install-id:v3:session:" + seed + ":" + clientSessionID[0])
 	}
 	return deriveStableUUIDv4("sub2api:codex-install-id:v2:" + seed)
 }
@@ -292,7 +296,11 @@ func resolveCodexFingerprintIDs(account *Account, clientSessionID string, mode c
 		turnStartedAtUnixMs: time.Now().UnixMilli(),
 	}
 
-	ids.installationID = resolveConvergedInstallationID(account, seed)
+	if mode == codexFingerprintDevice {
+		ids.installationID = resolveConvergedInstallationID(account, seed, clientSessionID)
+	} else {
+		ids.installationID = resolveConvergedInstallationID(account, seed)
+	}
 	if ids.installationID == "" {
 		return nil
 	}

--- a/backend/internal/service/openai_codex_fingerprint.go
+++ b/backend/internal/service/openai_codex_fingerprint.go
@@ -67,9 +67,9 @@ const (
 	// codexFingerprintOff 不做任何收敛，原样透传客户端标识。
 	// 仅当 extra 显式写 off 时生效；缺省不再走这条路径。
 	codexFingerprintOff codexFingerprintMode = "off"
-	// codexFingerprintDevice 收敛 installation_id。有客户端 session 时按
-	// (seed, session) 派生，避免多用户共享一台“设备”导致额度缩水（#5786）；
-	// 无 session 时仍回退账号级种子。session-id / thread 本身不折叠。
+	// codexFingerprintDevice 收敛 installation_id。客户端 session 稳定映射到
+	// 至多 codexDeviceModeInstallationLimit 个桶，避免一号多机，同时不让
+	// 多人完全共享一台设备额度（#5786）。session-id / thread 本身不折叠。
 	codexFingerprintDevice codexFingerprintMode = "device"
 	// codexFingerprintSession 收敛 installation_id + session_id，
 	// thread_id 按客户端原始 session-id 确定性派生（每个真实 Codex 会话一个独立线程）。
@@ -83,6 +83,9 @@ const (
 const (
 	codexFingerprintModeExtraKey = "codex_fingerprint_mode"
 	codexFingerprintSeedExtraKey = "codex_fingerprint_seed"
+	// codexDeviceModeInstallationLimit 是单个 OpenAI OAuth 号在 device 模式下
+	// 允许冒出的 installation 上限。超过此数会像设备农场，触发上游风控。
+	codexDeviceModeInstallationLimit = 3
 )
 
 func canonicalCodexFingerprintSeed(value any) (string, bool) {
@@ -199,7 +202,7 @@ func ShouldEnsureCodexFingerprintSeedForExtraUpdates(updates map[string]any) boo
 //
 // 上游 #5610 把缺省改成 off，是为了避开 v0.1.175 默认 session 后的额度缩水报告。
 // TokenKey 的 OpenAI OAuth 号会挂多个用户 / API Key；off 会让上游按真实
-// installation 数设备。device 只统一设备身份，session-id 仍按客户端隔离。
+// installation 数设备。device 把设备身份收到最多 3 个桶，session-id 仍按客户端隔离。
 func (a *Account) GetCodexFingerprintMode() codexFingerprintMode {
 	if a == nil || !a.IsOpenAIOAuth() {
 		return codexFingerprintOff
@@ -222,10 +225,9 @@ func deriveStableUUIDv4(seed string) string {
 		b[10:16])
 }
 
-// resolveConvergedInstallationID 返回收敛后的 installation_id。
-// 优先使用管理员配置的真实 device_id；否则从账号随机种子派生。
-// 传入 clientSessionID 时按 (seed, session) 派生，保证同会话稳定、跨会话隔离。
-func resolveConvergedInstallationID(account *Account, seed string, clientSessionID ...string) string {
+// resolveConvergedInstallationID 返回账号级恒定的 installation_id。
+// 优先使用管理员配置的真实 device_id，无则从系统管理的账号随机种子派生。
+func resolveConvergedInstallationID(account *Account, seed string) string {
 	if account == nil {
 		return ""
 	}
@@ -235,10 +237,30 @@ func resolveConvergedInstallationID(account *Account, seed string, clientSession
 	if seed == "" {
 		return ""
 	}
-	if len(clientSessionID) > 0 && clientSessionID[0] != "" {
-		return deriveStableUUIDv4("sub2api:codex-install-id:v3:session:" + seed + ":" + clientSessionID[0])
-	}
 	return deriveStableUUIDv4("sub2api:codex-install-id:v2:" + seed)
+}
+
+// codexDeviceModeInstallationBucket 把任意 session 稳定映射到 [0, limit) 个桶。
+// 空 session 也进桶，避免「无 session 的 v2 + 三个 session 桶」变成 4 个身份。
+func codexDeviceModeInstallationBucket(clientSessionID string) int {
+	h := sha256.Sum256([]byte(clientSessionID))
+	return int(binary.BigEndian.Uint32(h[:4]) % uint32(codexDeviceModeInstallationLimit))
+}
+
+// resolveDeviceModeInstallationID 在 device 模式下派生 installation_id。
+// 管理员 device_id 仍覆盖为 1 个身份；否则同一 OAuth 号最多 3 个桶。
+func resolveDeviceModeInstallationID(account *Account, seed, clientSessionID string) string {
+	if account == nil {
+		return ""
+	}
+	if deviceID := account.GetOpenAIDeviceID(); deviceID != "" {
+		return deviceID
+	}
+	if seed == "" {
+		return ""
+	}
+	bucket := codexDeviceModeInstallationBucket(clientSessionID)
+	return deriveStableUUIDv4(fmt.Sprintf("sub2api:codex-install-id:v3:bucket:%s:%d", seed, bucket))
 }
 
 // resolveConvergedSessionID 返回账号级恒定的 session_id。
@@ -297,7 +319,7 @@ func resolveCodexFingerprintIDs(account *Account, clientSessionID string, mode c
 	}
 
 	if mode == codexFingerprintDevice {
-		ids.installationID = resolveConvergedInstallationID(account, seed, clientSessionID)
+		ids.installationID = resolveDeviceModeInstallationID(account, seed, clientSessionID)
 	} else {
 		ids.installationID = resolveConvergedInstallationID(account, seed)
 	}

--- a/backend/internal/service/openai_codex_fingerprint_test.go
+++ b/backend/internal/service/openai_codex_fingerprint_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -105,13 +106,10 @@ func TestResolveConvergedInstallationID_DifferentSeeds(t *testing.T) {
 func TestResolveCodexFingerprintIDs_DeviceModeInstallationIsSessionStable(t *testing.T) {
 	account := newTestOAuthAccount(5786, map[string]any{codexFingerprintModeExtraKey: "device"})
 	first := resolveCodexFingerprintIDs(account, "sess-aaa", codexFingerprintDevice)
-	other := resolveCodexFingerprintIDs(account, "sess-bbb", codexFingerprintDevice)
 	again := resolveCodexFingerprintIDs(account, "sess-aaa", codexFingerprintDevice)
 	require.NotNil(t, first)
-	require.NotNil(t, other)
 	require.NotNil(t, again)
-	assert.NotEqual(t, first.installationID, other.installationID, "不同客户端 session 不得共享同一 installation")
-	assert.Equal(t, first.installationID, again.installationID, "同一 session 必须稳定")
+	assert.Equal(t, first.installationID, again.installationID, "同一 session 必须稳定落在同一桶")
 	assert.Empty(t, first.sessionID, "device 模式不得折叠 session")
 }
 
@@ -122,6 +120,40 @@ func TestResolveCodexFingerprintIDs_DeviceModeWithoutSessionKeepsAccountInstall(
 	require.NotNil(t, a)
 	require.NotNil(t, b)
 	assert.Equal(t, a.installationID, b.installationID)
+	assert.Equal(t, resolveDeviceModeInstallationID(account, testCodexFingerprintSeed, ""), a.installationID)
+}
+
+func TestCodexDeviceModeInstallationBucket_CoversThreeSlots(t *testing.T) {
+	t.Parallel()
+	seen := map[int]struct{}{}
+	for i := 0; i < 200 && len(seen) < codexDeviceModeInstallationLimit; i++ {
+		seen[codexDeviceModeInstallationBucket(fmt.Sprintf("sess-%d", i))] = struct{}{}
+	}
+	require.Len(t, seen, codexDeviceModeInstallationLimit)
+}
+
+func TestResolveCodexFingerprintIDs_DeviceModeInstallationCappedAt3(t *testing.T) {
+	account := newTestOAuthAccount(5786, map[string]any{codexFingerprintModeExtraKey: "device"})
+	seen := map[string]struct{}{}
+	for i := 0; i < 64; i++ {
+		ids := resolveCodexFingerprintIDs(account, fmt.Sprintf("sess-%d", i), codexFingerprintDevice)
+		require.NotNil(t, ids)
+		seen[ids.installationID] = struct{}{}
+	}
+	empty := resolveCodexFingerprintIDs(account, "", codexFingerprintDevice)
+	require.NotNil(t, empty)
+	seen[empty.installationID] = struct{}{}
+	require.Equal(t, 3, codexDeviceModeInstallationLimit)
+	require.LessOrEqual(t, len(seen), codexDeviceModeInstallationLimit)
+	require.GreaterOrEqual(t, len(seen), 2, "64 个 session 应至少打到两个桶，否则额度仍被摊成一台设备")
+}
+
+func TestResolveDeviceModeInstallationID_AdminDeviceIDStaysSingle(t *testing.T) {
+	account := newTestOAuthAccount(1, map[string]any{"openai_device_id": "real-device-id"})
+	a := resolveDeviceModeInstallationID(account, testCodexFingerprintSeed, "sess-a")
+	b := resolveDeviceModeInstallationID(account, testCodexFingerprintSeed, "sess-b")
+	assert.Equal(t, "real-device-id", a)
+	assert.Equal(t, a, b, "管理员 device_id 覆盖时仍只能冒出 1 个 installation")
 }
 
 func TestResolveCodexFingerprintIDs_SessionModeKeepsAccountInstall(t *testing.T) {

--- a/backend/internal/service/openai_codex_fingerprint_test.go
+++ b/backend/internal/service/openai_codex_fingerprint_test.go
@@ -102,6 +102,37 @@ func TestResolveConvergedInstallationID_DifferentSeeds(t *testing.T) {
 	assert.NotEqual(t, a, b)
 }
 
+func TestResolveCodexFingerprintIDs_DeviceModeInstallationIsSessionStable(t *testing.T) {
+	account := newTestOAuthAccount(5786, map[string]any{codexFingerprintModeExtraKey: "device"})
+	first := resolveCodexFingerprintIDs(account, "sess-aaa", codexFingerprintDevice)
+	other := resolveCodexFingerprintIDs(account, "sess-bbb", codexFingerprintDevice)
+	again := resolveCodexFingerprintIDs(account, "sess-aaa", codexFingerprintDevice)
+	require.NotNil(t, first)
+	require.NotNil(t, other)
+	require.NotNil(t, again)
+	assert.NotEqual(t, first.installationID, other.installationID, "不同客户端 session 不得共享同一 installation")
+	assert.Equal(t, first.installationID, again.installationID, "同一 session 必须稳定")
+	assert.Empty(t, first.sessionID, "device 模式不得折叠 session")
+}
+
+func TestResolveCodexFingerprintIDs_DeviceModeWithoutSessionKeepsAccountInstall(t *testing.T) {
+	account := newTestOAuthAccount(5786, map[string]any{codexFingerprintModeExtraKey: "device"})
+	a := resolveCodexFingerprintIDs(account, "", codexFingerprintDevice)
+	b := resolveCodexFingerprintIDs(account, "", codexFingerprintDevice)
+	require.NotNil(t, a)
+	require.NotNil(t, b)
+	assert.Equal(t, a.installationID, b.installationID)
+}
+
+func TestResolveCodexFingerprintIDs_SessionModeKeepsAccountInstall(t *testing.T) {
+	account := newTestOAuthAccount(5786, map[string]any{codexFingerprintModeExtraKey: "session"})
+	a := resolveCodexFingerprintIDs(account, "sess-aaa", codexFingerprintSession)
+	b := resolveCodexFingerprintIDs(account, "sess-bbb", codexFingerprintSession)
+	require.NotNil(t, a)
+	require.NotNil(t, b)
+	assert.Equal(t, a.installationID, b.installationID, "session/full 仍保持账号级 installation")
+}
+
 // --- resolveConvergedThreadID ---
 
 func TestResolveConvergedThreadID_PerClientSession(t *testing.T) {

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -861,6 +861,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 
 	httpInvalidEncryptedContentRetryTried := false
 	agentTaskRecoveryTried := false
+	oauth401RefreshTried := false
 	rejectedFieldRetryState := newOpenAIResponsesRejectedFieldRetryState(body)
 	for {
 		// Build upstream request
@@ -929,6 +930,13 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
 			upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
 			upstreamCode := extractUpstreamErrorCode(respBody)
+			if resp.StatusCode == http.StatusUnauthorized && !oauth401RefreshTried {
+				if newToken, ok := s.tryRefreshOpenAI401Token(ctx, account, respBody); ok {
+					token = newToken
+					oauth401RefreshTried = true
+					continue
+				}
+			}
 			if !agentTaskRecoveryTried && s.isAgentIdentityAccount(ctx, account) && isAgentIdentityTaskInvalidHTTPResponse(resp.StatusCode, respBody) {
 				agentTaskRecoveryTried = true
 				expectedTaskID := account.GetCredential("task_id")

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -308,6 +308,7 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 	}
 
 	agentTaskRecoveryTried := false
+	oauth401RefreshTried := false
 	var resp *http.Response
 	for {
 		upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
@@ -334,6 +335,13 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		probeBody := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(probeBody))
+		if resp.StatusCode == http.StatusUnauthorized && !oauth401RefreshTried {
+			if newToken, ok := s.tryRefreshOpenAI401Token(ctx, account, probeBody); ok {
+				token = newToken
+				oauth401RefreshTried = true
+				continue
+			}
+		}
 		if !agentTaskRecoveryTried && s.isAgentIdentityAccount(ctx, account) && isAgentIdentityTaskInvalidHTTPResponse(resp.StatusCode, probeBody) {
 			agentTaskRecoveryTried = true
 			expectedTaskID := account.GetCredential("task_id")

--- a/backend/internal/service/openai_gateway_tk_oauth401_refresh.go
+++ b/backend/internal/service/openai_gateway_tk_oauth401_refresh.go
@@ -41,3 +41,28 @@ func (s *OpenAIGatewayService) tryRefreshOpenAI401Token(ctx context.Context, acc
 	slog.Info("openai_oauth_401_force_refresh_retry", "account_id", account.ID)
 	return token, true
 }
+
+// recoverOpenAIWS401AccessToken 是 WS 握手 401 的唯一注入。它复用
+// tryRefreshOpenAI401Token，并把新 token 写回 Authorization，避免 HTTP / WS
+// 各写一份刷新逻辑。
+func (s *OpenAIGatewayService) recoverOpenAIWS401AccessToken(
+	ctx context.Context,
+	account *Account,
+	statusCode int,
+	respBody []byte,
+	headers http.Header,
+) (http.Header, string, bool) {
+	if statusCode != http.StatusUnauthorized {
+		return headers, "", false
+	}
+	token, ok := s.tryRefreshOpenAI401Token(ctx, account, respBody)
+	if !ok {
+		return headers, "", false
+	}
+	refreshed := cloneHeader(headers)
+	if refreshed == nil {
+		refreshed = make(http.Header)
+	}
+	refreshed.Set("Authorization", "Bearer "+token)
+	return refreshed, token, true
+}

--- a/backend/internal/service/openai_gateway_tk_oauth401_refresh.go
+++ b/backend/internal/service/openai_gateway_tk_oauth401_refresh.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// tryRefreshOpenAI401Token 在 OpenAI OAuth 上游 401 后强制刷新并返回新 token。
+// 成功时调用方应 continue 用新 token 重试当前请求，且不得先 temp-unschedule。
+func (s *OpenAIGatewayService) tryRefreshOpenAI401Token(ctx context.Context, account *Account, respBody []byte) (string, bool) {
+	if s == nil || account == nil || s.openAITokenProvider == nil {
+		return "", false
+	}
+	if account.Platform != PlatformOpenAI || account.Type != AccountTypeOAuth {
+		return "", false
+	}
+	if !tkIsRecoverableOpenAI401(http.StatusUnauthorized, respBody) {
+		return "", false
+	}
+
+	refreshed, err := s.openAITokenProvider.ForceRefresh(ctx, account)
+	if err != nil || refreshed == nil {
+		slog.Warn("openai_oauth_401_force_refresh_failed",
+			"account_id", account.ID,
+			"error", err)
+		return "", false
+	}
+	if refreshed != account && refreshed.Credentials != nil {
+		account.Credentials = refreshed.Credentials
+	}
+
+	token, _, err := s.GetAccessToken(ctx, account)
+	if err != nil || strings.TrimSpace(token) == "" {
+		slog.Warn("openai_oauth_401_force_refresh_token_reload_failed",
+			"account_id", account.ID,
+			"error", err)
+		return "", false
+	}
+	slog.Info("openai_oauth_401_force_refresh_retry", "account_id", account.ID)
+	return token, true
+}

--- a/backend/internal/service/openai_gateway_tk_oauth401_refresh_test.go
+++ b/backend/internal/service/openai_gateway_tk_oauth401_refresh_test.go
@@ -1,0 +1,202 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTkIsRecoverableOpenAI401(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, tkIsRecoverableOpenAI401(http.StatusUnauthorized, []byte(`{"error":{"message":"invalid_api_key"}}`)))
+	require.False(t, tkIsRecoverableOpenAI401(http.StatusForbidden, []byte(`{"error":{"message":"invalid_api_key"}}`)))
+	require.False(t, tkIsRecoverableOpenAI401(http.StatusUnauthorized, []byte(`{"error":{"code":"token_revoked","message":"revoked"}}`)))
+	require.False(t, tkIsRecoverableOpenAI401(http.StatusUnauthorized, []byte(`{"error":{"code":"token_invalidated","message":"invalidated"}}`)))
+	require.False(t, tkIsRecoverableOpenAI401(http.StatusUnauthorized, []byte(`{"detail":"Unauthorized"}`)))
+	require.False(t, tkIsRecoverableOpenAI401(http.StatusUnauthorized, []byte(tkCapabilityScope401IncidentBody)))
+}
+
+func TestOpenAITokenProvider_ForceRefresh_BypassesExpirySkewAndClearsCache(t *testing.T) {
+	account := &Account{
+		ID:       5542,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Status:   StatusActive,
+		Credentials: map[string]any{
+			"access_token":  "stale-token",
+			"refresh_token": "rt-5542",
+			"expires_at":    time.Now().Add(2 * time.Hour).Format(time.RFC3339),
+		},
+	}
+	repo := &refreshAPIAccountRepo{account: account}
+	cache := newOpenAITokenCacheStub()
+	cache.tokens[OpenAITokenCacheKey(account)] = "stale-token"
+	executor := &refreshAPIExecutorStub{
+		needsRefresh: false,
+		credentials: map[string]any{
+			"access_token":  "fresh-token",
+			"refresh_token": "rt-5542",
+			"expires_at":    time.Now().Add(2 * time.Hour).Format(time.RFC3339),
+		},
+	}
+
+	provider := NewOpenAITokenProvider(repo, cache, nil)
+	provider.SetRefreshAPI(NewOAuthRefreshAPI(repo, cache), executor)
+
+	refreshed, err := provider.ForceRefresh(context.Background(), account)
+	require.NoError(t, err)
+	require.NotNil(t, refreshed)
+	require.Equal(t, "fresh-token", refreshed.GetOpenAIAccessToken())
+	require.Equal(t, 1, executor.refreshCalls)
+	_, cached := cache.tokens[OpenAITokenCacheKey(account)]
+	require.False(t, cached, "强制刷新后不得继续命中过期 cache")
+}
+
+func TestOpenAITokenProvider_ForceRefresh_MissingRefreshToken(t *testing.T) {
+	account := &Account{
+		ID:       5543,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Status:   StatusActive,
+		Credentials: map[string]any{
+			"access_token": "stale-token",
+			"expires_at":   time.Now().Add(2 * time.Hour).Format(time.RFC3339),
+		},
+	}
+	provider := NewOpenAITokenProvider(nil, nil, nil)
+	_, err := provider.ForceRefresh(context.Background(), account)
+	require.Error(t, err)
+}
+
+func TestOpenAIGatewayService_Forward_OAuth401RefreshesOnceAndSucceeds(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	c.Request.Header.Set("User-Agent", "custom-client/1.0")
+	SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+	account := &Account{
+		ID:          5544,
+		Name:        "openai-oauth-401",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":  "stale-token",
+			"refresh_token": "rt-5544",
+			"expires_at":    time.Now().Add(2 * time.Hour).Format(time.RFC3339),
+		},
+	}
+	repo := &refreshAPIAccountRepo{account: account}
+	cache := newOpenAITokenCacheStub()
+	executor := &refreshAPIExecutorStub{
+		needsRefresh: false,
+		credentials: map[string]any{
+			"access_token":  "fresh-token",
+			"refresh_token": "rt-5544",
+			"expires_at":    time.Now().Add(2 * time.Hour).Format(time.RFC3339),
+		},
+	}
+	provider := NewOpenAITokenProvider(repo, cache, nil)
+	provider.SetRefreshAPI(NewOAuthRefreshAPI(repo, cache), executor)
+
+	upstream := &httpUpstreamSequenceRecorder{
+		responses: []*http.Response{
+			{
+				StatusCode: http.StatusUnauthorized,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"invalid_api_key"}}`)),
+			},
+			{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(
+					`{"id":"resp_oauth_401_retry","usage":{"input_tokens":1,"output_tokens":2,"input_tokens_details":{"cached_tokens":0}}}`,
+				)),
+			},
+		},
+	}
+
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	rateRepo := &modelNotFoundAccountRepoStub{}
+	svc := &OpenAIGatewayService{
+		cfg:                 cfg,
+		httpUpstream:        upstream,
+		openAITokenProvider: provider,
+		rateLimitService:    &RateLimitService{accountRepo: rateRepo},
+	}
+
+	result, err := svc.Forward(context.Background(), c, account, []byte(`{"model":"gpt-5.1","stream":false,"input":[{"type":"input_text","text":"hello"}]}`))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 2, upstream.callCount)
+	require.Equal(t, "Bearer stale-token", upstream.reqs[0].Header.Get("Authorization"))
+	require.Equal(t, "Bearer fresh-token", upstream.reqs[1].Header.Get("Authorization"))
+	require.Zero(t, rateRepo.tempCalls)
+}
+
+func TestOpenAIGatewayService_Forward_OAuth401RevokedDoesNotRefresh(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+	account := &Account{
+		ID:          5545,
+		Name:        "openai-oauth-revoked",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":  "revoked-token",
+			"refresh_token": "rt-5545",
+			"expires_at":    time.Now().Add(2 * time.Hour).Format(time.RFC3339),
+		},
+	}
+	repo := &refreshAPIAccountRepo{account: account}
+	executor := &refreshAPIExecutorStub{
+		needsRefresh: false,
+		credentials:  map[string]any{"access_token": "should-not-use"},
+	}
+	provider := NewOpenAITokenProvider(repo, newOpenAITokenCacheStub(), nil)
+	provider.SetRefreshAPI(NewOAuthRefreshAPI(repo, nil), executor)
+
+	upstream := &httpUpstreamSequenceRecorder{
+		responses: []*http.Response{{
+			StatusCode: http.StatusUnauthorized,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"code":"token_revoked","message":"token revoked"}}`)),
+		}},
+	}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	svc := &OpenAIGatewayService{
+		cfg:                 cfg,
+		httpUpstream:        upstream,
+		openAITokenProvider: provider,
+		rateLimitService:    &RateLimitService{accountRepo: &modelNotFoundAccountRepoStub{}},
+	}
+
+	result, err := svc.Forward(context.Background(), c, account, []byte(`{"model":"gpt-5.1","stream":false,"input":[{"type":"input_text","text":"hello"}]}`))
+	require.Nil(t, result)
+	require.Error(t, err)
+	require.Equal(t, 1, upstream.callCount)
+	require.Equal(t, 0, executor.refreshCalls)
+}

--- a/backend/internal/service/openai_gateway_tk_oauth401_refresh_test.go
+++ b/backend/internal/service/openai_gateway_tk_oauth401_refresh_test.go
@@ -4,16 +4,20 @@ package service
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	coderws "github.com/coder/websocket"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 func TestTkIsRecoverableOpenAI401(t *testing.T) {
@@ -199,4 +203,406 @@ func TestOpenAIGatewayService_Forward_OAuth401RevokedDoesNotRefresh(t *testing.T
 	require.Error(t, err)
 	require.Equal(t, 1, upstream.callCount)
 	require.Equal(t, 0, executor.refreshCalls)
+}
+
+func newOpenAI401OAuthAccount(id int64, accessToken string) *Account {
+	return &Account{
+		ID:          id,
+		Name:        "openai-oauth-401-ssot",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":  accessToken,
+			"refresh_token": "rt-ssot",
+			"expires_at":    time.Now().Add(2 * time.Hour).Format(time.RFC3339),
+		},
+	}
+}
+
+func TestOpenAITokenProvider_ForceRefresh_LockHeldAdoptsWinnerToken(t *testing.T) {
+	stale := newOpenAI401OAuthAccount(5610, "stale-token")
+	winner := newOpenAI401OAuthAccount(5610, "winner-token")
+	repo := &refreshAPIAccountRepo{account: winner}
+	cache := newOpenAITokenCacheStub()
+	cache.lockAcquired = false
+	cache.tokens[OpenAITokenCacheKey(stale)] = "stale-token"
+	executor := &refreshAPIExecutorStub{needsRefresh: false}
+
+	provider := NewOpenAITokenProvider(repo, cache, nil)
+	provider.SetRefreshAPI(NewOAuthRefreshAPI(repo, cache), executor)
+
+	refreshed, err := provider.ForceRefresh(context.Background(), stale)
+	require.NoError(t, err)
+	require.Equal(t, "winner-token", refreshed.GetOpenAIAccessToken())
+	require.Equal(t, 0, executor.refreshCalls, "输家不得自己再刷一次")
+}
+
+func TestOpenAITokenProvider_ForceRefresh_LockHeldStaleTokenIsFailure(t *testing.T) {
+	account := newOpenAI401OAuthAccount(5611, "stale-token")
+	repo := &refreshAPIAccountRepo{account: account}
+	cache := newOpenAITokenCacheStub()
+	cache.lockAcquired = false
+	cache.tokens[OpenAITokenCacheKey(account)] = "stale-token"
+	executor := &refreshAPIExecutorStub{needsRefresh: false}
+
+	provider := NewOpenAITokenProvider(repo, cache, nil)
+	provider.SetRefreshAPI(NewOAuthRefreshAPI(repo, cache), executor)
+
+	_, err := provider.ForceRefresh(context.Background(), account)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "lock held")
+	require.Equal(t, 0, executor.refreshCalls)
+}
+
+func TestOpenAIGatewayService_Forward_OAuth401LockHeldUsesWinnerToken(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+	stale := newOpenAI401OAuthAccount(5612, "stale-token")
+	winner := newOpenAI401OAuthAccount(5612, "winner-token")
+	repo := &refreshAPIAccountRepo{account: winner}
+	cache := newOpenAITokenCacheStub()
+	cache.lockAcquired = false
+	executor := &refreshAPIExecutorStub{needsRefresh: false}
+	provider := NewOpenAITokenProvider(repo, cache, nil)
+	provider.SetRefreshAPI(NewOAuthRefreshAPI(repo, cache), executor)
+
+	rateRepo := &rateLimitAccountRepoStub{}
+	upstream := &httpUpstreamSequenceRecorder{
+		responses: []*http.Response{
+			{
+				StatusCode: http.StatusUnauthorized,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"invalid_api_key"}}`)),
+			},
+			{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(
+					`{"id":"resp_oauth_401_lock","usage":{"input_tokens":1,"output_tokens":2,"input_tokens_details":{"cached_tokens":0}}}`,
+				)),
+			},
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	svc := &OpenAIGatewayService{
+		cfg:                 cfg,
+		httpUpstream:        upstream,
+		openAITokenProvider: provider,
+		rateLimitService:    &RateLimitService{accountRepo: rateRepo},
+	}
+
+	result, err := svc.Forward(context.Background(), c, stale, []byte(`{"model":"gpt-5.1","stream":false,"input":[{"type":"input_text","text":"hello"}]}`))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 2, upstream.callCount)
+	require.Equal(t, "Bearer stale-token", upstream.reqs[0].Header.Get("Authorization"))
+	require.Equal(t, "Bearer winner-token", upstream.reqs[1].Header.Get("Authorization"))
+	require.Zero(t, rateRepo.setErrorCalls)
+	require.Equal(t, 0, executor.refreshCalls)
+}
+
+func TestOpenAIGatewayService_recoverOpenAIWS401AccessToken(t *testing.T) {
+	account := newOpenAI401OAuthAccount(5613, "stale-token")
+	repo := &refreshAPIAccountRepo{account: account}
+	cache := newOpenAITokenCacheStub()
+	executor := &refreshAPIExecutorStub{
+		needsRefresh: false,
+		credentials: map[string]any{
+			"access_token":  "fresh-token",
+			"refresh_token": "rt-ssot",
+			"expires_at":    time.Now().Add(2 * time.Hour).Format(time.RFC3339),
+		},
+	}
+	provider := NewOpenAITokenProvider(repo, cache, nil)
+	provider.SetRefreshAPI(NewOAuthRefreshAPI(repo, cache), executor)
+	svc := &OpenAIGatewayService{openAITokenProvider: provider}
+
+	headers := http.Header{"Authorization": []string{"Bearer stale-token"}}
+	refreshed, token, ok := svc.recoverOpenAIWS401AccessToken(
+		context.Background(),
+		account,
+		http.StatusUnauthorized,
+		[]byte(`{"error":{"message":"invalid_api_key"}}`),
+		headers,
+	)
+	require.True(t, ok)
+	require.Equal(t, "fresh-token", token)
+	require.Equal(t, "Bearer fresh-token", refreshed.Get("Authorization"))
+	require.Equal(t, 1, executor.refreshCalls)
+
+	_, _, ok = svc.recoverOpenAIWS401AccessToken(
+		context.Background(),
+		account,
+		http.StatusUnauthorized,
+		[]byte(`{"error":{"code":"token_revoked","message":"revoked"}}`),
+		headers,
+	)
+	require.False(t, ok)
+	require.Equal(t, 1, executor.refreshCalls, "永久 401 不得再走 RefreshNow")
+}
+
+type openAIWS401ThenOKDialer struct {
+	mu        sync.Mutex
+	conn      openAIWSClientConn
+	auths     []string
+	dialCount int
+}
+
+func (d *openAIWS401ThenOKDialer) Dial(
+	_ context.Context,
+	_ string,
+	headers http.Header,
+	_ string,
+) (openAIWSClientConn, int, http.Header, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.dialCount++
+	d.auths = append(d.auths, headers.Get("Authorization"))
+	if d.dialCount == 1 {
+		return nil, http.StatusUnauthorized, nil, &openAIWSHandshakeError{
+			Body: []byte(`{"error":{"message":"invalid_api_key"}}`),
+			Err:  errors.New("unauthorized"),
+		}
+	}
+	return d.conn, http.StatusSwitchingProtocols, http.Header{}, nil
+}
+
+func TestOpenAIGatewayService_Forward_WSv2OAuth401RefreshesOnce(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	c.Request.Header.Set("User-Agent", "unit-test-agent/1.0")
+
+	account := newOpenAI401OAuthAccount(5614, "stale-token")
+	account.Extra = map[string]any{"openai_oauth_responses_websockets_v2_enabled": true}
+	repo := &refreshAPIAccountRepo{account: account}
+	cache := newOpenAITokenCacheStub()
+	executor := &refreshAPIExecutorStub{
+		needsRefresh: false,
+		credentials: map[string]any{
+			"access_token":  "fresh-token",
+			"refresh_token": "rt-ssot",
+			"expires_at":    time.Now().Add(2 * time.Hour).Format(time.RFC3339),
+		},
+	}
+	provider := NewOpenAITokenProvider(repo, cache, nil)
+	provider.SetRefreshAPI(NewOAuthRefreshAPI(repo, cache), executor)
+
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	cfg.Gateway.OpenAIWS.Enabled = true
+	cfg.Gateway.OpenAIWS.OAuthEnabled = true
+	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 1
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 1
+	cfg.Gateway.OpenAIWS.QueueLimitPerConn = 8
+	cfg.Gateway.OpenAIWS.DialTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 5
+	cfg.Gateway.OpenAIWS.WriteTimeoutSeconds = 3
+
+	captureConn := &openAIWSCaptureConn{
+		events: [][]byte{
+			[]byte(`{"type":"response.completed","response":{"id":"resp_ws_401","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`),
+		},
+	}
+	dialer := &openAIWS401ThenOKDialer{conn: captureConn}
+	pool := newOpenAIWSConnPool(cfg)
+	pool.setClientDialerForTest(dialer)
+	rateRepo := &rateLimitAccountRepoStub{}
+	svc := &OpenAIGatewayService{
+		cfg:                 cfg,
+		httpUpstream:        &httpUpstreamRecorder{},
+		cache:               &stubGatewayCache{},
+		openaiWSResolver:    NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:       NewCodexToolCorrector(),
+		openaiWSPool:        pool,
+		openAITokenProvider: provider,
+		rateLimitService:    &RateLimitService{accountRepo: rateRepo},
+	}
+
+	result, err := svc.Forward(context.Background(), c, account, []byte(`{"model":"gpt-5.1","stream":false,"input":[{"type":"input_text","text":"hello"}]}`))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "resp_ws_401", result.RequestID)
+	require.Equal(t, 2, dialer.dialCount)
+	require.Equal(t, []string{"Bearer stale-token", "Bearer fresh-token"}, dialer.auths)
+	require.Zero(t, rateRepo.setErrorCalls)
+	require.Equal(t, 1, executor.refreshCalls)
+}
+
+func TestOpenAIGatewayService_PassthroughWS_OAuth401RefreshesOnce(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	account := newOpenAI401OAuthAccount(5615, "stale-token")
+	account.Extra = map[string]any{"openai_oauth_responses_websockets_v2_mode": OpenAIWSIngressModePassthrough}
+	repo := &refreshAPIAccountRepo{account: account}
+	cache := newOpenAITokenCacheStub()
+	executor := &refreshAPIExecutorStub{
+		needsRefresh: false,
+		credentials: map[string]any{
+			"access_token":  "fresh-token",
+			"refresh_token": "rt-ssot",
+			"expires_at":    time.Now().Add(2 * time.Hour).Format(time.RFC3339),
+		},
+	}
+	provider := NewOpenAITokenProvider(repo, cache, nil)
+	provider.SetRefreshAPI(NewOAuthRefreshAPI(repo, cache), executor)
+
+	cfg := passthroughLifecycleConfig()
+	cfg.Gateway.OpenAIWS.OAuthEnabled = true
+	cfg.Gateway.OpenAIWS.ModeRouterV2Enabled = true
+	cfg.Gateway.OpenAIWS.IngressModeDefault = OpenAIWSIngressModePassthrough
+
+	upstream := newStagedPassthroughConn()
+	upstream.Send(`{"type":"response.completed","response":{"id":"resp_ws_pt_401","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`)
+	dialer := &openAIWS401ThenOKDialer{conn: upstream}
+	rateRepo := &rateLimitAccountRepoStub{}
+	svc := &OpenAIGatewayService{
+		cfg:                       cfg,
+		httpUpstream:              &httpUpstreamRecorder{},
+		cache:                     &stubGatewayCache{},
+		openaiWSResolver:          NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:             NewCodexToolCorrector(),
+		openaiWSPassthroughDialer: dialer,
+		openAITokenProvider:       provider,
+		rateLimitService:          &RateLimitService{accountRepo: rateRepo},
+	}
+
+	controlCtx, cancelControl := context.WithCancelCause(context.Background())
+	defer cancelControl(context.Canceled)
+	server, serverErr := startOpenAIWS401PassthroughServer(t, controlCtx, svc, account, "stale-token")
+	defer server.Close()
+
+	clientConn := dialPassthroughLifecycleClient(t, server)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	event, err := readPassthroughLifecycleFrame(t, clientConn, 3*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "response.completed", gjson.GetBytes(event, "type").String())
+	require.Equal(t, 2, dialer.dialCount)
+	require.Equal(t, []string{"Bearer stale-token", "Bearer fresh-token"}, dialer.auths)
+	require.Zero(t, rateRepo.setErrorCalls)
+	select {
+	case <-serverErr:
+	case <-time.After(3 * time.Second):
+	}
+}
+
+func TestOpenAIGatewayService_PassthroughWS_OAuth401RevokedDoesNotRefresh(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	account := newOpenAI401OAuthAccount(5616, "revoked-token")
+	account.Extra = map[string]any{"openai_oauth_responses_websockets_v2_mode": OpenAIWSIngressModePassthrough}
+	repo := &refreshAPIAccountRepo{account: account}
+	executor := &refreshAPIExecutorStub{needsRefresh: false, credentials: map[string]any{"access_token": "should-not-use"}}
+	provider := NewOpenAITokenProvider(repo, newOpenAITokenCacheStub(), nil)
+	provider.SetRefreshAPI(NewOAuthRefreshAPI(repo, nil), executor)
+
+	cfg := passthroughLifecycleConfig()
+	cfg.Gateway.OpenAIWS.OAuthEnabled = true
+	cfg.Gateway.OpenAIWS.ModeRouterV2Enabled = true
+	cfg.Gateway.OpenAIWS.IngressModeDefault = OpenAIWSIngressModePassthrough
+
+	dialer := &openAIWSAlways401Dialer{body: []byte(`{"error":{"code":"token_revoked","message":"revoked"}}`)}
+	svc := &OpenAIGatewayService{
+		cfg:                       cfg,
+		httpUpstream:              &httpUpstreamRecorder{},
+		cache:                     &stubGatewayCache{},
+		openaiWSResolver:          NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:             NewCodexToolCorrector(),
+		openaiWSPassthroughDialer: dialer,
+		openAITokenProvider:       provider,
+		rateLimitService:          &RateLimitService{accountRepo: &rateLimitAccountRepoStub{}},
+	}
+
+	controlCtx, cancelControl := context.WithCancelCause(context.Background())
+	defer cancelControl(context.Canceled)
+	server, serverErr := startOpenAIWS401PassthroughServer(t, controlCtx, svc, account, "revoked-token")
+	defer server.Close()
+
+	clientConn := dialPassthroughLifecycleClient(t, server)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	select {
+	case err := <-serverErr:
+		require.Error(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("revoked WS 401 应立即失败")
+	}
+	require.Equal(t, 1, dialer.dialCount)
+	require.Equal(t, 0, executor.refreshCalls)
+}
+
+func startOpenAIWS401PassthroughServer(
+	t *testing.T,
+	controlCtx context.Context,
+	svc *OpenAIGatewayService,
+	account *Account,
+	token string,
+) (*httptest.Server, <-chan error) {
+	t.Helper()
+	serverErr := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := coderws.Accept(w, r, &coderws.AcceptOptions{CompressionMode: coderws.CompressionContextTakeover})
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+
+		msgType, firstMessage, err := ReadOpenAIWSClientMessage(
+			controlCtx,
+			conn,
+			3*time.Second,
+			coderws.StatusPolicyViolation,
+			"missing first response.create message",
+		)
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		if msgType != coderws.MessageText {
+			serverErr <- errors.New("first message was not text")
+			return
+		}
+
+		recorder := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(recorder)
+		req := r.Clone(controlCtx)
+		req.Header = req.Header.Clone()
+		ginCtx.Request = req
+		serverErr <- svc.ProxyResponsesWebSocketFromClient(controlCtx, ginCtx, conn, account, token, firstMessage, nil)
+	}))
+	return server, serverErr
+}
+
+type openAIWSAlways401Dialer struct {
+	mu        sync.Mutex
+	body      []byte
+	dialCount int
+}
+
+func (d *openAIWSAlways401Dialer) Dial(
+	_ context.Context,
+	_ string,
+	_ http.Header,
+	_ string,
+) (openAIWSClientConn, int, http.Header, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.dialCount++
+	return nil, http.StatusUnauthorized, nil, &openAIWSHandshakeError{
+		Body: append([]byte(nil), d.body...),
+		Err:  errors.New("unauthorized"),
+	}
 }

--- a/backend/internal/service/openai_token_provider_tk_force_refresh.go
+++ b/backend/internal/service/openai_token_provider_tk_force_refresh.go
@@ -58,8 +58,18 @@ func (p *OpenAITokenProvider) ForceRefresh(ctx context.Context, account *Account
 	return account, nil
 }
 
+// tkIsPermanentOpenAIAuth401 是 OpenAI 永久认证失败的单一判定。
+// HandleUpstreamError 与请求内 RefreshNow 必须共用，避免一边刷新一边停号。
+func tkIsPermanentOpenAIAuth401(body []byte) bool {
+	switch strings.ToLower(strings.TrimSpace(extractUpstreamErrorCode(body))) {
+	case "token_invalidated", "token_revoked":
+		return true
+	}
+	return gjson.GetBytes(body, "detail").String() == "Unauthorized"
+}
+
 // tkIsRecoverableOpenAI401 识别「当前 access_token 被拒、但 refresh_token 仍可能救活」的 401。
-// 能力缺失 / 永久吊销 / Unauthorized 细节必须继续走既有惩罚路径。
+// 能力缺失 / 永久吊销必须继续走既有惩罚路径。
 func tkIsRecoverableOpenAI401(statusCode int, body []byte) bool {
 	if statusCode != http.StatusUnauthorized {
 		return false
@@ -67,12 +77,5 @@ func tkIsRecoverableOpenAI401(statusCode int, body []byte) bool {
 	if tkIsCapabilityScope401(statusCode, body) {
 		return false
 	}
-	code := strings.ToLower(strings.TrimSpace(extractUpstreamErrorCode(body)))
-	if code == "token_invalidated" || code == "token_revoked" {
-		return false
-	}
-	if gjson.GetBytes(body, "detail").String() == "Unauthorized" {
-		return false
-	}
-	return true
+	return !tkIsPermanentOpenAIAuth401(body)
 }

--- a/backend/internal/service/openai_token_provider_tk_force_refresh.go
+++ b/backend/internal/service/openai_token_provider_tk_force_refresh.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/tidwall/gjson"
 )
@@ -32,13 +33,8 @@ func (p *OpenAITokenProvider) ForceRefresh(ctx context.Context, account *Account
 		return account, errors.New("oauth refresh api is not configured")
 	}
 
-	if p.tokenCache != nil {
-		if err := p.tokenCache.DeleteAccessToken(ctx, OpenAITokenCacheKey(account)); err != nil {
-			slog.Warn("openai_token_force_refresh_cache_delete_failed",
-				"account_id", account.ID, "error", err)
-		}
-	}
-
+	// 先 RefreshNow 再清 cache。并发 401 的输家若先 DeleteAccessToken，
+	// 会把赢家刚写入的新 token 抹掉，然后把 LockHeld 当成刷新失败停号。
 	result, err := p.refreshAPI.RefreshNow(ctx, account, p.executor)
 	if err != nil {
 		return account, err
@@ -47,7 +43,12 @@ func (p *OpenAITokenProvider) ForceRefresh(ctx context.Context, account *Account
 		return account, errors.New("empty oauth refresh result")
 	}
 	if result.LockHeld {
-		return account, errors.New("oauth refresh lock held")
+		refreshed, waitErr := p.awaitForceRefreshWinner(ctx, account)
+		if waitErr != nil {
+			return account, waitErr
+		}
+		p.dropOpenAIAccessTokenCache(ctx, refreshed)
+		return refreshed, nil
 	}
 	if result.Account != nil {
 		account = result.Account
@@ -55,7 +56,116 @@ func (p *OpenAITokenProvider) ForceRefresh(ctx context.Context, account *Account
 	if strings.TrimSpace(account.GetOpenAIAccessToken()) == "" {
 		return account, errors.New("force refresh did not produce access_token")
 	}
+	p.dropOpenAIAccessTokenCache(ctx, account)
 	return account, nil
+}
+
+func (p *OpenAITokenProvider) dropOpenAIAccessTokenCache(ctx context.Context, account *Account) {
+	if p == nil || p.tokenCache == nil || account == nil {
+		return
+	}
+	if err := p.tokenCache.DeleteAccessToken(ctx, OpenAITokenCacheKey(account)); err != nil {
+		slog.Warn("openai_token_force_refresh_cache_delete_failed",
+			"account_id", account.ID, "error", err)
+	}
+}
+
+// awaitForceRefreshWinner 在 RefreshNow 返回 LockHeld 时复用 GetAccessToken
+// 的锁等待节奏，但只接受与被拒 token 不同的新 access_token。
+// cache 与 DB 共用同一判定：别人正在 RefreshNow，不是本请求刷新失败。
+func (p *OpenAITokenProvider) awaitForceRefreshWinner(ctx context.Context, account *Account) (*Account, error) {
+	if p == nil || account == nil {
+		return account, errors.New("oauth refresh lock held")
+	}
+	stale := strings.TrimSpace(account.GetOpenAIAccessToken())
+	if p.metrics != nil {
+		p.metrics.lockContention.Add(1)
+		p.metrics.touchNow()
+	}
+	if refreshed := p.lookupForceRefreshWinner(ctx, account, stale); refreshed != nil {
+		return refreshed, nil
+	}
+
+	wait := openAILockInitialWait
+	for i := 0; i < openAILockMaxAttempts; i++ {
+		actualWait := jitterLockWait(wait)
+		timer := time.NewTimer(actualWait)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return account, ctx.Err()
+		case <-timer.C:
+		}
+		if p.metrics != nil {
+			waitMs := actualWait.Milliseconds()
+			if waitMs < 0 {
+				waitMs = 0
+			}
+			p.metrics.lockWaitSamples.Add(1)
+			p.metrics.lockWaitTotalMs.Add(waitMs)
+			p.metrics.touchNow()
+		}
+		if refreshed := p.lookupForceRefreshWinner(ctx, account, stale); refreshed != nil {
+			if p.metrics != nil {
+				p.metrics.lockWaitHit.Add(1)
+			}
+			return refreshed, nil
+		}
+		if wait < openAILockMaxWait {
+			wait *= 2
+			if wait > openAILockMaxWait {
+				wait = openAILockMaxWait
+			}
+		}
+	}
+	if p.metrics != nil {
+		p.metrics.lockWaitMiss.Add(1)
+	}
+	return account, errors.New("oauth refresh lock held")
+}
+
+func (p *OpenAITokenProvider) lookupForceRefreshWinner(ctx context.Context, account *Account, stale string) *Account {
+	if p == nil || account == nil {
+		return nil
+	}
+	if p.tokenCache != nil {
+		token, err := p.tokenCache.GetAccessToken(ctx, OpenAITokenCacheKey(account))
+		if err == nil {
+			if next := strings.TrimSpace(token); next != "" && next != stale {
+				if p.accountRepo != nil {
+					if fresh, rerr := p.accountRepo.GetByID(ctx, account.ID); rerr == nil && fresh != nil {
+						if dbToken := strings.TrimSpace(fresh.GetOpenAIAccessToken()); dbToken != "" && dbToken != stale {
+							return fresh
+						}
+					}
+				}
+				updated := *account
+				creds := make(map[string]any, len(account.Credentials)+1)
+				for key, value := range account.Credentials {
+					creds[key] = value
+				}
+				creds["access_token"] = next
+				updated.Credentials = creds
+				return &updated
+			}
+		}
+	}
+	if p.accountRepo == nil {
+		return nil
+	}
+	fresh, err := p.accountRepo.GetByID(ctx, account.ID)
+	if err != nil || fresh == nil {
+		return nil
+	}
+	if next := strings.TrimSpace(fresh.GetOpenAIAccessToken()); next != "" && next != stale {
+		return fresh
+	}
+	return nil
 }
 
 // tkIsPermanentOpenAIAuth401 是 OpenAI 永久认证失败的单一判定。

--- a/backend/internal/service/openai_token_provider_tk_force_refresh.go
+++ b/backend/internal/service/openai_token_provider_tk_force_refresh.go
@@ -1,0 +1,78 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// ForceRefresh 在上游已明确拒绝当前 access_token 时强制刷新（忽略 3min skew）。
+// 成功后清掉本地 cache，避免下一跳再命中被拒的 token。
+func (p *OpenAITokenProvider) ForceRefresh(ctx context.Context, account *Account) (*Account, error) {
+	if p == nil {
+		return account, errors.New("openai token provider is nil")
+	}
+	if account == nil {
+		return nil, errors.New("account is nil")
+	}
+	if account.Platform != PlatformOpenAI || account.Type != AccountTypeOAuth {
+		return account, errors.New("not an openai oauth account")
+	}
+	if account.IsOpenAIPersonalAccessToken() {
+		return account, errors.New("personal access token cannot be force-refreshed")
+	}
+	if strings.TrimSpace(account.GetOpenAIRefreshToken()) == "" {
+		return account, errors.New("refresh_token missing")
+	}
+	if p.refreshAPI == nil || p.executor == nil {
+		return account, errors.New("oauth refresh api is not configured")
+	}
+
+	if p.tokenCache != nil {
+		if err := p.tokenCache.DeleteAccessToken(ctx, OpenAITokenCacheKey(account)); err != nil {
+			slog.Warn("openai_token_force_refresh_cache_delete_failed",
+				"account_id", account.ID, "error", err)
+		}
+	}
+
+	result, err := p.refreshAPI.RefreshNow(ctx, account, p.executor)
+	if err != nil {
+		return account, err
+	}
+	if result == nil {
+		return account, errors.New("empty oauth refresh result")
+	}
+	if result.LockHeld {
+		return account, errors.New("oauth refresh lock held")
+	}
+	if result.Account != nil {
+		account = result.Account
+	}
+	if strings.TrimSpace(account.GetOpenAIAccessToken()) == "" {
+		return account, errors.New("force refresh did not produce access_token")
+	}
+	return account, nil
+}
+
+// tkIsRecoverableOpenAI401 识别「当前 access_token 被拒、但 refresh_token 仍可能救活」的 401。
+// 能力缺失 / 永久吊销 / Unauthorized 细节必须继续走既有惩罚路径。
+func tkIsRecoverableOpenAI401(statusCode int, body []byte) bool {
+	if statusCode != http.StatusUnauthorized {
+		return false
+	}
+	if tkIsCapabilityScope401(statusCode, body) {
+		return false
+	}
+	code := strings.ToLower(strings.TrimSpace(extractUpstreamErrorCode(body)))
+	if code == "token_invalidated" || code == "token_revoked" {
+		return false
+	}
+	if gjson.GetBytes(body, "detail").String() == "Unauthorized" {
+		return false
+	}
+	return true
+}

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -698,6 +698,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 	}
 
 	agentTaskRecoveryTried := false
+	oauth401RefreshTried := false
 	var acquireTurnLease func(int, string, bool) (*openAIWSConnLease, error)
 	acquireTurnLease = func(turn int, preferred string, forcePreferredConn bool) (*openAIWSConnLease, error) {
 		req := cloneOpenAIWSAcquireRequest(baseAcquireReq)
@@ -715,6 +716,19 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 				return nil, fmt.Errorf("agent identity task recovery failed: %w", recoveryErr)
 			}
 			return acquireTurnLease(turn, preferred, forcePreferredConn)
+		}
+		if acquireErr != nil && !oauth401RefreshTried {
+			statusCode := 0
+			var responseBody []byte
+			if errors.As(acquireErr, &dialErr) && dialErr != nil {
+				statusCode = dialErr.StatusCode
+				responseBody = dialErr.ResponseBody
+			}
+			if newHeaders, _, ok := s.recoverOpenAIWS401AccessToken(ctx, account, statusCode, responseBody, baseAcquireReq.Headers); ok {
+				oauth401RefreshTried = true
+				baseAcquireReq.Headers = newHeaders
+				return acquireTurnLease(turn, preferred, forcePreferredConn)
+			}
 		}
 		if acquireErr != nil {
 			dialStatus, dialClass, dialCloseStatus, dialCloseReason, dialRespServer, dialRespVia, dialRespCFRay, dialRespReqID := summarizeOpenAIWSDialError(acquireErr)

--- a/backend/internal/service/openai_ws_forwarder_v2.go
+++ b/backend/internal/service/openai_ws_forwarder_v2.go
@@ -185,26 +185,30 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 		account.ProxyID != nil && account.Proxy != nil,
 	)
 
-	acquireCtx, acquireCancel := context.WithTimeout(ctx, s.openAIWSAcquireTimeout())
-	defer acquireCancel()
-
-	lease, err := s.getOpenAIWSConnPool().Acquire(acquireCtx, openAIWSAcquireRequest{
-		Account: account,
-		WSURL:   wsURL,
-		Headers: wsHeaders,
-		HeadersFactory: func(factoryCtx context.Context, headers http.Header) (http.Header, error) {
-			return s.refreshOpenAIAgentIdentityHeaders(factoryCtx, account, headers)
-		},
-		PreferredConnID: preferredConnID,
-		ForceNewConn:    forceNewConn,
-		ProxyURL: func() string {
-			if account.ProxyID != nil && account.Proxy != nil {
-				return account.Proxy.URL()
-			}
-			return ""
-		}(),
-	})
-	if err != nil {
+	oauth401RefreshTried := false
+	var lease *openAIWSConnLease
+	for {
+		acquireCtx, acquireCancel := context.WithTimeout(ctx, s.openAIWSAcquireTimeout())
+		lease, err = s.getOpenAIWSConnPool().Acquire(acquireCtx, openAIWSAcquireRequest{
+			Account: account,
+			WSURL:   wsURL,
+			Headers: wsHeaders,
+			HeadersFactory: func(factoryCtx context.Context, headers http.Header) (http.Header, error) {
+				return s.refreshOpenAIAgentIdentityHeaders(factoryCtx, account, headers)
+			},
+			PreferredConnID: preferredConnID,
+			ForceNewConn:    forceNewConn,
+			ProxyURL: func() string {
+				if account.ProxyID != nil && account.Proxy != nil {
+					return account.Proxy.URL()
+				}
+				return ""
+			}(),
+		})
+		acquireCancel()
+		if err == nil {
+			break
+		}
 		var agentDialErr *openAIWSDialError
 		if s.isAgentIdentityAccount(ctx, account) && errors.As(err, &agentDialErr) && isAgentIdentityTaskInvalidWSDialError(agentDialErr) && agentTaskRecoveryTried != nil && !*agentTaskRecoveryTried {
 			*agentTaskRecoveryTried = true
@@ -212,6 +216,21 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 				return nil, fmt.Errorf("agent identity task recovery failed: %w", recoveryErr)
 			}
 			return nil, &agentIdentityTaskRecoveredError{}
+		}
+		if !oauth401RefreshTried {
+			var dialErr *openAIWSDialError
+			statusCode := 0
+			var responseBody []byte
+			if errors.As(err, &dialErr) && dialErr != nil {
+				statusCode = dialErr.StatusCode
+				responseBody = dialErr.ResponseBody
+			}
+			if newHeaders, _, ok := s.recoverOpenAIWS401AccessToken(ctx, account, statusCode, responseBody, wsHeaders); ok {
+				oauth401RefreshTried = true
+				wsHeaders = newHeaders
+				forceNewConn = true
+				continue
+			}
 		}
 		dialStatus, dialClass, dialCloseStatus, dialCloseReason, dialRespServer, dialRespVia, dialRespCFRay, dialRespReqID := summarizeOpenAIWSDialError(err)
 		logOpenAIWSModeInfo(

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -838,6 +838,7 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 	}
 
 	agentTaskRecoveryTried := false
+	oauth401RefreshTried := false
 	var upstreamConn openAIWSClientConn
 	statusCode := 0
 	var handshakeHeaders http.Header
@@ -864,6 +865,13 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 				return fmt.Errorf("agent identity task recovery failed: %w", recoveryErr)
 			}
 			continue
+		}
+		if !oauth401RefreshTried {
+			if newHeaders, _, ok := s.recoverOpenAIWS401AccessToken(ctx, account, statusCode, responseBody, headers); ok {
+				oauth401RefreshTried = true
+				headers = newHeaders
+				continue
+			}
 		}
 		logOpenAIWSV2Passthrough(
 			"relay_dial_failed account_id=%d status_code=%d err=%s",

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -509,6 +509,8 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 			msg := "Identity verification required (400): " + upstreamMsg
 			s.handleAuthError(ctx, account, msg)
 			shouldDisable = true
+		} else if account.Platform == PlatformOpenAI && isOpenAIImageCapabilityLoss400(statusCode, responseBody) {
+			_ = s.HandleOpenAIImageCapabilityLoss400(ctx, account, statusCode, responseBody)
 		} else if account.Platform == PlatformAnthropic && tkIsAnthropicClientInducedBadRequest(responseBody) {
 			// TK (upstream#2608): client-induced invalid_request_error is caller-side;
 			// atypical 400s are also out of stub-health fuse scope (see

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -567,22 +567,20 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 		if resolved, rerr := resolveCredentialAccount(ctx, s.accountRepo, account); rerr == nil && resolved != nil {
 			authAccount = resolved
 		}
-		// OpenAI: token_invalidated / token_revoked 表示 token 被永久作废（非过期），直接标记 error
-		openai401Code := extractUpstreamErrorCode(responseBody)
-		if authAccount.Platform == PlatformOpenAI && (openai401Code == "token_invalidated" || openai401Code == "token_revoked") {
-			msg := "Token revoked (401): account authentication permanently revoked"
-			if upstreamMsg != "" {
-				msg = "Token revoked (401): " + upstreamMsg
-			}
-			s.handleAuthError(ctx, authAccount, msg)
-			shouldDisable = true
-			break
-		}
-		// OpenAI: {"detail":"Unauthorized"} 表示 token 完全无效（非标准 OpenAI 错误格式），直接标记 error
-		if authAccount.Platform == PlatformOpenAI && gjson.GetBytes(responseBody, "detail").String() == "Unauthorized" {
+		// OpenAI: 永久认证失败（token_invalidated / token_revoked / detail=Unauthorized）
+		// 判定只在 tkIsPermanentOpenAIAuth401，这里只负责文案。
+		if authAccount.Platform == PlatformOpenAI && tkIsPermanentOpenAIAuth401(responseBody) {
+			openai401Code := extractUpstreamErrorCode(responseBody)
 			msg := "Unauthorized (401): account authentication failed permanently"
+			if openai401Code == "token_invalidated" || openai401Code == "token_revoked" {
+				msg = "Token revoked (401): account authentication permanently revoked"
+			}
 			if upstreamMsg != "" {
-				msg = "Unauthorized (401): " + upstreamMsg
+				if openai401Code == "token_invalidated" || openai401Code == "token_revoked" {
+					msg = "Token revoked (401): " + upstreamMsg
+				} else {
+					msg = "Unauthorized (401): " + upstreamMsg
+				}
 			}
 			s.handleAuthError(ctx, authAccount, msg)
 			shouldDisable = true

--- a/backend/internal/service/ratelimit_service_tk_account_capability_400.go
+++ b/backend/internal/service/ratelimit_service_tk_account_capability_400.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	openAIImageCapabilityLossReason = "openai_image_capability_lost"
+	openAIImageCapabilityLossTTL    = 24 * time.Hour
+)
+
+// isOpenAIImageCapabilityLoss400 识别账号级生图能力丢失的 400。
+// 调用方自己的 invalid_request（缺参、非法 size）不得命中。
+func isOpenAIImageCapabilityLoss400(statusCode int, body []byte) bool {
+	if statusCode != http.StatusBadRequest || len(body) == 0 {
+		return false
+	}
+	hay := strings.ToLower(string(body))
+	hasImage := strings.Contains(hay, "image_generation") ||
+		strings.Contains(hay, "gpt-image") ||
+		strings.Contains(hay, "image generation")
+	if !hasImage {
+		return false
+	}
+	for _, marker := range []string{
+		"not supported",
+		"not available",
+		"not enabled",
+		"unknown tool",
+		"does not have access",
+		"tool is not",
+	} {
+		if strings.Contains(hay, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// HandleOpenAIImageCapabilityLoss400 把账号从生图调度里摘掉，但不罚整号。
+func (s *RateLimitService) HandleOpenAIImageCapabilityLoss400(ctx context.Context, account *Account, statusCode int, responseBody []byte) bool {
+	if s == nil || account == nil || s.accountRepo == nil {
+		return false
+	}
+	if account.Platform != PlatformOpenAI {
+		return false
+	}
+	if !isOpenAIImageCapabilityLoss400(statusCode, responseBody) {
+		return false
+	}
+
+	resetAt := time.Now().Add(openAIImageCapabilityLossTTL)
+	if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, openAIImageGenerationRateLimitKey, resetAt, openAIImageCapabilityLossReason); err != nil {
+		slog.Warn("openai_image_capability_loss_set_model_rate_limit_failed",
+			"account_id", account.ID,
+			"scope", openAIImageGenerationRateLimitKey,
+			"error", err)
+		return true
+	}
+	slog.Info("openai_image_capability_lost",
+		"account_id", account.ID,
+		"scope", openAIImageGenerationRateLimitKey,
+		"reset_at", resetAt)
+	return true
+}

--- a/backend/internal/service/ratelimit_service_tk_account_capability_400_test.go
+++ b/backend/internal/service/ratelimit_service_tk_account_capability_400_test.go
@@ -1,0 +1,77 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsOpenAIImageCapabilityLoss400(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isOpenAIImageCapabilityLoss400(http.StatusBadRequest, []byte(
+		`{"error":{"message":"The image_generation tool is not supported for this account."}}`,
+	)))
+	require.True(t, isOpenAIImageCapabilityLoss400(http.StatusBadRequest, []byte(
+		`{"error":{"message":"image_generation is not available"}}`,
+	)))
+	require.False(t, isOpenAIImageCapabilityLoss400(http.StatusTooManyRequests, []byte(
+		`{"error":{"message":"The image_generation tool is not supported for this account."}}`,
+	)))
+	require.False(t, isOpenAIImageCapabilityLoss400(http.StatusBadRequest, []byte(
+		`{"error":{"message":"Invalid value for 'size'."}}`,
+	)))
+	require.False(t, isOpenAIImageCapabilityLoss400(http.StatusBadRequest, []byte(
+		`{"error":{"type":"invalid_request_error","message":"Missing required parameter: 'prompt'."}}`,
+	)))
+}
+
+func TestRateLimitService_HandleOpenAIImageCapabilityLoss400_CoolsCapabilityOnly(t *testing.T) {
+	repo := &modelNotFoundAccountRepoStub{}
+	svc := &RateLimitService{accountRepo: repo}
+	account := &Account{ID: 4466, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Status: StatusActive}
+	body := []byte(`{"error":{"message":"The image_generation tool is not supported for this account."}}`)
+
+	before := time.Now()
+	handled := svc.HandleOpenAIImageCapabilityLoss400(context.Background(), account, http.StatusBadRequest, body)
+
+	require.True(t, handled)
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	call := repo.modelRateLimitCalls[0]
+	require.Equal(t, account.ID, call.accountID)
+	require.Equal(t, openAIImageGenerationRateLimitKey, call.scope)
+	require.Equal(t, openAIImageCapabilityLossReason, call.reason)
+	require.WithinDuration(t, before.Add(24*time.Hour), call.resetAt, 2*time.Second)
+	require.Zero(t, repo.tempCalls)
+}
+
+func TestRateLimitService_HandleOpenAIImageCapabilityLoss400_IgnoresCallerInvalidRequest(t *testing.T) {
+	repo := &modelNotFoundAccountRepoStub{}
+	svc := &RateLimitService{accountRepo: repo}
+	account := &Account{ID: 4467, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Status: StatusActive}
+	body := []byte(`{"error":{"type":"invalid_request_error","message":"Invalid value for 'size'."}}`)
+
+	handled := svc.HandleOpenAIImageCapabilityLoss400(context.Background(), account, http.StatusBadRequest, body)
+	require.False(t, handled)
+	require.Empty(t, repo.modelRateLimitCalls)
+}
+
+func TestOpenAIGatewayService_HandleOpenAIAccountUpstreamError_ImageCapability400DoesNotBlockWholeAccount(t *testing.T) {
+	repo := &modelNotFoundAccountRepoStub{}
+	svc := &OpenAIGatewayService{rateLimitService: &RateLimitService{accountRepo: repo}}
+	account := &Account{ID: 4468, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Status: StatusActive}
+	body := []byte(`{"error":{"message":"The image_generation tool is not supported for this account."}}`)
+
+	disabled := svc.handleOpenAIAccountUpstreamError(context.Background(), account, http.StatusBadRequest, http.Header{}, body, "gpt-image-2")
+	require.False(t, disabled)
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	require.Equal(t, openAIImageGenerationRateLimitKey, repo.modelRateLimitCalls[0].scope)
+	_, wholeAccountBlocked := svc.openaiAccountRuntimeBlockUntil.Load(account.ID)
+	require.False(t, wholeAccountBlocked)
+	require.Zero(t, repo.tempCalls)
+}

--- a/scripts/sentinels/antigravity.json
+++ b/scripts/sentinels/antigravity.json
@@ -10,6 +10,26 @@
       "rationale": "On-wire-confirmed: the real Antigravity IDE UA carries a `/hub/` subclient segment (`antigravity/hub/<ver> ...`). Upstream's BuildUserAgent emits `antigravity/%s windows/amd64` (no subclient). An upstream merge reverting to that silently de-aligns every Antigravity request's UA fingerprint."
     },
     {
+      "path": "backend/internal/pkg/antigravity/oauth.go",
+      "must_contain": [
+        "antigravityDailyBaseURL = \"https://daily-cloudcode-pa.googleapis.com\"",
+        "func DailyBaseURL() string",
+        "func DailyHost() string"
+      ],
+      "rationale": "Official daily hostname is the single owner for paid-tier gateway forward and privacy Host. Restoring sandbox.googleapis.com or a second hostname literal sends Pro/Ultra traffic to the wrong host again."
+    },
+    {
+      "path": "backend/internal/pkg/antigravity/client.go",
+      "must_contain": [
+        "func IsPaidPlanType(planOrTier string) bool",
+        "req.Host = DailyHost()"
+      ],
+      "must_not_contain": [
+        "req.Host = \"daily-cloudcode-pa.googleapis.com\""
+      ],
+      "rationale": "Paid-tier membership and privacy Host must stay derived from TierIDToPlanType / DailyBaseURL. A second hardcoded Host or paid-tier list will drift from the official daily owner."
+    },
+    {
       "path": "backend/internal/pkg/antigravity/client.go",
       "must_not_contain": [
         "Header.Set(\"X-Goog-Api-Client\""

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6805,17 +6805,42 @@
       "path": "backend/internal/service/openai_gateway_tk_oauth401_refresh.go",
       "must_contain": [
         "func (s *OpenAIGatewayService) tryRefreshOpenAI401Token(ctx context.Context, account *Account, respBody []byte) (string, bool)",
-        "s.openAITokenProvider.ForceRefresh(ctx, account)"
+        "func (s *OpenAIGatewayService) recoverOpenAIWS401AccessToken(",
+        "s.openAITokenProvider.ForceRefresh(ctx, account)",
+        "s.tryRefreshOpenAI401Token(ctx, account, respBody)"
       ],
-      "rationale": "TokenKey companion that owns the OpenAI OAuth 401 force-refresh seam. The classifier lives with ForceRefresh so permanent-auth 401s never refresh."
+      "rationale": "TokenKey companion that owns the OpenAI OAuth 401 force-refresh seam. HTTP calls tryRefresh; WS handshake must go through recoverOpenAIWS401AccessToken so it cannot grow a second refresh owner."
     },
     {
       "path": "backend/internal/service/openai_token_provider_tk_force_refresh.go",
       "must_contain": [
         "func tkIsPermanentOpenAIAuth401(body []byte) bool",
-        "func tkIsRecoverableOpenAI401(statusCode int, body []byte) bool"
+        "func tkIsRecoverableOpenAI401(statusCode int, body []byte) bool",
+        "func (p *OpenAITokenProvider) awaitForceRefreshWinner(ctx context.Context, account *Account) (*Account, error)",
+        "if result.LockHeld {"
       ],
-      "rationale": "Single classifier for permanent vs recoverable OpenAI 401. HandleUpstreamError and the in-request retry must not maintain a second copy of token_revoked / Unauthorized."
+      "rationale": "Single classifier for permanent vs recoverable OpenAI 401, and LockHeld must wait for the in-flight RefreshNow winner instead of returning a refresh failure that SetError can take as a permanent disable."
+    },
+    {
+      "path": "backend/internal/service/openai_ws_v2_passthrough_adapter.go",
+      "must_contain": [
+        "s.recoverOpenAIWS401AccessToken(ctx, account, statusCode, responseBody, headers)"
+      ],
+      "rationale": "WS passthrough handshake 401 must share tryRefresh via recoverOpenAIWS401AccessToken. Dropping this hook leaves Codex WS users on the stale token while HTTP already recovered."
+    },
+    {
+      "path": "backend/internal/service/openai_ws_forwarder_v2.go",
+      "must_contain": [
+        "s.recoverOpenAIWS401AccessToken(ctx, account, statusCode, responseBody, wsHeaders)"
+      ],
+      "rationale": "HTTP-to-WS v2 acquire 401 must retry with the same 401 refresh owner. This is the Codex responses websocket pool path."
+    },
+    {
+      "path": "backend/internal/service/openai_ws_forwarder_ingress.go",
+      "must_contain": [
+        "s.recoverOpenAIWS401AccessToken(ctx, account, statusCode, responseBody, baseAcquireReq.Headers)"
+      ],
+      "rationale": "Native WS ingress acquire 401 must update baseAcquireReq.Headers from the same recover owner so later turns do not keep the rejected token."
     },
     {
       "path": "backend/internal/service/ratelimit_service.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6844,6 +6844,8 @@
       "path": "backend/internal/service/antigravity_gateway_retry.go",
       "must_contain": [
         "func resolveAntigravityForwardBaseURL(account *Account) string",
+        "antigravity.ProdBaseURL()",
+        "antigravity.DailyBaseURL()",
         "antigravity.IsPaidPlanType(plan)"
       ],
       "rationale": "Paid Antigravity accounts must resolve daily from the antigravity plan-type owner. A local Pro/Ultra list would drift from TierIDToPlanType."

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6853,17 +6853,19 @@
     {
       "path": "backend/internal/service/openai_codex_fingerprint.go",
       "must_contain": [
-        "sub2api:codex-install-id:v3:session:",
-        "ids.installationID = resolveConvergedInstallationID(account, seed, clientSessionID)"
+        "codexDeviceModeInstallationLimit = 3",
+        "sub2api:codex-install-id:v3:bucket:",
+        "ids.installationID = resolveDeviceModeInstallationID(account, seed, clientSessionID)"
       ],
-      "rationale": "Device-mode Codex installation is session-stable and account-isolated. An upstream merge that restores account-wide installation reintroduces shared-device quota shrink."
+      "rationale": "Device-mode Codex installation is session-stable and hard-capped at 3 buckets per OAuth account. Restoring per-session installation reintroduces one-account-many-devices risk; restoring a single account-wide installation reintroduces shared-device quota shrink."
     },
     {
       "path": "backend/internal/service/openai_codex_fingerprint_test.go",
       "must_contain": [
-        "func TestResolveCodexFingerprintIDs_DeviceModeInstallationIsSessionStable(t *testing.T)"
+        "func TestResolveCodexFingerprintIDs_DeviceModeInstallationIsSessionStable(t *testing.T)",
+        "func TestResolveCodexFingerprintIDs_DeviceModeInstallationCappedAt3(t *testing.T)"
       ],
-      "rationale": "Focused regression: different Codex client sessions must not share a device-mode installation_id."
+      "rationale": "Focused regression: same session stays in one bucket, and one OAuth account cannot emit more than 3 device-mode installation IDs."
     }
   ]
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6786,6 +6786,82 @@
         "\"gemini-3.5-flash-lite\", \"gemini-3.6-flash\", \"gemini-3.7-flash\""
       ],
       "rationale": "Gemini 3.5 Flash Lite / 3.6 Flash / 3.7 Flash are publisher-global-only on Vertex. vertexModelUsesGlobalLocation must keep these ids on the global endpoint; an upstream merge that drops the case or the 3.7 id sends traffic to the account default us-central1 and the publisher model 404s. Live extras can write vertex_model_locations, but the compiled owner is what survives the next release and empty extras."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_forward.go",
+      "must_contain": [
+        "if newToken, ok := s.tryRefreshOpenAI401Token(ctx, account, respBody); ok {"
+      ],
+      "rationale": "OpenAI OAuth recoverable 401 must RefreshNow and retry once on the same request. Dropping this injection cools the whole group to 502/503 before the token provider can recover."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_passthrough.go",
+      "must_contain": [
+        "if newToken, ok := s.tryRefreshOpenAI401Token(ctx, account, probeBody); ok {"
+      ],
+      "rationale": "Passthrough /v1/responses must share the same in-request OpenAI 401 refresh owner as the non-passthrough forward loop."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_tk_oauth401_refresh.go",
+      "must_contain": [
+        "func (s *OpenAIGatewayService) tryRefreshOpenAI401Token(ctx context.Context, account *Account, respBody []byte) (string, bool)",
+        "s.openAITokenProvider.ForceRefresh(ctx, account)"
+      ],
+      "rationale": "TokenKey companion that owns the OpenAI OAuth 401 force-refresh seam. The classifier lives with ForceRefresh so permanent-auth 401s never refresh."
+    },
+    {
+      "path": "backend/internal/service/openai_token_provider_tk_force_refresh.go",
+      "must_contain": [
+        "func tkIsPermanentOpenAIAuth401(body []byte) bool",
+        "func tkIsRecoverableOpenAI401(statusCode int, body []byte) bool"
+      ],
+      "rationale": "Single classifier for permanent vs recoverable OpenAI 401. HandleUpstreamError and the in-request retry must not maintain a second copy of token_revoked / Unauthorized."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service.go",
+      "must_contain": [
+        "tkIsPermanentOpenAIAuth401(responseBody)",
+        "HandleOpenAIImageCapabilityLoss400(ctx, account, statusCode, responseBody)"
+      ],
+      "rationale": "Upstream-shaped injection: permanent OpenAI 401 and account-level image-capability 400 must keep calling the TokenKey owners. Losing either hook restores whole-account disable or reschedules dead image capability."
+    },
+    {
+      "path": "backend/internal/service/openai_account_runtime_block_fastpath.go",
+      "must_contain": [
+        "HandleOpenAIImageCapabilityLoss400(stateCtx, account, statusCode, responseBody)"
+      ],
+      "rationale": "Gateway error fastpath must cool openai:image_generation on capability-loss 400 without blocking the whole account."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_account_capability_400.go",
+      "must_contain": [
+        "func isOpenAIImageCapabilityLoss400(statusCode int, body []byte) bool",
+        "openAIImageGenerationRateLimitKey"
+      ],
+      "rationale": "Account-level image capability 400 owner. Reuses the existing image-generation rate-limit key so scheduling has one skip signal."
+    },
+    {
+      "path": "backend/internal/service/antigravity_gateway_retry.go",
+      "must_contain": [
+        "func resolveAntigravityForwardBaseURL(account *Account) string",
+        "antigravity.IsPaidPlanType(plan)"
+      ],
+      "rationale": "Paid Antigravity accounts must resolve daily from the antigravity plan-type owner. A local Pro/Ultra list would drift from TierIDToPlanType."
+    },
+    {
+      "path": "backend/internal/service/openai_codex_fingerprint.go",
+      "must_contain": [
+        "sub2api:codex-install-id:v3:session:",
+        "ids.installationID = resolveConvergedInstallationID(account, seed, clientSessionID)"
+      ],
+      "rationale": "Device-mode Codex installation is session-stable and account-isolated. An upstream merge that restores account-wide installation reintroduces shared-device quota shrink."
+    },
+    {
+      "path": "backend/internal/service/openai_codex_fingerprint_test.go",
+      "must_contain": [
+        "func TestResolveCodexFingerprintIDs_DeviceModeInstallationIsSessionStable(t *testing.T)"
+      ],
+      "rationale": "Focused regression: different Codex client sessions must not share a device-mode installation_id."
     }
   ]
 }


### PR DESCRIPTION
## 摘要

修上游社区里对 TokenKey 线上池伤害最大的四条，不修 #4994（Claude Code 403 扩散整组）。

- OpenAI OAuth 401：请求内 `RefreshNow` 一次再重试。HTTP Forward/passthrough、WS passthrough / v2 pool / ingress 都走同一个 `tryRefreshOpenAI401Token`。`LockHeld` 等赢家的新 token，不再当成刷新失败去 `SetError`（us3/us6 单号边）。
- Antigravity：Pro/Ultra 走官方 daily，免费档仍走 prod。`resolve` 直接读 named URL owner，禁止从 `BaseURLs` 下标推断。
- 账号级持续生图 400：只停 `openai:image_generation`，不罚整号。
- Codex device 模式：每 OAuth 号最多 3 个 installation（session 哈希分桶）。线上可调度真 OAuth 都是 device，且没有 `openai_device_id`。

## 风险

常规。无 WebUI/API 契约变化。注入点在上游形文件里，已用 gateway-tk sentinel 钉住。us3/us6 仍是单号边，永久吊销 401 仍会停号。

upstream-conflict-surface-accepted
sentinel-registry-reviewed

## 验证

```
cd backend && go test -tags=unit -count=1 ./internal/service/ \
  -run 'TestTkIsRecoverableOpenAI401|TestOpenAITokenProvider_ForceRefresh_|TestOpenAIGatewayService_Forward_OAuth401|TestOpenAIGatewayService_recoverOpenAIWS401|TestOpenAIGatewayService_Forward_WSv2OAuth401|TestOpenAIGatewayService_PassthroughWS_OAuth401'
```

结果：`ok  github.com/Wei-Shaw/sub2api/internal/service  4.970s`

正向：HTTP 401 刷新重试、LockHeld 采用赢家 token、WS v2 / passthrough 握手 401 刷新后第二次拨号成功。
负向：`token_revoked` / 能力缺失 401 不刷新；LockHeld 仍是旧 token 则失败且不自己再刷。

## 提交

- `878e19093` fix: recover OpenAI and Antigravity pool stalls from stale 401, daily 429, and Codex identity
- `93f4f94c2` fix(review): fold paid-tier, daily URL, and 401 classifiers onto one owner
- `2a144c03f` fix(review): address R-001 — resolve Antigravity daily from named URL owners
- `9d60ab49b` fix(codex): cap device-mode installations at 3 per OAuth account
- `e6883ac84` fix(review): wait out OpenAI 401 lock races and refresh WS from one owner

最新提交：e6883ac84