### PR TITLE
fix(openai): recover relay HTTP continuation mismatch

### DIFF
--- a/backend/internal/service/openai_compat_model_test.go
+++ b/backend/internal/service/openai_compat_model_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -946,63 +947,80 @@ func TestForwardAsAnthropic_OAuthDisablesContinuationAfterPreviousResponseNotFou
 	require.False(t, gjson.GetBytes(upstream.bodies[2], "previous_response_id").Exists())
 }
 
-func TestForwardAsAnthropic_DisablesAPIKeyContinuationWhenUpstreamRequiresWebSocketV2(t *testing.T) {
+func TestForwardAsAnthropic_DisablesAPIKeyContinuationWhenUpstreamRejectsHTTPContinuation(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
 
-	upstream := &httpUpstreamRecorder{}
-	svc := &OpenAIGatewayService{
-		httpUpstream: upstream,
-		cfg:          &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
-	}
-	account := &Account{
-		ID:          1,
-		Name:        "openai-apikey",
-		Platform:    PlatformOpenAI,
-		Type:        AccountTypeAPIKey,
-		Concurrency: 1,
-		Credentials: map[string]any{
-			"api_key":  "sk-test",
-			"base_url": "https://api.openai.com/v1",
-		},
-	}
-
-	svc.bindOpenAICompatSessionResponseID(context.Background(), nil, account, "stable-cache-key", "resp_http_unsupported")
-	body := []byte(`{"model":"claude-sonnet-4-5","max_tokens":16,"messages":[{"role":"user","content":"first"},{"role":"assistant","content":"ok"},{"role":"user","content":"second"}],"stream":false}`)
-	upstream.responses = []*http.Response{
+	for _, tc := range []struct {
+		name    string
+		message string
+	}{
 		{
-			StatusCode: http.StatusBadRequest,
-			Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid_prev_http_unsupported"}},
-			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"previous_response_id is only supported on Responses WebSocket v2","type":"invalid_request_error"}}`)),
+			name:    "websocket only upstream",
+			message: "previous_response_id is only supported on Responses WebSocket v2",
 		},
-		openAICompatSSECompletedResponse("resp_replayed", "gpt-5.5"),
-		openAICompatSSECompletedResponse("resp_later", "gpt-5.5"),
+		{
+			name:    "oauth edge behind api key relay",
+			message: "previous_response_id requires an OpenAI API-key account for HTTP requests",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream := &httpUpstreamRecorder{}
+			svc := &OpenAIGatewayService{
+				httpUpstream: upstream,
+				cfg:          &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
+			}
+			account := &Account{
+				ID:          1,
+				Name:        "openai-apikey",
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Concurrency: 1,
+				Credentials: map[string]any{
+					"api_key":  "sk-test",
+					"base_url": "https://api.openai.com/v1",
+				},
+			}
+
+			svc.bindOpenAICompatSessionResponseID(context.Background(), nil, account, "stable-cache-key", "resp_http_unsupported")
+			body := []byte(`{"model":"claude-sonnet-4-5","max_tokens":16,"messages":[{"role":"user","content":"first"},{"role":"assistant","content":"ok"},{"role":"user","content":"second"}],"stream":false}`)
+			upstream.responses = []*http.Response{
+				{
+					StatusCode: http.StatusBadRequest,
+					Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid_prev_http_unsupported"}},
+					Body:       io.NopCloser(strings.NewReader(`{"error":{"message":` + strconv.Quote(tc.message) + `,"type":"invalid_request_error"}}`)),
+				},
+				openAICompatSSECompletedResponse("resp_replayed", "gpt-5.5"),
+				openAICompatSSECompletedResponse("resp_later", "gpt-5.5"),
+			}
+
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "stable-cache-key", "gpt-5.5")
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, "resp_replayed", result.ResponseID)
+			require.Len(t, upstream.requests, 2)
+			require.Equal(t, "resp_http_unsupported", gjson.GetBytes(upstream.bodies[0], "previous_response_id").String())
+			require.False(t, gjson.GetBytes(upstream.bodies[1], "previous_response_id").Exists())
+			require.Equal(t, int64(4), gjson.GetBytes(upstream.bodies[1], "input.#").Int())
+
+			laterRec := httptest.NewRecorder()
+			laterCtx, _ := gin.CreateTestContext(laterRec)
+			laterCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+			laterCtx.Request.Header.Set("Content-Type", "application/json")
+
+			laterResult, err := svc.ForwardAsAnthropic(context.Background(), laterCtx, account, body, "stable-cache-key", "gpt-5.5")
+			require.NoError(t, err)
+			require.NotNil(t, laterResult)
+			require.Equal(t, "resp_later", laterResult.ResponseID)
+			require.Len(t, upstream.requests, 3)
+			require.False(t, gjson.GetBytes(upstream.bodies[2], "previous_response_id").Exists())
+		})
 	}
-
-	rec := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(rec)
-	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
-	c.Request.Header.Set("Content-Type", "application/json")
-
-	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "stable-cache-key", "gpt-5.5")
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Equal(t, "resp_replayed", result.ResponseID)
-	require.Len(t, upstream.requests, 2)
-	require.Equal(t, "resp_http_unsupported", gjson.GetBytes(upstream.bodies[0], "previous_response_id").String())
-	require.False(t, gjson.GetBytes(upstream.bodies[1], "previous_response_id").Exists())
-
-	laterRec := httptest.NewRecorder()
-	laterCtx, _ := gin.CreateTestContext(laterRec)
-	laterCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
-	laterCtx.Request.Header.Set("Content-Type", "application/json")
-
-	laterResult, err := svc.ForwardAsAnthropic(context.Background(), laterCtx, account, body, "stable-cache-key", "gpt-5.5")
-	require.NoError(t, err)
-	require.NotNil(t, laterResult)
-	require.Equal(t, "resp_later", laterResult.ResponseID)
-	require.Len(t, upstream.requests, 3)
-	require.False(t, gjson.GetBytes(upstream.bodies[2], "previous_response_id").Exists())
 }
 
 func TestForwardAsAnthropic_APIKeyMetadataSessionSurvivesChangingCacheControlAnchorAfterContinuationDisabled(t *testing.T) {

--- a/backend/internal/service/openai_messages_continuation.go
+++ b/backend/internal/service/openai_messages_continuation.go
@@ -132,6 +132,7 @@ func isOpenAICompatPreviousResponseUnsupported(statusCode int, upstreamMsg strin
 		}
 		return strings.Contains(lower, "unsupported parameter") ||
 			strings.Contains(lower, "only supported on responses websocket") ||
+			strings.Contains(lower, "requires an openai api-key account") ||
 			strings.Contains(lower, "not supported")
 	}
 	if check(upstreamMsg) || check(string(upstreamBody)) {

--- a/scripts/sentinels/relay-invariants.json
+++ b/scripts/sentinels/relay-invariants.json
@@ -3,6 +3,13 @@
   "rationale": "Relay-invariant test registry. Each entry pins a load-bearing, TokenKey-DELIBERATE relay behavior to the characterization test(s) that encode it. PR #835 (80 upstream commits) showed the recurring failure class this guards: an upstream rewrite silently deletes a TK behavior (G4 5h-window cooldown class, kiro/grok refresh candidates) or overrides a deliberate TK choice (SSE stream-error 502→403) with no merge conflict, no compile error, and a green CI — because the only proof of the TK choice was a test that got deleted/gutted in the same merge. This registry makes that mechanically impossible: `must_contain` anchors each test's FUNCTION DEFINITION (`func TestX(`), so an upstream merge that removes or renames the test fails this check (run by scripts/preflight.sh AND .github/workflows/upstream-merge-pr-shape.yml). The schema is the standard sentinels/path/must_contain form (not a bespoke one) so check-registry-update-gate.py also treats these test files as covered surfaces — deleting a pinned test then additionally trips the registry-update gate. Adding a new load-bearing TK relay behavior MUST add its characterization test AND an entry here in the same commit. Conversely, if you intentionally retire a behavior, you must edit this registry in the same PR (which is the human-review checkpoint, not a rubber stamp).",
   "sentinels": [
     {
+      "path": "backend/internal/service/openai_compat_model_test.go",
+      "must_contain": [
+        "func TestForwardAsAnthropic_DisablesAPIKeyContinuationWhenUpstreamRejectsHTTPContinuation("
+      ],
+      "rationale": "OpenAI API-key relay HTTP continuation fallback. An API-key account can route through an OAuth-backed edge that rejects previous_response_id on HTTP; the gateway must replay full history once and disable continuation for the sticky window instead of returning repeated 400s. The characterization test pins both the exact relay error classification and the subsequent no-continuation behavior so an upstream rewrite cannot silently remove the recovery path together with its test."
+    },
+    {
       "path": "backend/internal/service/ratelimit_service_tk_model_cooldown_test.go",
       "must_contain": [
         "func TestG4_OverallWindow429_CoolsAccountNotModelClass(",


### PR DESCRIPTION
## 摘要

- 识别 OAuth edge 经 API-key relay 返回的 HTTP continuation unsupported 错误。
- 复用既有完整历史重放与 continuation disable 状态机，首次命中后移除 previous_response_id 重试，避免 Claude CLI 连续收到 400。
- 将该 load-bearing fallback 的回归测试登记到 relay-invariant registry，防止未来 upstream merge 静默移除行为与测试。

## 风险

- 变更仅扩展精确 400 错误分类并增加确定性测试锚点，不修改 API 路由、请求契约或其他 fallback 条件。
- Web impact: none

## 验证

- GOTOOLCHAIN=go1.26.6 PREFLIGHT_BASE=origin/main bash scripts/preflight.sh
- cd backend && GOTOOLCHAIN=go1.26.6 go test ./... -count=1
- cd backend && GOTOOLCHAIN=go1.26.6 make lint
- python3 scripts/sentinels/check-relay-invariants.py --json

## 提交

- 984aac907 fix(openai): recover relay HTTP continuation mismatch
- 336ad9de0 fix(review): address R-001 — anchor HTTP continuation fallback
- 最新提交：336ad9de0