### PR TITLE
fix(gateway): 订阅不可用时回退到余额专属组

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -401,7 +401,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	antigravitySaturationCounterCache := repository.NewAntigravitySaturationCounterCache(redisClient)
 	tkAntigravitySaturationReady := service.ProvideTKAntigravitySaturation(rateLimitService, antigravitySaturationCounterCache)
 	tkGatewayHandlerModelListReady := handler.ProvideTKGatewayHandlerModelList(gatewayHandler, openAIGatewayHandler, modelListFilter, universalCapabilityService)
-	tkUniversalModelsProviderReady := service.ProvideTKUniversalModelsProvider(apiKeyService, gatewayService)
+	tkUniversalModelsProviderReady := service.ProvideTKUniversalModelsProvider(apiKeyService, gatewayService, subscriptionService)
 	tkGroupUnsupportedModelCacheReady := service.ProvideTKGroupUnsupportedModelCache(gatewayService, openAIGatewayService, channelService)
 	userPlatformQuotaUsageFlusher := service.ProvideUserPlatformQuotaUsageFlusher(configConfig, billingCache, serviceUserPlatformQuotaRepository, timingWheelService)
 	telemetryArchiveHealth := service.ProvideTelemetryArchiveHealth(shadow, opsRepository)

--- a/backend/internal/server/middleware/api_key_auth.go
+++ b/backend/internal/server/middleware/api_key_auth.go
@@ -292,7 +292,7 @@ func apiKeyAuthWithSubscription(apiKeyService *service.APIKeyService, subscripti
 						code = "USAGE_LIMIT_EXCEEDED"
 						status = 429
 					}
-					AbortWithError(c, status, code, validateErr.Error())
+					AbortWithError(c, status, code, clientFacingAppErrorMessage(validateErr))
 					return
 				}
 			} else {

--- a/backend/internal/server/middleware/api_key_auth_google.go
+++ b/backend/internal/server/middleware/api_key_auth_google.go
@@ -195,7 +195,7 @@ func APIKeyAuthWithSubscriptionGoogle(apiKeyService *service.APIKeyService, subs
 					errors.Is(err, service.ErrMonthlyLimitExceeded) {
 					status = 429
 				}
-				abortWithGoogleError(c, status, err.Error())
+				abortWithGoogleError(c, status, clientFacingAppErrorMessage(err))
 				return
 			}
 

--- a/backend/internal/server/middleware/api_key_auth_google_test.go
+++ b/backend/internal/server/middleware/api_key_auth_google_test.go
@@ -968,5 +968,6 @@ func TestApiKeyAuthWithSubscriptionGoogle_SubscriptionLimitExceededReturns429(t 
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	require.Equal(t, http.StatusTooManyRequests, resp.Error.Code)
 	require.Equal(t, "RESOURCE_EXHAUSTED", resp.Error.Status)
-	require.Contains(t, resp.Error.Message, "daily usage limit exceeded")
+	require.Equal(t, "daily usage limit exceeded", resp.Error.Message)
+	require.NotContains(t, resp.Error.Message, "error: code=")
 }

--- a/backend/internal/server/middleware/api_key_auth_test.go
+++ b/backend/internal/server/middleware/api_key_auth_test.go
@@ -267,6 +267,8 @@ func TestSimpleModeBypassesQuotaCheck(t *testing.T) {
 
 		require.Equal(t, http.StatusTooManyRequests, w.Code)
 		require.Contains(t, w.Body.String(), "USAGE_LIMIT_EXCEEDED")
+		require.Contains(t, w.Body.String(), "daily usage limit exceeded")
+		require.NotContains(t, w.Body.String(), "error: code=")
 	})
 }
 

--- a/backend/internal/server/middleware/middleware.go
+++ b/backend/internal/server/middleware/middleware.go
@@ -8,6 +8,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/googleapi"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
@@ -89,6 +90,16 @@ func NewErrorResponse(code, message string) ErrorResponse {
 func AbortWithError(c *gin.Context, statusCode int, code, message string) {
 	c.JSON(statusCode, NewErrorResponse(code, message))
 	c.Abort()
+}
+
+func clientFacingAppErrorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	if msg := infraerrors.Message(err); msg != "" {
+		return msg
+	}
+	return err.Error()
 }
 
 // abortWithOpenAIQuotaError writes the OpenAI-compatible insufficient quota response.

--- a/backend/internal/server/middleware/universal_routing_tk_test.go
+++ b/backend/internal/server/middleware/universal_routing_tk_test.go
@@ -402,6 +402,36 @@ func TestMaybeResolveUniversal_SwapsToSubscriptionGroupForBilling(t *testing.T) 
 	}
 }
 
+func TestMaybeResolveUniversal_UnusableSubscriptionFallsBackToBalanceGroup(t *testing.T) {
+	c, _ := newTestCtx(http.MethodPost, "/v1/chat/completions", `{"model":"gpt-5"}`)
+	subGroup := activeGroup(22, service.PlatformOpenAI)
+	subGroup.SubscriptionType = service.SubscriptionTypeSubscription
+	subGroup.SortOrder = 90
+	balanceGroup := activeGroup(2, service.PlatformOpenAI)
+	balanceGroup.IsExclusive = true
+	resolver := service.NewUniversalRoutingResolver(&stubSpanLister{groups: []service.Group{subGroup, balanceGroup}})
+	resolver.SetSubscriptionUsability(unusableSubscriptionGate{ids: map[int64]bool{22: true}})
+	apiKey := &service.APIKey{ID: 1, UserID: 31, RoutingMode: service.RoutingModeUniversal}
+
+	if handled := MaybeResolveUniversal(c, apiKey, resolver); handled {
+		t.Fatalf("fallback resolve should succeed")
+	}
+	if apiKey.Group == nil || apiKey.Group.ID != 2 || apiKey.Group.IsSubscriptionType() {
+		t.Fatalf("unusable subscription must swap to exclusive balance group 2; got %+v", apiKey.Group)
+	}
+}
+
+type unusableSubscriptionGate struct {
+	ids map[int64]bool
+}
+
+func (g unusableSubscriptionGate) SubscriptionGroupUsable(_ context.Context, _ int64, group *service.Group) bool {
+	if group == nil {
+		return true
+	}
+	return !g.ids[group.ID]
+}
+
 // R-002 regression: a span-load/internal failure must surface as 500 (retryable),
 // NOT a 403 "no platform in your plan" (which would mislabel a server error as an
 // entitlement problem).

--- a/backend/internal/service/api_key_service.go
+++ b/backend/internal/service/api_key_service.go
@@ -397,6 +397,16 @@ func (s *APIKeyService) SetUniversalModelSupportProvider(p groupModelSupportProv
 	s.universalResolver.SetModelSupportProvider(p)
 }
 
+// SetUniversalSubscriptionUsability 后期绑定订阅可用性闸，供全能 key 在订阅
+// 到期/额度满时回退到余额专属组。构造期 SubscriptionService 已存在，但仍走
+// setter，避免 NewAPIKeyService 签名膨胀。
+func (s *APIKeyService) SetUniversalSubscriptionUsability(g subscriptionGroupUsability) {
+	if s == nil || s.universalResolver == nil {
+		return
+	}
+	s.universalResolver.SetSubscriptionUsability(g)
+}
+
 // SetRateLimitCacheInvalidator sets the optional rate limit cache invalidator.
 // Called after construction (e.g. in wire) to avoid circular dependencies.
 func (s *APIKeyService) SetRateLimitCacheInvalidator(inv RateLimitCacheInvalidator) {

--- a/backend/internal/service/subscription_service.go
+++ b/backend/internal/service/subscription_service.go
@@ -418,21 +418,29 @@ func (s *SubscriptionService) createSubscription(ctx context.Context, input *Ass
 	}
 
 	now := time.Now()
+	if s.now != nil {
+		now = s.now()
+	}
 	expiresAt := now.AddDate(0, 0, validityDays)
 	if expiresAt.After(MaxExpiresAt) {
 		expiresAt = MaxExpiresAt
 	}
 
+	dailyWindowStart := timezone.StartOfDay(now)
+	periodicWindowStart := now
 	sub := &UserSubscription{
-		UserID:     input.UserID,
-		GroupID:    input.GroupID,
-		StartsAt:   now,
-		ExpiresAt:  expiresAt,
-		Status:     SubscriptionStatusActive,
-		AssignedAt: now,
-		Notes:      input.Notes,
-		CreatedAt:  now,
-		UpdatedAt:  now,
+		UserID:             input.UserID,
+		GroupID:            input.GroupID,
+		StartsAt:           now,
+		ExpiresAt:          expiresAt,
+		Status:             SubscriptionStatusActive,
+		DailyWindowStart:   &dailyWindowStart,
+		WeeklyWindowStart:  &periodicWindowStart,
+		MonthlyWindowStart: &periodicWindowStart,
+		AssignedAt:         now,
+		Notes:              input.Notes,
+		CreatedAt:          now,
+		UpdatedAt:          now,
 	}
 	// 只有当 AssignedBy > 0 时才设置（0 表示系统分配，如兑换码）
 	if input.AssignedBy > 0 {
@@ -908,8 +916,8 @@ func (s *SubscriptionService) CheckAndResetWindows(ctx context.Context, sub *Use
 		needsInvalidateCache = true
 	}
 
-	// 周窗口重置（7天）
-	if windowStart, ok := sub.automaticWindowStartAt(sub.WeeklyWindowStart, 7*24*time.Hour, now); ok {
+	// 周窗口重置（7天，含 StartsAt 对齐回退，见 automaticWeeklyWindowStartAt）
+	if windowStart, ok := sub.automaticWeeklyWindowStartAt(now); ok {
 		expectedWindowStart := sub.WeeklyWindowStart
 		if err := s.userSubRepo.ResetWeeklyUsage(ctx, sub.ID, expectedWindowStart, windowStart); err != nil {
 			return err
@@ -980,6 +988,28 @@ func (s *SubscriptionService) CheckUsageLimits(ctx context.Context, sub *UserSub
 		return ErrMonthlyLimitExceeded
 	}
 	return nil
+}
+
+// SubscriptionGroupUsable 判断用户此刻能否用该订阅组接请求。
+// 到期、停用、找不到有效订阅、日/周/月额度满都返回 false。
+// 窗口该滚动时先做与鉴权中间件相同的维护，避免把可续期的订阅误判成不可用。
+func (s *SubscriptionService) SubscriptionGroupUsable(ctx context.Context, userID int64, group *Group) bool {
+	if s == nil || group == nil || !group.IsSubscriptionType() {
+		return group != nil && !group.IsSubscriptionType()
+	}
+	sub, err := s.GetActiveSubscription(ctx, userID, group.ID)
+	if err != nil || sub == nil {
+		return false
+	}
+	needsMaintenance, err := s.ValidateAndCheckLimits(sub, group)
+	if needsMaintenance {
+		refreshed, merr := s.EnsureWindowMaintenance(ctx, sub)
+		if merr != nil {
+			return false
+		}
+		_, err = s.ValidateAndCheckLimits(refreshed, group)
+	}
+	return err == nil
 }
 
 // ValidateAndCheckLimits 合并验证+限额检查（中间件热路径专用）

--- a/backend/internal/service/subscription_service.go
+++ b/backend/internal/service/subscription_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"math/rand/v2"
@@ -991,25 +992,37 @@ func (s *SubscriptionService) CheckUsageLimits(ctx context.Context, sub *UserSub
 }
 
 // SubscriptionGroupUsable 判断用户此刻能否用该订阅组接请求。
-// 到期、停用、找不到有效订阅、日/周/月额度满都返回 false。
-// 窗口该滚动时先做与鉴权中间件相同的维护，避免把可续期的订阅误判成不可用。
+// 到期、停用、找不到有效订阅、日/周/月额度满都返回 false，全能 key 可改走余额组。
+// 读订阅或窗口维护的基础设施错误返回 true，让鉴权中间件按原路径 403/500，避免误扣钱包。
 func (s *SubscriptionService) SubscriptionGroupUsable(ctx context.Context, userID int64, group *Group) bool {
 	if s == nil || group == nil || !group.IsSubscriptionType() {
 		return group != nil && !group.IsSubscriptionType()
 	}
 	sub, err := s.GetActiveSubscription(ctx, userID, group.ID)
-	if err != nil || sub == nil {
+	if err != nil {
+		return !subscriptionBusinessUnusable(err)
+	}
+	if sub == nil {
 		return false
 	}
 	needsMaintenance, err := s.ValidateAndCheckLimits(sub, group)
 	if needsMaintenance {
 		refreshed, merr := s.EnsureWindowMaintenance(ctx, sub)
 		if merr != nil {
-			return false
+			return true
 		}
 		_, err = s.ValidateAndCheckLimits(refreshed, group)
 	}
 	return err == nil
+}
+
+func subscriptionBusinessUnusable(err error) bool {
+	return errors.Is(err, ErrSubscriptionNotFound) ||
+		errors.Is(err, ErrSubscriptionExpired) ||
+		errors.Is(err, ErrSubscriptionSuspended) ||
+		errors.Is(err, ErrDailyLimitExceeded) ||
+		errors.Is(err, ErrWeeklyLimitExceeded) ||
+		errors.Is(err, ErrMonthlyLimitExceeded)
 }
 
 // ValidateAndCheckLimits 合并验证+限额检查（中间件热路径专用）

--- a/backend/internal/service/subscription_weekly_window_test.go
+++ b/backend/internal/service/subscription_weekly_window_test.go
@@ -1,0 +1,204 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateAndCheckLimits_LateWeeklyAnchorRecoversStartsAtAlignedWeek(t *testing.T) {
+	// Repro: 30-day invite trial (user 31 / group 22). Weekly window was
+	// re-anchored to first-activate/admin-reset time, so the rolling next
+	// reset falls after ExpiresAt. A StartsAt-aligned week has already begun
+	// and must refresh instead of returning WEEKLY_LIMIT_EXCEEDED.
+	startsAt := time.Date(2026, 7, 24, 4, 31, 4, 81236000, time.UTC)
+	expiresAt := startsAt.Add(30 * 24 * time.Hour)
+	lateAnchor := time.Date(2026, 8, 18, 6, 22, 6, 0, time.UTC)
+	now := time.Date(2026, 8, 21, 7, 39, 34, 0, time.UTC)
+	limit := 50.0
+	sub := &UserSubscription{
+		Status:            SubscriptionStatusActive,
+		StartsAt:          startsAt,
+		ExpiresAt:         expiresAt,
+		WeeklyWindowStart: &lateAnchor,
+		WeeklyUsageUSD:    50.06,
+	}
+	svc := NewSubscriptionService(groupRepoNoop{}, userSubRepoNoop{}, nil, nil, nil)
+	svc.now = func() time.Time { return now }
+
+	needsMaintenance, err := svc.ValidateAndCheckLimits(sub, &Group{WeeklyLimitUSD: &limit})
+
+	require.NoError(t, err)
+	require.True(t, needsMaintenance)
+	require.Zero(t, sub.WeeklyUsageUSD)
+}
+
+func TestValidateAndCheckLimits_LateWeeklyAnchorStillBlocksInsideSameStartsAtWeek(t *testing.T) {
+	startsAt := time.Date(2026, 7, 24, 4, 31, 4, 0, time.UTC)
+	expiresAt := startsAt.Add(30 * 24 * time.Hour)
+	lateAnchor := time.Date(2026, 8, 18, 6, 22, 6, 0, time.UTC)
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	limit := 50.0
+	sub := &UserSubscription{
+		Status:            SubscriptionStatusActive,
+		StartsAt:          startsAt,
+		ExpiresAt:         expiresAt,
+		WeeklyWindowStart: &lateAnchor,
+		WeeklyUsageUSD:    50.06,
+	}
+	svc := NewSubscriptionService(groupRepoNoop{}, userSubRepoNoop{}, nil, nil, nil)
+	svc.now = func() time.Time { return now }
+
+	needsMaintenance, err := svc.ValidateAndCheckLimits(sub, &Group{WeeklyLimitUSD: &limit})
+
+	require.ErrorIs(t, err, ErrWeeklyLimitExceeded)
+	require.False(t, needsMaintenance)
+	require.Equal(t, 50.06, sub.WeeklyUsageUSD)
+}
+
+func TestCheckAndResetWindows_LateWeeklyAnchorAdvancesToStartsAtAlignedWeek(t *testing.T) {
+	startsAt := time.Date(2026, 7, 24, 4, 31, 4, 81236000, time.UTC)
+	lateAnchor := time.Date(2026, 8, 18, 6, 22, 6, 0, time.UTC)
+	now := time.Date(2026, 8, 21, 7, 39, 34, 0, time.UTC)
+	repo := &weeklyResetUserSubRepo{}
+	svc := NewSubscriptionService(groupRepoNoop{}, repo, nil, nil, nil)
+	svc.now = func() time.Time { return now }
+	sub := &UserSubscription{
+		ID:                5,
+		StartsAt:          startsAt,
+		ExpiresAt:         startsAt.Add(30 * 24 * time.Hour),
+		WeeklyWindowStart: &lateAnchor,
+		WeeklyUsageUSD:    50.06,
+	}
+
+	require.NoError(t, svc.CheckAndResetWindows(context.Background(), sub))
+	require.True(t, repo.resetCalled)
+	require.Equal(t, startsAt.Add(28*24*time.Hour), repo.resetAt)
+	require.Zero(t, sub.WeeklyUsageUSD)
+	require.Equal(t, startsAt.Add(28*24*time.Hour), *sub.WeeklyWindowStart)
+}
+
+type weeklyResetUserSubRepo struct {
+	userSubRepoNoop
+	resetCalled bool
+	resetAt     time.Time
+}
+
+func (r *weeklyResetUserSubRepo) ResetWeeklyUsage(_ context.Context, _ int64, _ *time.Time, resetAt time.Time) error {
+	r.resetCalled = true
+	r.resetAt = resetAt
+	return nil
+}
+
+func TestAssignSubscriptionInitializesUsageWindows(t *testing.T) {
+	groupRepo := &subscriptionGroupRepoStub{
+		group: &Group{ID: 1, SubscriptionType: SubscriptionTypeSubscription},
+	}
+	subRepo := newSubscriptionUserSubRepoStub()
+	svc := NewSubscriptionService(groupRepo, subRepo, nil, nil, nil)
+
+	sub, err := svc.AssignSubscription(context.Background(), &AssignSubscriptionInput{
+		UserID:       31,
+		GroupID:      1,
+		ValidityDays: 30,
+		Notes:        "invite-trial",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 1, subRepo.createCalls)
+	require.False(t, sub.StartsAt.IsZero())
+	require.NotNil(t, sub.DailyWindowStart)
+	require.Equal(t, timezone.StartOfDay(sub.StartsAt), *sub.DailyWindowStart)
+	require.NotNil(t, sub.WeeklyWindowStart)
+	require.Equal(t, sub.StartsAt, *sub.WeeklyWindowStart)
+	require.NotNil(t, sub.MonthlyWindowStart)
+	require.Equal(t, sub.StartsAt, *sub.MonthlyWindowStart)
+}
+
+type usableSubRepoStub struct {
+	userSubRepoNoop
+	sub *UserSubscription
+	err error
+}
+
+func (r usableSubRepoStub) GetActiveByUserIDAndGroupID(context.Context, int64, int64) (*UserSubscription, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.sub == nil {
+		return nil, ErrSubscriptionNotFound
+	}
+	cp := *r.sub
+	return &cp, nil
+}
+
+func TestSubscriptionGroupUsable_WeeklyLimitExceeded(t *testing.T) {
+	startsAt := time.Date(2026, 7, 24, 4, 31, 4, 0, time.UTC)
+	lateAnchor := time.Date(2026, 8, 18, 6, 22, 6, 0, time.UTC)
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	limit := 50.0
+	sub := &UserSubscription{
+		Status:            SubscriptionStatusActive,
+		UserID:            31,
+		GroupID:           22,
+		StartsAt:          startsAt,
+		ExpiresAt:         startsAt.Add(30 * 24 * time.Hour),
+		WeeklyWindowStart: &lateAnchor,
+		WeeklyUsageUSD:    50.06,
+	}
+	svc := NewSubscriptionService(groupRepoNoop{}, usableSubRepoStub{sub: sub}, nil, nil, nil)
+	svc.now = func() time.Time { return now }
+	group := &Group{ID: 22, SubscriptionType: SubscriptionTypeSubscription, WeeklyLimitUSD: &limit}
+
+	require.False(t, svc.SubscriptionGroupUsable(context.Background(), 31, group))
+}
+
+func TestSubscriptionGroupUsable_Expired(t *testing.T) {
+	startsAt := time.Date(2026, 7, 24, 4, 31, 4, 0, time.UTC)
+	now := time.Date(2026, 8, 23, 12, 31, 4, 0, time.UTC)
+	sub := &UserSubscription{
+		Status:    SubscriptionStatusActive,
+		UserID:    31,
+		GroupID:   22,
+		StartsAt:  startsAt,
+		ExpiresAt: startsAt.Add(30 * 24 * time.Hour),
+	}
+	svc := NewSubscriptionService(groupRepoNoop{}, usableSubRepoStub{sub: sub}, nil, nil, nil)
+	svc.now = func() time.Time { return now }
+	group := &Group{ID: 22, SubscriptionType: SubscriptionTypeSubscription}
+
+	require.False(t, svc.SubscriptionGroupUsable(context.Background(), 31, group))
+}
+
+func TestSubscriptionGroupUsable_MissingSubscription(t *testing.T) {
+	svc := NewSubscriptionService(groupRepoNoop{}, usableSubRepoStub{err: ErrSubscriptionNotFound}, nil, nil, nil)
+	group := &Group{ID: 22, SubscriptionType: SubscriptionTypeSubscription}
+
+	require.False(t, svc.SubscriptionGroupUsable(context.Background(), 31, group))
+}
+
+func TestSubscriptionGroupUsable_ActiveUnderLimit(t *testing.T) {
+	startsAt := time.Date(2026, 7, 24, 4, 31, 4, 0, time.UTC)
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	limit := 50.0
+	window := startsAt.Add(28 * 24 * time.Hour)
+	sub := &UserSubscription{
+		Status:            SubscriptionStatusActive,
+		UserID:            31,
+		GroupID:           22,
+		StartsAt:          startsAt,
+		ExpiresAt:         startsAt.Add(30 * 24 * time.Hour),
+		WeeklyWindowStart: &window,
+		WeeklyUsageUSD:    10,
+	}
+	svc := NewSubscriptionService(groupRepoNoop{}, usableSubRepoStub{sub: sub}, nil, nil, nil)
+	svc.now = func() time.Time { return now }
+	group := &Group{ID: 22, SubscriptionType: SubscriptionTypeSubscription, WeeklyLimitUSD: &limit}
+
+	require.True(t, svc.SubscriptionGroupUsable(context.Background(), 31, group))
+}

--- a/backend/internal/service/subscription_weekly_window_test.go
+++ b/backend/internal/service/subscription_weekly_window_test.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -201,4 +202,41 @@ func TestSubscriptionGroupUsable_ActiveUnderLimit(t *testing.T) {
 	group := &Group{ID: 22, SubscriptionType: SubscriptionTypeSubscription, WeeklyLimitUSD: &limit}
 
 	require.True(t, svc.SubscriptionGroupUsable(context.Background(), 31, group))
+}
+
+func TestSubscriptionGroupUsable_LookupInfraErrorKeepsSubscription(t *testing.T) {
+	svc := NewSubscriptionService(groupRepoNoop{}, usableSubRepoStub{err: errors.New("db unavailable")}, nil, nil, nil)
+	group := &Group{ID: 22, SubscriptionType: SubscriptionTypeSubscription}
+
+	require.True(t, svc.SubscriptionGroupUsable(context.Background(), 31, group))
+}
+
+func TestSubscriptionGroupUsable_MaintenanceInfraErrorKeepsSubscription(t *testing.T) {
+	startsAt := time.Date(2026, 7, 24, 4, 31, 4, 81236000, time.UTC)
+	lateAnchor := time.Date(2026, 8, 18, 6, 22, 6, 0, time.UTC)
+	now := time.Date(2026, 8, 21, 7, 39, 34, 0, time.UTC)
+	sub := &UserSubscription{
+		ID:                5,
+		Status:            SubscriptionStatusActive,
+		UserID:            31,
+		GroupID:           22,
+		StartsAt:          startsAt,
+		ExpiresAt:         startsAt.Add(30 * 24 * time.Hour),
+		WeeklyWindowStart: &lateAnchor,
+		WeeklyUsageUSD:    50.06,
+	}
+	limit := 50.0
+	svc := NewSubscriptionService(groupRepoNoop{}, failingWeeklyResetRepo{usableSubRepoStub: usableSubRepoStub{sub: sub}}, nil, nil, nil)
+	svc.now = func() time.Time { return now }
+	group := &Group{ID: 22, SubscriptionType: SubscriptionTypeSubscription, WeeklyLimitUSD: &limit}
+
+	require.True(t, svc.SubscriptionGroupUsable(context.Background(), 31, group))
+}
+
+type failingWeeklyResetRepo struct {
+	usableSubRepoStub
+}
+
+func (r failingWeeklyResetRepo) ResetWeeklyUsage(context.Context, int64, *time.Time, time.Time) error {
+	return errors.New("reset failed")
 }

--- a/backend/internal/service/universal_routing_tk_resolver.go
+++ b/backend/internal/service/universal_routing_tk_resolver.go
@@ -17,7 +17,7 @@ import (
 //  1. 取 key 主人的权限跨度（GetAvailableGroups，带短 TTL 缓存，热路径命中 0 次 DB）；
 //  2. 按入口端点形状（+ /antigravity 的 forcedPlatform）得到候选平台集合；
 //  3. 跨度 ∩ 候选平台 → 候选后端组；用模型平台提示偏向、再按确定规则挑一个
-//     （持订阅优先 → group.sort_order → id）。
+//     （可用的持订阅优先 → group.sort_order → id；订阅到期/额度满则改走余额组）。
 //
 // 解析成功后，调用方（middleware.MaybeResolveUniversal）把请求“伪装”成绑定该后端组的
 // 普通 key（替换 apiKey.Group/GroupID），下游调度/计费/转发零改动。
@@ -33,8 +33,15 @@ type UniversalRoutingResolver struct {
 	// 经 APIKeyService.SetUniversalAvailableModelsProvider 在 GatewayService 构造后绑定
 	// (避免构造期环)。受 mu 保护。nil = 未接线/降级 → Resolve 退回平台级现状(安全兜底)。
 	// 见 universal_routing_tk_serving.go。
-	modelsProvider  availableModelsProvider
-	supportProvider groupModelSupportProvider
+	modelsProvider   availableModelsProvider
+	supportProvider  groupModelSupportProvider
+	subscriptionGate subscriptionGroupUsability
+}
+
+// subscriptionGroupUsability 判断订阅型后端组此刻能否接请求。
+// 到期、停用、日/周/月额度满都算不可用，解析器随后改走余额专属组。
+type subscriptionGroupUsability interface {
+	SubscriptionGroupUsable(ctx context.Context, userID int64, group *Group) bool
 }
 
 // availableGroupsLister 由 *APIKeyService 满足，给出某用户当前有权绑定的全部分组
@@ -88,6 +95,17 @@ func (r *UniversalRoutingResolver) SetModelSupportProvider(p groupModelSupportPr
 	}
 	r.mu.Lock()
 	r.supportProvider = p
+	r.mu.Unlock()
+}
+
+// SetSubscriptionUsability 后期注入订阅可用性闸（SubscriptionService）。
+// nil = 不检查，保持「持订阅优先」的旧行为（测试/未接线）。
+func (r *UniversalRoutingResolver) SetSubscriptionUsability(g subscriptionGroupUsability) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	r.subscriptionGate = g
 	r.mu.Unlock()
 }
 
@@ -219,7 +237,40 @@ func (r *UniversalRoutingResolver) Resolve(ctx context.Context, apiKey *APIKey, 
 		eligible = imageEligible
 	}
 
-	return pickUniversalBackingGroup(eligible), nil
+	return r.pickUsableBackingGroup(ctx, apiKey.UserID, eligible)
+}
+
+func (r *UniversalRoutingResolver) pickUsableBackingGroup(ctx context.Context, userID int64, eligible []Group) (*Group, error) {
+	for len(eligible) > 0 {
+		picked := pickUniversalBackingGroup(eligible)
+		if picked == nil {
+			break
+		}
+		if r.subscriptionGroupUsable(ctx, userID, picked) {
+			return picked, nil
+		}
+		filtered := eligible[:0]
+		for i := range eligible {
+			if eligible[i].ID != picked.ID {
+				filtered = append(filtered, eligible[i])
+			}
+		}
+		eligible = filtered
+	}
+	return nil, ErrUniversalNoEntitledGroup
+}
+
+func (r *UniversalRoutingResolver) subscriptionGroupUsable(ctx context.Context, userID int64, group *Group) bool {
+	if group == nil || !group.IsSubscriptionType() {
+		return group != nil
+	}
+	r.mu.RLock()
+	gate := r.subscriptionGate
+	r.mu.RUnlock()
+	if gate == nil {
+		return true
+	}
+	return gate.SubscriptionGroupUsable(ctx, userID, group)
 }
 
 func universalShapeRequiresImageGenerationEnabled(shape UniversalShape) bool {
@@ -363,8 +414,9 @@ func isUniversalProbeGroup(g Group) bool {
 	return strings.HasPrefix(g.Name, "__tk_probe_")
 }
 
-// pickUniversalBackingGroup 在候选后端组里按确定规则挑一个：持订阅优先 → sort_order → id。
-// （跨度里的订阅型组都是“已持有订阅”的，因为 GetAvailableGroups 已过滤掉未持有的订阅组。）
+// pickUniversalBackingGroup 在候选后端组里按确定规则挑一个：可用订阅优先 → sort_order → id。
+// （跨度里的订阅型组都是“已持有订阅”的，因为 GetAvailableGroups 已过滤掉未持有的订阅组。
+// 到期/额度满由 pickUsableBackingGroup 再滤一层，改走余额专属组。）
 func pickUniversalBackingGroup(eligible []Group) *Group {
 	if len(eligible) == 0 {
 		return nil

--- a/backend/internal/service/universal_routing_tk_resolver_test.go
+++ b/backend/internal/service/universal_routing_tk_resolver_test.go
@@ -184,18 +184,18 @@ func TestUniversalCandidatePlatforms(t *testing.T) {
 
 func TestUniversalModelPlatformHint(t *testing.T) {
 	cases := map[string]string{
-		"claude-opus-4-8":        PlatformAnthropic,
-		"grok-4":                 PlatformGrok,
-		"gpt-5":                  PlatformOpenAI,
-		"o3-mini":                PlatformOpenAI,
-		"gemini-3-pro":           PlatformGemini,
-		"gemini-3.1-flash-image": PlatformAntigravity,
-		"doubao-seedream-4":      PlatformNewAPI,
-		"deepseek-chat":          PlatformNewAPI,
+		"claude-opus-4-8":            PlatformAnthropic,
+		"grok-4":                     PlatformGrok,
+		"gpt-5":                      PlatformOpenAI,
+		"o3-mini":                    PlatformOpenAI,
+		"gemini-3-pro":               PlatformGemini,
+		"gemini-3.1-flash-image":     PlatformAntigravity,
+		"doubao-seedream-4":          PlatformNewAPI,
+		"deepseek-chat":              PlatformNewAPI,
 		"tokenkey/claude-sonnet-4-6": PlatformAnthropic,
 		"tokenkey/gpt-5.4":           PlatformOpenAI,
-		"some-unknown-model-xyz": "",
-		"":                       "",
+		"some-unknown-model-xyz":     "",
+		"":                           "",
 	}
 	for model, want := range cases {
 		if got := universalModelPlatformHint(model); got != want {
@@ -431,5 +431,71 @@ func TestResolve_ProbeMessagesDispatchDoesNotOpenOpenAICompatGate(t *testing.T) 
 	g, err := r.Resolve(context.Background(), universalKey(1), ShapeAnthropicMessages, "gpt-5", "")
 	if err != nil || g == nil || g.ID != regular.ID {
 		t.Fatalf("probe dispatch group must not open messages dispatch gate, got %v err %v", g, err)
+	}
+}
+
+type stubSubscriptionGate struct {
+	unusable map[int64]bool
+	calls    []int64
+}
+
+func (s *stubSubscriptionGate) SubscriptionGroupUsable(_ context.Context, _ int64, group *Group) bool {
+	if group == nil {
+		return true
+	}
+	s.calls = append(s.calls, group.ID)
+	return !s.unusable[group.ID]
+}
+
+func TestResolve_UnusableSubscriptionFallsBackToStandardExclusive(t *testing.T) {
+	// user 31 shape: invite-trial subscription + GPT专线 exclusive balance group.
+	sub := grp(22, PlatformOpenAI, 90, true)
+	balance := grp(2, PlatformOpenAI, 0, false)
+	balance.IsExclusive = true
+	gate := &stubSubscriptionGate{unusable: map[int64]bool{22: true}}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: []Group{sub, balance}})
+	r.SetSubscriptionUsability(gate)
+
+	g, err := r.Resolve(context.Background(), universalKey(31), ShapeOpenAIChat, "gpt-5", "")
+	if err != nil || g == nil || g.ID != 2 {
+		t.Fatalf("unusable subscription must fall back to exclusive balance group 2, got %+v err %v", g, err)
+	}
+	if g.IsSubscriptionType() {
+		t.Fatalf("fallback group must bill against balance, got subscription-type")
+	}
+}
+
+func TestResolve_UsableSubscriptionStillPreferred(t *testing.T) {
+	sub := grp(22, PlatformOpenAI, 90, true)
+	balance := grp(2, PlatformOpenAI, 0, false)
+	gate := &stubSubscriptionGate{}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: []Group{sub, balance}})
+	r.SetSubscriptionUsability(gate)
+
+	g, err := r.Resolve(context.Background(), universalKey(31), ShapeOpenAIChat, "gpt-5", "")
+	if err != nil || g == nil || g.ID != 22 {
+		t.Fatalf("usable subscription must still win, got %+v err %v", g, err)
+	}
+}
+
+func TestResolve_UnusableSubscriptionWithoutFallbackIsNoEntitled(t *testing.T) {
+	sub := grp(22, PlatformOpenAI, 90, true)
+	gate := &stubSubscriptionGate{unusable: map[int64]bool{22: true}}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: []Group{sub}})
+	r.SetSubscriptionUsability(gate)
+
+	if _, err := r.Resolve(context.Background(), universalKey(31), ShapeOpenAIChat, "gpt-5", ""); err != ErrUniversalNoEntitledGroup {
+		t.Fatalf("unusable subscription with no balance fallback must be no-entitled, got %v", err)
+	}
+}
+
+func TestResolve_NilSubscriptionGateKeepsSubscriptionPreference(t *testing.T) {
+	sub := grp(22, PlatformOpenAI, 90, true)
+	balance := grp(2, PlatformOpenAI, 0, false)
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: []Group{sub, balance}})
+
+	g, err := r.Resolve(context.Background(), universalKey(31), ShapeOpenAIChat, "gpt-5", "")
+	if err != nil || g == nil || g.ID != 22 {
+		t.Fatalf("unwired resolver must keep subscription preference, got %+v err %v", g, err)
 	}
 }

--- a/backend/internal/service/user_subscription.go
+++ b/backend/internal/service/user_subscription.go
@@ -88,10 +88,7 @@ func (s *UserSubscription) NeedsWeeklyReset() bool {
 }
 
 func (s *UserSubscription) NeedsWeeklyResetAt(now time.Time) bool {
-	if s.WeeklyWindowStart == nil {
-		return false
-	}
-	return !now.Before(s.WeeklyWindowStart.Add(7 * 24 * time.Hour))
+	return s.canAutomaticallyResetWeeklyAt(now)
 }
 
 func (s *UserSubscription) NeedsMonthlyReset() bool {
@@ -129,8 +126,46 @@ func (s *UserSubscription) automaticDailyWindowStartAt(now time.Time) (time.Time
 }
 
 func (s *UserSubscription) canAutomaticallyResetWeeklyAt(now time.Time) bool {
-	_, ok := s.automaticWindowStartAt(s.WeeklyWindowStart, 7*24*time.Hour, now)
+	_, ok := s.automaticWeeklyWindowStartAt(now)
 	return ok
+}
+
+// automaticWeeklyWindowStartAt 计算周窗口当前应推进到的起点。
+// 先走期限对齐滚动窗口；若滚动下一窗会落在订阅到期之后，再回退到
+// StartsAt 对齐且已经开始的周边界，避免首次激活/手动重置把锚点推晚后
+// 用户在仍有剩余订阅天数时被 WEEKLY_LIMIT_EXCEEDED 卡死。
+func (s *UserSubscription) automaticWeeklyWindowStartAt(now time.Time) (time.Time, bool) {
+	if start, ok := s.automaticWindowStartAt(s.WeeklyWindowStart, 7*24*time.Hour, now); ok {
+		return start, true
+	}
+	return s.startsAtAlignedElapsedWeeklyPeriod(now)
+}
+
+func (s *UserSubscription) startsAtAlignedElapsedWeeklyPeriod(now time.Time) (time.Time, bool) {
+	const weeklyPeriod = 7 * 24 * time.Hour
+	if s.WeeklyWindowStart == nil || s.StartsAt.IsZero() {
+		return time.Time{}, false
+	}
+	if now.Before(s.StartsAt) || !now.Before(s.ExpiresAt) {
+		return time.Time{}, false
+	}
+	elapsed := now.Sub(s.StartsAt)
+	if elapsed < weeklyPeriod {
+		return time.Time{}, false
+	}
+	periods := elapsed / weeklyPeriod
+	lastPeriodBeforeExpiry := (s.ExpiresAt.Sub(s.StartsAt) - 1) / weeklyPeriod
+	if periods > lastPeriodBeforeExpiry {
+		periods = lastPeriodBeforeExpiry
+	}
+	if periods < 1 {
+		return time.Time{}, false
+	}
+	candidate := s.StartsAt.Add(periods * weeklyPeriod)
+	if !candidate.After(*s.WeeklyWindowStart) || !candidate.Before(s.ExpiresAt) {
+		return time.Time{}, false
+	}
+	return candidate, true
 }
 
 func (s *UserSubscription) canAutomaticallyResetMonthlyAt(now time.Time) bool {

--- a/backend/internal/service/wire_tk.go
+++ b/backend/internal/service/wire_tk.go
@@ -61,19 +61,25 @@ func ProvideTKGatewayPricingAvailability(
 type TKUniversalModelsProviderReady struct{}
 
 // ProvideTKUniversalModelsProvider wires the universal-key resolver's model
-// support truth source post-construction. APIKeyService constructs the resolver
-// before GatewayService exists, so this late binding avoids the construction
-// cycle. Mirrors ProvideTKGatewayPricingAvailability in shape.
+// support truth source and subscription-usability gate post-construction.
+// APIKeyService constructs the resolver before GatewayService exists, so this
+// late binding avoids the construction cycle. Mirrors
+// ProvideTKGatewayPricingAvailability in shape.
 //
-// Setter is nil-safe; if either dep is nil the resolver keeps its safe
-// platform-level fallback. See docs/approved/universal-key-routing.md.
+// Setter is nil-safe; if gw is nil the resolver keeps its safe platform-level
+// fallback; if subs is nil, unusable subscriptions are not filtered.
+// See docs/approved/universal-key-routing.md.
 func ProvideTKUniversalModelsProvider(
 	api *APIKeyService,
 	gw *GatewayService,
+	subs *SubscriptionService,
 ) TKUniversalModelsProviderReady {
 	if api != nil && gw != nil {
 		api.SetUniversalModelSupportProvider(gw.UniversalGroupSupportsRequest)
 		api.SetUniversalAvailableModelsProvider(gw.GetAvailableModels)
+	}
+	if api != nil && subs != nil {
+		api.SetUniversalSubscriptionUsability(subs)
 	}
 	return TKUniversalModelsProviderReady{}
 }

--- a/docs/approved/universal-key-routing.md
+++ b/docs/approved/universal-key-routing.md
@@ -77,8 +77,10 @@ GPT 请求按 GPT 组的价/倍率,每用户还能有自己的专属倍率。
     (direct handler 当前支持这两个平台;JSON/multipart 的 `model` 字段用于在两者间收敛)。
   - `/v1beta/models/*` POST → `[gemini, antigravity]`;GET 元数据(含 `/v1/models`)→ 跳过。
 - 解析器 `universal_routing_tk_resolver.go`:取(短 TTL 缓存的)权限跨度 `GetAvailableGroups` →
-  跨度 ∩ 候选平台(active)→ **「组已服务模型集」真值过滤(见下)** → **确定性挑选(持订阅优先
-  → `group.sort_order` → id)**。空 → 按入口协议形状写 403"该模型不在你的套餐内"。
+  跨度 ∩ 候选平台(active)→ **「组已服务模型集」真值过滤(见下)** → **确定性挑选(可用订阅优先
+  → `group.sort_order` → id)**。订阅到期、停用或日/周/月额度满视为不可用，从候选里拿掉后
+  再挑，落到同一跨度里的余额专属组(按该组扣钱包)。两边都空 → 按入口协议形状写 403
+  "该模型不在你的套餐内"。
 
   **模型/模态服务真值过滤(`universal_routing_tk_serving.go`)**:旧版仅用前缀 hint(best-effort
   偏好)选平台,对「某组账号到底服不服务这个模型」零可见 —— newapi 多 vendor 平台(deepseek/

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -5263,9 +5263,11 @@
         "func (r *UniversalRoutingResolver) Resolve(",
         "var ErrUniversalNoEntitledGroup",
         "func pickUniversalBackingGroup(",
+        "func (r *UniversalRoutingResolver) pickUsableBackingGroup(",
+        "supportProvider  groupModelSupportProvider",
+        "subscriptionGate subscriptionGroupUsability",
         "universalShapeRequiresImageGenerationEnabled",
         "filterGroupsAllowImageGeneration",
-        "supportProvider groupModelSupportProvider",
         "supportProvider(ctx, &gid, eligible[i].Platform, model, shape)",
         "else if hint := universalRequestPlatformHint(shape, model); hint != \"\"",
         "收敛为空且模型有平台 hint → ErrUniversalNoEntitledGroup(403)"
@@ -5357,9 +5359,27 @@
       "must_contain": [
         "ProvideTKUniversalModelsProvider(",
         "api.SetUniversalModelSupportProvider(gw.UniversalGroupSupportsRequest)",
-        "api.SetUniversalAvailableModelsProvider(gw.GetAvailableModels)"
+        "api.SetUniversalAvailableModelsProvider(gw.GetAvailableModels)",
+        "api.SetUniversalSubscriptionUsability(subs)"
       ],
-      "rationale": "ProvideTKUniversalModelsProvider is the runtime injection point for universal-key model+protocol routing truth. The direct-scheduler support provider must be wired alongside GetAvailableModels; tests can call SetUniversalModelSupportProvider directly and still pass if an upstream merge drops this wire call, leaving production on the old lossy fallback. Pin both setter calls so the app cannot silently boot without direct-key parity."
+      "rationale": "ProvideTKUniversalModelsProvider is the runtime injection point for universal-key model+protocol routing truth and subscription fallback. The direct-scheduler support provider must be wired alongside GetAvailableModels; the subscription usability gate must be wired so expired/quota-full subscriptions fall back to exclusive balance groups. Tests can call setters directly and still pass if an upstream merge drops this wire call, leaving production on the old lossy fallback. Pin the setter calls so the app cannot silently boot without them."
+    },
+    {
+      "path": "backend/cmd/server/wire_gen.go",
+      "must_contain": [
+        "service.ProvideTKUniversalModelsProvider(apiKeyService, gatewayService, subscriptionService)"
+      ],
+      "rationale": "Generated production DI evidence that the universal-key resolver receives SubscriptionService. Source providers alone do not prove the real server graph retained the subscription-usability fallback."
+    },
+    {
+      "path": "backend/internal/service/universal_routing_tk_resolver_test.go",
+      "must_contain": [
+        "TestResolve_UnusableSubscriptionFallsBackToStandardExclusive",
+        "TestResolve_UsableSubscriptionStillPreferred",
+        "TestResolve_UnusableSubscriptionWithoutFallbackIsNoEntitled",
+        "TestResolve_NilSubscriptionGateKeepsSubscriptionPreference"
+      ],
+      "rationale": "Universal-key subscription fallback: quota-full or expired subscription groups must yield to exclusive balance groups; a still-usable subscription must keep winning; no remaining entitled group must stay 403; unwired resolvers keep the old preference."
     },
     {
       "path": "backend/internal/service/universal_routing_tk_serving_test.go",


### PR DESCRIPTION
## 摘要
- 全能 key 在订阅到期、停用或日/周/月额度满时，改走同一授权跨度里的余额专属组，按钱包调度和扣费，避免试用周额度用完后直接 429 卡死。
- 读订阅或窗口维护失败时不回退钱包，沿用鉴权原错误，避免瞬时故障误扣余额。
- 顺带修周窗口锚点偏晚时拒绝滚动的问题，并让客户端 429 文案回到干净的 `weekly usage limit exceeded`。
- 已并入当前 `main`（含 #1780），满足 ancestry guard。
- no-web-impact

## 风险
常规风险：订阅仍可用时行为不变；订阅业务上不可用后，OpenAI 等请求会落到已授权的 standard 组并扣钱包。基础设施错误 fail-closed。direct key 不改。设计锚点：`docs/approved/universal-key-routing.md`。

## 验证
- `go test -tags=unit ./internal/service/ ./internal/server/middleware/ ./cmd/server/` 通过
- `GOTOOLCHAIN=go1.26.6 ./scripts/preflight.sh` 通过

## 提交
- `aa826966e` fix(gateway): fall back to balance groups when a subscription cannot serve
- `9bc50ef67` fix(billing): address R-001 — do not wallet-fallback on subscription infra errors
- `1a5fc9418` merge(main): include #1780 so PR head contains current main ancestry
- 最新提交：`1a5fc9418`