### PR TITLE
fix(newapi): stop leaking newapi channel keys to api.openai.com on /v1/messages

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -2,14 +2,46 @@
 
 VERSION ?= $(shell ./scripts/resolve-version.sh)
 LDFLAGS ?= -s -w -X main.Version=$(VERSION)
+
+# Toolchain pin — go.mod is the single source of truth.
+#
+# GOTOOLCHAIN=auto (the default) only ever upgrades: if the developer's ambient
+# Go is NEWER than go.mod's `go` directive, every go command silently runs on
+# that newer GOROOT instead of the declared one. CI never sees this because
+# actions/setup-go installs exactly `go-version-file: backend/go.mod` (and
+# backend-ci asserts it in "Verify Go version").
+#
+# The recurring symptom is a golangci-lint crash that looks like a code defect
+# but is not: a v2.9.0 binary cannot decode a newer stdlib's export data
+# ("export data version 4 is greater than maximum supported version 2"), so it
+# panics or reports phantom typecheck errors on untouched files. What matters is
+# the toolchain the linter RUNS under, not the Go that built the binary.
+#
+# Deriving the exact version here makes local `make lint` / `make test` match CI
+# mechanically. Bumping go.mod is the only way to move it.
+GO_MOD_VERSION := $(shell awk '/^go /{print $$2; exit}' go.mod)
+GOTOOLCHAIN ?= go$(GO_MOD_VERSION)
+export GOTOOLCHAIN
+
 GOLANGCI_LINT ?= golangci-lint
 GOLANGCI_LINT_VERSION ?= v2.9.0
 GOLANGCI_LINT_CONCURRENCY ?= 4
 GOLANGCI_LINT_FAST_ARGS ?= --concurrency=$(GOLANGCI_LINT_CONCURRENCY)
 GOLANGCI_LINT_SECURITY_ARGS ?= --concurrency=$(GOLANGCI_LINT_CONCURRENCY)
 
+.PHONY: verify-toolchain
+verify-toolchain:
+	@actual=$$(go version | awk '{print $$3}'); \
+	if [ "$$actual" != "go$(GO_MOD_VERSION)" ]; then \
+		echo "toolchain mismatch: go.mod declares go$(GO_MOD_VERSION) but 'go version' reports $$actual"; \
+		echo "  GOTOOLCHAIN=$${GOTOOLCHAIN:-<unset>}"; \
+		echo "  This Makefile pins GOTOOLCHAIN=go$(GO_MOD_VERSION); an explicit override in the"; \
+		echo "  environment or 'go env -w GOTOOLCHAIN=...' defeats it. Unset it, or bump go.mod."; \
+		exit 1; \
+	fi
+
 .PHONY: ensure-golangci-lint
-ensure-golangci-lint:
+ensure-golangci-lint: verify-toolchain
 	@command -v $(GOLANGCI_LINT) >/dev/null 2>&1 || { \
 		echo "golangci-lint not found; installing $(GOLANGCI_LINT_VERSION)..."; \
 		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); \

--- a/backend/internal/service/openai_gateway_cc_pipeline.go
+++ b/backend/internal/service/openai_gateway_cc_pipeline.go
@@ -140,6 +140,12 @@ func (s *OpenAIGatewayService) failoverOpenAIUpstreamHTTPError(
 func (s *OpenAIGatewayService) openAIChatCompletionsTargetURL(account *Account) (string, error) {
 	baseURL := nativeOpenAIBaseURLForAccount(account)
 	if baseURL == "" {
+		// A foreign credential (newapi channel, relay, ...) must never be POSTed
+		// to the official OpenAI host: it returns "Incorrect API key provided",
+		// which reads as a dead credential instead of the routing defect it is.
+		if !OfficialOpenAIFallbackAllowed(account) {
+			return "", ErrForeignCredentialOfficialOpenAIFallback
+		}
 		baseURL = "https://api.openai.com"
 	}
 	validatedURL, err := s.validateUpstreamBaseURL(baseURL)

--- a/backend/internal/service/openai_gateway_messages_tk.go
+++ b/backend/internal/service/openai_gateway_messages_tk.go
@@ -12,6 +12,23 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// newAPIBridgeOwnsAnthropicMessages reports whether inbound /v1/messages for
+// this account must relay through the NewAPI adaptor bridge.
+//
+// The OpenAI-shaped fallbacks below (native Anthropic endpoint / raw Chat
+// Completions) resolve their upstream from OpenAI-family accessors, which
+// return "" for platform=newapi — and every caller turns "" into
+// api.openai.com. A newapi channel credential (DashScope, Ark, ...) sent
+// there comes back as "Incorrect API key provided". Bridge-eligible newapi
+// accounts therefore stay on the adaptor, which reads the account's own
+// channel base URL and key.
+func (s *OpenAIGatewayService) newAPIBridgeOwnsAnthropicMessages(account *Account) bool {
+	if account == nil || account.Platform != PlatformNewAPI {
+		return false
+	}
+	return s.ShouldDispatchToNewAPIBridge(account, BridgeEndpointChatCompletions)
+}
+
 // tkTryRouteForwardAsAnthropic handles TokenKey-specific /v1/messages entry
 // routing before the OpenAI Responses compat path.
 func (s *OpenAIGatewayService) tkTryRouteForwardAsAnthropic(
@@ -21,6 +38,12 @@ func (s *OpenAIGatewayService) tkTryRouteForwardAsAnthropic(
 	body []byte,
 	defaultMappedModel string,
 ) (*OpenAIForwardResult, bool, error) {
+	// Bridge-eligible newapi accounts are relayed by ForwardAsAnthropicDispatched;
+	// never claim them for an OpenAI-shaped fallback.
+	if s.newAPIBridgeOwnsAnthropicMessages(account) {
+		result, err := s.ForwardAsAnthropicDispatched(ctx, c, account, body, "", defaultMappedModel)
+		return result, true, err
+	}
 	if account.IsAnthropicProtocol() || account.IsAdaptiveAPIProtocol() {
 		result, err := s.forwardAnthropicViaNativeAnthropicEndpoint(ctx, c, account, body, defaultMappedModel)
 		return result, true, err

--- a/backend/internal/service/openai_gateway_messages_tk_newapi_leak_test.go
+++ b/backend/internal/service/openai_gateway_messages_tk_newapi_leak_test.go
@@ -1,0 +1,114 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression: a newapi (fifth platform) Qwen/DashScope account must never have
+// its channel credential sent to api.openai.com.
+//
+// Inbound /v1/messages reached ForwardAsAnthropic without the bridge dispatcher,
+// so a newapi api-key account fell through tkTryRouteForwardAsAnthropic's last
+// predicate into the OpenAI-shaped raw Chat Completions fallback. That path
+// resolves its upstream from OpenAI-family accessors, which return "" for
+// platform=newapi, and the caller turned "" into the official OpenAI host while
+// still sending the account's real DashScope key — producing upstream
+// "Incorrect API key provided", the exact shape
+// IsForeignCredentialOfficialOpenAIReject already classifies as a routing
+// defect rather than a dead credential.
+func newapiQwenAccountForLeakTest(name string, id int64) *Account {
+	return &Account{
+		ID:          id,
+		Name:        name,
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeAli,
+		Credentials: map[string]any{
+			"api_key":       "sk-dashscope-not-an-openai-key",
+			"base_url":      "https://dashscope.aliyuncs.com",
+			"model_mapping": map[string]any{"qwen3-max": "qwen3-max"},
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+}
+
+// The credential does reach the wire on the native path, so the destination is
+// the only thing standing between a DashScope key and api.openai.com.
+func TestNewAPIQwenCredentialIsWireBoundOnNativePath(t *testing.T) {
+	for _, name := range []string{"Qwen", "Qwen-2", "Qwen-4"} {
+		t.Run(name, func(t *testing.T) {
+			account := newapiQwenAccountForLeakTest(name, 60)
+			require.Equal(t, "sk-dashscope-not-an-openai-key", account.GetOpenAIProtocolAPIKey())
+			require.False(t, AccountUsesOfficialOpenAIUpstream(account))
+			require.False(t, OfficialOpenAIFallbackAllowed(account),
+				"a newapi channel credential must never be allowed to default to api.openai.com")
+		})
+	}
+}
+
+// Primary fix: inbound /v1/messages for a bridge-eligible newapi account is
+// owned by the NewAPI adaptor, never by an OpenAI-shaped fallback.
+func TestNewAPIBridgeOwnsAnthropicMessagesForQwen(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+
+	for _, name := range []string{"Qwen", "Qwen-2", "Qwen-4"} {
+		require.True(t, svc.newAPIBridgeOwnsAnthropicMessages(newapiQwenAccountForLeakTest(name, 60)),
+			"inbound /v1/messages for %s must relay through the NewAPI adaptor", name)
+	}
+
+	// An OpenAI api-key account keeps the existing OpenAI-shaped fallbacks.
+	require.False(t, svc.newAPIBridgeOwnsAnthropicMessages(&Account{
+		ID:          76,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Credentials: map[string]any{"api_key": "sk-openai"},
+	}))
+
+	// A newapi row with no channel type cannot enter the bridge.
+	require.False(t, svc.newAPIBridgeOwnsAnthropicMessages(&Account{
+		ID:          61,
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: 0,
+		Credentials: map[string]any{"api_key": "sk-x", "base_url": "https://dashscope.aliyuncs.com"},
+	}))
+}
+
+// Defense in depth: even a newapi row that cannot enter the bridge (channel_type
+// unset, so ShouldDispatchToNewAPIBridge is false) must fail closed rather than
+// POST its foreign credential to the official OpenAI host.
+func TestChatCompletionsTargetFailsClosedForForeignCredential(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+
+	offBridge := &Account{
+		ID:          61,
+		Name:        "Qwen-no-channel-type",
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: 0,
+		Credentials: map[string]any{
+			"api_key":  "sk-dashscope-not-an-openai-key",
+			"base_url": "https://dashscope.aliyuncs.com",
+		},
+	}
+	_, err := svc.openAIChatCompletionsTargetURL(offBridge)
+	require.ErrorIs(t, err, ErrForeignCredentialOfficialOpenAIFallback,
+		"a foreign credential with no OpenAI-resolvable base must not fall back to api.openai.com")
+
+	// An OpenAI api-key account still resolves the official host as before.
+	official := &Account{
+		ID:          76,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Credentials: map[string]any{"api_key": "sk-openai"},
+	}
+	targetURL, err := svc.openAIChatCompletionsTargetURL(official)
+	require.NoError(t, err)
+	require.Contains(t, targetURL, "api.openai.com")
+}

--- a/backend/internal/service/openai_official_upstream_tk.go
+++ b/backend/internal/service/openai_official_upstream_tk.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 )
@@ -65,4 +66,20 @@ func IsOfficialOpenAIAPIKeyHelpText(statusCode int, body []byte) bool {
 func IsForeignCredentialOfficialOpenAIReject(account *Account, statusCode int, body []byte) bool {
 	return !AccountUsesOfficialOpenAIUpstream(account) &&
 		IsOfficialOpenAIAPIKeyHelpText(statusCode, body)
+}
+
+// ErrForeignCredentialOfficialOpenAIFallback is returned instead of silently
+// defaulting an unresolved upstream to api.openai.com. The native
+// OpenAI-compatible forwarders resolve their base URL from OpenAI-family
+// accessors, which return "" for foreign platforms (newapi channels, ...);
+// turning that "" into the official host POSTs a DashScope/Ark key to OpenAI
+// and yields "Incorrect API key provided" — a routing defect that also looks
+// like a dead credential. Fail closed instead.
+var ErrForeignCredentialOfficialOpenAIFallback = errors.New(
+	"refusing to send foreign account credential to api.openai.com: account has no resolved base_url")
+
+// OfficialOpenAIFallbackAllowed reports whether an unresolved (empty) base URL
+// may fall back to the official OpenAI host for this account.
+func OfficialOpenAIFallbackAllowed(account *Account) bool {
+	return AccountUsesOfficialOpenAIUpstream(account)
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1138,6 +1138,9 @@
       "path": "backend/internal/service/openai_gateway_messages_tk.go",
       "must_contain": [
         "func (s *OpenAIGatewayService) tkTryRouteForwardAsAnthropic(",
+        "func (s *OpenAIGatewayService) newAPIBridgeOwnsAnthropicMessages(",
+        "if s.newAPIBridgeOwnsAnthropicMessages(account) {",
+        "s.ForwardAsAnthropicDispatched(ctx, c, account, body, \"\", defaultMappedModel)",
         "ShouldUseNativeAnthropicMessagesAPI",
         "if shouldForwardNativeAnthropicMessagesForModel(body)",
         "forwardAnthropicViaNativeMessages",
@@ -1145,7 +1148,7 @@
         "IsOpenAITokenseaRelay() && shouldForwardNativeAnthropicMessagesForModel",
         "account.IsOpenAIOAuthLike() && promptCacheKey != \"\" && strings.TrimSpace(c.GetHeader(\"conversation_id\")) == \"\""
       ],
-      "rationale": "TK /v1/messages entry routing (tokensea native /v1/messages, CC fallback, CN providers) and OAuth prompt-cache conversation_id cleanup extracted to companion. OpenAI APIKey dual-stack relays (tokensea/cloudwise) branch to native /v1/messages passthrough for claude-* models; tokensea #92 must do this even when extra.openai_native_messages_supported is a false-negative (GPT probe timeout). Non-Claude models (MiniMax-M3, glm-5) must fall back to raw chat completions like /v1/responses."
+      "rationale": "TK /v1/messages entry routing (tokensea native /v1/messages, CC fallback, CN providers) and OAuth prompt-cache conversation_id cleanup extracted to companion. OpenAI APIKey dual-stack relays (tokensea/cloudwise) branch to native /v1/messages passthrough for claude-* models; tokensea #92 must do this even when extra.openai_native_messages_supported is a false-negative (GPT probe timeout). Non-Claude models (MiniMax-M3, glm-5) must fall back to raw chat completions like /v1/responses. The newAPIBridgeOwnsAnthropicMessages guard MUST stay the FIRST branch: inbound /v1/messages reaches ForwardAsAnthropic directly from the handler, so without it a bridge-eligible newapi account falls through the last predicate into the OpenAI-shaped CC fallback, whose base URL resolves to \"\" for platform=newapi and defaults to api.openai.com while still sending the real channel key (Qwen/Qwen-2/Qwen-4, 2026-08-24). Dropping it compiles clean and silently re-leaks the credential."
     },
     {
       "path": "backend/internal/service/openai_gateway_messages_native.go",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -802,10 +802,12 @@
         "func AccountShouldLocalEstimateCountTokens",
         "func IsOfficialOpenAIAPIKeyHelpText",
         "func IsForeignCredentialOfficialOpenAIReject",
+        "func OfficialOpenAIFallbackAllowed",
+        "ErrForeignCredentialOfficialOpenAIFallback",
         "isOfficialOpenAIModelsBaseURL",
         "platform.openai.com/account/api-keys"
       ],
-      "rationale": "Official OpenAI host decisions are a single owner. NewAPI channels, CN providers, CloudWise/tokensea, and any future platform default to foreign. Adding another vendor-specific 401 exception instead of this SSOT is the leak that permanently disabled Qwen #60/#72."
+      "rationale": "Official OpenAI host decisions are a single owner. NewAPI channels, CN providers, CloudWise/tokensea, and any future platform default to foreign. Adding another vendor-specific 401 exception instead of this SSOT is the leak that permanently disabled Qwen #60/#72. OfficialOpenAIFallbackAllowed / ErrForeignCredentialOfficialOpenAIFallback are the write side of the same SSOT: native forwarders must fail closed instead of defaulting an unresolved base_url to api.openai.com, which POSTs a DashScope/Ark key to OpenAI and returns the 'Incorrect API key provided' shape this file already classifies as a routing defect (Qwen/Qwen-2/Qwen-4, 2026-08-24)."
     },
     {
       "path": "backend/internal/service/ratelimit_service.go",
@@ -814,6 +816,24 @@
         "foreign_credential_official_openai_reject_skip_penalty"
       ],
       "rationale": "HandleUpstreamError must consult the official-OpenAI-host SSOT before generic 401 handling. Removing this call silently restores SetError plus the false permanent-auth Feishu alert even if the classifier file still compiles."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_cc_pipeline.go",
+      "must_contain": [
+        "if !OfficialOpenAIFallbackAllowed(account) {",
+        "return \"\", ErrForeignCredentialOfficialOpenAIFallback"
+      ],
+      "rationale": "openAIChatCompletionsTargetURL is the shared target resolver for both CC fallback paths (/v1/messages and /v1/responses). nativeOpenAIBaseURLForAccount returns \"\" for platform=newapi, so without this fail-closed guard the empty base defaults to https://api.openai.com while the same function still sends GetOpenAIProtocolAPIKey() — the real DashScope/Ark channel key. That is exactly how Qwen/Qwen-2/Qwen-4 returned upstream 'Incorrect API key provided' (2026-08-24). Restoring the bare api.openai.com default compiles clean and silently re-leaks foreign credentials to OpenAI."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_messages_tk_newapi_leak_test.go",
+      "must_contain": [
+        "TestNewAPIBridgeOwnsAnthropicMessagesForQwen",
+        "TestChatCompletionsTargetFailsClosedForForeignCredential",
+        "TestNewAPIQwenCredentialIsWireBoundOnNativePath",
+        "ErrForeignCredentialOfficialOpenAIFallback"
+      ],
+      "rationale": "Behavior regressions for the Qwen credential-leak fix: inbound /v1/messages for a bridge-eligible newapi account is owned by the NewAPI adaptor (not an OpenAI-shaped fallback), a foreign credential with no OpenAI-resolvable base fails closed instead of reaching api.openai.com, and an OpenAI api-key account still resolves the official host. Deleting these tests would let an upstream merge restore either leak with a green build."
     }
   ]
 }


### PR DESCRIPTION
## 问题

Qwen / Qwen-2 / Qwen-4（newapi 平台，`channel_type=17` DashScope）返回 `Incorrect API key provided`。

根因是**路由缺陷，不是凭据失效**：账号真实的 DashScope key 被发到了 `api.openai.com`，所以上游回的是 OpenAI 的帮助文案。

## 证据链

1. `internal/handler/openai_gateway_handler.go:1208` 入站 `/v1/messages` 直接调 `ForwardAsAnthropic`，绕过 bridge 分发器。`ForwardAsAnthropicDispatched`（`openai_gateway_bridge_dispatch_tk_anthropic.go:28`）本就是为此而写，但**全仓零调用者**，是未接线的死代码。
2. 于是 newapi 账号落到 `openai_gateway_messages_tk.go` 最后一个判据（`Type == api_key && !IsCNProvider() && 未探测 Responses 支持`），进入 `forwardAnthropicViaRawChatCompletions`。
3. 该路径解析上游：`openai_gateway_cc_pipeline.go:140-143` 经 `nativeOpenAIBaseURLForAccount()` → `GetOpenAIBaseURL()`，后者对 `platform=newapi` 返回 `""`（既非 `IsOpenAI()` 也非 `IsCNProvider()`），空值被兜底成 `https://api.openai.com`。
4. 同一函数 `:155` 却用 `GetOpenAIProtocolAPIKey()` 取到**真实 DashScope key**（该方法对 newapi 显式返回 `credentials.api_key`）。真 key + 错域名 = OpenAI 401。

仓库里 `IsForeignCredentialOfficialOpenAIReject`（`openai_official_upstream_tk.go:65`）早已把这个响应形状定义为「网关路由缺陷，而非凭据失效」——它描述的正是本 bug，只是之前没堵住产生它的路径。

已证伪的假设（非病因）：凭据合并清空 key（`MergePreservingSensitiveCreds` 保留敏感键）；脱敏掩码被写回（`RedactCredentials` 整键剔除，无掩码）；header override 篡改认证头（newapi 不在 `IsHeaderOverrideEligible` 白名单）；bridge kill switch 关闭（默认开启）；前端把 `channel_type` 置 0（两处提交路径都守卫 `> 0`）。

## 改动

- **主修** `openai_gateway_messages_tk.go`：新增 `newAPIBridgeOwnsAnthropicMessages()`，在 `tkTryRouteForwardAsAnthropic` 最前把 bridge-eligible 的 newapi 账号交给 `ForwardAsAnthropicDispatched`，由 adaptor 读账号自己的 channel base URL 与 key。无递归风险：仅当 `ShouldDispatchToNewAPIBridge` 已为 true 时进入，dispatched 侧必走 bridge 分支。
- **兜底** `openai_official_upstream_tk.go` + `openai_gateway_cc_pipeline.go`：新增 `OfficialOpenAIFallbackAllowed()` 与 `ErrForeignCredentialOfficialOpenAIFallback`，base URL 解析不出时对非官方账号 **fail closed**，不再静默兜底到官方域。

沿用既有 SSOT：官方 host 判定仍由 `AccountUsesOfficialOpenAIUpstream` 单一 owner 负责，未新增第二套平台清单。无删除 upstream 符号。

## 测试

新增 `openai_gateway_messages_tk_newapi_leak_test.go`：覆盖三个账号名、OpenAI 账号不回归、以及无 `channel_type` 时的 fail-closed 分支。**先写出失败测试**（首轮因 helper 不存在编译失败）再实现。

中途一次试探是直接改 `nativeOpenAIBaseURLForAccount` 返回 newapi 自己的 base_url，被现有测试否掉：`AccountShouldLocalEstimateCountTokens` 依赖它返回 `""` 判定「无原生 input_tokens 端点」，那样会让 count_tokens 误以为 DashScope 有原生端点。已回退，改为在泄漏点收口。

- `go test -tags=unit ./...` → **exit 0，71 包全绿**（含此前因那次过宽改动而红的 `TestAccountShouldLocalEstimateCountTokens_DerivedForeignAccounts`、`TestForwardCountTokensAsAnthropic_NewAPIAliWithAPIKeyNeverHitsOfficialOpenAI`，现均通过）
- `golangci-lint run ./...` → **0 issues**（须在 CI 钉定的 go1.26.6 下跑；本机 go1.27.0 会让 v2.9.0 二进制 panic，与本改动无关）
- `./scripts/preflight.sh` → 通用层 PASS

## 未做 / 已知

- `test_tokenkey_not_behind_upstream_main` 失败，**与本 PR 无关**：它跑 `check-drift.sh` 比较 `origin/main` 与 `upstream/main`，不读任何 Go 文件；当前 TK fork 落后 upstream 8 个 commit，属独立的 upstream merge 任务（CLAUDE.md §5.y）。两条 FAIL 是同一测试被通用层与 sub2api 层各跑一次。
- 未读取线上三个账号的实际配置（未碰生产凭据）。修复不依赖它——路由缺陷已在代码层闭合。


## Web 面影响：no-web-impact

本 PR 改动集：后端 Go（3 个 service 文件 + 1 个新测试）与 2 个 sentinel registry。**无** frontend / OpenAPI / 契约 / config / migration 变更，未改动任何 API 形状、请求字段或响应字段，无需 Web 侧对齐。

对客户端唯一可见的差异是行为修正本身：原先 newapi Qwen 账号的 `/v1/messages` 会返回上游 401 `Incorrect API key provided`，现在正常经 NewAPI adaptor 转发。没有新增需要前端呈现或配置的开关、字段与状态。


<!-- gate: re-evaluate PR body -->
