### PR TITLE
fix(ops): 5xx 错误风暴阻断发布后检查

### DIFF
--- a/scripts/release_post_check.py
+++ b/scripts/release_post_check.py
@@ -323,14 +323,24 @@ def evaluate(
         )
 
     status_5xx = tick.get("status_5xx") or {}
+    status_5xx_total = sum(int(count or 0) for count in status_5xx.values())
+    status_5xx_verdict = (
+        "fail" if status_5xx_total >= ERROR_STORM_THRESHOLD else "observe"
+    )
     results.append(
         {
             "id": "status-5xx",
             "source": "baseline",
-            "verdict": "observe",
-            "observed": {"status_5xx": status_5xx},
+            "verdict": status_5xx_verdict,
+            "observed": {
+                "status_5xx": status_5xx,
+                "total": status_5xx_total,
+                "storm_threshold": ERROR_STORM_THRESHOLD,
+            },
         }
     )
+    if status_5xx_verdict == "fail":
+        bump("red")
 
     failover_count = int(hooks.get(FAILOVER_LOG) or 0)
     for item in plan.get("checks") or []:

--- a/scripts/test_release_post_check.py
+++ b/scripts/test_release_post_check.py
@@ -247,7 +247,7 @@ class ReleasePostCheckEvaluateTest(unittest.TestCase):
         by_id = {c["id"]: c for c in result["checks"]}
         self.assertEqual(by_id["pr-1780-Status=424"]["verdict"], "fail")
 
-    def test_evaluate_observe_weekly_limit_does_not_redden(self) -> None:
+    def test_evaluate_observe_weekly_limit_and_sparse_5xx_do_not_redden(self) -> None:
         tick = {
             "hooks": {"WEEKLY_LIMIT_EXCEEDED": 12, "Status=424": 0, "NEW_LIMIT_CODE": 0},
             "panic": 0,
@@ -259,6 +259,36 @@ class ReleasePostCheckEvaluateTest(unittest.TestCase):
         by_id = {c["id"]: c for c in result["checks"]}
         self.assertEqual(by_id["pr-1781-WEEKLY_LIMIT_EXCEEDED"]["verdict"], "observe")
         self.assertEqual(by_id["status-5xx"]["verdict"], "observe")
+        self.assertEqual(by_id["status-5xx"]["observed"]["total"], 2)
+
+    def test_evaluate_red_on_5xx_storm_seen_in_v1_8_171_release(self) -> None:
+        tick = {
+            "hooks": {},
+            "panic": 0,
+            "status_5xx": {"502": 21},
+            "completed_total": 125,
+        }
+        result = rpc.evaluate(self._plan(), tick, control_plane_ok=True)
+        self.assertEqual(result["verdict"], "red")
+        by_id = {c["id"]: c for c in result["checks"]}
+        self.assertEqual(by_id["status-5xx"]["verdict"], "fail")
+        self.assertEqual(by_id["status-5xx"]["observed"]["total"], 21)
+        self.assertEqual(
+            by_id["status-5xx"]["observed"]["storm_threshold"],
+            rpc.ERROR_STORM_THRESHOLD,
+        )
+
+    def test_evaluate_5xx_storm_threshold_is_inclusive_across_statuses(self) -> None:
+        tick = {
+            "hooks": {},
+            "panic": 0,
+            "status_5xx": {"500": 9, "502": 10, "503": 1},
+            "completed_total": 40,
+        }
+        result = rpc.evaluate(self._plan(), tick, control_plane_ok=True)
+        self.assertEqual(result["verdict"], "red")
+        by_id = {c["id"]: c for c in result["checks"]}
+        self.assertEqual(by_id["status-5xx"]["observed"]["total"], 20)
 
     def test_evaluate_red_on_added_error_ctor_storm(self) -> None:
         tick = {
@@ -270,7 +300,7 @@ class ReleasePostCheckEvaluateTest(unittest.TestCase):
         result = rpc.evaluate(self._plan(), tick, control_plane_ok=True)
         self.assertEqual(result["verdict"], "red")
 
-    def test_evaluate_red_on_panic_or_control_plane_not_ambient_5xx(self) -> None:
+    def test_evaluate_red_on_panic_or_control_plane_not_sparse_5xx(self) -> None:
         tick = {"hooks": {}, "panic": 1, "status_5xx": {}, "completed_total": 1}
         self.assertEqual(rpc.evaluate(self._plan(), tick, control_plane_ok=True)["verdict"], "red")
         tick = {"hooks": {}, "panic": 0, "status_5xx": {"500": 2}, "completed_total": 1}


### PR DESCRIPTION
## 摘要

- 审计 1.8.171 上线后的 prod 与全部 deployable edge 错误日志，并用 prod 蓝绿切换精确窗口 `2026-08-24T01:02:38Z..02:09:05Z` 复核最终错误。
- prod 窗口内的确定性回归为 newapi 认证路由 502（121 次）与 Responses Lite `parallel_tool_calls` 400（19 次），已分别由 #1800、#1799 修复；其余 edge 错误归类为上游配额、内容过滤、客户端取消或瞬时网络事件。
- 修复 +5 分钟发布检查漏报：累计 5xx 达到既有错误风暴阈值 20 时返回 red；稀疏 5xx 继续仅观察。1.8.171 实际 tick 为 125 个请求、21 个 502，修复后会从 green 改判 red。

## 风险

- 低。只调整发布后只读评估器，不修改网关请求路径、线上配置或部署流程。
- 阈值复用现有 `ERROR_STORM_THRESHOLD=20`，避免单次上游波动阻塞发布；不同 5xx 状态会合并计数。

## 验证

- `python3 scripts/test_release_post_check.py`（18 tests）
- 1.8.171 tick 回放：`status_5xx={502:21}` 返回 `rc=1`、`verdict=red`
- `GOTOOLCHAIN=go1.26.6 ./scripts/preflight.sh`
- `GOTOOLCHAIN=go1.26.6 make test`（backend unit、golangci-lint、frontend lint/typecheck、180 Vitest）

## 提交

- `d81a1fd8a fix(ops): fail post-release check on 5xx storms`

ai
