### PR TITLE
fix(ops): 用线上版本到本次发版的 PR 做 +5min 实测

### DIFF
--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -33,7 +33,7 @@ description: Drive TokenKey Stage0 release, prod deploy, edge rollout, smoke, ro
 | 发版前 smoke 模型校验 | 机械 | `python3 scripts/stage0/check_smoke_config.py`（`TK_SMOKE_ANTHROPIC_MODELS` / `TK_SMOKE_GEMINI_MODELS` / `TK_SMOKE_OPENAI_OAUTH_MODELS` 均 ∈ `TK_SMOKE_API_KEY` 的 `/v1/models`）。**完整校验需要 smoke key，只在 CI 可跑**；本地降级为 `bash ops/stage0/load_smoke_github_env.sh --check prod`（只验 secret/vars 已配置） |
 | 发版后跟进档位（skip / single） | 机械 | `bash scripts/release-impact-files.sh PREV NEW` → `.followup.tier`（是否值得人工再跟；**实测检查不走这里**） |
 | 发版后控制面探活（prod + deployable edge） | 机械 | `bash ops/observability/probe-release-control-plane.sh`（prod `/health` + `/api/v1/settings/public`，deployable Edge `/health`，JSON lines + summary） |
-| **发版后 +5min 实测（live tag→本次 tag 的全部 PR）** | 机械 | `deploy-stage0.yml` job `post-release-check` → `ops/observability/run-post-release-check.sh`（plan 从 git 派生，禁止模型自造 `HOOK_PATTERNS`） |
+| **发版后 +5min 实测（live tag→本次 tag 的全部 PR）** | 机械 | `deploy-stage0.yml` 的 `deploy` job 在 smoke 后跑 `ops/observability/run-post-release-check.sh`（plan 从 git 派生，禁止模型自造 `HOOK_PATTERNS`；复用已批的 prod Environment，不再另开审批） |
 | **发版后 Anthropic OAuth 配置检查（snapshot → check）** | 机械 | `python3 ops/anthropic/manage-anthropic-config.py snapshot` + `check --snapshot`（见 §「发版后 Anthropic OAuth 配置检查」；canonical：`/tokenkey-anthropic-oauth-config`） |
 | **发版后 Account model_mapping 配置 diff** | 机械 | `python3 ops/pricing/manage-account-model-mapping-runtime.py check-accounts --json`（默认 prod only；期望 mapping 与 forbidden policy metadata 均来自 Go SSOT；edge 保持空 mapping 不纳入检查，见 §「发版后 Account model_mapping 配置检查」） |
 | rollout 摘要（git log / diff stat / sentinel / deletion） | 机械 | `bash scripts/release-rollout-summary.sh --mode release` |
@@ -307,7 +307,7 @@ python3 scripts/stage0/resolve-edge-deploy-route.py --edge-id "$EDGE_ID" --json
    ```
 
    脚本按 batch dispatch upgrade（`--smoke-phase infra`）→ watch → 验 `tk_edge_post_deploy_smoke: OK phase=infra`。**默认 `--parallel 1`（顺序）**；`N>1` 仅在可接受换容器窗口影响时用。批内失败则 fail-stop。
-8. **发版后 +5min 实测（CI 唯一源）**：watch 同一 `deploy-stage0` run 的 `post-release-check` job（`needs: deploy`，换镜像成功后等 5 分钟）。它用换镜像前的线上 tag → 本次 tag 列出全部产品 PR，再对照 prod 日志评分。摘要转述 job 的 `evaluate.json`，**不要**自造 `HOOK_PATTERNS`，也**不要**另开一轮 tick。CI 不可解析时才本地重跑 `ops/observability/run-post-release-check.sh`。
+8. **发版后 +5min 实测（CI 唯一源）**：watch 同一 `deploy-stage0` run 的 `deploy` job 在 smoke 之后的 post-release 步（换镜像成功后等 5 分钟，**不再**另开 `environment: prod` 审批）。它用换镜像前的线上 tag → 本次 tag 列出全部产品 PR，再对照 prod 日志评分。摘要转述 `evaluate.json`，**不要**自造 `HOOK_PATTERNS`，也**不要**另开一轮 tick。CI 不可解析时才本地重跑 `ops/observability/run-post-release-check.sh`。
 9. **只读配置检查（默认）**：先跑 §「发版后 Anthropic OAuth 配置检查」，再跑 §「发版后 Account model_mapping 配置检查」。violations 不触发 rollback，写入 rollout 摘要为 **yellow**；Anthropic violation 指向 `/tokenkey-anthropic-oauth-config`，model_mapping violation 指向 `/tokenkey-modelops-planner` 分支 D，先审 Go SSOT 派生的 diff，再按需 `apply-accounts --confirm yes-apply-account-model-mapping`。
 
 ## prod 真实测试
@@ -443,7 +443,7 @@ prod smoke 失败：停，优先 rollback prod；不要继续 Edge rollout。Edg
 
 ## 完成后：发版后 +5min 实测（live tag → 本次 tag）
 
-**一条路径**：`deploy-stage0.yml` 的 `post-release-check` job。范围是换镜像前线上正在跑的 tag（`resolve-prod-running-tag-via-ssm`），不是「上一个 git tag」猜测。job 用 `scripts/release_post_check.py` 列出该范围内全部产品 PR，再投递控制面 + tick，按 plan 评分。
+**一条路径**：`deploy-stage0.yml` 的 `deploy` job 在 smoke 之后的 post-release 步。范围是换镜像前线上正在跑的 tag（`resolve-prod-running-tag-via-ssm`），不是「上一个 git tag」猜测。脚本用 `scripts/release_post_check.py` 列出该范围内全部产品 PR，再投递控制面 + tick，按 plan 评分。检查留在同一 job，避免第二次 prod Environment 审批把 +5min 时钟推后。
 
 禁止：
 

--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -31,15 +31,14 @@ description: Drive TokenKey Stage0 release, prod deploy, edge rollout, smoke, ro
 | prod 完整 smoke（CI 唯一验收源） | 机械 | `deploy-stage0.yml` job log 内 `tk_post_deploy_smoke: OK`（`GATEWAY_SMOKE_SUITE=full`） |
 | Edge smoke 分阶段（infra / edge-native-oauth / main-via-edge / full） | 机械 | `ops/stage0/edge_post_deploy_smoke.sh` + workflow `smoke_phase`；**upgrade/rollback 默认 infra**；canary 显式 **full**（infra + 容器内 per-account OAuth 拟真 `probe_account_model`）；`main-via-edge` 为可选 prod 中转链路 |
 | 发版前 smoke 模型校验 | 机械 | `python3 scripts/stage0/check_smoke_config.py`（`TK_SMOKE_ANTHROPIC_MODELS` / `TK_SMOKE_GEMINI_MODELS` / `TK_SMOKE_OPENAI_OAUTH_MODELS` 均 ∈ `TK_SMOKE_API_KEY` 的 `/v1/models`）。**完整校验需要 smoke key，只在 CI 可跑**；本地降级为 `bash ops/stage0/load_smoke_github_env.sh --check prod`（只验 secret/vars 已配置） |
-| 发版后跟进档位（skip / single） | 机械 | `bash scripts/release-impact-files.sh PREV NEW` → `.followup.tier` |
+| 发版后跟进档位（skip / single） | 机械 | `bash scripts/release-impact-files.sh PREV NEW` → `.followup.tier`（是否值得人工再跟；**实测检查不走这里**） |
 | 发版后控制面探活（prod + deployable edge） | 机械 | `bash ops/observability/probe-release-control-plane.sh`（prod `/health` + `/api/v1/settings/public`，deployable Edge `/health`，JSON lines + summary） |
-| 发版后 tick 探针（hook 计数 + 流量/5xx/panic） | 机械 | `ops/observability/probe-post-release-tick.sh`（经 `run-probe.sh` 投递；默认 `CONTAINER=auto` 自动识别 prod blue/green active container；`HOOK_PATTERNS` 里的 hook 关键词由模型按 Step A 命名——命名是判断，计数是机械） |
+| **发版后 +5min 实测（live tag→本次 tag 的全部 PR）** | 机械 | `deploy-stage0.yml` job `post-release-check` → `ops/observability/run-post-release-check.sh`（plan 从 git 派生，禁止模型自造 `HOOK_PATTERNS`） |
 | **发版后 Anthropic OAuth 配置检查（snapshot → check）** | 机械 | `python3 ops/anthropic/manage-anthropic-config.py snapshot` + `check --snapshot`（见 §「发版后 Anthropic OAuth 配置检查」；canonical：`/tokenkey-anthropic-oauth-config`） |
 | **发版后 Account model_mapping 配置 diff** | 机械 | `python3 ops/pricing/manage-account-model-mapping-runtime.py check-accounts --json`（默认 prod only；期望 mapping 与 forbidden policy metadata 均来自 Go SSOT；edge 保持空 mapping 不纳入检查，见 §「发版后 Account model_mapping 配置检查」） |
 | rollout 摘要（git log / diff stat / sentinel / deletion） | 机械 | `bash scripts/release-rollout-summary.sh --mode release` |
 | prod approval 时机、smoke 模型回退 | 判断 | prompt（爆炸半径、用户入口顺序） |
-| verdict 评级（green/yellow/red） | 判断 | prompt（错误聚类 vs 基线、流量趋势） |
-| Step A → 「重点观察 trace 关键词」语义命名 | 判断 | prompt（文件→hook 名映射；脚本只给文件桶） |
+| +5min 实测 verdict | 机械 | `release_post_check.py evaluate`（agent 只转述，禁止另编 hook / 另评 green） |
 | `simple_release=true` / `[skip ci]` 等 hard rules | 判断 + 机械门禁 | prompt + `scripts/release-tag.sh` / preflight |
 
 ## 调用参数
@@ -308,10 +307,8 @@ python3 scripts/stage0/resolve-edge-deploy-route.py --edge-id "$EDGE_ID" --json
    ```
 
    脚本按 batch dispatch upgrade（`--smoke-phase infra`）→ watch → 验 `tk_edge_post_deploy_smoke: OK phase=infra`。**默认 `--parallel 1`（顺序）**；`N>1` 仅在可接受换容器窗口影响时用。批内失败则 fail-stop。
-8. **发版后跟进（按 diff 档位，至多一次 tick）**：跑 `release-impact-files.sh` 读 `.followup.tier`：
-   - `skip` → 不跟进，直接 rollout summary。
-   - `single` → 仅 **+5min** 一次轻量诊断（含 gateway/schema/config 类变更；多轮 extended 档已下线，更长窗口仅人工显式发起）。
-9. **只读配置检查（默认，在 followup 之前）**：先跑 §「发版后 Anthropic OAuth 配置检查」，再跑 §「发版后 Account model_mapping 配置检查」。violations 不触发 rollback，写入 rollout 摘要为 **yellow**；Anthropic violation 指向 `/tokenkey-anthropic-oauth-config`，model_mapping violation 指向 `/tokenkey-modelops-planner` 分支 D，先审 Go SSOT 派生的 diff，再按需 `apply-accounts --confirm yes-apply-account-model-mapping`。
+8. **发版后 +5min 实测（CI 唯一源）**：watch 同一 `deploy-stage0` run 的 `post-release-check` job（`needs: deploy`，换镜像成功后等 5 分钟）。它用换镜像前的线上 tag → 本次 tag 列出全部产品 PR，再对照 prod 日志评分。摘要转述 job 的 `evaluate.json`，**不要**自造 `HOOK_PATTERNS`，也**不要**另开一轮 tick。CI 不可解析时才本地重跑 `ops/observability/run-post-release-check.sh`。
+9. **只读配置检查（默认）**：先跑 §「发版后 Anthropic OAuth 配置检查」，再跑 §「发版后 Account model_mapping 配置检查」。violations 不触发 rollback，写入 rollout 摘要为 **yellow**；Anthropic violation 指向 `/tokenkey-anthropic-oauth-config`，model_mapping violation 指向 `/tokenkey-modelops-planner` 分支 D，先审 Go SSOT 派生的 diff，再按需 `apply-accounts --confirm yes-apply-account-model-mapping`。
 
 ## prod 真实测试
 
@@ -444,114 +441,44 @@ prod smoke 失败：停，优先 rollback prod；不要继续 Edge rollout。Edg
 
 **自动 rollback 也救不回 → 切灾难恢复（单次救不回即切，不必等"反复 N 次"）**：`deploy-stage0.yml` 调的 `ops/stage0/deploy_via_ssm.sh` 已内置 rollback ERR trap（失败自动恢复上一镜像）。当它**也救不回**——SSM 日志出现 `::error::…node requires MANUAL intervention`——或 dispatch rollback 到 `previous_tag` 后 external_health / smoke 仍失败，说明这已不是镜像级问题（整机 / OS / 数据卷 / 迁移 checksum 钉死）。此时切到 `deploy/aws/RUNBOOK-disaster-recovery.md`，按其 **§Agent 协同契约** 执行（Agent 自主跑只读/可逆步骤、高风险步骤先 plan 再等人类批）——具体边界与命令以该 runbook 为唯一权威，本段不复述。
 
-## 完成后：发版后跟进（按 diff 档位）
+## 完成后：发版后 +5min 实测（live tag → 本次 tag）
 
-发版后跟进**至多一次 +5min tick**（多轮 extended 档已下线——一次 tick 足以暴露启动/hook 级回归，更长窗口仅人工显式发起）。先机械化分档：
+**一条路径**：`deploy-stage0.yml` 的 `post-release-check` job。范围是换镜像前线上正在跑的 tag（`resolve-prod-running-tag-via-ssm`），不是「上一个 git tag」猜测。job 用 `scripts/release_post_check.py` 列出该范围内全部产品 PR，再投递控制面 + tick，按 plan 评分。
+
+禁止：
+
+- 模型按文件桶现场编 `HOOK_PATTERNS`
+- 用 `release-impact-files.sh` 的 `.followup.tier` 决定「查不查」（那只表示是否值得人工再跟）
+- smoke 通过后另开一轮手写 grep tick
+
+CI 已跑完：从同一 run 的 job summary / `evaluate.json` 转述 changes + checks + verdict。CI 不可解析时才本地重跑：
 
 ```bash
-PREV_TAG=$(git tag --sort=-version:refname | grep '^v[0-9]' | sed -n '2p')
-NEW_TAG=$(git tag --sort=-version:refname | grep '^v[0-9]' | head -1)
-bash scripts/release-impact-files.sh "${PREV_TAG}" "${NEW_TAG}"
-# 读 JSON .followup.tier → skip | single
+LIVE_TAG="${LIVE_TAG:?set to the tag that was serving before this deploy}"
+NEW_TAG="${NEW_TAG:?set to the tag just deployed}"
+bash ops/observability/run-post-release-check.sh \
+  --live "$LIVE_TAG" \
+  --new "$NEW_TAG" \
+  --target prod
 ```
 
-| tier | 动作 |
-|---|---|
-| `skip` | 不跟进；直接 rollout summary |
-| `single` | **仅 +5min** 一次轻量诊断 |
+wrapper 会自己 `plan` → 控制面 → `probe-post-release-tick.sh`（hooks 来自 plan）→ `evaluate`。`probe-post-release-tick.sh` 默认 `CONTAINER=auto`：读 `/var/lib/tokenkey/active-color` 转成 `tokenkey-blue` / `tokenkey-green`，找不到再回退 legacy `tokenkey`。不要因为 `No such container: tokenkey` 手工猜颜色。
 
-### Step A：重点观察变量（single 时）
-
-跟进基于本次 diff，不跑固定 metric 集。文件桶分类机械化（`release-impact-files.sh`），桶内 hook 名由模型按 release 内容命名（判断）。
-
-JSON 出来后，对每个非空 bucket，**模型**按下表把改动文件映射到「重点观察 trace 关键词」。脚本只给桶（机械），关键词由模型按 hook 命名（判断）：
-
-| 改动类型 | 重点观察的 trace 关键词 |
-|---|---|
-| 新背景 goroutine（如 `*_reaper.go`） | grep `XxxReaper` 启动日志、cycle 频率、Cleanup 退出消息 |
-| 新 gateway 路径 hook（如 `*_tk_signature_preempt.go`） | grep `applyXxxIfArmed` / `armXxxOnError` 触发次数、影响的 account_id 分布 |
-| 新错误处理分支（如 `*_silent_refusal.go`） | grep `silent_refusal` / 新增 `ops_error_logs.reason` 取值 |
-| Stream 行为改动（keepalive ticker、超时等） | 看 SSE 连接持续时间分布、`Gateway.StreamKeepaliveInterval` 是否实际启用 |
-| `wire.go` / `wire_gen.go` DI 变化 | 看启动日志 provider 顺序无 panic、新依赖构造无 nil |
-| `config.go` 新字段 | 在 prod / Edge `.env` 与 `.env.example` 对齐确认；进容器后只输出字段是否设置或 redacted 状态，不打印变量值 |
-| 数据库 schema / migrations | 新表/列的写入路径在 5 分钟窗口是否 surfacing 异常 |
-| 前端 frontend dist hash 变化 | embedded dist freshness + 关键页面 200 |
-
-把「重点观察变量」列在第一次跟进的开头，让 user 看到这一次跟进是按本次发版定制的，而非通用模板。
-
-### Step B：每次 tick 的内容
-
-1. **控制面探活（一条命令）**：不要手写 `curl`/`jq` loop；用统一脚本输出 JSON lines + summary：
-
-   ```bash
-   bash ops/observability/probe-release-control-plane.sh
-   # summary.status 期望 ok；EDGE_IDS=us3,us4 可缩小范围，EDGE_IDS=none 仅查 prod
-   ```
-
-2. **hook + 流量 + 5xx + panic（一条命令）**：Step A 命名的 hook 关键词作为 `HOOK_PATTERNS`（逗号分隔的固定字符串，grep -F 语义）传给入库探针——不要每次现场手写探针脚本：
-
-   ```bash
-   bash ops/observability/run-probe.sh --target prod \
-     --script ops/observability/probe-post-release-tick.sh \
-     --env SINCE=6m \
-     --env "HOOK_PATTERNS=<hook1>,<hook2>" \
-     --timeout-seconds 120
-   ```
-
-   `probe-post-release-tick.sh` 默认 `CONTAINER=auto`：prod blue/green deploy 后会读 `/var/lib/tokenkey/active-color` 自动转成 `tokenkey-blue` / `tokenkey-green`，找不到时回退 legacy `tokenkey`。不要因为 `No such container: tokenkey` 手工补救；若仍失败，记录 stdout 的 `container_resolution` 后再排查。
-
-3. **错误聚类**（tick 2 起，或任何 5xx/异常出现时）：`ops/observability/ops-error-triage.sh` 经 run-probe 投递，分钟窗用 `--env WINDOW_MINUTES=15`；更深排查转 `/tokenkey-online-log-troubleshooting`。
-4. **hook 触发语义**：没看到触发 = 正常（流量未触达该路径）；触发频次明显高于基线 = 异常；触发后立即 5xx 跟随 = 异常。
-
-### Step C：每次 tick 的固定输出形状
-
-每次跟进结束输出一段 5–12 行的简洁汇报，结构固定（占位符在执行时按 Step A 提取结果填实）：
+输出只转述 evaluate，不要另评：
 
 ```text
-[+Nmin post-release ${NEW_TAG}]
-control plane: api 200 ✓ | settings/public 200 ✓ | <each deployable edge> 200 ✓
-errors (last 5m): <cluster summary by reason/status_code/platform, or "none">
-traffic (last 5m): N total | chat=X messages=Y models=Z
-new-code hooks:
-  - <hook 1 from Step A>: <grep result, or "no fires">
-  - <hook 2 from Step A>: <grep result, or "no activity">
-  - ...
-verdict: green | yellow | red — <one-line reason>
+[+5min post-release ${NEW_TAG}]
+range: ${LIVE_TAG} → ${NEW_TAG}
+changes:
+  - #<pr> <subject>
+checks:
+  - <verdict> <id> observed=<n>
+verdict: green | skip | red — <evaluate reason>
 ```
 
-不要把上面模板照搬当输出：`new-code hooks` 的具体 hook 名由 Step A 的 diff 分析动态产出。纯前端 / 纯 chore release 没有 backend hook 时，直接写 `(no new backend hooks this release)`。
-
-`verdict` 判定原则：
-
-- **green**：control plane 全 200 + 错误聚类无新 cluster + 重点观察变量按预期触发或合理静默 + 流量量级与基线一致
-- **yellow**：control plane OK 但某条路径错误率上升 / 重点 hook 未按预期触发或频次异常 / 流量明显偏低或偏高 → 列出可疑 cluster + 建议是否需要人工触发更长窗口观察
-- **red**：control plane 任一点 fail / 错误聚类含 new type 且 rate 高于基线 2× / 重点 hook 触发后立即 5xx / 流量塌方 → **立即汇报，不再续 tick**，建议人工立即决定是否 rollback 到 `previous_tag`
-
-### Step D：tick 后的综合建议
-
-- **`single`**：+5min 一次 tick 后立即给综合建议（1 tick）。
-- **`skip`**：跳过本节。
-
-综合建议结构：
-
-```text
-=== Post-release follow-up summary (${NEW_TAG}, <N> tick(s)) ===
-重点变更：<列出 Step A 的关键 hook / 配置项>
-control plane：<N>/<N> ticks green | <or list any failure tick>
-错误聚类汇总：<去重的 cluster + 频次趋势>
-流量趋势：<是否与基线一致>
-重点观察变量结论：<逐项 hook 是否按预期>
-综合 verdict: green / yellow / red
-建议：
-  - <green>: 发版稳定，无 follow-up。
-  - <yellow>: 列出 1-3 条需要在 24h / 1week 内再观察或修复的事项；建议是否人工触发 +1h / +6h 跟进。
-  - <red>: 列出可疑回归点，建议立即 `gh workflow run deploy-stage0.yml -f tag=${PREVIOUS_TAG}` rollback；其余 Edge 暂不批准 prod approval。
-```
-
-### 调度纪律
-
-- **`single`**：最后一个 smoke 通过后 **+5min** 一次，green / yellow / red 都在这一次 tick 给结论，不自行加轮。
-- 更长窗口（+1h / +6h）仅人工显式发起；会话内不要自行无限延期。
+- **green / skip**：范围内 PR 未打出回归（无流量 = inconclusive，不 redden）；或没有产品提交。
+- **red**：control plane fail / panic / 5xx / 新增 failover 状态未伴随 failover 日志 / 新增 error code 风暴。立即汇报。job 失败**不会**自动 rollback 已切的颜色；是否 `gh workflow run deploy-stage0.yml -f tag=${LIVE_TAG}` 由人决定。
+- 更深排查转 `/tokenkey-online-log-troubleshooting`。更长窗口（+1h / +6h）仅人工显式发起。
 
 ## 发版后 Anthropic OAuth 配置检查（默认）
 
@@ -731,8 +658,10 @@ bash scripts/release-rollout-summary.sh --mode release
 - `scripts/stage0/pick_oauth_canary_edge.py` — 按 deployable 顺序选第一个有 native OAuth/Kiro 池的 Edge 作 canary full smoke。
 - `ops/stage0/edge_oauth_pool_probe.sh` — canary 选择用的 SSM 账号池计数探针（与 edge-native smoke 同 eligibility）。
 - `scripts/stage0/dispatch-edge-deploy.sh` — 单一 Edge deploy dispatch（edges 均为 Lightsail）。
+- `ops/observability/run-post-release-check.sh` — +5min 实测唯一入口（live→new PR plan + 控制面 + tick + evaluate）。
+- `scripts/release_post_check.py` — 从 live tag→new tag 派生 PR 检查与评分；禁止模型自造 hook。
 - `ops/observability/probe-release-control-plane.sh` — 发版后控制面探活（prod + deployable Edge，JSON lines + summary）。
-- `ops/observability/probe-post-release-tick.sh` — 发版后 tick 探针（blue/green active container auto + HOOK_PATTERNS 计数 + 流量/5xx/panic）。
+- `ops/observability/probe-post-release-tick.sh` — tick 探针（由 wrapper 投递；hooks 来自 plan，不是 prompt）。
 - `scripts/stage0/resolve-edge-deploy-route.py` — Edge → workflow + confirm 参数。
 - `.github/workflows/deploy-stage0.yml` — prod deploy。
 - `.github/workflows/deploy-edge-lightsail-stage0.yml` — Lightsail Edge deploy（edges 唯一路径）。

--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -33,7 +33,7 @@ description: Drive TokenKey Stage0 release, prod deploy, edge rollout, smoke, ro
 | 发版前 smoke 模型校验 | 机械 | `python3 scripts/stage0/check_smoke_config.py`（`TK_SMOKE_ANTHROPIC_MODELS` / `TK_SMOKE_GEMINI_MODELS` / `TK_SMOKE_OPENAI_OAUTH_MODELS` 均 ∈ `TK_SMOKE_API_KEY` 的 `/v1/models`）。**完整校验需要 smoke key，只在 CI 可跑**；本地降级为 `bash ops/stage0/load_smoke_github_env.sh --check prod`（只验 secret/vars 已配置） |
 | 发版后跟进档位（skip / single） | 机械 | `bash scripts/release-impact-files.sh PREV NEW` → `.followup.tier`（是否值得人工再跟；**实测检查不走这里**） |
 | 发版后控制面探活（prod + deployable edge） | 机械 | `bash ops/observability/probe-release-control-plane.sh`（prod `/health` + `/api/v1/settings/public`，deployable Edge `/health`，JSON lines + summary） |
-| **发版后 +5min 实测（live tag→本次 tag 的全部 PR）** | 机械 | `deploy-stage0.yml` 的 `deploy` job 在 smoke 后跑 `ops/observability/run-post-release-check.sh`（plan 从 git 派生，禁止模型自造 `HOOK_PATTERNS`；复用已批的 prod Environment，不再另开审批） |
+| **发版后 +5min 实测（live tag→本次 tag 的全部 PR）** | 机械 | `deploy-stage0.yml` 的 `deploy` job 在 smoke/SSOT gate 后、飞书发版公告前跑 `ops/observability/run-post-release-check.sh`（workflow 先 `plan` 再 `--plan-file` 传入 wrapper，禁止重复 plan 与模型自造 `HOOK_PATTERNS`；复用已批的 prod Environment） |
 | **发版后 Anthropic OAuth 配置检查（snapshot → check）** | 机械 | `python3 ops/anthropic/manage-anthropic-config.py snapshot` + `check --snapshot`（见 §「发版后 Anthropic OAuth 配置检查」；canonical：`/tokenkey-anthropic-oauth-config`） |
 | **发版后 Account model_mapping 配置 diff** | 机械 | `python3 ops/pricing/manage-account-model-mapping-runtime.py check-accounts --json`（默认 prod only；期望 mapping 与 forbidden policy metadata 均来自 Go SSOT；edge 保持空 mapping 不纳入检查，见 §「发版后 Account model_mapping 配置检查」） |
 | rollout 摘要（git log / diff stat / sentinel / deletion） | 机械 | `bash scripts/release-rollout-summary.sh --mode release` |
@@ -307,7 +307,7 @@ python3 scripts/stage0/resolve-edge-deploy-route.py --edge-id "$EDGE_ID" --json
    ```
 
    脚本按 batch dispatch upgrade（`--smoke-phase infra`）→ watch → 验 `tk_edge_post_deploy_smoke: OK phase=infra`。**默认 `--parallel 1`（顺序）**；`N>1` 仅在可接受换容器窗口影响时用。批内失败则 fail-stop。
-8. **发版后 +5min 实测（CI 唯一源）**：watch 同一 `deploy-stage0` run 的 `deploy` job 在 smoke 之后的 post-release 步（换镜像成功后等 5 分钟，**不再**另开 `environment: prod` 审批）。它用换镜像前的线上 tag → 本次 tag 列出全部产品 PR，再对照 prod 日志评分。摘要转述 `evaluate.json`，**不要**自造 `HOOK_PATTERNS`，也**不要**另开一轮 tick。CI 不可解析时才本地重跑 `ops/observability/run-post-release-check.sh`。
+8. **发版后 +5min 实测（CI 唯一源）**：watch 同一 `deploy-stage0` run 的 `deploy` job 在 smoke/SSOT gate 之后、飞书发版公告之前的 post-release 步（换镜像成功后等 5 分钟，**不再**另开 `environment: prod` 审批）。workflow 先写 `plan.json` 再 `--plan-file` 传入 wrapper，避免重复 plan。它用换镜像前的线上 tag → 本次 tag 列出全部产品 PR，再对照 prod 日志评分。摘要转述 `evaluate.json`，**不要**自造 `HOOK_PATTERNS`，也**不要**另开一轮 tick。CI 不可解析时才本地重跑 `ops/observability/run-post-release-check.sh`。
 9. **只读配置检查（默认）**：先跑 §「发版后 Anthropic OAuth 配置检查」，再跑 §「发版后 Account model_mapping 配置检查」。violations 不触发 rollback，写入 rollout 摘要为 **yellow**；Anthropic violation 指向 `/tokenkey-anthropic-oauth-config`，model_mapping violation 指向 `/tokenkey-modelops-planner` 分支 D，先审 Go SSOT 派生的 diff，再按需 `apply-accounts --confirm yes-apply-account-model-mapping`。
 
 ## prod 真实测试
@@ -443,7 +443,7 @@ prod smoke 失败：停，优先 rollback prod；不要继续 Edge rollout。Edg
 
 ## 完成后：发版后 +5min 实测（live tag → 本次 tag）
 
-**一条路径**：`deploy-stage0.yml` 的 `deploy` job 在 smoke 之后的 post-release 步。范围是换镜像前线上正在跑的 tag（`resolve-prod-running-tag-via-ssm`），不是「上一个 git tag」猜测。脚本用 `scripts/release_post_check.py` 列出该范围内全部产品 PR，再投递控制面 + tick，按 plan 评分。检查留在同一 job，避免第二次 prod Environment 审批把 +5min 时钟推后。
+**一条路径**：`deploy-stage0.yml` 的 `deploy` job 在 smoke/SSOT gate 之后、飞书发版公告之前的 post-release 步。范围是换镜像前线上正在跑的 tag（`resolve-prod-running-tag-via-ssm`），不是「上一个 git tag」猜测。workflow 先 `plan` 写 `plan.json`，check 步用 `--plan-file` 复用；本地 wrapper 若 `out-dir/plan.json` 已存在也会复用。脚本用 `scripts/release_post_check.py` 列出该范围内全部产品 PR，再投递控制面 + tick，按 plan 评分。检查留在同一 job，避免第二次 prod Environment 审批把 +5min 时钟推后。
 
 禁止：
 

--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -539,9 +539,85 @@ jobs:
           set -euo pipefail
           bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --deploy-canary --deploy-closeout
 
+      # Same deploy job: reuse the already-approved prod Environment + OIDC.
+      # A second job with environment: prod would re-open Required reviewers
+      # and start the +5min clock after that gate, not after cutover.
+      - name: Plan checks from live→new PRs
+        id: post_release_plan
+        env:
+          LIVE_TAG: ${{ steps.previous_runtime.outputs.tag }}
+        run: |
+          set -euo pipefail
+          test -n "${LIVE_TAG:-}" || { echo "::error::previous prod runtime tag is empty"; exit 1; }
+          git fetch --tags --force origin
+          git fetch --unshallow origin || true
+          OUT_DIR="${RUNNER_TEMP}/post-release-check"
+          mkdir -p "$OUT_DIR"
+          python3 scripts/release_post_check.py plan --live "$LIVE_TAG" --new "$INPUT_TAG" > "$OUT_DIR/plan.json"
+          COUNT="$(python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1])).get("changes") or []))' "$OUT_DIR/plan.json")"
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "out_dir=$OUT_DIR" >> "$GITHUB_OUTPUT"
+          echo "planned $COUNT product change(s) in ${LIVE_TAG}..${INPUT_TAG}"
+          if [ "$COUNT" = "0" ]; then
+            python3 -c 'import json,sys; json.dump({"verdict":"skip","reason":"no product commits","range":{"live":sys.argv[1],"new":sys.argv[2]},"changes":[],"checks":[]}, open(sys.argv[3],"w"), indent=2)' \
+              "$LIVE_TAG" "$INPUT_TAG" "$OUT_DIR/evaluate.json"
+          fi
+
+      - name: Wait 5 minutes for live traffic
+        if: steps.post_release_plan.outputs.count != '0'
+        run: sleep 300
+
+      - name: Check live→new PRs against prod
+        if: steps.post_release_plan.outputs.count != '0'
+        id: post_release_check
+        env:
+          LIVE_TAG: ${{ steps.previous_runtime.outputs.tag }}
+          OUT_DIR: ${{ steps.post_release_plan.outputs.out_dir }}
+        run: |
+          set -euo pipefail
+          bash ops/observability/run-post-release-check.sh \
+            --live "$LIVE_TAG" \
+            --new "$INPUT_TAG" \
+            --target prod \
+            --plan-file "$OUT_DIR/plan.json" \
+            --out-dir "$OUT_DIR"
+
+      - name: Post-release check summary
+        if: always() && steps.post_release_plan.outcome != 'skipped'
+        env:
+          LIVE_TAG: ${{ steps.previous_runtime.outputs.tag }}
+          OUT_DIR: ${{ steps.post_release_plan.outputs.out_dir }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## post-release-check"
+            echo "- live (was serving): \`${LIVE_TAG}\`"
+            echo "- new: \`${INPUT_TAG}\`"
+            if [ -n "${OUT_DIR:-}" ] && [ -f "${OUT_DIR}/evaluate.json" ]; then
+              python3 - <<'PY'
+          import json, os, pathlib
+          p = pathlib.Path(os.environ["OUT_DIR"]) / "evaluate.json"
+          data = json.loads(p.read_text())
+          print(f"- verdict: \`{data.get('verdict')}\`")
+          print("")
+          print("### Changes")
+          for change in data.get("changes") or []:
+              pr = f"#{change['pr']}" if change.get("pr") else change.get("sha", "")[:12]
+              print(f"- {pr} {change.get('subject', '')}")
+          print("")
+          print("### Checks")
+          for item in data.get("checks") or []:
+              print(f"- \`{item.get('verdict')}\` {item.get('id')} observed={item.get('observed')}")
+          PY
+            else
+              echo "- evaluate.json missing (job failed before scoring)"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Notify Feishu (release rollout)
-        # Best-effort 发版公告。默认 step gating 保证它只在 prod 换镜像 +
-        # External health + smoke 全绿后才跑 —— 卡片 == "该版本已上线且烟测通过"。
+        # Best-effort 发版公告。只在 prod 换镜像 + external health + smoke +
+        # +5min post-release（green 或 skip）之后才跑 —— 卡片 == 该版本已上线且
+        # 烟测与 live→new PR 实测均通过（或无可测产品提交）。
         # 标 continue-on-error 让 webhook 抽风不把成功的 prod deploy 标红(对齐
         # release.yml 的 Telegram 步)。脚本本身也始终 exit 0(双保险),失败时
         # 打 ::warning::,绝不打印 webhook/secret。
@@ -599,80 +675,6 @@ jobs:
             echo '```bash'
             echo "gh workflow run deploy-stage0.yml -f tag=<previous>"
             echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      # Same deploy job: reuse the already-approved prod Environment + OIDC.
-      # A second job with environment: prod would re-open Required reviewers
-      # and start the +5min clock after that gate, not after cutover.
-      - name: Plan checks from live→new PRs
-        id: post_release_plan
-        env:
-          LIVE_TAG: ${{ steps.previous_runtime.outputs.tag }}
-        run: |
-          set -euo pipefail
-          test -n "${LIVE_TAG:-}" || { echo "::error::previous prod runtime tag is empty"; exit 1; }
-          git fetch --tags --force origin
-          git fetch --unshallow origin || true
-          OUT_DIR="${RUNNER_TEMP}/post-release-check"
-          mkdir -p "$OUT_DIR"
-          python3 scripts/release_post_check.py plan --live "$LIVE_TAG" --new "$INPUT_TAG" > "$OUT_DIR/plan.json"
-          COUNT="$(python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1])).get("changes") or []))' "$OUT_DIR/plan.json")"
-          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
-          echo "out_dir=$OUT_DIR" >> "$GITHUB_OUTPUT"
-          echo "planned $COUNT product change(s) in ${LIVE_TAG}..${INPUT_TAG}"
-          if [ "$COUNT" = "0" ]; then
-            python3 -c 'import json,sys; json.dump({"verdict":"skip","reason":"no product commits","range":{"live":sys.argv[1],"new":sys.argv[2]},"changes":[],"checks":[]}, open(sys.argv[3],"w"), indent=2)' \
-              "$LIVE_TAG" "$INPUT_TAG" "$OUT_DIR/evaluate.json"
-          fi
-
-      - name: Wait 5 minutes for live traffic
-        if: steps.post_release_plan.outputs.count != '0'
-        run: sleep 300
-
-      - name: Check live→new PRs against prod
-        if: steps.post_release_plan.outputs.count != '0'
-        id: post_release_check
-        env:
-          LIVE_TAG: ${{ steps.previous_runtime.outputs.tag }}
-          OUT_DIR: ${{ steps.post_release_plan.outputs.out_dir }}
-        run: |
-          set -euo pipefail
-          bash ops/observability/run-post-release-check.sh \
-            --live "$LIVE_TAG" \
-            --new "$INPUT_TAG" \
-            --target prod \
-            --out-dir "$OUT_DIR"
-
-      - name: Post-release check summary
-        if: always() && steps.post_release_plan.outcome != 'skipped'
-        env:
-          LIVE_TAG: ${{ steps.previous_runtime.outputs.tag }}
-          OUT_DIR: ${{ steps.post_release_plan.outputs.out_dir }}
-        run: |
-          set -euo pipefail
-          {
-            echo "## post-release-check"
-            echo "- live (was serving): \`${LIVE_TAG}\`"
-            echo "- new: \`${INPUT_TAG}\`"
-            if [ -n "${OUT_DIR:-}" ] && [ -f "${OUT_DIR}/evaluate.json" ]; then
-              python3 - <<'PY'
-          import json, os, pathlib
-          p = pathlib.Path(os.environ["OUT_DIR"]) / "evaluate.json"
-          data = json.loads(p.read_text())
-          print(f"- verdict: \`{data.get('verdict')}\`")
-          print("")
-          print("### Changes")
-          for change in data.get("changes") or []:
-              pr = f"#{change['pr']}" if change.get("pr") else change.get("sha", "")[:12]
-              print(f"- {pr} {change.get('subject', '')}")
-          print("")
-          print("### Checks")
-          for item in data.get("checks") or []:
-              print(f"- \`{item.get('verdict')}\` {item.get('id')} observed={item.get('observed')}")
-          PY
-            else
-              echo "- evaluate.json missing (job failed before scoring)"
-            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
   qa-infra-check:

--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -45,8 +45,6 @@ jobs:
   deploy:
     if: inputs.operation == 'deploy'
     runs-on: ubuntu-latest
-    outputs:
-      previous_tag: ${{ steps.previous_runtime.outputs.tag }}
     permissions:
       contents: read
       id-token: write
@@ -54,7 +52,7 @@ jobs:
     # Bound well above a normal prod SSM upgrade (~5-10 min) but far below the
     # 6h GHA default, so a hung describe-stacks / health-poll can't hold the
     # cancel-in-progress:false prod concurrency lock for hours.
-    timeout-minutes: 30
+    timeout-minutes: 40
     # GitHub Environment binding for prod only:
     #   1. Adds environment:prod to the OIDC sub claim (IAM trust in cicd-oidc.yaml).
     #   2. Pauses for Required reviewers when configured on the prod Environment.
@@ -603,35 +601,18 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-  post-release-check:
-    # +5min live check: every product PR between the tag that was serving and
-    # this deploy is planned from git, then scored against prod logs. Failure
-    # here does not roll back the already-switched color; it fails the workflow
-    # so the regression is visible.
-    needs: deploy
-    if: ${{ needs.deploy.result == 'success' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    environment: prod
-    permissions:
-      contents: read
-      id-token: write
-    env:
-      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
-      OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
-      INPUT_TAG: ${{ inputs.tag }}
-      LIVE_TAG: ${{ needs.deploy.outputs.previous_tag }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
+      # Same deploy job: reuse the already-approved prod Environment + OIDC.
+      # A second job with environment: prod would re-open Required reviewers
+      # and start the +5min clock after that gate, not after cutover.
       - name: Plan checks from live→new PRs
-        id: plan
+        id: post_release_plan
+        env:
+          LIVE_TAG: ${{ steps.previous_runtime.outputs.tag }}
         run: |
           set -euo pipefail
           test -n "${LIVE_TAG:-}" || { echo "::error::previous prod runtime tag is empty"; exit 1; }
+          git fetch --tags --force origin
+          git fetch --unshallow origin || true
           OUT_DIR="${RUNNER_TEMP}/post-release-check"
           mkdir -p "$OUT_DIR"
           python3 scripts/release_post_check.py plan --live "$LIVE_TAG" --new "$INPUT_TAG" > "$OUT_DIR/plan.json"
@@ -645,21 +626,15 @@ jobs:
           fi
 
       - name: Wait 5 minutes for live traffic
-        if: steps.plan.outputs.count != '0'
+        if: steps.post_release_plan.outputs.count != '0'
         run: sleep 300
 
-      - name: Configure Stage0 read credentials via OIDC
-        if: steps.plan.outputs.count != '0'
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ env.OIDC_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
-
       - name: Check live→new PRs against prod
-        if: steps.plan.outputs.count != '0'
-        id: check
+        if: steps.post_release_plan.outputs.count != '0'
+        id: post_release_check
         env:
-          OUT_DIR: ${{ steps.plan.outputs.out_dir }}
+          LIVE_TAG: ${{ steps.previous_runtime.outputs.tag }}
+          OUT_DIR: ${{ steps.post_release_plan.outputs.out_dir }}
         run: |
           set -euo pipefail
           bash ops/observability/run-post-release-check.sh \
@@ -668,17 +643,18 @@ jobs:
             --target prod \
             --out-dir "$OUT_DIR"
 
-      - name: Job summary
-        if: always()
+      - name: Post-release check summary
+        if: always() && steps.post_release_plan.outcome != 'skipped'
         env:
-          OUT_DIR: ${{ steps.plan.outputs.out_dir }}
+          LIVE_TAG: ${{ steps.previous_runtime.outputs.tag }}
+          OUT_DIR: ${{ steps.post_release_plan.outputs.out_dir }}
         run: |
           set -euo pipefail
           {
             echo "## post-release-check"
             echo "- live (was serving): \`${LIVE_TAG}\`"
             echo "- new: \`${INPUT_TAG}\`"
-            if [ -f "${OUT_DIR}/evaluate.json" ]; then
+            if [ -n "${OUT_DIR:-}" ] && [ -f "${OUT_DIR}/evaluate.json" ]; then
               python3 - <<'PY'
           import json, os, pathlib
           p = pathlib.Path(os.environ["OUT_DIR"]) / "evaluate.json"

--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -45,6 +45,8 @@ jobs:
   deploy:
     if: inputs.operation == 'deploy'
     runs-on: ubuntu-latest
+    outputs:
+      previous_tag: ${{ steps.previous_runtime.outputs.tag }}
     permissions:
       contents: read
       id-token: write
@@ -599,6 +601,102 @@ jobs:
             echo '```bash'
             echo "gh workflow run deploy-stage0.yml -f tag=<previous>"
             echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  post-release-check:
+    # +5min live check: every product PR between the tag that was serving and
+    # this deploy is planned from git, then scored against prod logs. Failure
+    # here does not roll back the already-switched color; it fails the workflow
+    # so the regression is visible.
+    needs: deploy
+    if: ${{ needs.deploy.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: prod
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
+      INPUT_TAG: ${{ inputs.tag }}
+      LIVE_TAG: ${{ needs.deploy.outputs.previous_tag }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Plan checks from live→new PRs
+        id: plan
+        run: |
+          set -euo pipefail
+          test -n "${LIVE_TAG:-}" || { echo "::error::previous prod runtime tag is empty"; exit 1; }
+          OUT_DIR="${RUNNER_TEMP}/post-release-check"
+          mkdir -p "$OUT_DIR"
+          python3 scripts/release_post_check.py plan --live "$LIVE_TAG" --new "$INPUT_TAG" > "$OUT_DIR/plan.json"
+          COUNT="$(python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1])).get("changes") or []))' "$OUT_DIR/plan.json")"
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "out_dir=$OUT_DIR" >> "$GITHUB_OUTPUT"
+          echo "planned $COUNT product change(s) in ${LIVE_TAG}..${INPUT_TAG}"
+          if [ "$COUNT" = "0" ]; then
+            python3 -c 'import json,sys; json.dump({"verdict":"skip","reason":"no product commits","range":{"live":sys.argv[1],"new":sys.argv[2]},"changes":[],"checks":[]}, open(sys.argv[3],"w"), indent=2)' \
+              "$LIVE_TAG" "$INPUT_TAG" "$OUT_DIR/evaluate.json"
+          fi
+
+      - name: Wait 5 minutes for live traffic
+        if: steps.plan.outputs.count != '0'
+        run: sleep 300
+
+      - name: Configure Stage0 read credentials via OIDC
+        if: steps.plan.outputs.count != '0'
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.OIDC_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Check live→new PRs against prod
+        if: steps.plan.outputs.count != '0'
+        id: check
+        env:
+          OUT_DIR: ${{ steps.plan.outputs.out_dir }}
+        run: |
+          set -euo pipefail
+          bash ops/observability/run-post-release-check.sh \
+            --live "$LIVE_TAG" \
+            --new "$INPUT_TAG" \
+            --target prod \
+            --out-dir "$OUT_DIR"
+
+      - name: Job summary
+        if: always()
+        env:
+          OUT_DIR: ${{ steps.plan.outputs.out_dir }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## post-release-check"
+            echo "- live (was serving): \`${LIVE_TAG}\`"
+            echo "- new: \`${INPUT_TAG}\`"
+            if [ -f "${OUT_DIR}/evaluate.json" ]; then
+              python3 - <<'PY'
+          import json, os, pathlib
+          p = pathlib.Path(os.environ["OUT_DIR"]) / "evaluate.json"
+          data = json.loads(p.read_text())
+          print(f"- verdict: \`{data.get('verdict')}\`")
+          print("")
+          print("### Changes")
+          for change in data.get("changes") or []:
+              pr = f"#{change['pr']}" if change.get("pr") else change.get("sha", "")[:12]
+              print(f"- {pr} {change.get('subject', '')}")
+          print("")
+          print("### Checks")
+          for item in data.get("checks") or []:
+              print(f"- \`{item.get('verdict')}\` {item.get('id')} observed={item.get('observed')}")
+          PY
+            else
+              echo "- evaluate.json missing (job failed before scoring)"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
   qa-infra-check:

--- a/docs/approved/deploy-stage0-workflow.md
+++ b/docs/approved/deploy-stage0-workflow.md
@@ -172,13 +172,14 @@ Steps:
    verified live Worker, converges the current maintenance runner, disables
    boundary before app mutation, skips canary, and pauses DROP until a
    Phase 3 app is restored. No auto-rollback (would mask transient failures).
-12. **Post-release live check** — after a successful `deploy` job, a dependent
-   `post-release-check` job waits 5 minutes, then scores every product PR
-   between the previously serving tag and this tag against prod logs
-   (`scripts/release_post_check.py` + `ops/observability/run-post-release-check.sh`).
-   Failure does not roll back the already-switched color; it fails the
-   workflow so the regression is visible. Empty product-commit ranges skip
-   the wait.
+12. **Post-release live check** — after smoke in the same `deploy` job, wait
+   5 minutes and score every product PR between the previously serving tag
+   and this tag against prod logs (`scripts/release_post_check.py` +
+   `ops/observability/run-post-release-check.sh`). It reuses the already
+   approved prod Environment/OIDC so the clock starts after cutover, not
+   after a second reviewer gate. Failure does not roll back the already
+   switched color; it fails the workflow so the regression is visible.
+   Empty product-commit ranges skip the wait.
 13. **Read-only QA infrastructure acceptance** — `operation=qa-infra-check`
    validates both IAM stack outputs, exact `QA_INFRA_OIDC_ROLE_ARN` binding,
    real deployment-role assumption, recognized raw-archive stack identity,
@@ -187,10 +188,11 @@ Steps:
 
 Concurrency `group: deploy-stage0-prod`, `cancel-in-progress: false` is shared
 by all operations. Workflow-level permission is `contents: read`; the `deploy`
-job adds `id-token: write` and `packages: read`, `post-release-check` and
-`qa-infra-check` add only `id-token: write`, and `smoke-only` keeps the
-workflow default. No job receives `contents: write`. `post-release-check`
-is read-only SSM plus git history; it does not mutate host colors.
+job adds `id-token: write` and `packages: read`, `qa-infra-check` adds only
+`id-token: write`, and `smoke-only` keeps the workflow default. No job
+receives `contents: write`. The post-release live check is a later step in
+`deploy`; it is read-only SSM plus git history and does not mutate host
+colors.
 
 ## 5. Required pre-deploy operator setup
 

--- a/docs/approved/deploy-stage0-workflow.md
+++ b/docs/approved/deploy-stage0-workflow.md
@@ -166,21 +166,26 @@ Steps:
    `claude-sonnet-4-6`), `TK_SMOKE_GEMINI_MODELS` (default empty; native
    Gemini Google One pool retired 2026-07-04), `TK_SMOKE_OPENAI_OAUTH_MODELS`
    (default `gpt-5.4`).
-11. **Job summary** — write app and QA Worker images, Worker source, rollout
+11. **Post-release live check** — after smoke and the SSOT display gate in the
+   same `deploy` job, wait 5 minutes and score every product PR between the
+   previously serving tag and this tag against prod logs
+   (`scripts/release_post_check.py` +
+   `ops/observability/run-post-release-check.sh`). The workflow plans once and
+   passes `--plan-file` into the wrapper so check does not re-plan. It reuses
+   the already approved prod Environment/OIDC so the clock starts after
+   cutover, not after a second reviewer gate. Failure does not roll back the
+   already switched color; it fails the workflow so the regression is visible.
+   Empty product-commit ranges skip the wait.
+12. **Feishu release rollout notification** — best-effort rollout card after
+   smoke and post-release check (green or skip). Uses the pre-mutation runtime
+   tag baseline for release notes.
+13. **Job summary** — write app and QA Worker images, Worker source, rollout
    mode, host runtime mode, the SSM command id, and a one-line app rollback
    dispatch. Legacy rollback is explicitly degraded: it requires a fully
    verified live Worker, converges the current maintenance runner, disables
    boundary before app mutation, skips canary, and pauses DROP until a
    Phase 3 app is restored. No auto-rollback (would mask transient failures).
-12. **Post-release live check** — after smoke in the same `deploy` job, wait
-   5 minutes and score every product PR between the previously serving tag
-   and this tag against prod logs (`scripts/release_post_check.py` +
-   `ops/observability/run-post-release-check.sh`). It reuses the already
-   approved prod Environment/OIDC so the clock starts after cutover, not
-   after a second reviewer gate. Failure does not roll back the already
-   switched color; it fails the workflow so the regression is visible.
-   Empty product-commit ranges skip the wait.
-13. **Read-only QA infrastructure acceptance** — `operation=qa-infra-check`
+14. **Read-only QA infrastructure acceptance** — `operation=qa-infra-check`
    validates both IAM stack outputs, exact `QA_INFRA_OIDC_ROLE_ARN` binding,
    real deployment-role assumption, recognized raw-archive stack identity,
    and Bundle-era CloudFormation service-role binding. It contains no change

--- a/docs/approved/deploy-stage0-workflow.md
+++ b/docs/approved/deploy-stage0-workflow.md
@@ -172,7 +172,14 @@ Steps:
    verified live Worker, converges the current maintenance runner, disables
    boundary before app mutation, skips canary, and pauses DROP until a
    Phase 3 app is restored. No auto-rollback (would mask transient failures).
-12. **Read-only QA infrastructure acceptance** — `operation=qa-infra-check`
+12. **Post-release live check** — after a successful `deploy` job, a dependent
+   `post-release-check` job waits 5 minutes, then scores every product PR
+   between the previously serving tag and this tag against prod logs
+   (`scripts/release_post_check.py` + `ops/observability/run-post-release-check.sh`).
+   Failure does not roll back the already-switched color; it fails the
+   workflow so the regression is visible. Empty product-commit ranges skip
+   the wait.
+13. **Read-only QA infrastructure acceptance** — `operation=qa-infra-check`
    validates both IAM stack outputs, exact `QA_INFRA_OIDC_ROLE_ARN` binding,
    real deployment-role assumption, recognized raw-archive stack identity,
    and Bundle-era CloudFormation service-role binding. It contains no change
@@ -180,9 +187,10 @@ Steps:
 
 Concurrency `group: deploy-stage0-prod`, `cancel-in-progress: false` is shared
 by all operations. Workflow-level permission is `contents: read`; the `deploy`
-job adds `id-token: write` and `packages: read`, `qa-infra-check` adds only
-`id-token: write`, and `smoke-only` keeps the workflow default. No job receives
-`contents: write`.
+job adds `id-token: write` and `packages: read`, `post-release-check` and
+`qa-infra-check` add only `id-token: write`, and `smoke-only` keeps the
+workflow default. No job receives `contents: write`. `post-release-check`
+is read-only SSM plus git history; it does not mutate host colors.
 
 ## 5. Required pre-deploy operator setup
 

--- a/ops/observability/probe-post-release-tick.sh
+++ b/ops/observability/probe-post-release-tick.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 # probe-post-release-tick.sh — post-release follow-up tick probe (read-only).
 #
-# Ships to prod/edge via run-probe.sh on each follow-up tick of the
-# tokenkey-stage0-release-rollout skill. The generic signals (traffic volume,
-# per-path mix, 5xx, panic) are fixed here; the release-specific "new-code
-# hook" greps are supplied per release via HOOK_PATTERNS — the model names the
-# hooks (judgment), this script counts them (mechanical).
+# Ships to prod via run-post-release-check.sh (the +5min live→new PR check).
+# Generic signals (traffic volume, per-path mix, 5xx, panic) are fixed here;
+# HOOK_PATTERNS come from scripts/release_post_check.py plan — do not invent
+# them in prompt prose. This script only counts the supplied fixed strings.
 #
 # Env (consumed inside the remote shell):
 #   SINCE          docker logs --since window (default 6m)
@@ -16,9 +15,8 @@
 #   ACTIVE_COLOR_FILE
 #                  active-color file path for CONTAINER=auto
 #                  (default /var/lib/tokenkey/active-color; test seam).
-#   HOOK_PATTERNS  comma-separated FIXED strings (grep -F semantics), one per
-#                  release hook, e.g.:
-#                  HOOK_PATTERNS='stripped explicit thinking.type=disabled,pricing_missing'
+#   HOOK_PATTERNS  comma-separated FIXED strings from release_post_check.py
+#                  hook-patterns (grep -F). Example: Status=424,WEEKLY_LIMIT_EXCEEDED
 #                  Empty → hooks section reports none configured.
 #
 # Output: stable `=== section ===` markers; the traffic section is JSON

--- a/ops/observability/run-post-release-check.sh
+++ b/ops/observability/run-post-release-check.sh
@@ -14,6 +14,7 @@
 #       [--skip-probe] \
 #       [--tick-file PATH] \
 #       [--control-plane-ok true|false] \
+#       [--plan-file PATH] \
 #       [--out-dir DIR]
 #
 # Exit:
@@ -33,6 +34,7 @@ REPO="."
 SKIP_PROBE=0
 TICK_FILE=""
 CONTROL_PLANE_OK=""
+PLAN_FILE_ARG=""
 OUT_DIR=""
 
 while [ "$#" -gt 0 ]; do
@@ -44,6 +46,7 @@ while [ "$#" -gt 0 ]; do
     --skip-probe) SKIP_PROBE=1; shift ;;
     --tick-file) TICK_FILE="${2:-}"; shift 2 ;;
     --control-plane-ok) CONTROL_PLANE_OK="${2:-}"; shift 2 ;;
+    --plan-file) PLAN_FILE_ARG="${2:-}"; shift 2 ;;
     --out-dir) OUT_DIR="${2:-}"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "[run-post-release-check] unknown arg: $1" >&2; usage >&2; exit 1 ;;
@@ -67,11 +70,23 @@ if [ -z "$OUT_DIR" ]; then
   OUT_DIR="$(mktemp -d /tmp/tk-post-release-check.XXXXXX)"
 fi
 mkdir -p "$OUT_DIR"
-PLAN_FILE="$OUT_DIR/plan.json"
+if [ -n "$PLAN_FILE_ARG" ]; then
+  PLAN_FILE="$PLAN_FILE_ARG"
+  if [ ! -f "$PLAN_FILE" ]; then
+    echo "[run-post-release-check] --plan-file not found: $PLAN_FILE" >&2
+    exit 1
+  fi
+else
+  PLAN_FILE="$OUT_DIR/plan.json"
+fi
 TICK_OUT="$OUT_DIR/tick.txt"
 EVAL_FILE="$OUT_DIR/evaluate.json"
 
-python3 "$PLANNER" plan --live "$LIVE" --new "$NEW" --repo "$REPO" > "$PLAN_FILE"
+if [ -f "$PLAN_FILE" ]; then
+  echo "[run-post-release-check] reusing existing plan $PLAN_FILE" >&2
+else
+  python3 "$PLANNER" plan --live "$LIVE" --new "$NEW" --repo "$REPO" > "$PLAN_FILE"
+fi
 CHANGE_COUNT="$(python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1])).get("changes") or []))' "$PLAN_FILE")"
 if [ "$CHANGE_COUNT" = "0" ]; then
   echo "[run-post-release-check] skip: no product commits in $LIVE..$NEW" >&2

--- a/ops/observability/run-post-release-check.sh
+++ b/ops/observability/run-post-release-check.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# run-post-release-check.sh — +5min post-release check owned by one script.
+#
+# Builds a check plan from the commits/PRs between the tag that was serving
+# (live) and the tag just deployed (new), probes prod, and evaluates whether
+# those changes look like the expected live behavior. Do not invent
+# HOOK_PATTERNS in prompt prose — this script derives them from the plan.
+#
+# Usage:
+#   bash ops/observability/run-post-release-check.sh \
+#       --live 1.8.169 --new 1.8.170 \
+#       [--target prod] \
+#       [--repo DIR] \
+#       [--skip-probe] \
+#       [--tick-file PATH] \
+#       [--control-plane-ok true|false] \
+#       [--out-dir DIR]
+#
+# Exit:
+#   0 — verdict green (or skip: no product commits in range)
+#   1 — verdict red (regression) or plan/probe usage failure
+#   2 — AWS/SSM transport failure
+set -euo pipefail
+
+usage() {
+  sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+LIVE=""
+NEW=""
+TARGET="prod"
+REPO="."
+SKIP_PROBE=0
+TICK_FILE=""
+CONTROL_PLANE_OK=""
+OUT_DIR=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --live) LIVE="${2:-}"; shift 2 ;;
+    --new) NEW="${2:-}"; shift 2 ;;
+    --target) TARGET="${2:-}"; shift 2 ;;
+    --repo) REPO="${2:-}"; shift 2 ;;
+    --skip-probe) SKIP_PROBE=1; shift ;;
+    --tick-file) TICK_FILE="${2:-}"; shift 2 ;;
+    --control-plane-ok) CONTROL_PLANE_OK="${2:-}"; shift 2 ;;
+    --out-dir) OUT_DIR="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "[run-post-release-check] unknown arg: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+if [ -z "$LIVE" ] || [ -z "$NEW" ]; then
+  echo "[run-post-release-check] --live and --new are required" >&2
+  usage >&2
+  exit 1
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLANNER="$ROOT/scripts/release_post_check.py"
+if [ ! -f "$PLANNER" ]; then
+  echo "[run-post-release-check] missing $PLANNER" >&2
+  exit 1
+fi
+
+if [ -z "$OUT_DIR" ]; then
+  OUT_DIR="$(mktemp -d /tmp/tk-post-release-check.XXXXXX)"
+fi
+mkdir -p "$OUT_DIR"
+PLAN_FILE="$OUT_DIR/plan.json"
+TICK_OUT="$OUT_DIR/tick.txt"
+EVAL_FILE="$OUT_DIR/evaluate.json"
+
+python3 "$PLANNER" plan --live "$LIVE" --new "$NEW" --repo "$REPO" > "$PLAN_FILE"
+CHANGE_COUNT="$(python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1])).get("changes") or []))' "$PLAN_FILE")"
+if [ "$CHANGE_COUNT" = "0" ]; then
+  echo "[run-post-release-check] skip: no product commits in $LIVE..$NEW" >&2
+  printf '%s\n' '{"verdict":"skip","reason":"no product commits","range":{"live":"'"$LIVE"'","new":"'"$NEW"'"}}' | tee "$EVAL_FILE"
+  exit 0
+fi
+
+HOOKS="$(python3 "$PLANNER" hook-patterns --plan-file "$PLAN_FILE")"
+echo "[run-post-release-check] plan=$PLAN_FILE changes=$CHANGE_COUNT hooks=$HOOKS" >&2
+
+CP_OK="${CONTROL_PLANE_OK:-true}"
+if [ "$SKIP_PROBE" -eq 0 ]; then
+  if ! bash "$ROOT/ops/observability/probe-release-control-plane.sh" | tee "$OUT_DIR/control-plane.jsonl"; then
+    CP_OK="false"
+  else
+    if python3 -c 'import json,sys; rows=[json.loads(l) for l in open(sys.argv[1]) if l.startswith("{")];
+print("ok" if any(r.get("summary")=="control_plane" and r.get("status")=="ok" for r in rows) else "bad")' \
+      "$OUT_DIR/control-plane.jsonl" | grep -qx ok; then
+      CP_OK="true"
+    else
+      CP_OK="false"
+    fi
+  fi
+
+  set +e
+  bash "$ROOT/ops/observability/run-probe.sh" --target "$TARGET" \
+    --script "$ROOT/ops/observability/probe-post-release-tick.sh" \
+    --env SINCE=6m \
+    --env "HOOK_PATTERNS=${HOOKS}" \
+    --timeout-seconds 120 \
+    | tee "$TICK_OUT"
+  PROBE_RC=${PIPESTATUS[0]}
+  set -e
+  if [ "$PROBE_RC" -eq 2 ] || [ "$PROBE_RC" -eq 3 ]; then
+    echo "[run-post-release-check] probe transport/remote failed rc=$PROBE_RC" >&2
+    exit 2
+  fi
+  if [ "$PROBE_RC" -ne 0 ]; then
+    echo "[run-post-release-check] probe failed rc=$PROBE_RC" >&2
+    exit 1
+  fi
+else
+  if [ -z "$TICK_FILE" ]; then
+    echo "[run-post-release-check] --skip-probe requires --tick-file" >&2
+    exit 1
+  fi
+  cp "$TICK_FILE" "$TICK_OUT"
+  CP_OK="${CONTROL_PLANE_OK:-true}"
+fi
+
+set +e
+python3 "$PLANNER" evaluate \
+  --plan-file "$PLAN_FILE" \
+  --tick-file "$TICK_OUT" \
+  --control-plane-ok "$CP_OK" \
+  | tee "$EVAL_FILE"
+EVAL_RC=${PIPESTATUS[0]}
+set -e
+echo "[run-post-release-check] evaluate=$EVAL_FILE rc=$EVAL_RC" >&2
+exit "$EVAL_RC"

--- a/ops/observability/run-post-release-check.sh
+++ b/ops/observability/run-post-release-check.sh
@@ -84,6 +84,9 @@ echo "[run-post-release-check] plan=$PLAN_FILE changes=$CHANGE_COUNT hooks=$HOOK
 
 CP_OK="${CONTROL_PLANE_OK:-true}"
 if [ "$SKIP_PROBE" -eq 0 ]; then
+  if [ "$TARGET" = "prod" ]; then
+    export EDGE_IDS="${EDGE_IDS:-none}"
+  fi
   if ! bash "$ROOT/ops/observability/probe-release-control-plane.sh" | tee "$OUT_DIR/control-plane.jsonl"; then
     CP_OK="false"
   else

--- a/ops/stage0/test_deploy_stage0_workflow.py
+++ b/ops/stage0/test_deploy_stage0_workflow.py
@@ -93,7 +93,10 @@ class DeployStage0WorkflowTest(unittest.TestCase):
         smoke = deploy.index("name: Post-deploy gateway smoke (API + Claude paths)")
 
         self.assertLess(baseline, image_mutation)
-        self.assertLess(smoke, notification)
+        post_release = deploy.index("name: Plan checks from live→new PRs")
+        post_release_check = deploy.index("name: Check live→new PRs against prod")
+        self.assertLess(smoke, post_release)
+        self.assertLess(post_release_check, notification)
         block = deploy[baseline:image_mutation]
         self.assertIn("resolve-prod-running-tag-via-ssm.sh", block)
         self.assertIn('INSTANCE_ID: ${{ steps.instance.outputs.id }}', block)

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1611,6 +1611,10 @@ elif ! python3 ./ops/observability/test_ops_daily_diagnostics_workflow.py >/dev/
     echo "  FAIL: Fleet pg_dump restore canary daily diagnostics contracts"
     echo "        - run: python3 ops/observability/test_ops_daily_diagnostics_workflow.py"
     errors=$((errors + 1))
+elif ! python3 ./scripts/test_release_post_check.py >/dev/null 2>&1; then
+    echo "  FAIL: post-release live→new PR check contracts"
+    echo "        - run: python3 scripts/test_release_post_check.py"
+    errors=$((errors + 1))
 else
     echo "  ok: fail-closed probes + Fleet restore and partition operators"
 fi

--- a/scripts/release_post_check.py
+++ b/scripts/release_post_check.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Plan and evaluate the +5min post-release check from live tag → new tag.
+
+Owner for "did every change/PR between the serving version and this release
+behave as expected on live?" Model-invented HOOK_PATTERNS are not a plan:
+this module enumerates first-parent commits, extracts PR numbers, and derives
+observables from the actual diff plus a path table.
+
+Subcommands:
+  plan --live vX.Y.Z --new vA.B.C [--repo DIR]
+  hook-patterns --plan-file PATH
+  evaluate --plan-file PATH --tick-file PATH [--control-plane-ok true|false]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+NOISE_SUBJECT = re.compile(r"bump VERSION|sync.version.file", re.I)
+PR_SUBJECT = re.compile(r"\(#(\d+)\)\s*$")
+ERROR_CTOR = re.compile(
+    r'(?:TooManyRequests|Forbidden|NotFound|BadRequest|Conflict)\("([A-Z][A-Z0-9_]+)"'
+)
+HTTP_STATUS = re.compile(r"\b([45]\d\d)\b")
+FAILOVER_PATH = re.compile(r"gateway_forward|upstream_errors|failover", re.I)
+SUBSCRIPTION_PATH = re.compile(r"subscription|universal_routing")
+AUTH_PATH = re.compile(r"api_key_auth|internal/server/middleware/middleware\.go")
+SUBSCRIPTION_CODES = (
+    "WEEKLY_LIMIT_EXCEEDED",
+    "DAILY_LIMIT_EXCEEDED",
+    "MONTHLY_LIMIT_EXCEEDED",
+    "SUBSCRIPTION_EXPIRED",
+)
+FAILOVER_LOG = "[Forward] Upstream error (failover)"
+ERROR_STORM_THRESHOLD = 3
+SKIP_PREFIXES = ("docs/",)
+SKIP_NAMES = {"backend/cmd/server/VERSION"}
+
+
+def _run_git(repo: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or f"git {' '.join(args)} failed")
+    return proc.stdout
+
+
+def _norm_tag(tag: str) -> str:
+    tag = tag.strip()
+    if not tag:
+        raise ValueError("empty tag")
+    return tag if tag.startswith("v") else f"v{tag}"
+
+
+def _is_skipped_path(path: str) -> bool:
+    return path in SKIP_NAMES or path.startswith(SKIP_PREFIXES)
+
+
+def _commit_files(repo: Path, sha: str) -> list[str]:
+    out = _run_git(repo, "diff-tree", "--no-commit-id", "--name-only", "-r", sha)
+    return [line for line in out.splitlines() if line]
+
+
+def _commit_diff(repo: Path, sha: str) -> str:
+    return _commit_diff_for(repo, sha, None)
+
+
+def _commit_diff_for(repo: Path, sha: str, paths: list[str] | None) -> str:
+    args = ["show", "--format=", "-U0", sha]
+    if paths:
+        args.extend(["--", *paths])
+    return _run_git(repo, *args)
+
+
+def _is_test_path(path: str) -> bool:
+    return path.endswith("_test.go") or "/testdata/" in path
+
+
+def _statuses_added(diff_text: str) -> list[str]:
+    """Statuses newly present on `case` arms — ignore comments and test fixtures."""
+    old: set[str] = set()
+    new: set[str] = set()
+    for line in diff_text.splitlines():
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if not re.search(r"\bcase\b", line):
+            continue
+        if line.startswith("+"):
+            new.update(HTTP_STATUS.findall(line))
+        elif line.startswith("-"):
+            old.update(HTTP_STATUS.findall(line))
+    return sorted(new - old)
+
+
+def _added_error_codes(diff_text: str) -> list[str]:
+    codes: set[str] = set()
+    for line in diff_text.splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            codes.update(ERROR_CTOR.findall(line))
+    return sorted(codes)
+
+
+def _change_id(pr: int | None, sha: str) -> str:
+    return f"#{pr}" if pr is not None else sha[:12]
+
+
+def _check(
+    *,
+    source: str,
+    kind: str,
+    pattern: str,
+    expect: str,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    item = {
+        "id": f"{source.lstrip('#') if source.startswith('#') else source}-{pattern}".replace(
+            " ", "_"
+        ),
+        "source": source,
+        "kind": kind,
+        "pattern": pattern,
+        "expect": expect,
+    }
+    if source.startswith("#"):
+        item["id"] = f"pr-{source[1:]}-{pattern}"
+    if extra:
+        item.update(extra)
+    return item
+
+
+def _derive_checks(source: str, files: list[str], diff_text: str) -> list[dict[str, Any]]:
+    checks: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    def add(item: dict[str, Any]) -> None:
+        if item["id"] in seen:
+            return
+        seen.add(item["id"])
+        checks.append(item)
+
+    failover_files = [p for p in files if FAILOVER_PATH.search(p) and not _is_test_path(p)]
+    if failover_files:
+        for status in _statuses_added(diff_text):
+            add(
+                _check(
+                    source=source,
+                    kind="failover_status",
+                    pattern=f"Status={status}",
+                    expect="failover_if_present",
+                )
+            )
+
+    for code in _added_error_codes(diff_text):
+        add(_check(source=source, kind="error_absent", pattern=code, expect="not_storming"))
+
+    if any(SUBSCRIPTION_PATH.search(p) for p in files):
+        for code in SUBSCRIPTION_CODES:
+            add(_check(source=source, kind="error_absent", pattern=code, expect="not_storming"))
+
+    if any(AUTH_PATH.search(p) for p in files):
+        add(
+            _check(
+                source=source,
+                kind="error_absent",
+                pattern="error: code=",
+                expect="not_storming",
+            )
+        )
+
+    return checks
+
+
+def build_plan(repo: Path, live: str, new: str) -> dict[str, Any]:
+    live_ref = _norm_tag(live)
+    new_ref = _norm_tag(new)
+    shas = _run_git(
+        repo,
+        "rev-list",
+        "--reverse",
+        "--first-parent",
+        f"{live_ref}..{new_ref}",
+    )
+    changes: list[dict[str, Any]] = []
+    checks: list[dict[str, Any]] = []
+    for sha in shas.splitlines():
+        if not sha.strip():
+            continue
+        subject = _run_git(repo, "log", "-1", "--pretty=%s", sha).strip()
+        if NOISE_SUBJECT.search(subject):
+            continue
+        files = [p for p in _commit_files(repo, sha) if not _is_skipped_path(p)]
+        if not files:
+            continue
+        pr_match = PR_SUBJECT.search(subject)
+        pr = int(pr_match.group(1)) if pr_match else None
+        source = _change_id(pr, sha)
+        change = {
+            "sha": sha,
+            "subject": subject,
+            "pr": pr,
+            "files": files,
+        }
+        changes.append(change)
+        impl_files = [p for p in files if not _is_test_path(p)]
+        impl_diff = _commit_diff_for(repo, sha, impl_files) if impl_files else ""
+        checks.extend(_derive_checks(source, impl_files, impl_diff))
+
+    seen: set[str] = set()
+    unique_checks: list[dict[str, Any]] = []
+    for item in checks:
+        if item["id"] in seen:
+            continue
+        seen.add(item["id"])
+        unique_checks.append(item)
+
+    return {
+        "range": {"live": live_ref, "new": new_ref},
+        "changes": changes,
+        "checks": unique_checks,
+    }
+
+
+def hook_patterns(plan: dict[str, Any]) -> list[str]:
+    patterns: list[str] = []
+    for item in plan.get("checks") or []:
+        pat = item.get("pattern")
+        if pat and pat not in patterns:
+            patterns.append(pat)
+        if item.get("kind") == "failover_status" and FAILOVER_LOG not in patterns:
+            patterns.append(FAILOVER_LOG)
+    return patterns
+
+
+def parse_tick_stdout(stdout: str) -> dict[str, Any]:
+    hooks: dict[str, int] = {}
+    panic = 0
+    traffic: dict[str, Any] = {"completed_total": 0, "status_5xx": {}, "top_paths": []}
+    section = ""
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        if line.startswith("=== ") and line.endswith(" ==="):
+            section = line.strip("= ").strip()
+            continue
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if section == "hooks" and "pattern" in obj:
+            hooks[str(obj["pattern"])] = int(obj.get("count") or 0)
+        elif section == "panic":
+            panic = int(obj.get("count") or 0)
+        elif section == "traffic":
+            traffic = {
+                "completed_total": int(obj.get("completed_total") or 0),
+                "status_5xx": obj.get("status_5xx") or {},
+                "top_paths": obj.get("top_paths") or [],
+            }
+    return {
+        "hooks": hooks,
+        "panic": panic,
+        "status_5xx": traffic["status_5xx"],
+        "completed_total": traffic["completed_total"],
+        "top_paths": traffic["top_paths"],
+    }
+
+
+def evaluate(
+    plan: dict[str, Any],
+    tick: dict[str, Any],
+    *,
+    control_plane_ok: bool,
+) -> dict[str, Any]:
+    hooks = tick.get("hooks") or {}
+    results: list[dict[str, Any]] = []
+    worst = "green"
+
+    def bump(level: str) -> None:
+        nonlocal worst
+        rank = {"green": 0, "yellow": 1, "red": 2}
+        if rank[level] > rank[worst]:
+            worst = level
+
+    if not control_plane_ok:
+        results.append(
+            {
+                "id": "control-plane",
+                "source": "baseline",
+                "verdict": "fail",
+                "observed": {"ok": False},
+            }
+        )
+        bump("red")
+    else:
+        results.append(
+            {
+                "id": "control-plane",
+                "source": "baseline",
+                "verdict": "pass",
+                "observed": {"ok": True},
+            }
+        )
+
+    panic = int(tick.get("panic") or 0)
+    if panic:
+        results.append(
+            {
+                "id": "panic",
+                "source": "baseline",
+                "verdict": "fail",
+                "observed": {"count": panic},
+            }
+        )
+        bump("red")
+    else:
+        results.append(
+            {
+                "id": "panic",
+                "source": "baseline",
+                "verdict": "pass",
+                "observed": {"count": 0},
+            }
+        )
+
+    status_5xx = tick.get("status_5xx") or {}
+    five_xx_count = sum(int(v) for v in status_5xx.values())
+    if five_xx_count:
+        results.append(
+            {
+                "id": "status-5xx",
+                "source": "baseline",
+                "verdict": "fail",
+                "observed": {"status_5xx": status_5xx},
+            }
+        )
+        bump("red")
+    else:
+        results.append(
+            {
+                "id": "status-5xx",
+                "source": "baseline",
+                "verdict": "pass",
+                "observed": {"status_5xx": {}},
+            }
+        )
+
+    failover_count = int(hooks.get(FAILOVER_LOG) or 0)
+    for item in plan.get("checks") or []:
+        pattern = item["pattern"]
+        count = int(hooks.get(pattern) or 0)
+        kind = item["kind"]
+        verdict = "pass"
+        if kind == "error_absent":
+            verdict = "fail" if count >= ERROR_STORM_THRESHOLD else "pass"
+        elif kind == "failover_status":
+            if count == 0:
+                verdict = "inconclusive"
+            elif failover_count == 0:
+                verdict = "fail"
+            else:
+                verdict = "pass"
+        row = {
+            "id": item["id"],
+            "source": item.get("source"),
+            "kind": kind,
+            "pattern": pattern,
+            "verdict": verdict,
+            "observed": {"count": count},
+        }
+        if kind == "failover_status":
+            row["observed"]["failover_count"] = failover_count
+        results.append(row)
+        if verdict == "fail":
+            bump("red")
+        # inconclusive = path not hit in the window. Report it; do not redden.
+
+    return {
+        "verdict": worst,
+        "range": plan.get("range"),
+        "changes": plan.get("changes") or [],
+        "checks": results,
+        "traffic": {
+            "completed_total": int(tick.get("completed_total") or 0),
+            "top_paths": tick.get("top_paths") or [],
+        },
+    }
+
+
+def _load_json(path: str) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _print(obj: Any) -> None:
+    json.dump(obj, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Plan/evaluate post-release live checks")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_plan = sub.add_parser("plan")
+    p_plan.add_argument("--live", required=True)
+    p_plan.add_argument("--new", required=True)
+    p_plan.add_argument("--repo", default=".")
+
+    p_hooks = sub.add_parser("hook-patterns")
+    p_hooks.add_argument("--plan-file", required=True)
+
+    p_eval = sub.add_parser("evaluate")
+    p_eval.add_argument("--plan-file", required=True)
+    p_eval.add_argument("--tick-file", required=True)
+    p_eval.add_argument("--control-plane-ok", choices=("true", "false"), default="true")
+
+    args = parser.parse_args(argv)
+    if args.cmd == "plan":
+        _print(build_plan(Path(args.repo), args.live, args.new))
+        return 0
+    if args.cmd == "hook-patterns":
+        plan = _load_json(args.plan_file)
+        print(",".join(hook_patterns(plan)))
+        return 0
+
+    plan = _load_json(args.plan_file)
+    tick_raw = Path(args.tick_file).read_text(encoding="utf-8")
+    try:
+        tick = json.loads(tick_raw)
+        if "hooks" not in tick:
+            tick = parse_tick_stdout(tick_raw)
+    except json.JSONDecodeError:
+        tick = parse_tick_stdout(tick_raw)
+    result = evaluate(plan, tick, control_plane_ok=args.control_plane_ok == "true")
+    _print(result)
+    return 1 if result["verdict"] == "red" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_post_check.py
+++ b/scripts/release_post_check.py
@@ -29,7 +29,6 @@ ERROR_CTOR = re.compile(
 HTTP_STATUS = re.compile(r"\b([45]\d\d)\b")
 FAILOVER_PATH = re.compile(r"gateway_forward|upstream_errors|failover", re.I)
 SUBSCRIPTION_PATH = re.compile(r"subscription|universal_routing")
-AUTH_PATH = re.compile(r"api_key_auth|internal/server/middleware/middleware\.go")
 SUBSCRIPTION_CODES = (
     "WEEKLY_LIMIT_EXCEEDED",
     "DAILY_LIMIT_EXCEEDED",
@@ -37,7 +36,7 @@ SUBSCRIPTION_CODES = (
     "SUBSCRIPTION_EXPIRED",
 )
 FAILOVER_LOG = "[Forward] Upstream error (failover)"
-ERROR_STORM_THRESHOLD = 3
+ERROR_STORM_THRESHOLD = 20
 SKIP_PREFIXES = ("docs/",)
 SKIP_NAMES = {"backend/cmd/server/VERSION"}
 
@@ -165,17 +164,7 @@ def _derive_checks(source: str, files: list[str], diff_text: str) -> list[dict[s
 
     if any(SUBSCRIPTION_PATH.search(p) for p in files):
         for code in SUBSCRIPTION_CODES:
-            add(_check(source=source, kind="error_absent", pattern=code, expect="not_storming"))
-
-    if any(AUTH_PATH.search(p) for p in files):
-        add(
-            _check(
-                source=source,
-                kind="error_absent",
-                pattern="error: code=",
-                expect="not_storming",
-            )
-        )
+            add(_check(source=source, kind="observe", pattern=code, expect="report_only"))
 
     return checks
 
@@ -334,26 +323,14 @@ def evaluate(
         )
 
     status_5xx = tick.get("status_5xx") or {}
-    five_xx_count = sum(int(v) for v in status_5xx.values())
-    if five_xx_count:
-        results.append(
-            {
-                "id": "status-5xx",
-                "source": "baseline",
-                "verdict": "fail",
-                "observed": {"status_5xx": status_5xx},
-            }
-        )
-        bump("red")
-    else:
-        results.append(
-            {
-                "id": "status-5xx",
-                "source": "baseline",
-                "verdict": "pass",
-                "observed": {"status_5xx": {}},
-            }
-        )
+    results.append(
+        {
+            "id": "status-5xx",
+            "source": "baseline",
+            "verdict": "observe",
+            "observed": {"status_5xx": status_5xx},
+        }
+    )
 
     failover_count = int(hooks.get(FAILOVER_LOG) or 0)
     for item in plan.get("checks") or []:
@@ -361,7 +338,9 @@ def evaluate(
         count = int(hooks.get(pattern) or 0)
         kind = item["kind"]
         verdict = "pass"
-        if kind == "error_absent":
+        if kind == "observe":
+            verdict = "observe"
+        elif kind == "error_absent":
             verdict = "fail" if count >= ERROR_STORM_THRESHOLD else "pass"
         elif kind == "failover_status":
             if count == 0:

--- a/scripts/test_release_post_check.py
+++ b/scripts/test_release_post_check.py
@@ -157,8 +157,9 @@ class ReleasePostCheckPlanTest(unittest.TestCase):
         plan = rpc.build_plan(self.repo, "v1.8.169", "v1.8.170")
         by_id = {c["id"]: c for c in plan["checks"]}
         self.assertIn("pr-1781-WEEKLY_LIMIT_EXCEEDED", by_id)
-        self.assertEqual(by_id["pr-1781-WEEKLY_LIMIT_EXCEEDED"]["kind"], "error_absent")
+        self.assertEqual(by_id["pr-1781-WEEKLY_LIMIT_EXCEEDED"]["kind"], "observe")
         self.assertEqual(by_id["pr-1781-WEEKLY_LIMIT_EXCEEDED"]["source"], "#1781")
+        self.assertFalse(any(c["pattern"] == "error: code=" for c in plan["checks"]))
 
     def test_hook_patterns_come_from_plan_not_empty(self) -> None:
         self._commit(
@@ -182,6 +183,10 @@ class ReleasePostCheckPlanTest(unittest.TestCase):
         sources = {c["source"] for c in plan["checks"]}
         self.assertIn("#1780", sources)
         self.assertIn("#1781", sources)
+        self.assertFalse(any(c["pattern"] == "error: code=" for c in plan["checks"]))
+        self.assertTrue(
+            all(c["kind"] == "observe" for c in plan["checks"] if c["source"] == "#1781")
+        )
 
 
 class ReleasePostCheckEvaluateTest(unittest.TestCase):
@@ -203,8 +208,15 @@ class ReleasePostCheckEvaluateTest(unittest.TestCase):
                 {
                     "id": "pr-1781-WEEKLY_LIMIT_EXCEEDED",
                     "source": "#1781",
-                    "kind": "error_absent",
+                    "kind": "observe",
                     "pattern": "WEEKLY_LIMIT_EXCEEDED",
+                    "expect": "report_only",
+                },
+                {
+                    "id": "pr-1781-NEW_CODE",
+                    "source": "#1781",
+                    "kind": "error_absent",
+                    "pattern": "NEW_LIMIT_CODE",
                     "expect": "not_storming",
                 },
             ],
@@ -221,7 +233,7 @@ class ReleasePostCheckEvaluateTest(unittest.TestCase):
         self.assertEqual(result["verdict"], "green")
         by_id = {c["id"]: c for c in result["checks"]}
         self.assertEqual(by_id["pr-1780-Status=424"]["verdict"], "inconclusive")
-        self.assertEqual(by_id["pr-1781-WEEKLY_LIMIT_EXCEEDED"]["verdict"], "pass")
+        self.assertEqual(by_id["pr-1781-WEEKLY_LIMIT_EXCEEDED"]["verdict"], "observe")
 
     def test_evaluate_red_when_424_is_terminal_without_failover(self) -> None:
         tick = {
@@ -235,9 +247,22 @@ class ReleasePostCheckEvaluateTest(unittest.TestCase):
         by_id = {c["id"]: c for c in result["checks"]}
         self.assertEqual(by_id["pr-1780-Status=424"]["verdict"], "fail")
 
-    def test_evaluate_red_on_weekly_limit_storm(self) -> None:
+    def test_evaluate_observe_weekly_limit_does_not_redden(self) -> None:
         tick = {
-            "hooks": {"WEEKLY_LIMIT_EXCEEDED": 12, "Status=424": 0},
+            "hooks": {"WEEKLY_LIMIT_EXCEEDED": 12, "Status=424": 0, "NEW_LIMIT_CODE": 0},
+            "panic": 0,
+            "status_5xx": {"500": 2},
+            "completed_total": 20,
+        }
+        result = rpc.evaluate(self._plan(), tick, control_plane_ok=True)
+        self.assertEqual(result["verdict"], "green")
+        by_id = {c["id"]: c for c in result["checks"]}
+        self.assertEqual(by_id["pr-1781-WEEKLY_LIMIT_EXCEEDED"]["verdict"], "observe")
+        self.assertEqual(by_id["status-5xx"]["verdict"], "observe")
+
+    def test_evaluate_red_on_added_error_ctor_storm(self) -> None:
+        tick = {
+            "hooks": {"NEW_LIMIT_CODE": 20, "WEEKLY_LIMIT_EXCEEDED": 0, "Status=424": 0},
             "panic": 0,
             "status_5xx": {},
             "completed_total": 20,
@@ -245,11 +270,11 @@ class ReleasePostCheckEvaluateTest(unittest.TestCase):
         result = rpc.evaluate(self._plan(), tick, control_plane_ok=True)
         self.assertEqual(result["verdict"], "red")
 
-    def test_evaluate_red_on_panic_or_5xx_or_control_plane(self) -> None:
+    def test_evaluate_red_on_panic_or_control_plane_not_ambient_5xx(self) -> None:
         tick = {"hooks": {}, "panic": 1, "status_5xx": {}, "completed_total": 1}
         self.assertEqual(rpc.evaluate(self._plan(), tick, control_plane_ok=True)["verdict"], "red")
         tick = {"hooks": {}, "panic": 0, "status_5xx": {"500": 2}, "completed_total": 1}
-        self.assertEqual(rpc.evaluate(self._plan(), tick, control_plane_ok=True)["verdict"], "red")
+        self.assertEqual(rpc.evaluate(self._plan(), tick, control_plane_ok=True)["verdict"], "green")
         tick = {"hooks": {}, "panic": 0, "status_5xx": {}, "completed_total": 1}
         self.assertEqual(rpc.evaluate(self._plan(), tick, control_plane_ok=False)["verdict"], "red")
 
@@ -272,16 +297,20 @@ class ReleasePostCheckEvaluateTest(unittest.TestCase):
 
 
 class DeployStage0PostReleaseJobTest(unittest.TestCase):
-    def test_workflow_has_post_release_check_job(self) -> None:
+    def test_workflow_runs_post_release_check_in_deploy_job(self) -> None:
         text = (_ROOT / ".github/workflows/deploy-stage0.yml").read_text(encoding="utf-8")
-        self.assertIn("post-release-check:", text)
         self.assertIn("run-post-release-check.sh", text)
         self.assertIn("release_post_check.py plan", text)
-        self.assertIn("needs: deploy", text)
         self.assertIn("sleep 300", text)
-        self.assertIn("previous_tag: ${{ steps.previous_runtime.outputs.tag }}", text)
-        self.assertIn("LIVE_TAG: ${{ needs.deploy.outputs.previous_tag }}", text)
+        self.assertIn("steps.previous_runtime.outputs.tag", text)
         self.assertNotIn("HOOK_PATTERNS=<hook", text)
+        self.assertNotIn("\n  post-release-check:\n", text)
+        self.assertNotIn("needs: deploy", text)
+        deploy_start = text.index("  deploy:")
+        next_job = text.find("\n  qa-infra-check:", deploy_start)
+        deploy_block = text[deploy_start:next_job]
+        self.assertIn("id: post_release_check", deploy_block)
+        self.assertEqual(deploy_block.split("steps:", 1)[0].count("environment: prod"), 1)
 
     def test_skill_forbids_model_invented_hooks(self) -> None:
         text = (

--- a/scripts/test_release_post_check.py
+++ b/scripts/test_release_post_check.py
@@ -310,6 +310,10 @@ class DeployStage0PostReleaseJobTest(unittest.TestCase):
         next_job = text.find("\n  qa-infra-check:", deploy_start)
         deploy_block = text[deploy_start:next_job]
         self.assertIn("id: post_release_check", deploy_block)
+        self.assertIn("--plan-file", deploy_block)
+        feishu_pos = deploy_block.index("name: Notify Feishu (release rollout)")
+        plan_pos = deploy_block.index("name: Plan checks from live→new PRs")
+        self.assertLess(plan_pos, feishu_pos)
         self.assertEqual(deploy_block.split("steps:", 1)[0].count("environment: prod"), 1)
 
     def test_skill_forbids_model_invented_hooks(self) -> None:
@@ -375,6 +379,80 @@ class DeployStage0PostReleaseJobTest(unittest.TestCase):
             result = json.loads((out_dir / "evaluate.json").read_text(encoding="utf-8"))
             self.assertEqual(result["verdict"], "green")
             self.assertEqual(result["changes"][0]["pr"], 1781)
+
+    def test_wrapper_reuses_existing_plan_file(self) -> None:
+        wrapper = _ROOT / "ops/observability/run-post-release-check.sh"
+        with tempfile.TemporaryDirectory() as raw:
+            repo = pathlib.Path(raw) / "repo"
+            repo.mkdir()
+            _git(repo, "init", "-q", "-b", "main")
+            _git(repo, "config", "user.email", "test@example.com")
+            _git(repo, "config", "user.name", "Test")
+            (repo / "README.md").write_text("base\n")
+            _git(repo, "add", "-A")
+            _git(repo, "commit", "-q", "-m", "base")
+            _git(repo, "tag", "-a", "v1.8.169", "-m", "Release 1.8.169")
+            target = repo / "backend/internal/service/subscription_service.go"
+            target.parent.mkdir(parents=True)
+            target.write_text("package service\n")
+            _git(repo, "add", "-A")
+            _git(repo, "commit", "-q", "-m", "fix(gateway): fallback (#1781)")
+            _git(repo, "tag", "-a", "v1.8.170", "-m", "Release 1.8.170")
+            out_dir = pathlib.Path(raw) / "out"
+            out_dir.mkdir()
+            plan_proc = subprocess.run(
+                [
+                    "python3",
+                    str(_ROOT / "scripts/release_post_check.py"),
+                    "plan",
+                    "--live",
+                    "1.8.169",
+                    "--new",
+                    "1.8.170",
+                    "--repo",
+                    str(repo),
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            plan_path = out_dir / "plan.json"
+            plan_path.write_text(plan_proc.stdout, encoding="utf-8")
+            tick = {
+                "hooks": {"WEEKLY_LIMIT_EXCEEDED": 0},
+                "panic": 0,
+                "status_5xx": {},
+                "completed_total": 4,
+            }
+            tick_path = pathlib.Path(raw) / "tick.json"
+            tick_path.write_text(json.dumps(tick), encoding="utf-8")
+            proc = subprocess.run(
+                [
+                    "bash",
+                    str(wrapper),
+                    "--live",
+                    "1.8.169",
+                    "--new",
+                    "1.8.170",
+                    "--repo",
+                    str(repo),
+                    "--skip-probe",
+                    "--tick-file",
+                    str(tick_path),
+                    "--plan-file",
+                    str(plan_path),
+                    "--out-dir",
+                    str(out_dir),
+                ],
+                cwd=_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("reusing existing plan", proc.stderr)
+            plan_data = json.loads(plan_path.read_text(encoding="utf-8"))
+            self.assertEqual(plan_data["range"]["live"], "v1.8.169")
 
 
 if __name__ == "__main__":

--- a/scripts/test_release_post_check.py
+++ b/scripts/test_release_post_check.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Tests for scripts/release_post_check.py — plan from live→new PRs, evaluate live ticks.
+
+The +5min post-release check must be derived from the commits/PRs between the
+tag that was actually serving and the tag just deployed. Model-invented hook
+strings are not a valid plan.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT / "scripts"))
+
+import release_post_check as rpc  # noqa: E402
+
+
+def _clean_env() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
+def _git(cwd: pathlib.Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        env=_clean_env(),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout
+
+
+class ReleasePostCheckPlanTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = pathlib.Path(self._tmp.name) / "repo"
+        self.repo.mkdir()
+        _git(self.repo, "init", "-q", "-b", "main")
+        _git(self.repo, "config", "user.email", "test@example.com")
+        _git(self.repo, "config", "user.name", "Test")
+        (self.repo / "README.md").write_text("base\n")
+        _git(self.repo, "add", "-A")
+        _git(self.repo, "commit", "-q", "-m", "base")
+        _git(self.repo, "tag", "-a", "v1.8.169", "-m", "Release 1.8.169")
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _commit(self, files: dict[str, str], msg: str) -> str:
+        for relpath, content in files.items():
+            target = self.repo / relpath
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if target.exists() and content == "":
+                target.unlink()
+            else:
+                target.write_text(content)
+        _git(self.repo, "add", "-A")
+        _git(self.repo, "commit", "-q", "-m", msg)
+        return _git(self.repo, "rev-parse", "--short", "HEAD").strip()
+
+    def test_plan_lists_prs_and_skips_version_bump(self) -> None:
+        self._commit(
+            {"backend/internal/service/gateway_forward.go": "package service\n"},
+            "fix(gateway): failover CloudWise-class 424 (#1780)",
+        )
+        self._commit(
+            {"backend/internal/service/subscription_service.go": "package service\n"},
+            "fix(gateway): 订阅不可用时回退到余额专属组 (#1781)",
+        )
+        self._commit({"backend/cmd/server/VERSION": "1.8.170\n"}, "chore: bump VERSION to 1.8.170")
+        _git(self.repo, "tag", "-a", "v1.8.170", "-m", "Release 1.8.170")
+
+        plan = rpc.build_plan(self.repo, "v1.8.169", "v1.8.170")
+        prs = [c["pr"] for c in plan["changes"]]
+        self.assertEqual(prs, [1780, 1781])
+        self.assertTrue(all("bump VERSION" not in c["subject"] for c in plan["changes"]))
+        self.assertEqual(plan["range"], {"live": "v1.8.169", "new": "v1.8.170"})
+
+    def test_plan_derives_added_failover_status(self) -> None:
+        old = (
+            "package service\n"
+            "func shouldFailover(statusCode int) bool {\n"
+            "\tswitch statusCode {\n"
+            "\tcase 401, 403, 429, 529:\n"
+            "\t\treturn true\n"
+            "\t}\n"
+            "\treturn false\n"
+            "}\n"
+        )
+        new = old.replace("case 401, 403, 429, 529:", "case 401, 403, 424, 429, 529:")
+        self._commit({"backend/internal/service/gateway_forward.go": old}, "base forward")
+        _git(self.repo, "tag", "-d", "v1.8.169")
+        _git(self.repo, "tag", "-a", "v1.8.169", "-m", "Release 1.8.169")
+        self._commit(
+            {"backend/internal/service/gateway_forward.go": new},
+            "fix(gateway): failover CloudWise-class 424 (#1780)",
+        )
+        _git(self.repo, "tag", "-a", "v1.8.170", "-m", "Release 1.8.170")
+
+        plan = rpc.build_plan(self.repo, "v1.8.169", "v1.8.170")
+        patterns = {c["pattern"] for c in plan["checks"] if c["kind"] == "failover_status"}
+        self.assertEqual(patterns, {"Status=424"})
+        self.assertNotIn("Status=429", patterns)
+
+    def test_plan_ignores_status_codes_only_mentioned_in_tests(self) -> None:
+        old = (
+            "package service\n"
+            "func shouldFailover(statusCode int) bool {\n"
+            "\tswitch statusCode {\n"
+            "\tcase 401, 403, 429, 529:\n"
+            "\t\treturn true\n"
+            "\t}\n"
+            "\treturn false\n"
+            "}\n"
+        )
+        new = old.replace("case 401, 403, 429, 529:", "case 401, 403, 424, 429, 529:")
+        self._commit({"backend/internal/service/gateway_forward.go": old}, "base forward")
+        _git(self.repo, "tag", "-d", "v1.8.169")
+        _git(self.repo, "tag", "-a", "v1.8.169", "-m", "Release 1.8.169")
+        self._commit(
+            {
+                "backend/internal/service/gateway_forward.go": new,
+                "backend/internal/service/gateway_forward_failover_status_test.go": (
+                    "package service\n"
+                    "func TestNotFailover() {\n"
+                    "\t_ = []int{400, 404, 408, 422}\n"
+                    "}\n"
+                ),
+            },
+            "fix(gateway): failover CloudWise-class 424 (#1780)",
+        )
+        _git(self.repo, "tag", "-a", "v1.8.170", "-m", "Release 1.8.170")
+
+        plan = rpc.build_plan(self.repo, "v1.8.169", "v1.8.170")
+        patterns = {c["pattern"] for c in plan["checks"] if c["kind"] == "failover_status"}
+        self.assertEqual(patterns, {"Status=424"})
+        self.assertNotIn("Status=400", patterns)
+
+    def test_plan_derives_subscription_error_checks_from_path(self) -> None:
+        self._commit(
+            {
+                "backend/internal/service/subscription_service.go": "package service\nfunc SubscriptionGroupUsable() {}\n",
+                "backend/internal/service/universal_routing_tk_resolver.go": "package service\nfunc pickUsableBackingGroup() {}\n",
+            },
+            "fix(gateway): fall back when subscription cannot serve (#1781)",
+        )
+        _git(self.repo, "tag", "-a", "v1.8.170", "-m", "Release 1.8.170")
+
+        plan = rpc.build_plan(self.repo, "v1.8.169", "v1.8.170")
+        by_id = {c["id"]: c for c in plan["checks"]}
+        self.assertIn("pr-1781-WEEKLY_LIMIT_EXCEEDED", by_id)
+        self.assertEqual(by_id["pr-1781-WEEKLY_LIMIT_EXCEEDED"]["kind"], "error_absent")
+        self.assertEqual(by_id["pr-1781-WEEKLY_LIMIT_EXCEEDED"]["source"], "#1781")
+
+    def test_hook_patterns_come_from_plan_not_empty(self) -> None:
+        self._commit(
+            {"backend/internal/service/subscription_service.go": "package service\n"},
+            "fix(gateway): subscription fallback (#1781)",
+        )
+        _git(self.repo, "tag", "-a", "v1.8.170", "-m", "Release 1.8.170")
+        plan = rpc.build_plan(self.repo, "v1.8.169", "v1.8.170")
+        patterns = rpc.hook_patterns(plan)
+        self.assertIn("WEEKLY_LIMIT_EXCEEDED", patterns)
+        self.assertTrue(patterns)
+
+    def test_real_v1_8_169_to_v1_8_170_lists_prs_and_only_new_424(self) -> None:
+        try:
+            plan = rpc.build_plan(_ROOT, "v1.8.169", "v1.8.170")
+        except RuntimeError as exc:
+            self.skipTest(f"release tags unavailable: {exc}")
+        self.assertEqual([c["pr"] for c in plan["changes"]], [1780, 1781])
+        failover = {c["pattern"] for c in plan["checks"] if c["kind"] == "failover_status"}
+        self.assertEqual(failover, {"Status=424"})
+        sources = {c["source"] for c in plan["checks"]}
+        self.assertIn("#1780", sources)
+        self.assertIn("#1781", sources)
+
+
+class ReleasePostCheckEvaluateTest(unittest.TestCase):
+    def _plan(self) -> dict:
+        return {
+            "range": {"live": "v1.8.169", "new": "v1.8.170"},
+            "changes": [
+                {"pr": 1780, "subject": "fix 424 (#1780)", "files": ["backend/internal/service/gateway_forward.go"]},
+                {"pr": 1781, "subject": "fix sub (#1781)", "files": ["backend/internal/service/subscription_service.go"]},
+            ],
+            "checks": [
+                {
+                    "id": "pr-1780-Status=424",
+                    "source": "#1780",
+                    "kind": "failover_status",
+                    "pattern": "Status=424",
+                    "expect": "failover_if_present",
+                },
+                {
+                    "id": "pr-1781-WEEKLY_LIMIT_EXCEEDED",
+                    "source": "#1781",
+                    "kind": "error_absent",
+                    "pattern": "WEEKLY_LIMIT_EXCEEDED",
+                    "expect": "not_storming",
+                },
+            ],
+        }
+
+    def test_evaluate_inconclusive_when_new_path_has_no_traffic(self) -> None:
+        tick = {
+            "hooks": {"Status=424": 0, "WEEKLY_LIMIT_EXCEEDED": 0, "[Forward] Upstream error (failover)": 0},
+            "panic": 0,
+            "status_5xx": {},
+            "completed_total": 20,
+        }
+        result = rpc.evaluate(self._plan(), tick, control_plane_ok=True)
+        self.assertEqual(result["verdict"], "green")
+        by_id = {c["id"]: c for c in result["checks"]}
+        self.assertEqual(by_id["pr-1780-Status=424"]["verdict"], "inconclusive")
+        self.assertEqual(by_id["pr-1781-WEEKLY_LIMIT_EXCEEDED"]["verdict"], "pass")
+
+    def test_evaluate_red_when_424_is_terminal_without_failover(self) -> None:
+        tick = {
+            "hooks": {"Status=424": 4, "[Forward] Upstream error (failover)": 0},
+            "panic": 0,
+            "status_5xx": {},
+            "completed_total": 20,
+        }
+        result = rpc.evaluate(self._plan(), tick, control_plane_ok=True)
+        self.assertEqual(result["verdict"], "red")
+        by_id = {c["id"]: c for c in result["checks"]}
+        self.assertEqual(by_id["pr-1780-Status=424"]["verdict"], "fail")
+
+    def test_evaluate_red_on_weekly_limit_storm(self) -> None:
+        tick = {
+            "hooks": {"WEEKLY_LIMIT_EXCEEDED": 12, "Status=424": 0},
+            "panic": 0,
+            "status_5xx": {},
+            "completed_total": 20,
+        }
+        result = rpc.evaluate(self._plan(), tick, control_plane_ok=True)
+        self.assertEqual(result["verdict"], "red")
+
+    def test_evaluate_red_on_panic_or_5xx_or_control_plane(self) -> None:
+        tick = {"hooks": {}, "panic": 1, "status_5xx": {}, "completed_total": 1}
+        self.assertEqual(rpc.evaluate(self._plan(), tick, control_plane_ok=True)["verdict"], "red")
+        tick = {"hooks": {}, "panic": 0, "status_5xx": {"500": 2}, "completed_total": 1}
+        self.assertEqual(rpc.evaluate(self._plan(), tick, control_plane_ok=True)["verdict"], "red")
+        tick = {"hooks": {}, "panic": 0, "status_5xx": {}, "completed_total": 1}
+        self.assertEqual(rpc.evaluate(self._plan(), tick, control_plane_ok=False)["verdict"], "red")
+
+    def test_parse_tick_stdout(self) -> None:
+        stdout = """
+=== meta ===
+{"container": "tokenkey-blue", "log_lines": 10}
+=== hooks ===
+{"pattern": "Status=424", "count": 2}
+{"pattern": "WEEKLY_LIMIT_EXCEEDED", "count": 0}
+=== panic ===
+{"count": 0}
+=== traffic ===
+{"completed_total": 9, "top_paths": [{"path": "/v1/messages", "n": 9}], "status_5xx": {}}
+"""
+        parsed = rpc.parse_tick_stdout(stdout)
+        self.assertEqual(parsed["hooks"]["Status=424"], 2)
+        self.assertEqual(parsed["completed_total"], 9)
+        self.assertEqual(parsed["panic"], 0)
+
+
+class DeployStage0PostReleaseJobTest(unittest.TestCase):
+    def test_workflow_has_post_release_check_job(self) -> None:
+        text = (_ROOT / ".github/workflows/deploy-stage0.yml").read_text(encoding="utf-8")
+        self.assertIn("post-release-check:", text)
+        self.assertIn("run-post-release-check.sh", text)
+        self.assertIn("release_post_check.py plan", text)
+        self.assertIn("needs: deploy", text)
+        self.assertIn("sleep 300", text)
+        self.assertIn("previous_tag: ${{ steps.previous_runtime.outputs.tag }}", text)
+        self.assertIn("LIVE_TAG: ${{ needs.deploy.outputs.previous_tag }}", text)
+        self.assertNotIn("HOOK_PATTERNS=<hook", text)
+
+    def test_skill_forbids_model_invented_hooks(self) -> None:
+        text = (
+            _ROOT / ".cursor/skills/tokenkey-stage0-release-rollout/SKILL.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn("run-post-release-check.sh", text)
+        self.assertIn("release_post_check.py", text)
+        self.assertNotIn("HOOK_PATTERNS=<hook1>", text)
+        self.assertNotIn("关键词由模型按 hook 命名", text)
+        self.assertNotIn("模型按 Step A 命名", text)
+
+    def test_wrapper_evaluates_skip_probe_tick(self) -> None:
+        wrapper = _ROOT / "ops/observability/run-post-release-check.sh"
+        self.assertTrue(os.access(wrapper, os.X_OK), f"{wrapper} must be executable")
+        with tempfile.TemporaryDirectory() as raw:
+            repo = pathlib.Path(raw) / "repo"
+            repo.mkdir()
+            _git(repo, "init", "-q", "-b", "main")
+            _git(repo, "config", "user.email", "test@example.com")
+            _git(repo, "config", "user.name", "Test")
+            (repo / "README.md").write_text("base\n")
+            _git(repo, "add", "-A")
+            _git(repo, "commit", "-q", "-m", "base")
+            _git(repo, "tag", "-a", "v1.8.169", "-m", "Release 1.8.169")
+            target = repo / "backend/internal/service/subscription_service.go"
+            target.parent.mkdir(parents=True)
+            target.write_text("package service\n")
+            _git(repo, "add", "-A")
+            _git(repo, "commit", "-q", "-m", "fix(gateway): fallback (#1781)")
+            _git(repo, "tag", "-a", "v1.8.170", "-m", "Release 1.8.170")
+            tick = {
+                "hooks": {"WEEKLY_LIMIT_EXCEEDED": 0},
+                "panic": 0,
+                "status_5xx": {},
+                "completed_total": 4,
+            }
+            tick_path = pathlib.Path(raw) / "tick.json"
+            out_dir = pathlib.Path(raw) / "out"
+            tick_path.write_text(json.dumps(tick), encoding="utf-8")
+            proc = subprocess.run(
+                [
+                    "bash",
+                    str(wrapper),
+                    "--live",
+                    "1.8.169",
+                    "--new",
+                    "1.8.170",
+                    "--repo",
+                    str(repo),
+                    "--skip-probe",
+                    "--tick-file",
+                    str(tick_path),
+                    "--out-dir",
+                    str(out_dir),
+                ],
+                cwd=_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            result = json.loads((out_dir / "evaluate.json").read_text(encoding="utf-8"))
+            self.assertEqual(result["verdict"], "green")
+            self.assertEqual(result["changes"][0]["pr"], 1781)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要
- `deploy-stage0` 的 `deploy` job 在 smoke/SSOT gate 之后做 +5min 实测：对照换镜像前线上 tag → 本次 tag 的全部产品 PR，对照 prod 日志评分。
- 飞书发版公告挪到 post-release 通过（或 skip）之后，卡片表示烟测与 live→new 实测均完成。
- workflow 先 `plan` 写 `plan.json`，check 步 `--plan-file` 传入 wrapper，避免重复 plan。
- 检查留在同一 job，复用已批的 prod Environment/OIDC，避免第二次审批把时钟推后。
- 检查从 git diff / 路径表派生，禁止模型现场编 `HOOK_PATTERNS`；无产品提交则跳过等待。
- panic / prod 控制面失败 / 新增 failover 状态未伴随 failover 日志 / 新增 error ctor 风暴才红。常态 5xx、订阅限额计数只报告。
- 检查变红只红 workflow，不 rollback 已切的颜色。

## 风险
- 常规风险，偏运维门禁：只读 SSM + git history，不改线上颜色/数据。
- 已更新 `docs/approved/deploy-stage0-workflow.md`。无 Web 页面或用户契约变化（`no-web-impact`）。
- 改的是 deploy workflow 步骤，不是 gateway 语义；sentinel-registry-reviewed。

## 验证
- `python3 scripts/test_release_post_check.py`（16 通过）
- `python3 ops/stage0/test_deploy_stage0_workflow.py -k test_feishu_rollout` 通过
- `GOTOOLCHAIN=go1.26.6 ./scripts/preflight.sh` 通过

## 提交
- `c187b8d86` fix(ops): 用线上版本到本次发版的 PR 做 +5min 实测
- `b0feb0776` fix(ops): address R-001..R-003 — keep +5min check in deploy job
- `f10f32afd` fix(deploy): Feishu after post-release; reuse plan in wrapper
- 最新提交：`f10f32afd`