### PR TITLE
fix(migration): route 226 indexes through partition attach

### DIFF
--- a/backend/internal/repository/migrations_runner.go
+++ b/backend/internal/repository/migrations_runner.go
@@ -93,34 +93,55 @@ type nonTransactionalIndexPolicy struct {
 	partitionedIndexWhere  string
 }
 
-var nonTransactionalIndexPolicies = map[string]nonTransactionalIndexPolicy{
+var nonTransactionalIndexPolicies = map[string][]nonTransactionalIndexPolicy{
 	schedulerOutboxPendingDedupKeyMigration: {
-		indexName: schedulerOutboxPendingDedupKeyIndex,
+		{
+			indexName: schedulerOutboxPendingDedupKeyIndex,
+		},
 	},
 	opsSystemLogsAPIKeyIDIndexMigration: {
-		indexName:              opsSystemLogsAPIKeyIDIndex,
-		partitionedTable:       "ops_system_logs",
-		partitionedFallbackDDL: opsSystemLogsAPIKeyIDIndexDDL,
+		{
+			indexName:              opsSystemLogsAPIKeyIDIndex,
+			partitionedTable:       "ops_system_logs",
+			partitionedFallbackDDL: opsSystemLogsAPIKeyIDIndexDDL,
+		},
 	},
 	latestAPIKeyIPIndexMigration: {
-		indexName: latestAPIKeyIPIndex,
+		{
+			indexName: latestAPIKeyIPIndex,
+		},
 	},
 	usersEmailAliasDedupIndexMigration: {
-		indexName: usersEmailAliasDedupIndex,
+		{
+			indexName: usersEmailAliasDedupIndex,
+		},
 	},
 	opsSystemLogsHostIndexMigration: {
-		indexName:            opsSystemLogsHostIndex,
-		partitionedTable:     "ops_system_logs",
-		partitionedIndexExpr: "host, created_at DESC",
+		{
+			indexName:            opsSystemLogsHostIndex,
+			partitionedTable:     "ops_system_logs",
+			partitionedIndexExpr: "host, created_at DESC",
+		},
 	},
 	upstreamModelMismatchIndexMigration: {
-		indexName:             upstreamModelMismatchIndex,
-		partitionedTable:      "usage_logs",
-		partitionedIndexExpr:  "created_at DESC, id DESC",
-		partitionedIndexWhere: "upstream_model_mismatch IS TRUE",
+		{
+			indexName:             upstreamModelMismatchIndex,
+			partitionedTable:      "usage_logs",
+			partitionedIndexExpr:  "created_at DESC, id DESC",
+			partitionedIndexWhere: "upstream_model_mismatch IS TRUE",
+		},
 	},
 	usageLogsEffectiveModelIndexesMigration: {
-		indexName: usageLogsEffectiveRequestedModelIndex,
+		{
+			indexName:            usageLogsEffectiveRequestedModelIndex,
+			partitionedTable:     "usage_logs",
+			partitionedIndexExpr: "(COALESCE(NULLIF(BTRIM(requested_model), ''), model)), created_at DESC, id DESC",
+		},
+		{
+			indexName:            usageLogsEffectiveUpstreamModelIndex,
+			partitionedTable:     "usage_logs",
+			partitionedIndexExpr: "(COALESCE(NULLIF(BTRIM(upstream_model), ''), model)), created_at DESC, id DESC",
+		},
 	},
 }
 
@@ -366,24 +387,44 @@ func shouldRecordMigrationWithoutExecution(ctx context.Context, db migrationDB, 
 }
 
 func applyNonTransactionalMigration(ctx context.Context, db migrationDB, name, content string) error {
-	policy, hasPolicy := nonTransactionalIndexPolicies[name]
-	if hasPolicy && policy.partitionedTable != "" {
-		partitioned, err := pgpartition.IsPartitioned(ctx, db, policy.partitionedTable)
-		if err != nil {
-			return fmt.Errorf("check %s partition state for migration %s: %w", policy.partitionedTable, name, err)
+	policies := nonTransactionalIndexPolicies[name]
+	usePartitionedPath := len(policies) > 0
+	partitionStates := make(map[string]bool)
+	for _, policy := range policies {
+		if policy.partitionedTable == "" {
+			usePartitionedPath = false
+			break
 		}
-		if partitioned {
+		partitioned, ok := partitionStates[policy.partitionedTable]
+		if !ok {
+			var err error
+			partitioned, err = pgpartition.IsPartitioned(ctx, db, policy.partitionedTable)
+			if err != nil {
+				return fmt.Errorf("check %s partition state for migration %s: %w", policy.partitionedTable, name, err)
+			}
+			partitionStates[policy.partitionedTable] = partitioned
+		}
+		if !partitioned {
+			usePartitionedPath = false
+			break
+		}
+	}
+	if usePartitionedPath {
+		for _, policy := range policies {
 			if policy.partitionedIndexExpr != "" {
 				if err := createPartitionedIndexConcurrently(ctx, db, policy); err != nil {
 					return fmt.Errorf("apply migration %s (partitioned online index): %w", name, err)
 				}
-				return nil
+				continue
+			}
+			if policy.partitionedFallbackDDL == "" {
+				return fmt.Errorf("apply migration %s: partitioned index policy %s has no DDL", name, policy.indexName)
 			}
 			if _, err := db.ExecContext(ctx, policy.partitionedFallbackDDL); err != nil {
 				return fmt.Errorf("apply migration %s (partitioned fallback): %w", name, err)
 			}
-			return nil
 		}
+		return nil
 	}
 
 	if err := prepareNonTransactionalMigration(ctx, db, name); err != nil {
@@ -405,22 +446,18 @@ func applyNonTransactionalMigration(ctx context.Context, db migrationDB, name, c
 }
 
 func prepareNonTransactionalMigration(ctx context.Context, db migrationDB, name string) error {
-	if name == usageLogsEffectiveModelIndexesMigration {
-		for _, indexName := range []string{usageLogsEffectiveRequestedModelIndex, usageLogsEffectiveUpstreamModelIndex} {
-			if err := dropInvalidIndexIfPresent(ctx, db, indexName); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
 	if name == paymentOrdersOutTradeNoUniqueMigration {
 		return preparePaymentOrdersOutTradeNoUniqueMigration(ctx, db)
 	}
-	policy, ok := nonTransactionalIndexPolicies[name]
-	if !ok || policy.indexName == "" {
-		return nil
+	for _, policy := range nonTransactionalIndexPolicies[name] {
+		if policy.indexName == "" {
+			continue
+		}
+		if err := dropInvalidIndexIfPresent(ctx, db, policy.indexName); err != nil {
+			return err
+		}
 	}
-	return dropInvalidIndexIfPresent(ctx, db, policy.indexName)
+	return nil
 }
 
 func preparePaymentOrdersOutTradeNoUniqueMigration(ctx context.Context, db migrationDB) error {

--- a/backend/internal/repository/migrations_runner_notx_test.go
+++ b/backend/internal/repository/migrations_runner_notx_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"regexp"
 	"testing"
 	"testing/fstest"
 
@@ -213,6 +214,9 @@ func TestApplyMigrationsFS_NonTransactionalMigration_EffectiveModelIndexesDropIn
 	mock.ExpectQuery("SELECT checksum FROM schema_migrations WHERE filename = \\$1").
 		WithArgs(usageLogsEffectiveModelIndexesMigration).
 		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("pg_partitioned_table").
+		WithArgs("usage_logs").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
 	for _, indexName := range []string{usageLogsEffectiveRequestedModelIndex, usageLogsEffectiveUpstreamModelIndex} {
 		mock.ExpectQuery("SELECT EXISTS \\(").
 			WithArgs(indexName).
@@ -241,6 +245,74 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_usage_logs_effective_upstream_model_
 	}
 
 	err = applyMigrationsSession(context.Background(), db, fsys)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestApplyMigrationsFS_EffectiveModelIndexes_BuildsPartitionIndexesConcurrently(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	prepareMigrationsBootstrapExpectations(mock)
+	mock.ExpectQuery("SELECT checksum FROM schema_migrations WHERE filename = \\$1").
+		WithArgs(usageLogsEffectiveModelIndexesMigration).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("pg_partitioned_table").
+		WithArgs("usage_logs").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+	expectPartitionedIndex := func(indexName, expression string) {
+		childIndex := indexName + "_p61001"
+		mock.ExpectQuery("SELECT i.indisvalid").
+			WithArgs("public", indexName).
+			WillReturnError(sql.ErrNoRows)
+		mock.ExpectQuery("SELECT child_ns.nspname, child.relname, child.oid").
+			WithArgs("usage_logs").
+			WillReturnRows(sqlmock.NewRows([]string{"nspname", "relname", "oid"}).
+				AddRow("public", "usage_logs_202608", 61001))
+		mock.ExpectQuery("SELECT i.indisvalid").
+			WithArgs("public", childIndex).
+			WillReturnError(sql.ErrNoRows)
+		mock.ExpectExec(regexp.QuoteMeta(
+			`CREATE INDEX CONCURRENTLY IF NOT EXISTS "` + childIndex + `" ON "public"."usage_logs_202608" (` + expression + `)`,
+		)).WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec(regexp.QuoteMeta(
+			`CREATE INDEX IF NOT EXISTS "` + indexName + `" ON ONLY "usage_logs" (` + expression + `)`,
+		)).WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectQuery("SELECT EXISTS \\(").
+			WithArgs(indexName, childIndex).
+			WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+		mock.ExpectExec(regexp.QuoteMeta(
+			`ALTER INDEX "` + indexName + `" ATTACH PARTITION "public"."` + childIndex + `"`,
+		)).WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectQuery("SELECT i.indisvalid").
+			WithArgs("public", indexName).
+			WillReturnRows(sqlmock.NewRows([]string{"indisvalid"}).AddRow(true))
+	}
+
+	expectPartitionedIndex(
+		usageLogsEffectiveRequestedModelIndex,
+		"(COALESCE(NULLIF(BTRIM(requested_model), ''), model)), created_at DESC, id DESC",
+	)
+	expectPartitionedIndex(
+		usageLogsEffectiveUpstreamModelIndex,
+		"(COALESCE(NULLIF(BTRIM(upstream_model), ''), model)), created_at DESC, id DESC",
+	)
+	mock.ExpectExec("INSERT INTO schema_migrations \\(filename, checksum\\) VALUES \\(\\$1, \\$2\\)").
+		WithArgs(usageLogsEffectiveModelIndexesMigration, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("SELECT pg_advisory_unlock\\(\\$1\\)").
+		WithArgs(migrationsAdvisoryLockID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	content, err := migrations.FS.ReadFile(usageLogsEffectiveModelIndexesMigration)
+	require.NoError(t, err)
+	fSys := fstest.MapFS{
+		usageLogsEffectiveModelIndexesMigration: &fstest.MapFile{Data: content},
+	}
+
+	err = applyMigrationsSession(context.Background(), db, fSys)
 	require.NoError(t, err)
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/backend/internal/repository/pgpartition_integration_test.go
+++ b/backend/internal/repository/pgpartition_integration_test.go
@@ -152,6 +152,72 @@ func TestCreatePartitionedIndexConcurrently_PartialIndexWhereClause(t *testing.T
 	require.Equal(t, tablePartitions, indexPartitions)
 }
 
+func TestCreatePartitionedIndexConcurrently_EffectiveModelExpressions(t *testing.T) {
+	ctx := context.Background()
+	table := "pgpart_itest_effective_models"
+	qTable := pq.QuoteIdentifier(table)
+	_, _ = integrationDB.ExecContext(ctx, "DROP TABLE IF EXISTS "+qTable+" CASCADE")
+	t.Cleanup(func() {
+		_, _ = integrationDB.ExecContext(context.Background(), "DROP TABLE IF EXISTS "+qTable+" CASCADE")
+	})
+
+	_, err := integrationDB.ExecContext(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id BIGSERIAL,
+			created_at TIMESTAMPTZ NOT NULL,
+			model TEXT NOT NULL,
+			requested_model TEXT,
+			upstream_model TEXT
+		) PARTITION BY RANGE (created_at);
+		CREATE TABLE %s PARTITION OF %s FOR VALUES FROM ('2026-01-01') TO ('2026-02-01');
+		CREATE TABLE %s PARTITION OF %s FOR VALUES FROM ('2026-02-01') TO ('2026-03-01');
+		INSERT INTO %s (created_at, model, requested_model, upstream_model) VALUES
+			('2026-01-15', 'fallback-a', 'requested-a', 'upstream-a'),
+			('2026-02-15', 'fallback-b', '', NULL);`,
+		qTable,
+		pq.QuoteIdentifier(table+"_p1"), qTable,
+		pq.QuoteIdentifier(table+"_p2"), qTable,
+		qTable,
+	))
+	require.NoError(t, err)
+
+	policies := append([]nonTransactionalIndexPolicy(nil), nonTransactionalIndexPolicies[usageLogsEffectiveModelIndexesMigration]...)
+	require.Len(t, policies, 2)
+	parentIndexes := []string{
+		"idx_pgpart_itest_effective_requested",
+		"idx_pgpart_itest_effective_upstream",
+	}
+	for i := range policies {
+		policies[i].partitionedTable = table
+		policies[i].indexName = parentIndexes[i]
+		require.NoError(t, createPartitionedIndexConcurrently(ctx, integrationDB, policies[i]))
+		require.NoError(t, createPartitionedIndexConcurrently(ctx, integrationDB, policies[i]))
+	}
+
+	var tablePartitions int
+	require.NoError(t, integrationDB.QueryRowContext(ctx, `
+		SELECT count(*) FROM pg_inherits i
+		JOIN pg_class parent ON parent.oid = i.inhparent
+		WHERE parent.relname = $1`, table).Scan(&tablePartitions))
+	require.Equal(t, 2, tablePartitions)
+
+	for _, parentIndex := range parentIndexes {
+		var valid bool
+		require.NoError(t, integrationDB.QueryRowContext(ctx, `
+			SELECT i.indisvalid
+			FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+			WHERE c.relname = $1`, parentIndex).Scan(&valid))
+		require.True(t, valid)
+
+		var indexPartitions int
+		require.NoError(t, integrationDB.QueryRowContext(ctx, `
+			SELECT count(*) FROM pg_inherits i
+			JOIN pg_class parent ON parent.oid = i.inhparent
+			WHERE parent.relname = $1`, parentIndex).Scan(&indexPartitions))
+		require.Equal(t, tablePartitions, indexPartitions)
+	}
+}
+
 // TestPgPartition_EnsureMonthlySkipsLegacyOverlap mirrors the post-conversion state: a
 // wide legacy partition covers everything up to next month, so EnsureMonthly's current
 // month overlaps it (42P17) and must be skipped while future months are still created.

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6030,6 +6030,7 @@
         "applyNonTransactionalMigration(ctx, db, name, content)",
         "usePartitionedPath := len(policies) > 0",
         "partitionedIndexExpr: \"(COALESCE(NULLIF(BTRIM(requested_model), ''), model)), created_at DESC, id DESC\"",
+        "partitionedIndexExpr: \"(COALESCE(NULLIF(BTRIM(upstream_model), ''), model)), created_at DESC, id DESC\"",
         "for _, policy := range nonTransactionalIndexPolicies[name] {",
         "if err := dropInvalidIndexIfPresent(ctx, db, policy.indexName); err != nil {",
         "return applyMigrationsInUTCSession(ctx, conn, fsys)",
@@ -6087,18 +6088,21 @@
       "path": "backend/internal/repository/migrations_runner_notx_test.go",
       "must_contain": [
         "TestApplyMigrationsFS_OpsSystemLogsHostIndex_BuildsPartitionIndexesConcurrently",
-        "TestApplyMigrationsFS_OpsSystemLogsHostIndex_DropsInvalidIndexBeforeNonPartitionedRetry"
+        "TestApplyMigrationsFS_OpsSystemLogsHostIndex_DropsInvalidIndexBeforeNonPartitionedRetry",
+        "TestApplyMigrationsFS_NonTransactionalMigration_EffectiveModelIndexesDropInvalidIndexesBeforeRetry",
+        "TestApplyMigrationsFS_EffectiveModelIndexes_BuildsPartitionIndexesConcurrently"
       ],
-      "rationale": "Behavioral regression coverage for both live shapes: TokenKey prod partitioned ops_system_logs parent must use the online child-build/attach path, and a non-partitioned interrupted concurrent build must remove an invalid index before retrying."
+      "rationale": "Behavioral regression coverage for both live shapes: TokenKey prod partitioned parents must use the online child-build/attach path, migration 226 must dispatch both effective-model indexes through that path, and a non-partitioned interrupted concurrent build must remove every invalid index before retrying."
     },
     {
       "path": "backend/internal/repository/pgpartition_integration_test.go",
       "must_contain": [
         "TestCreatePartitionedIndexConcurrently_AttachesEveryPartitionAndRetries",
+        "TestCreatePartitionedIndexConcurrently_EffectiveModelExpressions",
         "createPartitionedIndexConcurrently(ctx, integrationDB, policy)",
         "require.Equal(t, tablePartitions, indexPartitions)"
       ],
-      "rationale": "Real PostgreSQL coverage proves the online partition-index sequence produces a valid parent, attaches one index per table partition, and remains idempotent on retry; sqlmock alone cannot validate PostgreSQL partitioned-index state transitions."
+      "rationale": "Real PostgreSQL coverage proves the online partition-index sequence produces valid parents, attaches one index per table partition, handles migration 226's effective-model expressions, and remains idempotent on retry; sqlmock alone cannot validate PostgreSQL partitioned-index state transitions."
     },
     {
       "path": "backend/internal/repository/migrations_runner_tk_partitioned_index.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6028,11 +6028,14 @@
         "partitionedIndexExpr: \"host, created_at DESC\"",
         "createPartitionedIndexConcurrently(ctx, db, policy)",
         "applyNonTransactionalMigration(ctx, db, name, content)",
-        "return dropInvalidIndexIfPresent(ctx, db, policy.indexName)",
+        "usePartitionedPath := len(policies) > 0",
+        "partitionedIndexExpr: \"(COALESCE(NULLIF(BTRIM(requested_model), ''), model)), created_at DESC, id DESC\"",
+        "for _, policy := range nonTransactionalIndexPolicies[name] {",
+        "if err := dropInvalidIndexIfPresent(ctx, db, policy.indexName); err != nil {",
         "return applyMigrationsInUTCSession(ctx, conn, fsys)",
         "migrationSessionCleanupError{err: err}"
       ],
-      "rationale": "The upstream-shared migration runner owns only declarative policies and thin TokenKey call sites. The online partition-index implementation and UTC migration-session lifecycle stay in companion files to minimize upstream conflict surface. Every caller must execute partition-bound migrations on the pinned connection in UTC, surface advisory-unlock failure, and restore the original application timezone before the connection returns to the pool."
+      "rationale": "The upstream-shared migration runner owns only declarative policies and thin TokenKey call sites. A migration may own multiple index policies: migration 226 must keep both effective-model expression indexes on the partition-aware child-index/parent-attach path, and non-partitioned retries must prepare every registered index. The online partition-index implementation and UTC migration-session lifecycle stay in companion files to minimize upstream conflict surface. Every caller must execute partition-bound migrations on the pinned connection in UTC, surface advisory-unlock failure, and restore the original application timezone before the connection returns to the pool."
     },
     {
       "path": "backend/internal/repository/migrations_runner_tk_session.go",


### PR DESCRIPTION
## 摘要

- 修复 migration 226 在分区表 usage_logs 父表上执行 CREATE INDEX CONCURRENTLY 导致 prod 部署失败的问题。
- 将 migration 226 的两个 effective-model expression index 注册为多策略，并复用子分区并发建索引、父索引 ATTACH PARTITION 路径。
- 保留非分区表执行及失败重试行为，补充真实 PostgreSQL 分区索引幂等性验证。
- 更新 gateway TK sentinel，保护两个 expression、partitioned dispatcher、非分区 retry 和真实 PostgreSQL regression test。

no-web-impact
upstream-touch-guarded
sentinel-registry-reviewed

## 风险

- 影响范围仅限 non-transactional migration runner 对已分区表的索引创建路径；migration SQL 文件未修改。
- 分区路径会依次创建并挂载两个索引，任一失败时 migration 不记完成，重试由现有幂等逻辑恢复。
- 不包含 VERSION、release workflow、部署配置或前端变更。

## 验证

- env -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy -u ALL_PROXY -u all_proxy bash scripts/preflight.sh
- go test ./internal/repository ./migrations -count=1
- DOCKER_HOST=unix:///Users/feng/.colima/default/docker.sock TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock go test -tags=integration ./internal/repository -run ^TestCreatePartitionedIndexConcurrently_EffectiveModelExpressions$ -count=1
- python3 scripts/sentinels/check-gateway-tk.py：730/730 intact
- bash ops/observability/probe-release-control-plane.sh：prod、settings/public、us3-us6 共 6/6 正常

## 提交

- 2742d3e43 fix(migration): route 226 indexes through partition attach
- ea781d517 fix(review): address R-001 sentinel coverage

最新提交：ea781d517