### PR TITLE
chore: 关闭已解决的 client-release / upstream 跟踪 issue

### DIFF
--- a/scripts/fingerprint/test_client_release_watch.py
+++ b/scripts/fingerprint/test_client_release_watch.py
@@ -44,6 +44,16 @@ class PinReadersLiveRepoTest(unittest.TestCase):
         self.assertRegex(crw.read_pinned_kiro_cli(), r"^\d+\.\d+\.\d+")
 
 
+class ResolvedClientReleasePinsTest(unittest.TestCase):
+    """Regression locks for automated client-release issues resolved on main."""
+
+    def test_kiro_cli_pin_aligned_with_issue_1778(self) -> None:
+        self.assertEqual(crw.read_pinned_kiro_cli(), "2.19.1")
+
+    def test_gemini_cli_pin_aligned_with_issue_1755(self) -> None:
+        self.assertEqual(crw.read_pinned_gemini_cli(), "0.56.0")
+
+
 class ScanPlatformTest(unittest.TestCase):
     def test_offline_fixture_marks_drift(self) -> None:
         spec = next(p for p in crw.PLATFORM_SPECS if p.id == "codex")

--- a/scripts/test_upstream_drift_resolved.py
+++ b/scripts/test_upstream_drift_resolved.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Regression guard for upstream-merge tracking issue #1792."""
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+CHECK_DRIFT = REPO_ROOT / "scripts/upstream/check-drift.sh"
+
+
+class UpstreamSyncRegressionTest(unittest.TestCase):
+    def test_tokenkey_not_behind_upstream_main(self) -> None:
+        self.assertTrue(CHECK_DRIFT.is_file(), f"missing {CHECK_DRIFT}")
+        proc = subprocess.run(
+            ["bash", str(CHECK_DRIFT)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=180,
+            check=False,
+        )
+        combined = proc.stdout + proc.stderr
+        self.assertEqual(proc.returncode, 0, combined)
+        self.assertIn("TK behind: 0 commits", combined)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

对齐 `origin/main` 后，仓库仅剩 3 个 open issue，均已在 main 上解决但未自动关闭：

- **#1755** Gemini 0.56.0 — 已在 #1794 对齐
- **#1778** Kiro 2.19.1 — 已在 #1794 对齐
- **#1792** upstream 106 commit 漂移 — 已在 #1796 合并完成（`TK behind: 0`）

本 PR 添加回归测试锁定上述状态，合并时通过 `Fixes` 自动关闭 issue。

## 风险

低风险：仅新增 Python 回归测试，无运行时行为变更。

## 验证

```bash
python3 scripts/fingerprint/test_client_release_watch.py ResolvedClientReleasePinsTest
python3 scripts/test_upstream_drift_resolved.py
python3 scripts/fingerprint/client_release_watch.py  # drift count 0（actionable）
```

## 提交

- 6430a5a78 test: 锁定已解决 issue 的 client-release / upstream 状态

最新提交：6430a5a78

Made with [Cursor](https://cursor.com)