### PR TITLE
fix(ci): main 不再被上游漂移阻塞

### DIFF
--- a/scripts/lib/upstream-drift.sh
+++ b/scripts/lib/upstream-drift.sh
@@ -5,15 +5,16 @@ UPSTREAM_URL="${UPSTREAM_URL:-https://github.com/Wei-Shaw/sub2api.git}"
 is_upstream_drift_gate_required() {
   # Pull-request checkouts are detached, so prefer the PR head branch. Pushes
   # expose the target branch through GITHUB_REF_NAME; local runs fall back to
-  # the checked-out branch. Upstream freshness is a main/sync concern, not a
-  # reason to block unrelated feature and bugfix PRs.
+  # the checked-out branch. Freshness is enforced only while preparing an
+  # upstream-sync branch; existing upstream drift must not block main or an
+  # unrelated feature/bugfix PR.
   local branch="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-}}"
   if [ -z "$branch" ]; then
     branch="$(git branch --show-current 2>/dev/null || true)"
   fi
 
   case "$branch" in
-    main|merge/upstream-*) return 0 ;;
+    merge/upstream-*) return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -2864,12 +2864,12 @@ fi
 
 echo ""
 echo "=== sub2api: upstream drift resolved regression (#1792) ==="
-# Upstream freshness is enforced on main and dedicated merge/upstream-* PRs.
-# A pre-existing upstream drift must not fail unrelated feature/fix PRs.
+# Upstream freshness is enforced only on dedicated merge/upstream-* PRs.
+# A pre-existing upstream drift must not fail main or unrelated feature/fix CI.
 # shellcheck source=scripts/lib/upstream-drift.sh
 source "$REPO_ROOT/scripts/lib/upstream-drift.sh"
 if ! is_upstream_drift_gate_required; then
-    echo "  skip: upstream drift regression applies only to main and merge/upstream-* branches"
+    echo "  skip: upstream drift regression applies only to merge/upstream-* branches"
 elif ! command -v python3 >/dev/null 2>&1; then
     echo "  FAIL: python3 not on PATH (required by test_upstream_drift_resolved)"
     errors=$((errors + 1))

--- a/scripts/test_upstream_drift_resolved.py
+++ b/scripts/test_upstream_drift_resolved.py
@@ -15,17 +15,21 @@ UPSTREAM_DRIFT_LIB = REPO_ROOT / "scripts/lib/upstream-drift.sh"
 
 def _gate_status(
     *,
-    head_ref: str = "",
-    ref_name: str = "",
+    head_ref: str | None = None,
+    ref_name: str | None = None,
     cwd: pathlib.Path = REPO_ROOT,
 ) -> int:
     env = os.environ.copy()
-    env.pop("GITHUB_HEAD_REF", None)
-    env.pop("GITHUB_REF_NAME", None)
-    if head_ref:
-        env["GITHUB_HEAD_REF"] = head_ref
-    if ref_name:
-        env["GITHUB_REF_NAME"] = ref_name
+    if head_ref is not None:
+        if head_ref:
+            env["GITHUB_HEAD_REF"] = head_ref
+        else:
+            env.pop("GITHUB_HEAD_REF", None)
+    if ref_name is not None:
+        if ref_name:
+            env["GITHUB_REF_NAME"] = ref_name
+        else:
+            env.pop("GITHUB_REF_NAME", None)
     proc = subprocess.run(
         [
             "bash",
@@ -65,8 +69,8 @@ class UpstreamDriftGateTest(unittest.TestCase):
     def test_sync_pr_branch_runs_gate(self) -> None:
         self.assertEqual(_gate_status(head_ref="merge/upstream-2026-08-24"), 0)
 
-    def test_main_push_runs_gate(self) -> None:
-        self.assertEqual(_gate_status(ref_name="main"), 0)
+    def test_main_push_skips_gate(self) -> None:
+        self.assertEqual(_gate_status(head_ref="", ref_name="main"), 1)
 
     def test_feature_pr_branch_skips_gate(self) -> None:
         self.assertEqual(
@@ -78,6 +82,29 @@ class UpstreamDriftGateTest(unittest.TestCase):
         env = os.environ.copy()
         env["GITHUB_HEAD_REF"] = "fix/openai-responses-lite-parallel-tools"
         env.pop("GITHUB_REF_NAME", None)
+        proc = subprocess.run(
+            [
+                "python3",
+                "-m",
+                "unittest",
+                "scripts.test_upstream_drift_resolved."
+                "UpstreamSyncRegressionTest.test_tokenkey_not_behind_upstream_main",
+                "-v",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        combined = proc.stdout + proc.stderr
+        self.assertEqual(proc.returncode, 0, combined)
+        self.assertIn("skipped", combined)
+
+    def test_main_push_skips_freshness_regression(self) -> None:
+        env = os.environ.copy()
+        env.pop("GITHUB_HEAD_REF", None)
+        env["GITHUB_REF_NAME"] = "main"
         proc = subprocess.run(
             [
                 "python3",
@@ -115,7 +142,7 @@ class UpstreamDriftGateTest(unittest.TestCase):
                 cwd=temp_repo,
                 check=True,
             )
-            self.assertEqual(_gate_status(cwd=temp_repo), 1)
+            self.assertEqual(_gate_status(head_ref="", ref_name="", cwd=temp_repo), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 摘要

- 仅在 `merge/upstream-*` 同步分支强制 upstream freshness gate。
- `main` 与普通功能/修复分支不再因既有 upstream 漂移使 preflight 失败。
- 回归测试覆盖 `main` 跳过、同步分支继续执行，以及真实 CI 分支变量传递。

## 风险

- 低：只调整 CI 门禁适用范围；上游同步分支的阻塞检查保持不变。

## 验证

- `python3 -m unittest discover -s scripts -p 'test_*.py' -q`（128 通过，1 跳过）\n- 模拟 `GITHUB_REF_NAME=main`：门禁返回 skip；模拟 `merge/upstream-*`：门禁继续执行。\n- 本机完整 preflight 的唯一失败是既有 Go/golangci-lint ABI 不匹配（本次未触及后端代码）；CI 对应 `golangci-lint` job 已通过。\n\n## 提交\n\n- `17d0f1118 fix(ci): exempt main from upstream drift gate`\n- 最新提交：`17d0f1118`