### PR TITLE
fix(gateway): failover CloudWise-class 424 so overflow traffic can leave the broken hop

### DIFF
--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -46,7 +46,10 @@ func (s *GatewayService) shouldRetryUpstreamError(account *Account, statusCode i
 // shouldFailoverUpstreamError determines whether an upstream error should trigger account failover.
 func (s *GatewayService) shouldFailoverUpstreamError(statusCode int) bool {
 	switch statusCode {
-	case 401, 403, 429, 529:
+	case 401, 403, 424, 429, 529:
+		// 424: CloudWise-class relays wrap their upstream outage as Failed
+		// Dependency + server_error. Prod 2026-08-21 #94 returned terminal
+		// 424s while kiro still served after 429 failover.
 		return true
 	default:
 		return statusCode >= 500

--- a/backend/internal/service/gateway_forward_failover_status_test.go
+++ b/backend/internal/service/gateway_forward_failover_status_test.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGatewayShouldFailoverUpstreamError_424IsFailoverEligible(t *testing.T) {
+	svc := &GatewayService{}
+
+	assert.True(t, svc.shouldFailoverUpstreamError(http.StatusFailedDependency),
+		"424 from CloudWise-class relays is a provider dependency failure and must leave the current account")
+}
+
+func TestGatewayShouldFailoverUpstreamError_ExistingCodesStillWork(t *testing.T) {
+	svc := &GatewayService{}
+
+	failoverCodes := []int{401, 403, 424, 429, 529, 500, 502, 503, 504}
+	for _, code := range failoverCodes {
+		assert.True(t, svc.shouldFailoverUpstreamError(code), "status %d should trigger failover", code)
+	}
+
+	nonFailoverCodes := []int{200, 201, 400, 404, 408, 422}
+	for _, code := range nonFailoverCodes {
+		assert.False(t, svc.shouldFailoverUpstreamError(code), "status %d should NOT trigger failover", code)
+	}
+}

--- a/backend/internal/service/openai_gateway_failover_ssot_test.go
+++ b/backend/internal/service/openai_gateway_failover_ssot_test.go
@@ -73,6 +73,13 @@ func TestShouldFailoverOpenAIUpstreamError_HTTPAndSSEShareDecision(t *testing.T)
 			want:       true,
 		},
 		{
+			name:    "cloudwise-style 424 provider error failovers",
+			status:  http.StatusFailedDependency,
+			message: "Provider error (request id: aitk-00000000-0000-0000-0000-000000000000)",
+			body:    []byte(`{"error":{"message":"Provider error (request id: aitk-00000000-0000-0000-0000-000000000000)","type":"server_error"}}`),
+			want:    true,
+		},
+		{
 			name:    "generic HTTP 400 without transient signal stays terminal",
 			status:  http.StatusBadRequest,
 			message: "Missing required parameter: 'instructions'",

--- a/backend/internal/service/openai_gateway_grok_405_test.go
+++ b/backend/internal/service/openai_gateway_grok_405_test.go
@@ -17,7 +17,7 @@ func TestShouldFailoverUpstreamError_405IsFailoverEligible(t *testing.T) {
 func TestShouldFailoverUpstreamError_ExistingCodesStillWork(t *testing.T) {
 	svc := &OpenAIGatewayService{}
 
-	failoverCodes := []int{401, 402, 403, 405, 429, 529, 500, 502, 503, 504}
+	failoverCodes := []int{401, 402, 403, 405, 424, 429, 529, 500, 502, 503, 504}
 	for _, code := range failoverCodes {
 		assert.True(t, svc.shouldFailoverUpstreamError(code), "status %d should trigger failover", code)
 	}

--- a/backend/internal/service/openai_gateway_upstream_errors.go
+++ b/backend/internal/service/openai_gateway_upstream_errors.go
@@ -248,7 +248,8 @@ func matchOpenAIUpstreamErrorFields(upstreamMsg string, upstreamBody []byte, mat
 
 func shouldFailoverOpenAIUpstreamStatus(statusCode int) bool {
 	switch statusCode {
-	case 401, 402, 403, 405, 429, 529:
+	case 401, 402, 403, 405, 424, 429, 529:
+		// 424: same CloudWise-class provider-outage envelope as anthropic #94.
 		return true
 	default:
 		return statusCode >= 500


### PR DESCRIPTION
## 摘要

Prod 2026-08-21 user #16 在 `claude-opus-4-8` 上看到 180 次终态 424，全部落在 account `#94` `cloudwise`。CloudWise 把上游故障包装成 HTTP 424 Failed Dependency，而 Gateway 原先只对 `401/403/429/529/>=500` failover，请求钉在坏 hop 上回给客户。本次把 424 加入 Anthropic 与 OpenAI 两条判定，让溢出流量能离开当前账号。

sentinel-registry-reviewed

## 风险

常规风险。官方 Anthropic 不用 424；残留是：若某家把 424 当请求级 Failed Dependency，会多跳一次。不改线上优先级，也不给 424 加冷却。

## 验证

```bash
cd backend && go test -tags=unit ./internal/service/ -run 'TestGatewayShouldFailoverUpstreamError_|TestShouldFailoverUpstreamError_|TestShouldFailoverOpenAIUpstreamError_HTTPAndSSEShareDecision'
```

发版后观察 CloudWise 424 是否变成 `final 200 + upstream_errors.kind=failover`。本地 Ent generation staleness 来自本机 Go 1.27 把 `json.RawMessage` 编成 `jsontext.Value`，与仓库 Go 1.26.6 不一致，已还原，未纳入本 PR。

## 提交

- `b35883cc5` fix(gateway): failover CloudWise-class 424 so overflow traffic can leave the broken hop

最新提交：`b35883cc5`

Made with [Cursor](https://cursor.com)