### PR TITLE
fix(pricing): 把 Qwen-4 #78 写入五个已实测模型的 served_on

### DIFF
--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -357,7 +357,7 @@
       "price_source": "overlay",
       "price_key": "qwen3.8-2.4t-a95b",
       "display": true,
-      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77,78 are static mapping evidence, not complete live pool membership. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14; account 78 exact-account gateway probes returned 200 on 2026-08-23."
+      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77,78 are static mapping evidence, not complete live pool membership. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14 (thinking/streaming only); account 78 exact-account gateway probes returned 200 on 2026-08-23 (thinking/streaming only). Non-thinking probe shape returns 400 (request-shape constraint, not upstream unavailability)."
     },
     "newapi/qwen3.8-max": {
       "platform": "newapi",

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -320,13 +320,14 @@
       "served_on": [
         "60",
         "72",
-        "77"
+        "77",
+        "78"
       ],
       "channel_type": 17,
       "price_source": "overlay",
       "price_key": "qwen3.7-flash",
       "display": true,
-      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77 are static mapping evidence, not complete live pool membership. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14. Tiered (overlay intervals)."
+      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77,78 are static mapping evidence, not complete live pool membership. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14; account 78 exact-account gateway probes returned 200 on 2026-08-23. Tiered (overlay intervals)."
     },
     "newapi/qwen3.7-flash-2026-07-15": {
       "platform": "newapi",
@@ -334,13 +335,14 @@
       "served_on": [
         "60",
         "72",
-        "77"
+        "77",
+        "78"
       ],
       "channel_type": 17,
       "price_source": "overlay",
       "price_key": "qwen3.7-flash-2026-07-15",
       "display": true,
-      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77 are static mapping evidence, not complete live pool membership. Dated snapshot of qwen3.7-flash. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14. Tiered (overlay intervals)."
+      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77,78 are static mapping evidence, not complete live pool membership. Dated snapshot of qwen3.7-flash. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14; account 78 exact-account gateway probes returned 200 on 2026-08-23. Tiered (overlay intervals)."
     },
     "newapi/qwen3.8-2.4t-a95b": {
       "platform": "newapi",
@@ -348,13 +350,14 @@
       "served_on": [
         "60",
         "72",
-        "77"
+        "77",
+        "78"
       ],
       "channel_type": 17,
       "price_source": "overlay",
       "price_key": "qwen3.8-2.4t-a95b",
       "display": true,
-      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77 are static mapping evidence, not complete live pool membership. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14."
+      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77,78 are static mapping evidence, not complete live pool membership. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14; account 78 exact-account gateway probes returned 200 on 2026-08-23."
     },
     "newapi/qwen3.8-max": {
       "platform": "newapi",
@@ -362,13 +365,14 @@
       "served_on": [
         "60",
         "72",
-        "77"
+        "77",
+        "78"
       ],
       "channel_type": 17,
       "price_source": "overlay",
       "price_key": "qwen3.8-max",
       "display": true,
-      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77 are static mapping evidence, not complete live pool membership. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14."
+      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77,78 are static mapping evidence, not complete live pool membership. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14; account 78 exact-account gateway probes returned 200 on 2026-08-23."
     },
     "newapi/qwen3.6-flash": {
       "platform": "newapi",
@@ -886,13 +890,14 @@
       "served_on": [
         "60",
         "72",
-        "77"
+        "77",
+        "78"
       ],
       "channel_type": 17,
       "price_source": "overlay",
       "price_key": "glm-5.2-fast-preview",
       "display": true,
-      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on accounts 60,72,77 are static mapping-evidence anchors, while live account membership comes from runtime DB/admin config. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14. Overlay uses Alibaba DashScope official China-mainland pricing (https://help.aliyun.com/zh/model-studio/model-pricing, captured 2026-08-14; CNY/USD=6.7)."
+      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on accounts 60,72,77,78 are static mapping-evidence anchors, while live account membership comes from runtime DB/admin config. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14; account 78 exact-account gateway probes returned 200 on 2026-08-23. Overlay uses Alibaba DashScope official China-mainland pricing (https://help.aliyun.com/zh/model-studio/model-pricing, captured 2026-08-14; CNY/USD=6.7)."
     },
     "newapi/glm-5.1": {
       "platform": "newapi",


### PR DESCRIPTION
## 摘要
- prod `#78` Qwen-4（newapi channel 17）已按 Go floor 热更新 `model_mapping`，补齐 5 个缺 key。
- 本 PR 只把 manifest 静态证据 `served_on` 对齐到 `#78`，并记下 2026-08-23 精确账号探测 200；不改价、不改 display、不发版。

## 风险
- 常规风险：仓库证据层，不改变公开 catalog / Menu / 计费。
- live mapping 已在 prod 落地；本 PR 不重复 apply。
- Web impact: none
- sentinel-registry-reviewed

## 验证
- 定价 / 可展示：overlay + `display=true`，`catalog-serving-drift.py` 通过。
- 池探测 thinking/non-thinking：9/10 为 200；`qwen3.8-2.4t-a95b` 仅 thinking 200。
- `#60` 精确账号：5/5 `verdict=servable`，`usage_match.account_id=60`。
- `#78` 补前：5/5 `gateway_rejected` / `Unsupported model`。
- `#78` apply 后：5/5 `servable`，`usage_match.account_id=78`；`check-accounts` `violation_count=0`。
- 本分支：`catalog-serving-drift.py`、manifest owner 派生测试、`export_agent_contract.py --check` 通过。
- 本地全量 preflight 仅 Ent generate 因本机 Go 1.27 噪音失败（未改 schema，已 checkout 还原）；CI PR 走 fast 路径会跳过该项。

## 提交
- `4d6f0e1a9` fix(pricing): record Qwen-4 #78 on five already-served DashScope models
- 最新提交：`4d6f0e1a9`


Made with [Cursor](https://cursor.com)