### PR TITLE
fix(gateway): attribute buffered Anthropic SSE error events upstream

### DIFF
--- a/.testing/user-stories/index.md
+++ b/.testing/user-stories/index.md
@@ -45,3 +45,4 @@
 | US-044 | QA S3 Bundle 用户面与单一生命周期 owner | Done | `.testing/user-stories/stories/US-044-qa-lifecycle-single-owner-and-export-contract.md` |
 | US-045 | QA Phase 2 历史证据与 single-owner 迁移边界 | Done | `.testing/user-stories/stories/US-045-qa-phase2-production-integrity.md` |
 | US-046 | 默认 API Key 的诚实能力发现与统一菜单 | Done | `.testing/user-stories/stories/US-046-universal-key-capability-discovery.md` |
+| US-047 | Anthropic 缓冲流失败进入 failover，部分内容诚实标记截断 | InTest | `.testing/user-stories/stories/US-047-anthropic-buffered-stream-failure-contract.md` |

--- a/.testing/user-stories/stories/US-047-anthropic-buffered-stream-failure-contract.md
+++ b/.testing/user-stories/stories/US-047-anthropic-buffered-stream-failure-contract.md
@@ -1,0 +1,61 @@
+# US-047-anthropic-buffered-stream-failure-contract
+
+- ID: US-047
+- Title: Anthropic 缓冲流失败进入 failover，部分内容诚实标记截断
+- Priority: P0
+- As a / I want / So that: 作为 OpenAI-compatible API 调用方，我希望 Anthropic SSE 缓冲组装失败时得到可恢复且真实的结果，从而避免空 200、错误重试和重复计费。
+- Trace: `docs/approved/anthropic-buffered-stream-failure-contract.md`
+- Risk Focus:
+  - 逻辑错误：区分只有 `message_start`、已有可用 content block、完整终止三种状态。
+  - 行为回归：无内容失败走既有 failover；已有内容失败保留 HTTP 200。
+  - 安全问题：错误 detail 继续受 `log_upstream_error_body` 控制，账号身份只进入既有 Ops 结构。
+  - 运行时问题：覆盖 terminal error、未完整 EOF、scanner read error 和 native idle timeout。
+
+## Acceptance Criteria
+
+1. AC-001 (正向): Given 完整 Anthropic SSE When 缓冲组装完成 Then 返回正常 HTTP 200，且没有 upstream failure 标记。
+2. AC-002 (负向): Given 尚无 content block When 收到 terminal `error`、超时、读错误或未完整 EOF Then service 返回 `UpstreamFailoverError`，未提前写客户端响应。
+3. AC-003 (负向): Given 只有 `message_start` When 随后收到 `error` Then 不得返回空 HTTP 200。
+4. AC-004 (回归): Given 已有 content block When 随后失败 Then 保留部分 HTTP 200，不 failover，并以 `stream_truncated` 计入 SLA。
+5. AC-005 (契约): Given `not_found_error` 或 `request_too_large` When 最终对客 Then 分别使用 `not_found_error` 或 `request_too_large`，不得使用 `server_error`。
+6. AC-006 (可观测性): Given 任一 buffered upstream failure When 记录 Ops event Then event 包含 platform、account ID 和 account name。
+
+## Assertions
+
+- 返回错误可通过 `errors.As(err, *UpstreamFailoverError)` 识别。
+- failover error 的 `ClientStatusCode`、`ClientErrorType`、`ClientMessage` 固定最终对客契约。
+- 部分内容路径 `GetOpsStreamErrors` 只有一个 `CountTowardsSLA=true` 的标记。
+- 完整路径没有 `OpsUpstreamErrorsKey` 和 stream failure。
+
+## Linked Tests
+
+- `backend/internal/service/gateway_anthropic_buffered_error_tk_test.go`::`TestUS047_MessageStartThenErrorReturnsFailover`
+- `backend/internal/service/gateway_anthropic_buffered_error_tk_test.go`::`TestUS047_PartialContentThenErrorPreservesResponse`
+- `backend/internal/service/gateway_anthropic_buffered_error_tk_test.go`::`TestUS047_IncompleteEOFRoutesByContentAvailability`
+- `backend/internal/service/gateway_anthropic_buffered_error_tk_test.go`::`TestUS047_ScannerReadErrorRoutesByContentAvailability`
+- `backend/internal/service/gateway_anthropic_buffered_error_tk_test.go`::`TestUS047_CompletionBeforeReadErrorRemainsSuccessful`
+- `backend/internal/service/openai_gateway_anthropic_native_pump_test.go`::`TestUS047_NativeBufferedIdleRoutesByContentAvailability`
+- `backend/internal/service/gateway_anthropic_buffered_error_tk_test.go`::`TestUS047_ClientErrorTypeMapping`
+- `backend/internal/handler/gateway_anthropic_buffered_failover_tk_test.go`::`TestUS047_GatewayFailoverExhaustedPreservesClientErrorType`
+- `backend/internal/handler/gateway_anthropic_buffered_failover_tk_test.go`::`TestUS047_ResponsesFailoverExhaustedPreservesClientErrorType`
+- `backend/internal/handler/gateway_anthropic_buffered_failover_tk_test.go`::`TestUS047_OpenAIFailoverExhaustedPreservesClientErrorType`
+- `backend/internal/handler/gateway_anthropic_buffered_failover_tk_test.go`::`TestUS047_EmptyClientErrorTypeKeepsLegacyDefaults`
+- Run:
+
+```bash
+cd backend && GOTOOLCHAIN=go1.26.6 go test -tags=unit ./internal/service -run 'TestUS047_' -count=1
+cd backend && GOTOOLCHAIN=go1.26.6 go test -tags=unit ./internal/handler -run 'TestUS047_' -count=1
+cd backend && GOTOOLCHAIN=go1.26.6 go test -tags=unit ./internal/service -count=1
+python3 scripts/sentinels/check-gateway-tk.py
+```
+
+## Evidence
+
+- `TestUS047_` service tests: PASS (`ok github.com/Wei-Shaw/sub2api/internal/service 3.211s`).
+- `TestUS047_` handler tests: PASS (`ok github.com/Wei-Shaw/sub2api/internal/handler 1.161s`).
+- Full `internal/service` unit package: PASS.
+- Gateway TK sentinel registry: PASS (`742/742 intact`).
+
+## Status
+
+- [x] Done

--- a/backend/internal/handler/gateway_anthropic_buffered_failover_tk_test.go
+++ b/backend/internal/handler/gateway_anthropic_buffered_failover_tk_test.go
@@ -1,0 +1,102 @@
+//go:build unit
+
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestUS047_GatewayFailoverExhaustedPreservesClientErrorType(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	(&GatewayHandler{}).handleFailoverExhausted(c, &service.UpstreamFailoverError{
+		StatusCode:       http.StatusOK,
+		ResponseBody:     []byte(`{"type":"error","error":{"type":"not_found_error","message":"model not found"}}`),
+		ClientStatusCode: http.StatusNotFound,
+		ClientErrorType:  "not_found_error",
+		ClientMessage:    "model not found",
+	}, service.PlatformAnthropic, false)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Equal(t, "not_found_error", gjson.GetBytes(rec.Body.Bytes(), "error.type").String())
+	require.Equal(t, "model not found", gjson.GetBytes(rec.Body.Bytes(), "error.message").String())
+}
+
+func TestUS047_ResponsesFailoverExhaustedPreservesClientErrorType(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	(&GatewayHandler{}).handleResponsesFailoverExhausted(c, &service.UpstreamFailoverError{
+		StatusCode:       http.StatusOK,
+		ClientStatusCode: http.StatusRequestEntityTooLarge,
+		ClientErrorType:  "request_too_large",
+		ClientMessage:    "request is too large",
+	}, false)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	require.Equal(t, "request_too_large", gjson.GetBytes(rec.Body.Bytes(), "error.code").String())
+	require.Equal(t, "request is too large", gjson.GetBytes(rec.Body.Bytes(), "error.message").String())
+}
+
+func TestUS047_OpenAIFailoverExhaustedPreservesClientErrorType(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	(&OpenAIGatewayHandler{}).handleFailoverExhausted(c, &service.UpstreamFailoverError{
+		StatusCode:       http.StatusOK,
+		ResponseBody:     []byte(`{"type":"error","error":{"type":"not_found_error","message":"model not found"}}`),
+		ClientStatusCode: http.StatusNotFound,
+		ClientErrorType:  "not_found_error",
+		ClientMessage:    "model not found",
+	}, false)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Equal(t, "not_found_error", gjson.GetBytes(rec.Body.Bytes(), "error.type").String())
+	require.Equal(t, "model not found", gjson.GetBytes(rec.Body.Bytes(), "error.message").String())
+}
+
+func TestUS047_EmptyClientErrorTypeKeepsLegacyDefaults(t *testing.T) {
+	t.Run("messages", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+		(&GatewayHandler{}).handleFailoverExhausted(c, &service.UpstreamFailoverError{
+			StatusCode:       http.StatusServiceUnavailable,
+			ClientStatusCode: http.StatusBadRequest,
+			ClientMessage:    "legacy client error",
+		}, service.PlatformAnthropic, false)
+
+		require.Equal(t, "api_error", gjson.GetBytes(rec.Body.Bytes(), "error.type").String())
+	})
+
+	t.Run("responses", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+		(&GatewayHandler{}).handleResponsesFailoverExhausted(c, &service.UpstreamFailoverError{
+			StatusCode:       http.StatusServiceUnavailable,
+			ClientStatusCode: http.StatusBadRequest,
+			ClientMessage:    "legacy client error",
+		}, false)
+
+		require.Equal(t, "server_error", gjson.GetBytes(rec.Body.Bytes(), "error.code").String())
+	})
+}

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -1962,7 +1962,11 @@ func (h *GatewayHandler) handleFailoverExhausted(c *gin.Context, failoverErr *se
 		if message == "" {
 			message = service.GatewayFailoverClientMessage(failoverErr.ClientStatusCode)
 		}
-		h.handleStreamingAwareError(c, failoverErr.ClientStatusCode, "api_error", message, streamStarted)
+		errType := strings.TrimSpace(failoverErr.ClientErrorType)
+		if errType == "" {
+			errType = "api_error"
+		}
+		h.handleStreamingAwareError(c, failoverErr.ClientStatusCode, errType, message, streamStarted)
 		return
 	}
 

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -429,6 +429,9 @@ func (h *GatewayHandler) handleResponsesFailoverExhausted(c *gin.Context, lastEr
 	if lastErr != nil && lastErr.ClientStatusCode > 0 {
 		statusCode = lastErr.ClientStatusCode
 		status = statusCode
+		if clientErrorType := strings.TrimSpace(lastErr.ClientErrorType); clientErrorType != "" {
+			code = clientErrorType
+		}
 		if lastErr.ClientMessage != "" {
 			message = lastErr.ClientMessage
 		}

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -2673,6 +2673,22 @@ func (h *OpenAIGatewayHandler) handleFailoverExhausted(c *gin.Context, failoverE
 		h.handleStreamingAwareError(c, http.StatusBadGateway, "upstream_error", service.OpenAISilentRefusalClientMessage(), streamStarted)
 		return
 	}
+	if failoverErr.ClientStatusCode > 0 && strings.TrimSpace(failoverErr.ClientErrorType) != "" {
+		upstreamMsg := service.ExtractUpstreamErrorMessage(responseBody)
+		service.SetOpsUpstreamError(c, statusCode, upstreamMsg, "")
+		message := strings.TrimSpace(failoverErr.ClientMessage)
+		if message == "" {
+			message = service.GatewayFailoverClientMessage(failoverErr.ClientStatusCode)
+		}
+		h.handleStreamingAwareError(
+			c,
+			failoverErr.ClientStatusCode,
+			strings.TrimSpace(failoverErr.ClientErrorType),
+			message,
+			streamStarted,
+		)
+		return
+	}
 
 	// 先检查透传规则
 	if h.errorPassthroughService != nil && len(responseBody) > 0 {

--- a/backend/internal/handler/ops_error_logger_tk_buffered_upstream_test.go
+++ b/backend/internal/handler/ops_error_logger_tk_buffered_upstream_test.go
@@ -1,0 +1,85 @@
+package handler
+
+// TK regression: the buffered Anthropic assembly paths now record upstream
+// context when a 200 SSE stream yields a terminal `error` event (or no events at
+// all) instead of a message. This test pins the classification consequence —
+// the reason that bug mattered — so a future refactor that drops the
+// setOpsUpstreamError call is caught here rather than in prod SLA numbers.
+//
+// Prod evidence (2026-08-24): 124 rows of status 502 /
+// error_message="Upstream stream ended without a response" landed as
+// error_phase=internal / error_owner=platform / error_source=gateway, booking an
+// upstream fault against the gateway.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyOpsBufferedAnthropicUpstreamErrorIsProviderOwned(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name           string
+		upstreamStatus int
+		message        string
+	}{
+		{
+			name:           "terminal rate_limit_error event",
+			upstreamStatus: http.StatusTooManyRequests,
+			message:        "Number of concurrent connections exceeded",
+		},
+		{
+			name:           "terminal overloaded_error event",
+			upstreamStatus: 529,
+			message:        "Overloaded",
+		},
+		{
+			// The empty-stream case: no error event, synthesized 502.
+			name:           "stream ended with no usable events",
+			upstreamStatus: http.StatusBadGateway,
+			message:        "Upstream stream ended without a response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+
+			// What tkAnthropicBufferedFailure records on the request context.
+			service.SetOpsUpstreamError(c, tt.upstreamStatus, tt.message, "")
+
+			phase, isBusinessLimited, owner, source := classifyOpsErrorLog(
+				c, "api_error", tt.message, "", http.StatusBadGateway,
+			)
+
+			require.Equal(t, "upstream", phase)
+			require.Equal(t, "provider", owner)
+			require.Equal(t, "upstream_http", source)
+			require.False(t, isBusinessLimited)
+		})
+	}
+}
+
+// Without upstream context the same shape still classifies as a gateway-internal
+// fault. This is the pre-fix behavior, kept as the contrast case so the test
+// above is provably about the recorded context and not about the message text.
+func TestClassifyOpsBufferedAnthropicWithoutUpstreamContextStaysInternal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	phase, _, owner, source := classifyOpsErrorLog(
+		c, "api_error", "Upstream stream ended without a response", "", http.StatusBadGateway,
+	)
+
+	require.Equal(t, "internal", phase)
+	require.Equal(t, "platform", owner)
+	require.Equal(t, "gateway", source)
+}

--- a/backend/internal/service/gateway_anthropic_buffered_error_tk.go
+++ b/backend/internal/service/gateway_anthropic_buffered_error_tk.go
@@ -1,75 +1,43 @@
 package service
 
-// TK: single owner for "buffered Anthropic SSE assembly hit a terminal error".
+// TK: single owner for buffered Anthropic SSE terminal failures.
 //
-// The four buffered assembly loops (Anthropic platform CC/Responses and CN
-// native-Anthropic CC/Responses) all reduce an upstream SSE stream to one
-// *apicompat.AnthropicResponse. apicompat.AnthropicStreamEvent models only
-// message_start / message_delta / content_block_*, so a terminal Anthropic
-// `error` event unmarshals into a bare Type=="error" and is then skipped by
-// every branch. Two outcomes follow, and both used to be misreported:
-//
-//  1. No message at all — finalResp stays nil and the loop falls through to a
-//     generic 502 "Upstream stream ended without a response". The real upstream
-//     reason (insufficient balance, rate limit, overloaded) never reached the
-//     client, which sees an opaque gateway 502 and retries. No upstream context
-//     was recorded either, so classifyOpsErrorLog saw errType api_error with no
-//     upstream status and produced error_phase=internal / error_owner=platform /
-//     error_source=gateway — an upstream fault booked against the gateway,
-//     polluting SLA and firing platform-side alerts.
-//
-//  2. Partial message then error — message_start (and possibly content) arrived
-//     before the error event, so finalResp is non-nil. The loop returned the
-//     truncated content as a clean HTTP 200 and recorded nothing: the client
-//     could not tell the answer was cut short, and the provider fault was
-//     invisible to ops.
-//
-// This file owns the parse and the attribution so the call sites stay small.
-// It deliberately does NOT add failover: once an account is chosen the buffered
-// path has already consumed the upstream response, and retrying here would
-// change scheduling behavior. Failover on 200-with-error-event is tracked
-// separately.
+// Four non-streaming OpenAI-compatible paths force Anthropic upstreams to SSE
+// and then assemble the events into one JSON response. A HTTP 200 stream can
+// still fail through an `error` event, a read error, an idle timeout, or EOF
+// before message completion. Before any content exists those failures must
+// return UpstreamFailoverError so the existing handler loop can switch account.
+// Once a content block exists, replay would risk duplicate billing and answer
+// drift, so the partial response is preserved and marked as a truncated SLA
+// failure instead.
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
 )
 
-// tkAnthropicBufferedUpstreamError is a normalized upstream failure recovered
-// from a buffered Anthropic SSE stream.
+const statusAnthropicOverloaded = 529
+
 type tkAnthropicBufferedUpstreamError struct {
-	// ErrType is the Anthropic error type (e.g. "rate_limit_error").
-	ErrType string
-	// Message is the client-facing upstream message, already sanitized.
-	Message string
-	// Detail is the raw event payload, retained only for ops logging and only
-	// when the operator enabled upstream error body logging.
-	Detail string
-	// UpstreamStatus is the HTTP status the error type corresponds to. It is
-	// always > 0 so that recording it flips ops classification to
-	// phase=upstream / owner=provider.
+	ErrType        string
+	Message        string
+	Detail         string
+	Payload        []byte
 	UpstreamStatus int
-	// EmptyStream marks the "200 with no usable events" case, where upstream
-	// sent no error event at all.
-	EmptyStream bool
+	Kind           string
 }
 
-// tkParseAnthropicBufferedSSEError reports whether one SSE data payload is a
-// terminal Anthropic `error` event, and normalizes it when so.
-//
-// cfg gates raw payload capture the same way every other appendOpsUpstreamError
-// call site in this package does (see gateway_count_tokens.go); it may be nil.
 func tkParseAnthropicBufferedSSEError(payload []byte, cfg *config.Config) (*tkAnthropicBufferedUpstreamError, bool) {
-	if len(payload) == 0 {
-		return nil, false
-	}
-	if strings.TrimSpace(gjson.GetBytes(payload, "type").String()) != "error" {
+	if len(payload) == 0 || strings.TrimSpace(gjson.GetBytes(payload, "type").String()) != "error" {
 		return nil, false
 	}
 	errType := strings.TrimSpace(gjson.GetBytes(payload, "error.type").String())
@@ -78,18 +46,39 @@ func tkParseAnthropicBufferedSSEError(payload []byte, cfg *config.Config) (*tkAn
 	}
 	message := sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(payload)))
 	if message == "" {
-		message = "Upstream returned an error before any response content"
+		message = "Upstream returned an error before response completion"
 	}
 	return &tkAnthropicBufferedUpstreamError{
 		ErrType:        errType,
 		Message:        message,
 		Detail:         tkAnthropicBufferedErrorDetail(payload, cfg),
+		Payload:        append([]byte(nil), payload...),
 		UpstreamStatus: tkAnthropicErrorTypeUpstreamStatus(errType),
+		Kind:           "stream_error",
 	}, true
 }
 
-// tkAnthropicBufferedErrorDetail returns the raw upstream payload for ops
-// logging only when the operator opted into upstream error body capture.
+func tkAnthropicBufferedSyntheticFailure(kind, message string) *tkAnthropicBufferedUpstreamError {
+	message = sanitizeUpstreamErrorMessage(strings.TrimSpace(message))
+	if message == "" {
+		message = "Upstream stream ended before response completion"
+	}
+	payload, _ := json.Marshal(gin.H{
+		"type": "error",
+		"error": gin.H{
+			"type":    "api_error",
+			"message": message,
+		},
+	})
+	return &tkAnthropicBufferedUpstreamError{
+		ErrType:        "api_error",
+		Message:        message,
+		Payload:        payload,
+		UpstreamStatus: http.StatusBadGateway,
+		Kind:           kind,
+	}
+}
+
 func tkAnthropicBufferedErrorDetail(payload []byte, cfg *config.Config) string {
 	if cfg == nil || !cfg.Gateway.LogUpstreamErrorBody {
 		return ""
@@ -101,11 +90,6 @@ func tkAnthropicBufferedErrorDetail(payload []byte, cfg *config.Config) string {
 	return truncateString(string(payload), maxBytes)
 }
 
-// tkAnthropicErrorTypeUpstreamStatus maps an Anthropic SSE error type to the
-// HTTP status it would have carried had upstream failed the request outright,
-// so a 200-with-error-event and a real error status classify identically. Only
-// types Anthropic actually puts on the wire are listed; anything else is a
-// server-side fault and takes the default.
 func tkAnthropicErrorTypeUpstreamStatus(errType string) int {
 	switch strings.TrimSpace(strings.ToLower(errType)) {
 	case "invalid_request_error":
@@ -127,69 +111,132 @@ func tkAnthropicErrorTypeUpstreamStatus(errType string) int {
 	}
 }
 
-// statusAnthropicOverloaded is Anthropic's non-standard overload status.
-const statusAnthropicOverloaded = 529
-
-// tkAnthropicBufferedFailure records upstream attribution for a buffered
-// assembly that produced no message, and returns the client-facing status,
-// error type and message the caller should write.
-//
-// upstreamErr is nil when the stream simply ended with nothing usable; that is
-// still an upstream protocol fault (HTTP 200, no assemblable events), so it is
-// attributed to the provider rather than left as a gateway-internal error.
-func tkAnthropicBufferedFailure(
-	c *gin.Context,
-	requestID string,
-	upstreamErr *tkAnthropicBufferedUpstreamError,
-) (status int, errType string, message string) {
-	if upstreamErr == nil {
-		upstreamErr = &tkAnthropicBufferedUpstreamError{
-			ErrType:        "upstream_error",
-			Message:        "Upstream stream ended without a response",
-			UpstreamStatus: http.StatusBadGateway,
-			EmptyStream:    true,
-		}
-	}
-
-	kind := "stream_error"
-	if upstreamErr.EmptyStream {
-		kind = "stream_incomplete"
-	}
-	tkRecordAnthropicBufferedUpstreamError(c, requestID, kind, upstreamErr)
-
-	return tkAnthropicBufferedClientStatus(upstreamErr.UpstreamStatus),
-		tkAnthropicBufferedClientErrType(upstreamErr.ErrType),
-		upstreamErr.Message
+func tkAnthropicBufferedHasUsableContent(finalResp *apicompat.AnthropicResponse) bool {
+	return finalResp != nil && len(finalResp.Content) > 0
 }
 
-// tkAnthropicBufferedPartialFailure records a truncated response when a terminal
-// error event arrived *after* the assembly already had a message.
-//
-// The caller still returns the partial content: the buffered path has consumed
-// the upstream response, the tokens were really produced, and discarding them
-// would turn a degraded answer into a hard failure. But a truncated answer is
-// NOT a success, and recording upstream context alone is not enough to say so —
-// with a sub-400 wire status the ops logger routes context-only requests to
-// logOpsRecoveredUpstream, which deliberately keeps recovered attempts outside
-// request SLA. That is correct for a retry that eventually succeeded and wrong
-// here: nothing recovered, the client got a cut-off answer.
-//
-// MarkOpsStreamFailure is the repo's primitive for exactly this shape — an
-// in-band failure on an already-committed HTTP 200 — and its CountTowardsSLA
-// flag makes the logger record IntendedStatus instead of the 200 wire status.
-//
-// The client-facing shape is intentionally left alone; surfacing truncation to
-// clients needs its own contract decision (Anthropic has no "upstream errored"
-// stop_reason to map onto).
+func tkAnthropicBufferedEventCompletesMessage(event *apicompat.AnthropicStreamEvent) bool {
+	if event == nil {
+		return false
+	}
+	if event.Type == "message_stop" {
+		return true
+	}
+	return event.Type == "message_delta" && event.Delta != nil && strings.TrimSpace(event.Delta.StopReason) != ""
+}
+
+func tkAnthropicBufferedFailure(
+	c *gin.Context,
+	account *Account,
+	resp *http.Response,
+	requestID string,
+	upstreamErr *tkAnthropicBufferedUpstreamError,
+) *UpstreamFailoverError {
+	if upstreamErr == nil {
+		upstreamErr = tkAnthropicBufferedSyntheticFailure(
+			"stream_incomplete",
+			"Upstream stream ended without a response",
+		)
+	}
+	tkRecordAnthropicBufferedUpstreamError(c, account, requestID, upstreamErr.Kind, upstreamErr)
+
+	var headers http.Header
+	if resp != nil && resp.Header != nil {
+		headers = resp.Header.Clone()
+	}
+	body := append([]byte(nil), upstreamErr.Payload...)
+	if len(body) == 0 {
+		body = tkAnthropicBufferedSyntheticFailure(upstreamErr.Kind, upstreamErr.Message).Payload
+	}
+	return &UpstreamFailoverError{
+		StatusCode:        upstreamErr.UpstreamStatus,
+		ResponseBody:      body,
+		ResponseHeaders:   headers,
+		ClientStatusCode:  tkAnthropicBufferedClientStatus(upstreamErr.UpstreamStatus),
+		ClientErrorType:   tkAnthropicBufferedClientErrType(upstreamErr.ErrType),
+		ClientMessage:     upstreamErr.Message,
+		NextAccountAction: NextAccountRetry,
+	}
+}
+
+func (s *GatewayService) tkAnthropicBufferedFailoverError(
+	c *gin.Context,
+	account *Account,
+	resp *http.Response,
+	requestID string,
+	requestedModel string,
+	upstreamErr *tkAnthropicBufferedUpstreamError,
+) *UpstreamFailoverError {
+	failoverErr := tkAnthropicBufferedFailure(c, account, resp, requestID, upstreamErr)
+	if s == nil || account == nil || s.rateLimitService == nil {
+		return failoverErr
+	}
+	ctx := context.Background()
+	if c != nil && c.Request != nil {
+		ctx = c.Request.Context()
+	}
+	shouldDisable := s.rateLimitService.HandleUpstreamError(
+		ctx,
+		account,
+		failoverErr.StatusCode,
+		failoverErr.ResponseHeaders,
+		failoverErr.ResponseBody,
+		requestedModel,
+	)
+	failoverErr.RetryableOnSameAccount = !shouldDisable && account.IsPoolMode() && account.IsPoolModeRetryableStatus(failoverErr.StatusCode)
+	return failoverErr
+}
+
+func (s *OpenAIGatewayService) tkAnthropicBufferedFailoverError(
+	c *gin.Context,
+	account *Account,
+	resp *http.Response,
+	requestID string,
+	requestedModel string,
+	upstreamErr *tkAnthropicBufferedUpstreamError,
+) *UpstreamFailoverError {
+	base := tkAnthropicBufferedFailure(c, account, resp, requestID, upstreamErr)
+	if s == nil || account == nil {
+		return base
+	}
+	ctx := context.Background()
+	if c != nil && c.Request != nil {
+		ctx = c.Request.Context()
+	}
+	shouldDisable := s.handleOpenAIAccountUpstreamError(
+		ctx,
+		account,
+		base.StatusCode,
+		base.ResponseHeaders,
+		base.ResponseBody,
+		requestedModel,
+	)
+	failoverErr := s.newOpenAIAccountFailoverError(
+		account,
+		base.StatusCode,
+		base.ResponseHeaders,
+		base.ResponseBody,
+		base.ClientMessage,
+		shouldDisable,
+		account.IsPoolMode() && account.IsPoolModeRetryableStatus(base.StatusCode),
+	)
+	failoverErr.ClientStatusCode = base.ClientStatusCode
+	failoverErr.ClientErrorType = base.ClientErrorType
+	failoverErr.ClientMessage = base.ClientMessage
+	failoverErr.NextAccountAction = NextAccountRetry
+	return failoverErr
+}
+
 func tkAnthropicBufferedPartialFailure(
 	c *gin.Context,
+	account *Account,
 	requestID string,
 	upstreamErr *tkAnthropicBufferedUpstreamError,
 ) {
 	if upstreamErr == nil {
 		return
 	}
-	tkRecordAnthropicBufferedUpstreamError(c, requestID, "stream_truncated", upstreamErr)
+	tkRecordAnthropicBufferedUpstreamError(c, account, requestID, "stream_truncated", upstreamErr)
 	MarkOpsStreamFailure(
 		c,
 		"upstream_error",
@@ -197,42 +244,40 @@ func tkAnthropicBufferedPartialFailure(
 		upstreamErr.Message,
 		tkAnthropicBufferedClientStatus(upstreamErr.UpstreamStatus),
 	)
-	logger.L().Warn("buffered anthropic assembly: upstream error after partial content",
+	logger.L().Warn("buffered anthropic assembly: upstream failed after partial content",
 		zap.String("request_id", requestID),
 		zap.String("upstream_error_type", upstreamErr.ErrType),
 		zap.Int("upstream_status", upstreamErr.UpstreamStatus),
 	)
 }
 
-// tkRecordAnthropicBufferedUpstreamError is the single place that writes ops
-// upstream attribution for this family of failures. Both the status and the
-// event are required: setOpsUpstreamError is what classifyOpsErrorLog reads to
-// pick phase=upstream / owner=provider, and the event carries the per-attempt
-// detail operators triage from.
 func tkRecordAnthropicBufferedUpstreamError(
 	c *gin.Context,
+	account *Account,
 	requestID string,
 	kind string,
 	upstreamErr *tkAnthropicBufferedUpstreamError,
 ) {
 	setOpsUpstreamError(c, upstreamErr.UpstreamStatus, upstreamErr.Message, upstreamErr.Detail)
-	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+	event := OpsUpstreamErrorEvent{
 		UpstreamStatusCode: upstreamErr.UpstreamStatus,
 		UpstreamRequestID:  requestID,
 		Kind:               kind,
 		Reason:             upstreamErr.ErrType,
 		Message:            upstreamErr.Message,
 		Detail:             upstreamErr.Detail,
-	})
+	}
+	if account != nil {
+		event.Platform = account.Platform
+		event.AccountID = account.ID
+		event.AccountName = account.Name
+	}
+	appendOpsUpstreamError(c, event)
 }
 
-// tkAnthropicBufferedClientStatus maps the synthesized upstream status to a
-// client-facing status. 5xx and Anthropic's 529 collapse to 502 the same way
-// mapUpstreamStatusCode handles real upstream error statuses.
 func tkAnthropicBufferedClientStatus(upstreamStatus int) int {
 	switch upstreamStatus {
 	case http.StatusUnauthorized, http.StatusForbidden:
-		// Upstream credential/permission faults are not the client's to fix.
 		return http.StatusBadGateway
 	case statusAnthropicOverloaded:
 		return http.StatusServiceUnavailable
@@ -240,12 +285,14 @@ func tkAnthropicBufferedClientStatus(upstreamStatus int) int {
 	return mapUpstreamStatusCode(upstreamStatus)
 }
 
-// tkAnthropicBufferedClientErrType keeps error types the OpenAI-compatible
-// surfaces already emit, and falls back to server_error otherwise.
 func tkAnthropicBufferedClientErrType(errType string) string {
 	switch strings.TrimSpace(strings.ToLower(errType)) {
 	case "invalid_request_error":
 		return "invalid_request_error"
+	case "not_found_error":
+		return "not_found_error"
+	case "request_too_large":
+		return "request_too_large"
 	case "rate_limit_error":
 		return "rate_limit_error"
 	case "overloaded_error":

--- a/backend/internal/service/gateway_anthropic_buffered_error_tk.go
+++ b/backend/internal/service/gateway_anthropic_buffered_error_tk.go
@@ -162,16 +162,25 @@ func tkAnthropicBufferedFailure(
 		upstreamErr.Message
 }
 
-// tkAnthropicBufferedPartialFailure records upstream attribution when a
-// terminal error event arrived *after* the assembly already had a message.
+// tkAnthropicBufferedPartialFailure records a truncated response when a terminal
+// error event arrived *after* the assembly already had a message.
 //
 // The caller still returns the partial content: the buffered path has consumed
 // the upstream response, the tokens were really produced, and discarding them
-// would turn a degraded answer into a hard failure. What must not happen is
-// booking it as a clean success — the provider fault has to reach ops, which is
-// the whole point of this file. The client-facing shape is intentionally left
-// alone here; surfacing truncation to clients needs its own contract decision
-// (Anthropic has no "upstream errored" stop_reason to map onto).
+// would turn a degraded answer into a hard failure. But a truncated answer is
+// NOT a success, and recording upstream context alone is not enough to say so —
+// with a sub-400 wire status the ops logger routes context-only requests to
+// logOpsRecoveredUpstream, which deliberately keeps recovered attempts outside
+// request SLA. That is correct for a retry that eventually succeeded and wrong
+// here: nothing recovered, the client got a cut-off answer.
+//
+// MarkOpsStreamFailure is the repo's primitive for exactly this shape — an
+// in-band failure on an already-committed HTTP 200 — and its CountTowardsSLA
+// flag makes the logger record IntendedStatus instead of the 200 wire status.
+//
+// The client-facing shape is intentionally left alone; surfacing truncation to
+// clients needs its own contract decision (Anthropic has no "upstream errored"
+// stop_reason to map onto).
 func tkAnthropicBufferedPartialFailure(
 	c *gin.Context,
 	requestID string,
@@ -181,6 +190,13 @@ func tkAnthropicBufferedPartialFailure(
 		return
 	}
 	tkRecordAnthropicBufferedUpstreamError(c, requestID, "stream_truncated", upstreamErr)
+	MarkOpsStreamFailure(
+		c,
+		"upstream_error",
+		"upstream_stream_truncated",
+		upstreamErr.Message,
+		tkAnthropicBufferedClientStatus(upstreamErr.UpstreamStatus),
+	)
 	logger.L().Warn("buffered anthropic assembly: upstream error after partial content",
 		zap.String("request_id", requestID),
 		zap.String("upstream_error_type", upstreamErr.ErrType),

--- a/backend/internal/service/gateway_anthropic_buffered_error_tk.go
+++ b/backend/internal/service/gateway_anthropic_buffered_error_tk.go
@@ -1,0 +1,179 @@
+package service
+
+// TK: single owner for "buffered Anthropic SSE assembly produced no message".
+//
+// The four buffered assembly loops (Anthropic platform CC/Responses and CN
+// native-Anthropic CC/Responses) all reduce an upstream SSE stream to one
+// *apicompat.AnthropicResponse. apicompat.AnthropicStreamEvent models only
+// message_start / message_delta / content_block_*, so a terminal Anthropic
+// `error` event unmarshals into a bare Type=="error" and is then skipped by
+// every branch. finalResp stays nil and the loop falls through to a generic
+// 502 "Upstream stream ended without a response".
+//
+// Two things went wrong with that fallthrough:
+//
+//  1. The real upstream reason (insufficient balance, rate limit, overloaded)
+//     never reached the client, which sees an opaque gateway 502 and retries.
+//  2. No upstream context was recorded, so classifyOpsErrorLog saw errType
+//     api_error with no upstream status and produced
+//     error_phase=internal / error_owner=platform / error_source=gateway —
+//     an upstream fault booked against the gateway, polluting SLA and firing
+//     platform-side alerts.
+//
+// This file owns both the parse and the attribution so the call sites stay two
+// lines each. It deliberately does NOT add failover: once an account is chosen
+// the buffered path has already consumed the upstream response, and retrying
+// here would change scheduling behavior. Failover on 200-with-error-event is
+// tracked separately.
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
+
+// tkAnthropicBufferedUpstreamError is a normalized upstream failure recovered
+// from a buffered Anthropic SSE stream that never yielded a message.
+type tkAnthropicBufferedUpstreamError struct {
+	// ErrType is the Anthropic error type (e.g. "rate_limit_error").
+	ErrType string
+	// Message is the client-facing upstream message, already sanitized.
+	Message string
+	// Detail is the raw event payload, retained only for ops logging.
+	Detail string
+	// UpstreamStatus is the HTTP status the error type corresponds to. It is
+	// always > 0 so that recording it flips ops classification to
+	// phase=upstream / owner=provider.
+	UpstreamStatus int
+	// EmptyStream marks the "200 with no usable events" case, where upstream
+	// sent no error event at all.
+	EmptyStream bool
+}
+
+// tkParseAnthropicBufferedSSEError reports whether one SSE data payload is a
+// terminal Anthropic `error` event, and normalizes it when so.
+func tkParseAnthropicBufferedSSEError(payload []byte) (*tkAnthropicBufferedUpstreamError, bool) {
+	if len(payload) == 0 {
+		return nil, false
+	}
+	if strings.TrimSpace(gjson.GetBytes(payload, "type").String()) != "error" {
+		return nil, false
+	}
+	errType := strings.TrimSpace(gjson.GetBytes(payload, "error.type").String())
+	if errType == "" {
+		errType = "api_error"
+	}
+	message := sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(payload)))
+	if message == "" {
+		message = "Upstream returned an error before any response content"
+	}
+	return &tkAnthropicBufferedUpstreamError{
+		ErrType:        errType,
+		Message:        message,
+		Detail:         truncateString(string(payload), 2048),
+		UpstreamStatus: tkAnthropicErrorTypeUpstreamStatus(errType),
+	}, true
+}
+
+// tkAnthropicErrorTypeUpstreamStatus maps an Anthropic error type to the HTTP
+// status it would have carried had upstream failed the request outright. The
+// mapping mirrors the status handling in gateway_upstream_response.go so a
+// 200-with-error-event and a real error status classify identically.
+func tkAnthropicErrorTypeUpstreamStatus(errType string) int {
+	switch strings.TrimSpace(strings.ToLower(errType)) {
+	case "invalid_request_error":
+		return http.StatusBadRequest
+	case "authentication_error":
+		return http.StatusUnauthorized
+	case "permission_error", "forbidden_error":
+		return http.StatusForbidden
+	case "not_found_error", "model_not_found":
+		return http.StatusNotFound
+	case "request_too_large":
+		return http.StatusRequestEntityTooLarge
+	case "rate_limit_error":
+		return http.StatusTooManyRequests
+	case "billing_error", "insufficient_quota":
+		return http.StatusPaymentRequired
+	case "overloaded_error":
+		return statusAnthropicOverloaded
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// statusAnthropicOverloaded is Anthropic's non-standard overload status.
+const statusAnthropicOverloaded = 529
+
+// tkAnthropicBufferedFailure records upstream attribution for a buffered
+// assembly that produced no message, and returns the client-facing status,
+// error type and message the caller should write.
+//
+// upstreamErr is nil when the stream simply ended with nothing usable; that is
+// still an upstream protocol fault (HTTP 200, no assemblable events), so it is
+// attributed to the provider rather than left as a gateway-internal error.
+func tkAnthropicBufferedFailure(
+	c *gin.Context,
+	requestID string,
+	upstreamErr *tkAnthropicBufferedUpstreamError,
+) (status int, errType string, message string) {
+	if upstreamErr == nil {
+		upstreamErr = &tkAnthropicBufferedUpstreamError{
+			ErrType:        "upstream_error",
+			Message:        "Upstream stream ended without a response",
+			UpstreamStatus: http.StatusBadGateway,
+			EmptyStream:    true,
+		}
+	}
+
+	setOpsUpstreamError(c, upstreamErr.UpstreamStatus, upstreamErr.Message, upstreamErr.Detail)
+	kind := "stream_error"
+	if upstreamErr.EmptyStream {
+		kind = "stream_incomplete"
+	}
+	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+		UpstreamStatusCode: upstreamErr.UpstreamStatus,
+		UpstreamRequestID:  requestID,
+		Kind:               kind,
+		Reason:             upstreamErr.ErrType,
+		Message:            upstreamErr.Message,
+		Detail:             upstreamErr.Detail,
+	})
+
+	return tkAnthropicBufferedClientStatus(upstreamErr.UpstreamStatus),
+		tkAnthropicBufferedClientErrType(upstreamErr.ErrType),
+		upstreamErr.Message
+}
+
+// tkAnthropicBufferedClientStatus maps the synthesized upstream status to a
+// client-facing status. 5xx and Anthropic's 529 collapse to 502 the same way
+// mapUpstreamStatusCode handles real upstream error statuses.
+func tkAnthropicBufferedClientStatus(upstreamStatus int) int {
+	switch upstreamStatus {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		// Upstream credential/permission faults are not the client's to fix.
+		return http.StatusBadGateway
+	case statusAnthropicOverloaded:
+		return http.StatusServiceUnavailable
+	}
+	return mapUpstreamStatusCode(upstreamStatus)
+}
+
+// tkAnthropicBufferedClientErrType keeps error types the OpenAI-compatible
+// surfaces already emit, and falls back to server_error otherwise.
+func tkAnthropicBufferedClientErrType(errType string) string {
+	switch strings.TrimSpace(strings.ToLower(errType)) {
+	case "invalid_request_error":
+		return "invalid_request_error"
+	case "rate_limit_error":
+		return "rate_limit_error"
+	case "overloaded_error":
+		return "overloaded_error"
+	case "authentication_error", "permission_error", "forbidden_error":
+		return "upstream_error"
+	default:
+		return "server_error"
+	}
+}

--- a/backend/internal/service/gateway_anthropic_buffered_error_tk.go
+++ b/backend/internal/service/gateway_anthropic_buffered_error_tk.go
@@ -1,47 +1,55 @@
 package service
 
-// TK: single owner for "buffered Anthropic SSE assembly produced no message".
+// TK: single owner for "buffered Anthropic SSE assembly hit a terminal error".
 //
 // The four buffered assembly loops (Anthropic platform CC/Responses and CN
 // native-Anthropic CC/Responses) all reduce an upstream SSE stream to one
 // *apicompat.AnthropicResponse. apicompat.AnthropicStreamEvent models only
 // message_start / message_delta / content_block_*, so a terminal Anthropic
 // `error` event unmarshals into a bare Type=="error" and is then skipped by
-// every branch. finalResp stays nil and the loop falls through to a generic
-// 502 "Upstream stream ended without a response".
+// every branch. Two outcomes follow, and both used to be misreported:
 //
-// Two things went wrong with that fallthrough:
+//  1. No message at all — finalResp stays nil and the loop falls through to a
+//     generic 502 "Upstream stream ended without a response". The real upstream
+//     reason (insufficient balance, rate limit, overloaded) never reached the
+//     client, which sees an opaque gateway 502 and retries. No upstream context
+//     was recorded either, so classifyOpsErrorLog saw errType api_error with no
+//     upstream status and produced error_phase=internal / error_owner=platform /
+//     error_source=gateway — an upstream fault booked against the gateway,
+//     polluting SLA and firing platform-side alerts.
 //
-//  1. The real upstream reason (insufficient balance, rate limit, overloaded)
-//     never reached the client, which sees an opaque gateway 502 and retries.
-//  2. No upstream context was recorded, so classifyOpsErrorLog saw errType
-//     api_error with no upstream status and produced
-//     error_phase=internal / error_owner=platform / error_source=gateway —
-//     an upstream fault booked against the gateway, polluting SLA and firing
-//     platform-side alerts.
+//  2. Partial message then error — message_start (and possibly content) arrived
+//     before the error event, so finalResp is non-nil. The loop returned the
+//     truncated content as a clean HTTP 200 and recorded nothing: the client
+//     could not tell the answer was cut short, and the provider fault was
+//     invisible to ops.
 //
-// This file owns both the parse and the attribution so the call sites stay two
-// lines each. It deliberately does NOT add failover: once an account is chosen
-// the buffered path has already consumed the upstream response, and retrying
-// here would change scheduling behavior. Failover on 200-with-error-event is
-// tracked separately.
+// This file owns the parse and the attribution so the call sites stay small.
+// It deliberately does NOT add failover: once an account is chosen the buffered
+// path has already consumed the upstream response, and retrying here would
+// change scheduling behavior. Failover on 200-with-error-event is tracked
+// separately.
 
 import (
 	"net/http"
 	"strings"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
+	"go.uber.org/zap"
 )
 
 // tkAnthropicBufferedUpstreamError is a normalized upstream failure recovered
-// from a buffered Anthropic SSE stream that never yielded a message.
+// from a buffered Anthropic SSE stream.
 type tkAnthropicBufferedUpstreamError struct {
 	// ErrType is the Anthropic error type (e.g. "rate_limit_error").
 	ErrType string
 	// Message is the client-facing upstream message, already sanitized.
 	Message string
-	// Detail is the raw event payload, retained only for ops logging.
+	// Detail is the raw event payload, retained only for ops logging and only
+	// when the operator enabled upstream error body logging.
 	Detail string
 	// UpstreamStatus is the HTTP status the error type corresponds to. It is
 	// always > 0 so that recording it flips ops classification to
@@ -54,7 +62,10 @@ type tkAnthropicBufferedUpstreamError struct {
 
 // tkParseAnthropicBufferedSSEError reports whether one SSE data payload is a
 // terminal Anthropic `error` event, and normalizes it when so.
-func tkParseAnthropicBufferedSSEError(payload []byte) (*tkAnthropicBufferedUpstreamError, bool) {
+//
+// cfg gates raw payload capture the same way every other appendOpsUpstreamError
+// call site in this package does (see gateway_count_tokens.go); it may be nil.
+func tkParseAnthropicBufferedSSEError(payload []byte, cfg *config.Config) (*tkAnthropicBufferedUpstreamError, bool) {
 	if len(payload) == 0 {
 		return nil, false
 	}
@@ -72,31 +83,43 @@ func tkParseAnthropicBufferedSSEError(payload []byte) (*tkAnthropicBufferedUpstr
 	return &tkAnthropicBufferedUpstreamError{
 		ErrType:        errType,
 		Message:        message,
-		Detail:         truncateString(string(payload), 2048),
+		Detail:         tkAnthropicBufferedErrorDetail(payload, cfg),
 		UpstreamStatus: tkAnthropicErrorTypeUpstreamStatus(errType),
 	}, true
 }
 
-// tkAnthropicErrorTypeUpstreamStatus maps an Anthropic error type to the HTTP
-// status it would have carried had upstream failed the request outright. The
-// mapping mirrors the status handling in gateway_upstream_response.go so a
-// 200-with-error-event and a real error status classify identically.
+// tkAnthropicBufferedErrorDetail returns the raw upstream payload for ops
+// logging only when the operator opted into upstream error body capture.
+func tkAnthropicBufferedErrorDetail(payload []byte, cfg *config.Config) string {
+	if cfg == nil || !cfg.Gateway.LogUpstreamErrorBody {
+		return ""
+	}
+	maxBytes := cfg.Gateway.LogUpstreamErrorBodyMaxBytes
+	if maxBytes <= 0 {
+		maxBytes = 2048
+	}
+	return truncateString(string(payload), maxBytes)
+}
+
+// tkAnthropicErrorTypeUpstreamStatus maps an Anthropic SSE error type to the
+// HTTP status it would have carried had upstream failed the request outright,
+// so a 200-with-error-event and a real error status classify identically. Only
+// types Anthropic actually puts on the wire are listed; anything else is a
+// server-side fault and takes the default.
 func tkAnthropicErrorTypeUpstreamStatus(errType string) int {
 	switch strings.TrimSpace(strings.ToLower(errType)) {
 	case "invalid_request_error":
 		return http.StatusBadRequest
 	case "authentication_error":
 		return http.StatusUnauthorized
-	case "permission_error", "forbidden_error":
+	case "permission_error":
 		return http.StatusForbidden
-	case "not_found_error", "model_not_found":
+	case "not_found_error":
 		return http.StatusNotFound
 	case "request_too_large":
 		return http.StatusRequestEntityTooLarge
 	case "rate_limit_error":
 		return http.StatusTooManyRequests
-	case "billing_error", "insufficient_quota":
-		return http.StatusPaymentRequired
 	case "overloaded_error":
 		return statusAnthropicOverloaded
 	default:
@@ -128,11 +151,55 @@ func tkAnthropicBufferedFailure(
 		}
 	}
 
-	setOpsUpstreamError(c, upstreamErr.UpstreamStatus, upstreamErr.Message, upstreamErr.Detail)
 	kind := "stream_error"
 	if upstreamErr.EmptyStream {
 		kind = "stream_incomplete"
 	}
+	tkRecordAnthropicBufferedUpstreamError(c, requestID, kind, upstreamErr)
+
+	return tkAnthropicBufferedClientStatus(upstreamErr.UpstreamStatus),
+		tkAnthropicBufferedClientErrType(upstreamErr.ErrType),
+		upstreamErr.Message
+}
+
+// tkAnthropicBufferedPartialFailure records upstream attribution when a
+// terminal error event arrived *after* the assembly already had a message.
+//
+// The caller still returns the partial content: the buffered path has consumed
+// the upstream response, the tokens were really produced, and discarding them
+// would turn a degraded answer into a hard failure. What must not happen is
+// booking it as a clean success — the provider fault has to reach ops, which is
+// the whole point of this file. The client-facing shape is intentionally left
+// alone here; surfacing truncation to clients needs its own contract decision
+// (Anthropic has no "upstream errored" stop_reason to map onto).
+func tkAnthropicBufferedPartialFailure(
+	c *gin.Context,
+	requestID string,
+	upstreamErr *tkAnthropicBufferedUpstreamError,
+) {
+	if upstreamErr == nil {
+		return
+	}
+	tkRecordAnthropicBufferedUpstreamError(c, requestID, "stream_truncated", upstreamErr)
+	logger.L().Warn("buffered anthropic assembly: upstream error after partial content",
+		zap.String("request_id", requestID),
+		zap.String("upstream_error_type", upstreamErr.ErrType),
+		zap.Int("upstream_status", upstreamErr.UpstreamStatus),
+	)
+}
+
+// tkRecordAnthropicBufferedUpstreamError is the single place that writes ops
+// upstream attribution for this family of failures. Both the status and the
+// event are required: setOpsUpstreamError is what classifyOpsErrorLog reads to
+// pick phase=upstream / owner=provider, and the event carries the per-attempt
+// detail operators triage from.
+func tkRecordAnthropicBufferedUpstreamError(
+	c *gin.Context,
+	requestID string,
+	kind string,
+	upstreamErr *tkAnthropicBufferedUpstreamError,
+) {
+	setOpsUpstreamError(c, upstreamErr.UpstreamStatus, upstreamErr.Message, upstreamErr.Detail)
 	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 		UpstreamStatusCode: upstreamErr.UpstreamStatus,
 		UpstreamRequestID:  requestID,
@@ -141,10 +208,6 @@ func tkAnthropicBufferedFailure(
 		Message:            upstreamErr.Message,
 		Detail:             upstreamErr.Detail,
 	})
-
-	return tkAnthropicBufferedClientStatus(upstreamErr.UpstreamStatus),
-		tkAnthropicBufferedClientErrType(upstreamErr.ErrType),
-		upstreamErr.Message
 }
 
 // tkAnthropicBufferedClientStatus maps the synthesized upstream status to a
@@ -171,7 +234,7 @@ func tkAnthropicBufferedClientErrType(errType string) string {
 		return "rate_limit_error"
 	case "overloaded_error":
 		return "overloaded_error"
-	case "authentication_error", "permission_error", "forbidden_error":
+	case "authentication_error", "permission_error":
 		return "upstream_error"
 	default:
 		return "server_error"

--- a/backend/internal/service/gateway_anthropic_buffered_error_tk_test.go
+++ b/backend/internal/service/gateway_anthropic_buffered_error_tk_test.go
@@ -12,6 +12,7 @@ package service
 // error_phase=internal / error_owner=platform / error_source=gateway.
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -23,8 +24,43 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
-	"github.com/tidwall/gjson"
 )
+
+var errBufferedAnthropicTestRead = errors.New("buffered anthropic test read failure")
+
+type errAfterPayloadReadCloser struct {
+	reader *strings.Reader
+}
+
+func (r *errAfterPayloadReadCloser) Read(p []byte) (int, error) {
+	if r.reader.Len() == 0 {
+		return 0, errBufferedAnthropicTestRead
+	}
+	return r.reader.Read(p)
+}
+
+func (r *errAfterPayloadReadCloser) Close() error { return nil }
+
+func anthropicMessageStartOnlySSE() string {
+	return strings.Join([]string{
+		"event: message_start",
+		`data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude-opus-4-8","usage":{"input_tokens":10}}}`,
+		"",
+		"",
+	}, "\n")
+}
+
+func anthropicMessageStartThenErrorSSE(errType, message string) string {
+	return strings.Join([]string{
+		"event: message_start",
+		`data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude-opus-4-8","usage":{"input_tokens":10}}}`,
+		"",
+		"event: error",
+		`data: {"type":"error","error":{"type":"` + errType + `","message":"` + message + `"}}`,
+		"",
+		"",
+	}, "\n")
+}
 
 func anthropicErrorOnlySSE(errType, message string) string {
 	return strings.Join([]string{
@@ -41,6 +77,18 @@ func newBufferedErrorUpstreamResponse(body string) *http.Response {
 		Header:     http.Header{"x-request-id": []string{"rid_buffered_err"}},
 		Body:       io.NopCloser(strings.NewReader(body)),
 	}
+}
+
+func newBufferedReadErrorUpstreamResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"x-request-id": []string{"rid_buffered_read_err"}},
+		Body:       &errAfterPayloadReadCloser{reader: strings.NewReader(body)},
+	}
+}
+
+func bufferedAnthropicTestAccount(platform string) *Account {
+	return &Account{ID: 1805, Name: "buffered-anthropic-test", Platform: platform}
 }
 
 func requireUpstreamAttributed(t *testing.T, c *gin.Context, wantUpstreamStatus int) {
@@ -88,15 +136,17 @@ func TestTKAnthropicBufferedError_CCPathAttributesUpstream(t *testing.T) {
 	)
 
 	svc := &GatewayService{}
-	result, err := svc.handleCCBufferedFromAnthropic(resp, c, "gpt-5", "claude-opus-4-8", nil, time.Now())
+	account := bufferedAnthropicTestAccount(PlatformAnthropic)
+	result, err := svc.handleCCBufferedFromAnthropic(resp, c, account, "gpt-5", "claude-opus-4-8", nil, time.Now())
 	require.Error(t, err)
 	require.Nil(t, result)
 
-	// Client sees the upstream reason and a retryable status, not an opaque 502.
-	require.Equal(t, http.StatusTooManyRequests, rec.Code)
-	body := rec.Body.String()
-	require.Equal(t, "rate_limit_error", gjson.Get(body, "error.type").String())
-	require.Contains(t, gjson.Get(body, "error.message").String(), "concurrent connections")
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusTooManyRequests, failoverErr.StatusCode)
+	require.Equal(t, "rate_limit_error", failoverErr.ClientErrorType)
+	require.Contains(t, failoverErr.ClientMessage, "concurrent connections")
+	require.False(t, c.Writer.Written())
 
 	requireUpstreamAttributed(t, c, http.StatusTooManyRequests)
 }
@@ -111,14 +161,18 @@ func TestTKAnthropicBufferedError_ResponsesPathAttributesUpstream(t *testing.T) 
 	)
 
 	svc := &GatewayService{}
+	account := bufferedAnthropicTestAccount(PlatformAnthropic)
 	result, err := svc.handleResponsesBufferedStreamingResponse(
-		resp, c, "gpt-5", "claude-opus-4-8", nil, time.Now(), apicompat.ResponsesClientToolMapping{},
+		resp, c, account, "gpt-5", "claude-opus-4-8", nil, time.Now(), apicompat.ResponsesClientToolMapping{},
 	)
 	require.Error(t, err)
 	require.Nil(t, result)
 
-	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
-	require.Equal(t, "overloaded_error", gjson.Get(rec.Body.String(), "error.code").String())
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusServiceUnavailable, failoverErr.ClientStatusCode)
+	require.Equal(t, "overloaded_error", failoverErr.ClientErrorType)
+	require.False(t, c.Writer.Written())
 
 	requireUpstreamAttributed(t, c, statusAnthropicOverloaded)
 }
@@ -133,15 +187,18 @@ func TestTKAnthropicBufferedError_NativeCCPathAttributesUpstream(t *testing.T) {
 	)
 
 	svc := &OpenAIGatewayService{}
+	account := bufferedAnthropicTestAccount(PlatformOpenAI)
 	result, err := svc.handleCCBufferedFromNativeAnthropic(
-		resp, c, "glm-4.7", "glm-4.7", "glm-4.7", nil, time.Now(),
+		resp, c, account, "glm-4.7", "glm-4.7", "glm-4.7", nil, time.Now(),
 	)
 	require.Error(t, err)
 	require.Nil(t, result)
 
-	// A client-caused 400 stays a 400 rather than being inflated to 502.
-	require.Equal(t, http.StatusBadRequest, rec.Code)
-	require.Equal(t, "invalid_request_error", gjson.Get(rec.Body.String(), "error.type").String())
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadRequest, failoverErr.ClientStatusCode)
+	require.Equal(t, "invalid_request_error", failoverErr.ClientErrorType)
+	require.False(t, c.Writer.Written())
 
 	requireUpstreamAttributed(t, c, http.StatusBadRequest)
 }
@@ -156,15 +213,18 @@ func TestTKAnthropicBufferedError_NativeResponsesPathAttributesUpstream(t *testi
 	)
 
 	svc := &OpenAIGatewayService{}
+	account := bufferedAnthropicTestAccount(PlatformOpenAI)
 	result, err := svc.handleResponsesBufferedFromNativeAnthropic(
-		resp, c, "glm-4.7", "glm-4.7", "glm-4.7", nil, time.Now(), apicompat.ResponsesClientToolMapping{},
+		resp, c, account, "glm-4.7", "glm-4.7", "glm-4.7", nil, time.Now(), apicompat.ResponsesClientToolMapping{},
 	)
 	require.Error(t, err)
 	require.Nil(t, result)
 
-	// Upstream credential faults must not surface as a client 401.
-	require.Equal(t, http.StatusBadGateway, rec.Code)
-	require.Equal(t, "upstream_error", gjson.Get(rec.Body.String(), "error.code").String())
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadGateway, failoverErr.ClientStatusCode)
+	require.Equal(t, "upstream_error", failoverErr.ClientErrorType)
+	require.False(t, c.Writer.Written())
 
 	requireUpstreamAttributed(t, c, http.StatusUnauthorized)
 }
@@ -179,12 +239,14 @@ func TestTKAnthropicBufferedError_EmptyStreamStillAttributedUpstream(t *testing.
 	resp := newBufferedErrorUpstreamResponse("event: ping\ndata: {\"type\":\"ping\"}\n\n")
 
 	svc := &GatewayService{}
-	_, err := svc.handleCCBufferedFromAnthropic(resp, c, "gpt-5", "claude-opus-4-8", nil, time.Now())
+	account := bufferedAnthropicTestAccount(PlatformAnthropic)
+	_, err := svc.handleCCBufferedFromAnthropic(resp, c, account, "gpt-5", "claude-opus-4-8", nil, time.Now())
 	require.Error(t, err)
 
-	require.Equal(t, http.StatusBadGateway, rec.Code)
-	// Message is preserved for operators who learned to grep for it.
-	require.Contains(t, rec.Body.String(), "Upstream stream ended without a response")
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadGateway, failoverErr.ClientStatusCode)
+	require.False(t, c.Writer.Written())
 
 	requireUpstreamAttributed(t, c, http.StatusBadGateway)
 
@@ -213,7 +275,7 @@ func TestTKAnthropicBufferedError_HappyPathRecordsNoUpstreamError(t *testing.T) 
 	}, "\n"))
 
 	svc := &GatewayService{}
-	result, err := svc.handleCCBufferedFromAnthropic(resp, c, "gpt-5", "claude-opus-4-8", nil, time.Now())
+	result, err := svc.handleCCBufferedFromAnthropic(resp, c, bufferedAnthropicTestAccount(PlatformAnthropic), "gpt-5", "claude-opus-4-8", nil, time.Now())
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -269,7 +331,7 @@ func TestTKParseAnthropicBufferedSSEError_IgnoresNonErrorEvents(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "rate_limit_error", parsed.ErrType)
 	require.Equal(t, "slow down", parsed.Message)
-	require.False(t, parsed.EmptyStream)
+	require.Equal(t, "stream_error", parsed.Kind)
 
 	// A bare error event with no usable message still classifies.
 	parsed, ok = tkParseAnthropicBufferedSSEError([]byte(`{"type":"error"}`), nil)
@@ -333,7 +395,7 @@ func TestTKAnthropicBufferedError_PartialContentThenErrorIsAttributed(t *testing
 	}, "\n"))
 
 	svc := &GatewayService{}
-	result, err := svc.handleCCBufferedFromAnthropic(resp, c, "gpt-5", "claude-opus-4-8", nil, time.Now())
+	result, err := svc.handleCCBufferedFromAnthropic(resp, c, bufferedAnthropicTestAccount(PlatformAnthropic), "gpt-5", "claude-opus-4-8", nil, time.Now())
 
 	// The partial answer is preserved rather than discarded.
 	require.NoError(t, err)
@@ -376,7 +438,7 @@ func TestTKAnthropicBufferedError_NativePartialContentThenErrorIsAttributed(t *t
 
 	svc := &OpenAIGatewayService{}
 	result, err := svc.handleCCBufferedFromNativeAnthropic(
-		resp, c, "glm-4.7", "glm-4.7", "glm-4.7", nil, time.Now(),
+		resp, c, bufferedAnthropicTestAccount(PlatformOpenAI), "glm-4.7", "glm-4.7", "glm-4.7", nil, time.Now(),
 	)
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -389,4 +451,199 @@ func TestTKAnthropicBufferedError_NativePartialContentThenErrorIsAttributed(t *t
 	require.Equal(t, "stream_truncated", events[0].Kind)
 
 	requireTruncationCountsTowardsSLA(t, c, http.StatusTooManyRequests)
+}
+
+func TestUS047_MessageStartThenErrorReturnsFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	resp := newBufferedErrorUpstreamResponse(
+		anthropicMessageStartThenErrorSSE("rate_limit_error", "slow down"),
+	)
+
+	svc := &GatewayService{}
+	account := bufferedAnthropicTestAccount(PlatformAnthropic)
+	result, err := svc.handleCCBufferedFromAnthropic(resp, c, account, "gpt-5", "claude-opus-4-8", nil, time.Now())
+
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusTooManyRequests, failoverErr.StatusCode)
+	require.Equal(t, http.StatusTooManyRequests, failoverErr.ClientStatusCode)
+	require.False(t, c.Writer.Written(), "service must not commit a response before failover is exhausted")
+
+	raw, ok := c.Get(OpsUpstreamErrorsKey)
+	require.True(t, ok)
+	events := raw.([]*OpsUpstreamErrorEvent)
+	require.Len(t, events, 1)
+	require.Equal(t, account.Platform, events[0].Platform)
+	require.Equal(t, account.ID, events[0].AccountID)
+	require.Equal(t, account.Name, events[0].AccountName)
+}
+
+func TestUS047_PartialContentThenErrorPreservesResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	resp := newBufferedErrorUpstreamResponse(strings.Join([]string{
+		"event: message_start",
+		`data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude-opus-4-8","usage":{"input_tokens":10}}}`,
+		"",
+		"event: content_block_start",
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"partial"}}`,
+		"",
+		"event: error",
+		`data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`,
+		"",
+		"",
+	}, "\n"))
+
+	svc := &GatewayService{}
+	result, err := svc.handleCCBufferedFromAnthropic(resp, c, bufferedAnthropicTestAccount(PlatformAnthropic), "gpt-5", "claude-opus-4-8", nil, time.Now())
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "partial")
+	requireTruncationCountsTowardsSLA(t, c, http.StatusServiceUnavailable)
+}
+
+func TestUS047_IncompleteEOFRoutesByContentAvailability(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("message_start only fails over", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		resp := newBufferedErrorUpstreamResponse(anthropicMessageStartOnlySSE())
+
+		result, err := (&GatewayService{}).handleCCBufferedFromAnthropic(
+			resp, c, bufferedAnthropicTestAccount(PlatformAnthropic), "gpt-5", "claude-opus-4-8", nil, time.Now(),
+		)
+
+		require.Nil(t, result)
+		var failoverErr *UpstreamFailoverError
+		require.True(t, errors.As(err, &failoverErr))
+		require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+		require.False(t, c.Writer.Written())
+	})
+
+	t.Run("content before EOF is preserved and marked", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		resp := newBufferedErrorUpstreamResponse(strings.Join([]string{
+			"event: message_start",
+			`data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude-opus-4-8","usage":{"input_tokens":10}}}`,
+			"",
+			"event: content_block_start",
+			`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"partial"}}`,
+			"",
+			"",
+		}, "\n"))
+
+		result, err := (&GatewayService{}).handleCCBufferedFromAnthropic(
+			resp, c, bufferedAnthropicTestAccount(PlatformAnthropic), "gpt-5", "claude-opus-4-8", nil, time.Now(),
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Contains(t, rec.Body.String(), "partial")
+		requireTruncationCountsTowardsSLA(t, c, http.StatusBadGateway)
+	})
+}
+
+func TestUS047_ScannerReadErrorRoutesByContentAvailability(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("message_start only fails over", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		resp := newBufferedReadErrorUpstreamResponse(anthropicMessageStartOnlySSE())
+
+		result, err := (&GatewayService{}).handleCCBufferedFromAnthropic(
+			resp, c, bufferedAnthropicTestAccount(PlatformAnthropic), "gpt-5", "claude-opus-4-8", nil, time.Now(),
+		)
+
+		require.Nil(t, result)
+		var failoverErr *UpstreamFailoverError
+		require.ErrorAs(t, err, &failoverErr)
+		require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+		require.Contains(t, failoverErr.ClientMessage, "read failed")
+		require.False(t, c.Writer.Written())
+
+		raw, ok := c.Get(OpsUpstreamErrorsKey)
+		require.True(t, ok)
+		events := raw.([]*OpsUpstreamErrorEvent)
+		require.Len(t, events, 1)
+		require.Equal(t, "stream_read_error", events[0].Kind)
+	})
+
+	t.Run("content before read error is preserved and marked", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		resp := newBufferedReadErrorUpstreamResponse(strings.Join([]string{
+			"event: message_start",
+			`data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude-opus-4-8","usage":{"input_tokens":10}}}`,
+			"",
+			"event: content_block_start",
+			`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"partial"}}`,
+			"",
+			"",
+		}, "\n"))
+
+		result, err := (&GatewayService{}).handleCCBufferedFromAnthropic(
+			resp, c, bufferedAnthropicTestAccount(PlatformAnthropic), "gpt-5", "claude-opus-4-8", nil, time.Now(),
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Contains(t, rec.Body.String(), "partial")
+		requireTruncationCountsTowardsSLA(t, c, http.StatusBadGateway)
+
+		raw, ok := c.Get(OpsUpstreamErrorsKey)
+		require.True(t, ok)
+		events := raw.([]*OpsUpstreamErrorEvent)
+		require.Len(t, events, 1)
+		require.Equal(t, "stream_truncated", events[0].Kind)
+	})
+}
+
+func TestUS047_CompletionBeforeReadErrorRemainsSuccessful(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	resp := newBufferedReadErrorUpstreamResponse(strings.Join([]string{
+		"event: message_start",
+		`data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude-opus-4-8","usage":{"input_tokens":10}}}`,
+		"",
+		"event: content_block_start",
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"complete"}}`,
+		"",
+		"event: message_delta",
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":4}}`,
+		"",
+		"",
+	}, "\n"))
+
+	result, err := (&GatewayService{}).handleCCBufferedFromAnthropic(
+		resp, c, bufferedAnthropicTestAccount(PlatformAnthropic), "gpt-5", "claude-opus-4-8", nil, time.Now(),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "complete")
+	require.Empty(t, GetOpsStreamErrors(c))
+	_, hasUpstreamEvents := c.Get(OpsUpstreamErrorsKey)
+	require.False(t, hasUpstreamEvents)
+}
+
+func TestUS047_ClientErrorTypeMapping(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "not_found_error", tkAnthropicBufferedClientErrType("not_found_error"))
+	require.Equal(t, "request_too_large", tkAnthropicBufferedClientErrType("request_too_large"))
 }

--- a/backend/internal/service/gateway_anthropic_buffered_error_tk_test.go
+++ b/backend/internal/service/gateway_anthropic_buffered_error_tk_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
@@ -60,7 +61,7 @@ func requireUpstreamAttributed(t *testing.T, c *gin.Context, wantUpstreamStatus 
 	// Recording the status is what flips ops classification away from
 	// phase=internal / owner=platform. The classifier itself lives in package
 	// handler, so the end-to-end assertion is in
-	// handler/ops_error_logger_tk_anthropic_buffered_test.go.
+	// handler/ops_error_logger_tk_buffered_upstream_test.go.
 }
 
 func TestTKAnthropicBufferedError_CCPathAttributesUpstream(t *testing.T) {
@@ -219,10 +220,13 @@ func TestTKAnthropicErrorTypeUpstreamStatusMapping(t *testing.T) {
 		"not_found_error":       http.StatusNotFound,
 		"request_too_large":     http.StatusRequestEntityTooLarge,
 		"rate_limit_error":      http.StatusTooManyRequests,
-		"billing_error":         http.StatusPaymentRequired,
 		"overloaded_error":      statusAnthropicOverloaded,
 		"api_error":             http.StatusInternalServerError,
-		"something_unknown":     http.StatusInternalServerError,
+		// Types Anthropic does not put on the wire take the server-fault default
+		// rather than each getting a speculative mapping.
+		"billing_error":     http.StatusInternalServerError,
+		"model_not_found":   http.StatusInternalServerError,
+		"something_unknown": http.StatusInternalServerError,
 	} {
 		require.Equal(t, want, tkAnthropicErrorTypeUpstreamStatus(errType), errType)
 	}
@@ -237,12 +241,12 @@ func TestTKParseAnthropicBufferedSSEError_IgnoresNonErrorEvents(t *testing.T) {
 		`{"type":"ping"}`,
 		``,
 	} {
-		_, ok := tkParseAnthropicBufferedSSEError([]byte(payload))
+		_, ok := tkParseAnthropicBufferedSSEError([]byte(payload), nil)
 		require.False(t, ok, payload)
 	}
 
 	parsed, ok := tkParseAnthropicBufferedSSEError(
-		[]byte(`{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`),
+		[]byte(`{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`), nil,
 	)
 	require.True(t, ok)
 	require.Equal(t, "rate_limit_error", parsed.ErrType)
@@ -250,8 +254,114 @@ func TestTKParseAnthropicBufferedSSEError_IgnoresNonErrorEvents(t *testing.T) {
 	require.False(t, parsed.EmptyStream)
 
 	// A bare error event with no usable message still classifies.
-	parsed, ok = tkParseAnthropicBufferedSSEError([]byte(`{"type":"error"}`))
+	parsed, ok = tkParseAnthropicBufferedSSEError([]byte(`{"type":"error"}`), nil)
 	require.True(t, ok)
 	require.Equal(t, "api_error", parsed.ErrType)
 	require.NotEmpty(t, parsed.Message)
+}
+
+// R-002: raw upstream payload capture must honor the operator's
+// log_upstream_error_body setting, like every other appendOpsUpstreamError site.
+func TestTKAnthropicBufferedError_DetailRespectsUpstreamBodyLogging(t *testing.T) {
+	t.Parallel()
+
+	const payload = `{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`
+
+	t.Run("nil cfg captures nothing", func(t *testing.T) {
+		parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), nil)
+		require.True(t, ok)
+		require.Empty(t, parsed.Detail)
+	})
+
+	t.Run("disabled captures nothing", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Gateway.LogUpstreamErrorBody = false
+		parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), cfg)
+		require.True(t, ok)
+		require.Empty(t, parsed.Detail)
+	})
+
+	t.Run("enabled captures truncated payload", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Gateway.LogUpstreamErrorBody = true
+		cfg.Gateway.LogUpstreamErrorBodyMaxBytes = 16
+		parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), cfg)
+		require.True(t, ok)
+		require.Len(t, parsed.Detail, 16)
+		require.Equal(t, payload[:16], parsed.Detail)
+	})
+}
+
+// R-001: message_start (and content) followed by a terminal error event leaves
+// finalResp non-nil. The partial content is still returned — those tokens were
+// really produced — but the provider fault must reach ops instead of being
+// booked as a clean success.
+func TestTKAnthropicBufferedError_PartialContentThenErrorIsAttributed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	resp := newBufferedErrorUpstreamResponse(strings.Join([]string{
+		"event: message_start",
+		`data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude-opus-4-8","usage":{"input_tokens":10}}}`,
+		"",
+		"event: content_block_start",
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"partial"}}`,
+		"",
+		"event: error",
+		`data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`,
+		"",
+		"",
+	}, "\n"))
+
+	svc := &GatewayService{}
+	result, err := svc.handleCCBufferedFromAnthropic(resp, c, "gpt-5", "claude-opus-4-8", nil, time.Now())
+
+	// The partial answer is preserved rather than discarded.
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "partial")
+
+	// But the upstream fault is recorded, so ops does not see a clean success.
+	requireUpstreamAttributed(t, c, statusAnthropicOverloaded)
+
+	raw, _ := c.Get(OpsUpstreamErrorsKey)
+	events := raw.([]*OpsUpstreamErrorEvent)
+	require.Equal(t, "stream_truncated", events[0].Kind)
+	require.Equal(t, "overloaded_error", events[0].Reason)
+}
+
+// The same partial-then-error shape on the CN native-Anthropic CC path.
+func TestTKAnthropicBufferedError_NativePartialContentThenErrorIsAttributed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	resp := newBufferedErrorUpstreamResponse(strings.Join([]string{
+		"event: message_start",
+		`data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"glm-4.7","usage":{"input_tokens":10}}}`,
+		"",
+		"event: content_block_start",
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"partial"}}`,
+		"",
+		"event: error",
+		`data: {"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`,
+		"",
+		"",
+	}, "\n"))
+
+	svc := &OpenAIGatewayService{}
+	result, err := svc.handleCCBufferedFromNativeAnthropic(
+		resp, c, "glm-4.7", "glm-4.7", "glm-4.7", nil, time.Now(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	requireUpstreamAttributed(t, c, http.StatusTooManyRequests)
+
+	raw, _ := c.Get(OpsUpstreamErrorsKey)
+	events := raw.([]*OpsUpstreamErrorEvent)
+	require.Equal(t, "stream_truncated", events[0].Kind)
 }

--- a/backend/internal/service/gateway_anthropic_buffered_error_tk_test.go
+++ b/backend/internal/service/gateway_anthropic_buffered_error_tk_test.go
@@ -1,0 +1,257 @@
+//go:build unit
+
+package service
+
+// TK regression: a buffered Anthropic SSE stream that carries a terminal
+// `error` event (HTTP 200 body, no message_start) must be attributed upstream.
+//
+// Before this fix apicompat.AnthropicStreamEvent silently dropped the error
+// event, finalResp stayed nil, and all four buffered assembly paths fell through
+// to a bare 502 "Upstream stream ended without a response" with no upstream
+// context — which classifyOpsErrorLog then booked as
+// error_phase=internal / error_owner=platform / error_source=gateway.
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func anthropicErrorOnlySSE(errType, message string) string {
+	return strings.Join([]string{
+		"event: error",
+		`data: {"type":"error","error":{"type":"` + errType + `","message":"` + message + `"}}`,
+		"",
+		"",
+	}, "\n")
+}
+
+func newBufferedErrorUpstreamResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"x-request-id": []string{"rid_buffered_err"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func requireUpstreamAttributed(t *testing.T, c *gin.Context, wantUpstreamStatus int) {
+	t.Helper()
+
+	got, ok := c.Get(OpsUpstreamStatusCodeKey)
+	require.True(t, ok, "upstream status must be recorded so ops classifies phase=upstream")
+	require.Equal(t, wantUpstreamStatus, got)
+
+	raw, ok := c.Get(OpsUpstreamErrorsKey)
+	require.True(t, ok, "an upstream error event must be appended")
+	events, ok := raw.([]*OpsUpstreamErrorEvent)
+	require.True(t, ok)
+	require.Len(t, events, 1)
+	require.Equal(t, wantUpstreamStatus, events[0].UpstreamStatusCode)
+	require.NotEmpty(t, events[0].Message)
+
+	// Recording the status is what flips ops classification away from
+	// phase=internal / owner=platform. The classifier itself lives in package
+	// handler, so the end-to-end assertion is in
+	// handler/ops_error_logger_tk_anthropic_buffered_test.go.
+}
+
+func TestTKAnthropicBufferedError_CCPathAttributesUpstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	resp := newBufferedErrorUpstreamResponse(
+		anthropicErrorOnlySSE("rate_limit_error", "Number of concurrent connections exceeded"),
+	)
+
+	svc := &GatewayService{}
+	result, err := svc.handleCCBufferedFromAnthropic(resp, c, "gpt-5", "claude-opus-4-8", nil, time.Now())
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	// Client sees the upstream reason and a retryable status, not an opaque 502.
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+	body := rec.Body.String()
+	require.Equal(t, "rate_limit_error", gjson.Get(body, "error.type").String())
+	require.Contains(t, gjson.Get(body, "error.message").String(), "concurrent connections")
+
+	requireUpstreamAttributed(t, c, http.StatusTooManyRequests)
+}
+
+func TestTKAnthropicBufferedError_ResponsesPathAttributesUpstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	resp := newBufferedErrorUpstreamResponse(
+		anthropicErrorOnlySSE("overloaded_error", "Overloaded"),
+	)
+
+	svc := &GatewayService{}
+	result, err := svc.handleResponsesBufferedStreamingResponse(
+		resp, c, "gpt-5", "claude-opus-4-8", nil, time.Now(), apicompat.ResponsesClientToolMapping{},
+	)
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "overloaded_error", gjson.Get(rec.Body.String(), "error.code").String())
+
+	requireUpstreamAttributed(t, c, statusAnthropicOverloaded)
+}
+
+func TestTKAnthropicBufferedError_NativeCCPathAttributesUpstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	resp := newBufferedErrorUpstreamResponse(
+		anthropicErrorOnlySSE("invalid_request_error", "max_tokens is too large"),
+	)
+
+	svc := &OpenAIGatewayService{}
+	result, err := svc.handleCCBufferedFromNativeAnthropic(
+		resp, c, "glm-4.7", "glm-4.7", "glm-4.7", nil, time.Now(),
+	)
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	// A client-caused 400 stays a 400 rather than being inflated to 502.
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "invalid_request_error", gjson.Get(rec.Body.String(), "error.type").String())
+
+	requireUpstreamAttributed(t, c, http.StatusBadRequest)
+}
+
+func TestTKAnthropicBufferedError_NativeResponsesPathAttributesUpstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	resp := newBufferedErrorUpstreamResponse(
+		anthropicErrorOnlySSE("authentication_error", "invalid x-api-key"),
+	)
+
+	svc := &OpenAIGatewayService{}
+	result, err := svc.handleResponsesBufferedFromNativeAnthropic(
+		resp, c, "glm-4.7", "glm-4.7", "glm-4.7", nil, time.Now(), apicompat.ResponsesClientToolMapping{},
+	)
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	// Upstream credential faults must not surface as a client 401.
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	require.Equal(t, "upstream_error", gjson.Get(rec.Body.String(), "error.code").String())
+
+	requireUpstreamAttributed(t, c, http.StatusUnauthorized)
+}
+
+// An empty-but-200 stream has no error event to parse. It is still an upstream
+// protocol fault, so it must not be booked as a gateway-internal error either.
+func TestTKAnthropicBufferedError_EmptyStreamStillAttributedUpstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	resp := newBufferedErrorUpstreamResponse("event: ping\ndata: {\"type\":\"ping\"}\n\n")
+
+	svc := &GatewayService{}
+	_, err := svc.handleCCBufferedFromAnthropic(resp, c, "gpt-5", "claude-opus-4-8", nil, time.Now())
+	require.Error(t, err)
+
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	// Message is preserved for operators who learned to grep for it.
+	require.Contains(t, rec.Body.String(), "Upstream stream ended without a response")
+
+	requireUpstreamAttributed(t, c, http.StatusBadGateway)
+
+	raw, _ := c.Get(OpsUpstreamErrorsKey)
+	events := raw.([]*OpsUpstreamErrorEvent)
+	require.Equal(t, "stream_incomplete", events[0].Kind)
+}
+
+// A well-formed stream must not be disturbed by the new error-event branch.
+func TestTKAnthropicBufferedError_HappyPathRecordsNoUpstreamError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	resp := newBufferedErrorUpstreamResponse(strings.Join([]string{
+		"event: message_start",
+		`data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude-opus-4-8","usage":{"input_tokens":11}}}`,
+		"",
+		"event: content_block_start",
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"hi"}}`,
+		"",
+		"event: message_delta",
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":4}}`,
+		"",
+		"",
+	}, "\n"))
+
+	svc := &GatewayService{}
+	result, err := svc.handleCCBufferedFromAnthropic(resp, c, "gpt-5", "claude-opus-4-8", nil, time.Now())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	_, hasStatus := c.Get(OpsUpstreamStatusCodeKey)
+	require.False(t, hasStatus)
+	_, hasEvents := c.Get(OpsUpstreamErrorsKey)
+	require.False(t, hasEvents)
+}
+
+func TestTKAnthropicErrorTypeUpstreamStatusMapping(t *testing.T) {
+	t.Parallel()
+
+	for errType, want := range map[string]int{
+		"invalid_request_error": http.StatusBadRequest,
+		"authentication_error":  http.StatusUnauthorized,
+		"permission_error":      http.StatusForbidden,
+		"not_found_error":       http.StatusNotFound,
+		"request_too_large":     http.StatusRequestEntityTooLarge,
+		"rate_limit_error":      http.StatusTooManyRequests,
+		"billing_error":         http.StatusPaymentRequired,
+		"overloaded_error":      statusAnthropicOverloaded,
+		"api_error":             http.StatusInternalServerError,
+		"something_unknown":     http.StatusInternalServerError,
+	} {
+		require.Equal(t, want, tkAnthropicErrorTypeUpstreamStatus(errType), errType)
+	}
+}
+
+func TestTKParseAnthropicBufferedSSEError_IgnoresNonErrorEvents(t *testing.T) {
+	t.Parallel()
+
+	for _, payload := range []string{
+		`{"type":"message_start","message":{"id":"m"}}`,
+		`{"type":"content_block_delta","delta":{"type":"text_delta","text":"x"}}`,
+		`{"type":"ping"}`,
+		``,
+	} {
+		_, ok := tkParseAnthropicBufferedSSEError([]byte(payload))
+		require.False(t, ok, payload)
+	}
+
+	parsed, ok := tkParseAnthropicBufferedSSEError(
+		[]byte(`{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`),
+	)
+	require.True(t, ok)
+	require.Equal(t, "rate_limit_error", parsed.ErrType)
+	require.Equal(t, "slow down", parsed.Message)
+	require.False(t, parsed.EmptyStream)
+
+	// A bare error event with no usable message still classifies.
+	parsed, ok = tkParseAnthropicBufferedSSEError([]byte(`{"type":"error"}`))
+	require.True(t, ok)
+	require.Equal(t, "api_error", parsed.ErrType)
+	require.NotEmpty(t, parsed.Message)
+}

--- a/backend/internal/service/gateway_anthropic_buffered_error_tk_test.go
+++ b/backend/internal/service/gateway_anthropic_buffered_error_tk_test.go
@@ -64,6 +64,20 @@ func requireUpstreamAttributed(t *testing.T, c *gin.Context, wantUpstreamStatus 
 	// handler/ops_error_logger_tk_buffered_upstream_test.go.
 }
 
+// requireTruncationCountsTowardsSLA pins the half of the truncation fix that
+// upstream context cannot express on its own: with a 2xx wire status the ops
+// logger only counts a request against SLA when an in-band failure is marked.
+func requireTruncationCountsTowardsSLA(t *testing.T, c *gin.Context, wantIntendedStatus int) {
+	t.Helper()
+
+	streamErrs := GetOpsStreamErrors(c)
+	require.Len(t, streamErrs, 1, "a truncated 200 must be marked as an in-band failure")
+	require.True(t, streamErrs[0].CountTowardsSLA,
+		"without CountTowardsSLA the truncated response is logged as recovered and escapes SLA")
+	require.Equal(t, wantIntendedStatus, streamErrs[0].IntendedStatus)
+	require.Equal(t, "upstream_stream_truncated", streamErrs[0].Code)
+}
+
 func TestTKAnthropicBufferedError_CCPathAttributesUpstream(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
@@ -208,6 +222,10 @@ func TestTKAnthropicBufferedError_HappyPathRecordsNoUpstreamError(t *testing.T) 
 	require.False(t, hasStatus)
 	_, hasEvents := c.Get(OpsUpstreamErrorsKey)
 	require.False(t, hasEvents)
+
+	// A complete stream must never be marked as a truncated in-band failure;
+	// otherwise the SLA assertions above could pass vacuously.
+	require.Empty(t, GetOpsStreamErrors(c))
 }
 
 func TestTKAnthropicErrorTypeUpstreamStatusMapping(t *testing.T) {
@@ -330,6 +348,11 @@ func TestTKAnthropicBufferedError_PartialContentThenErrorIsAttributed(t *testing
 	events := raw.([]*OpsUpstreamErrorEvent)
 	require.Equal(t, "stream_truncated", events[0].Kind)
 	require.Equal(t, "overloaded_error", events[0].Reason)
+
+	// Upstream context alone would land in logOpsRecoveredUpstream, which keeps
+	// recovered attempts out of request SLA. A truncated answer did not recover,
+	// so it must also be marked as an in-band failure that counts.
+	requireTruncationCountsTowardsSLA(t, c, http.StatusServiceUnavailable)
 }
 
 // The same partial-then-error shape on the CN native-Anthropic CC path.
@@ -364,4 +387,6 @@ func TestTKAnthropicBufferedError_NativePartialContentThenErrorIsAttributed(t *t
 	raw, _ := c.Get(OpsUpstreamErrorsKey)
 	events := raw.([]*OpsUpstreamErrorEvent)
 	require.Equal(t, "stream_truncated", events[0].Kind)
+
+	requireTruncationCountsTowardsSLA(t, c, http.StatusTooManyRequests)
 }

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -295,6 +295,10 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 
 	var finalResp *apicompat.AnthropicResponse
 	var usage ClaudeUsage
+	// TK: terminal Anthropic `error` events are not modelled by
+	// apicompat.AnthropicStreamEvent; capture them so the fallthrough below can
+	// attribute the failure upstream instead of to the gateway.
+	var upstreamErr *tkAnthropicBufferedUpstreamError
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -312,6 +316,11 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 			continue
 		}
 		observeOpenAIResponsesEvent(c, []byte(payload))
+
+		if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload)); ok {
+			upstreamErr = parsed
+			continue
+		}
 
 		var event apicompat.AnthropicStreamEvent
 		if err := json.Unmarshal([]byte(payload), &event); err != nil {
@@ -361,8 +370,9 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 	}
 
 	if finalResp == nil {
-		writeGatewayCCError(c, http.StatusBadGateway, "server_error", "Upstream stream ended without a response")
-		return nil, fmt.Errorf("upstream stream ended without response")
+		status, errType, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)
+		writeGatewayCCError(c, status, errType, message)
+		return nil, fmt.Errorf("upstream stream ended without response: %s", message)
 	}
 
 	// Update usage from accumulated delta

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -239,7 +239,7 @@ func (s *GatewayService) ForwardAsChatCompletions(
 	} else if isAnthropicMessagesJSONResponse(resp) {
 		result, handleErr = s.handleCCBufferedFromAnthropicJSON(resp, c, originalModel, mappedModel, reasoningEffort, startTime)
 	} else {
-		result, handleErr = s.handleCCBufferedFromAnthropic(resp, c, originalModel, mappedModel, reasoningEffort, startTime)
+		result, handleErr = s.handleCCBufferedFromAnthropic(resp, c, account, originalModel, mappedModel, reasoningEffort, startTime)
 	}
 
 	return result, handleErr
@@ -279,6 +279,7 @@ func extractCCReasoningEffortFromBody(body []byte, modelCandidates ...string) *s
 func (s *GatewayService) handleCCBufferedFromAnthropic(
 	resp *http.Response,
 	c *gin.Context,
+	account *Account,
 	originalModel string,
 	mappedModel string,
 	reasoningEffort *string,
@@ -295,6 +296,7 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 
 	var finalResp *apicompat.AnthropicResponse
 	var usage ClaudeUsage
+	streamCompleted := false
 	// TK: terminal Anthropic `error` events are not modelled by
 	// apicompat.AnthropicStreamEvent; capture them so the fallthrough below can
 	// attribute the failure upstream instead of to the gateway.
@@ -319,7 +321,7 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 
 		if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), s.cfg); ok {
 			upstreamErr = parsed
-			continue
+			break
 		}
 
 		var event apicompat.AnthropicStreamEvent
@@ -341,6 +343,10 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 			if event.Delta != nil && event.Delta.StopReason != "" && finalResp != nil {
 				finalResp.StopReason = apicompat.AnthropicStopReasonPtr(event.Delta.StopReason)
 			}
+		}
+		if tkAnthropicBufferedEventCompletesMessage(&event) {
+			streamCompleted = true
+			break
 		}
 		if event.Type == "content_block_start" && event.ContentBlock != nil && finalResp != nil {
 			finalResp.Content = append(finalResp.Content, *event.ContentBlock)
@@ -367,18 +373,23 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 				zap.String("request_id", requestID),
 			)
 		}
+		if upstreamErr == nil {
+			upstreamErr = tkAnthropicBufferedSyntheticFailure("stream_read_error", "Upstream stream read failed before response completion")
+		}
 	}
 
+	if !streamCompleted && upstreamErr == nil {
+		upstreamErr = tkAnthropicBufferedSyntheticFailure("stream_incomplete", "Upstream stream ended before response completion")
+	}
+	if upstreamErr != nil {
+		if !tkAnthropicBufferedHasUsableContent(finalResp) {
+			return nil, s.tkAnthropicBufferedFailoverError(c, account, resp, requestID, mappedModel, upstreamErr)
+		}
+		tkAnthropicBufferedPartialFailure(c, account, requestID, upstreamErr)
+	}
 	if finalResp == nil {
-		status, errType, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)
-		writeGatewayCCError(c, status, errType, message)
-		return nil, fmt.Errorf("upstream stream ended without response: %s", message)
+		return nil, s.tkAnthropicBufferedFailoverError(c, account, resp, requestID, mappedModel, nil)
 	}
-
-	// TK: upstream errored after partial content. Keep the tokens the client
-	// already paid for, but attribute the provider fault instead of reporting a
-	// clean success.
-	tkAnthropicBufferedPartialFailure(c, requestID, upstreamErr)
 
 	// Update usage from accumulated delta
 	if usage.InputTokens > 0 || usage.OutputTokens > 0 {

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -317,7 +317,7 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 		}
 		observeOpenAIResponsesEvent(c, []byte(payload))
 
-		if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload)); ok {
+		if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), s.cfg); ok {
 			upstreamErr = parsed
 			continue
 		}
@@ -374,6 +374,11 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 		writeGatewayCCError(c, status, errType, message)
 		return nil, fmt.Errorf("upstream stream ended without response: %s", message)
 	}
+
+	// TK: upstream errored after partial content. Keep the tokens the client
+	// already paid for, but attribute the provider fault instead of reporting a
+	// clean success.
+	tkAnthropicBufferedPartialFailure(c, requestID, upstreamErr)
 
 	// Update usage from accumulated delta
 	if usage.InputTokens > 0 || usage.OutputTokens > 0 {

--- a/backend/internal/service/gateway_forward_as_chat_completions_test.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_test.go
@@ -86,7 +86,7 @@ func TestHandleCCBufferedFromAnthropic_PreservesMessageStartCacheUsageAndReasoni
 	}
 
 	svc := &GatewayService{}
-	result, err := svc.handleCCBufferedFromAnthropic(resp, c, "gpt-5", "claude-sonnet-4.5", &reasoningEffort, time.Now())
+	result, err := svc.handleCCBufferedFromAnthropic(resp, c, nil, "gpt-5", "claude-sonnet-4.5", &reasoningEffort, time.Now())
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, 12, result.Usage.InputTokens)
@@ -123,7 +123,7 @@ func TestHandleCCBufferedFromAnthropic_CompactSSEFormat(t *testing.T) {
 	}
 
 	svc := &GatewayService{}
-	result, err := svc.handleCCBufferedFromAnthropic(resp, c, "k3", "k3", nil, time.Now())
+	result, err := svc.handleCCBufferedFromAnthropic(resp, c, nil, "k3", "k3", nil, time.Now())
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, 15, result.Usage.InputTokens)

--- a/backend/internal/service/gateway_forward_as_chat_completions_tk_bedrock.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_tk_bedrock.go
@@ -82,7 +82,7 @@ func (s *GatewayService) forwardAsChatCompletionsViaBedrock(
 	} else if isAnthropicMessagesJSONResponse(upstreamResp) {
 		result, err = s.handleCCBufferedFromAnthropicJSON(upstreamResp, c, originalModel, mappedModel, reasoningEffort, startTime)
 	} else {
-		result, err = s.handleCCBufferedFromAnthropic(upstreamResp, c, originalModel, mappedModel, reasoningEffort, startTime)
+		result, err = s.handleCCBufferedFromAnthropic(upstreamResp, c, account, originalModel, mappedModel, reasoningEffort, startTime)
 	}
 	if err != nil {
 		return nil, err

--- a/backend/internal/service/gateway_forward_as_chat_completions_tk_content_type_test.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_tk_content_type_test.go
@@ -58,7 +58,7 @@ func TestHandleCCBufferedFromAnthropic_NonStream_ReturnsApplicationJSONContentTy
 	svc := &GatewayService{
 		responseHeaderFilter: responseheaders.CompileHeaderFilter(config.ResponseHeaderConfig{}),
 	}
-	result, err := svc.handleCCBufferedFromAnthropic(resp, c, "claude-sonnet-4.5", "claude-sonnet-4.5", nil, time.Now())
+	result, err := svc.handleCCBufferedFromAnthropic(resp, c, nil, "claude-sonnet-4.5", "claude-sonnet-4.5", nil, time.Now())
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.False(t, result.Stream, "non-stream request must produce non-stream result")

--- a/backend/internal/service/gateway_forward_as_chat_completions_tk_kiro.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_tk_kiro.go
@@ -102,7 +102,7 @@ func (s *GatewayService) forwardAsChatCompletionsViaKiro(
 	} else if isAnthropicMessagesJSONResponse(upstreamResp) {
 		result, err = s.handleCCBufferedFromAnthropicJSON(upstreamResp, c, originalModel, mappedModel, reasoningEffort, startTime)
 	} else {
-		result, err = s.handleCCBufferedFromAnthropic(upstreamResp, c, originalModel, mappedModel, reasoningEffort, startTime)
+		result, err = s.handleCCBufferedFromAnthropic(upstreamResp, c, account, originalModel, mappedModel, reasoningEffort, startTime)
 	}
 	if err != nil {
 		return nil, err

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -214,7 +214,7 @@ func (s *GatewayService) ForwardAsResponses(
 	if clientStream {
 		result, handleErr = s.handleResponsesStreamingResponse(resp, c, originalModel, mappedModel, reasoningEffort, startTime, clientToolMapping)
 	} else {
-		result, handleErr = s.handleResponsesBufferedStreamingResponse(resp, c, originalModel, mappedModel, reasoningEffort, startTime, clientToolMapping)
+		result, handleErr = s.handleResponsesBufferedStreamingResponse(resp, c, account, originalModel, mappedModel, reasoningEffort, startTime, clientToolMapping)
 	}
 
 	return result, handleErr
@@ -330,6 +330,7 @@ func parseAnthropicSSEField(line, field string) (string, bool) {
 func (s *GatewayService) handleResponsesBufferedStreamingResponse(
 	resp *http.Response,
 	c *gin.Context,
+	account *Account,
 	originalModel string,
 	mappedModel string,
 	reasoningEffort *string,
@@ -348,6 +349,7 @@ func (s *GatewayService) handleResponsesBufferedStreamingResponse(
 	// Accumulate the final Anthropic response from streaming events
 	var finalResp *apicompat.AnthropicResponse
 	var usage ClaudeUsage
+	streamCompleted := false
 	// TK: terminal Anthropic `error` events are not modelled by
 	// apicompat.AnthropicStreamEvent; capture them so the fallthrough below can
 	// attribute the failure upstream instead of to the gateway.
@@ -372,7 +374,7 @@ func (s *GatewayService) handleResponsesBufferedStreamingResponse(
 
 		if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), s.cfg); ok {
 			upstreamErr = parsed
-			continue
+			break
 		}
 
 		var event apicompat.AnthropicStreamEvent
@@ -399,6 +401,10 @@ func (s *GatewayService) handleResponsesBufferedStreamingResponse(
 			if event.Delta != nil && event.Delta.StopReason != "" && finalResp != nil {
 				finalResp.StopReason = apicompat.AnthropicStopReasonPtr(event.Delta.StopReason)
 			}
+		}
+		if tkAnthropicBufferedEventCompletesMessage(&event) {
+			streamCompleted = true
+			break
 		}
 
 		// Accumulate content blocks
@@ -427,18 +433,23 @@ func (s *GatewayService) handleResponsesBufferedStreamingResponse(
 				zap.String("request_id", requestID),
 			)
 		}
+		if upstreamErr == nil {
+			upstreamErr = tkAnthropicBufferedSyntheticFailure("stream_read_error", "Upstream stream read failed before response completion")
+		}
 	}
 
+	if !streamCompleted && upstreamErr == nil {
+		upstreamErr = tkAnthropicBufferedSyntheticFailure("stream_incomplete", "Upstream stream ended before response completion")
+	}
+	if upstreamErr != nil {
+		if !tkAnthropicBufferedHasUsableContent(finalResp) {
+			return nil, s.tkAnthropicBufferedFailoverError(c, account, resp, requestID, mappedModel, upstreamErr)
+		}
+		tkAnthropicBufferedPartialFailure(c, account, requestID, upstreamErr)
+	}
 	if finalResp == nil {
-		status, errCode, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)
-		writeResponsesError(c, status, errCode, message)
-		return nil, fmt.Errorf("upstream stream ended without response: %s", message)
+		return nil, s.tkAnthropicBufferedFailoverError(c, account, resp, requestID, mappedModel, nil)
 	}
-
-	// TK: upstream errored after partial content. Keep the tokens the client
-	// already paid for, but attribute the provider fault instead of reporting a
-	// clean success.
-	tkAnthropicBufferedPartialFailure(c, requestID, upstreamErr)
 
 	// Update usage from accumulated delta
 	if usage.InputTokens > 0 || usage.OutputTokens > 0 {

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -348,6 +348,10 @@ func (s *GatewayService) handleResponsesBufferedStreamingResponse(
 	// Accumulate the final Anthropic response from streaming events
 	var finalResp *apicompat.AnthropicResponse
 	var usage ClaudeUsage
+	// TK: terminal Anthropic `error` events are not modelled by
+	// apicompat.AnthropicStreamEvent; capture them so the fallthrough below can
+	// attribute the failure upstream instead of to the gateway.
+	var upstreamErr *tkAnthropicBufferedUpstreamError
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -363,6 +367,11 @@ func (s *GatewayService) handleResponsesBufferedStreamingResponse(
 		dataLine := scanner.Text()
 		payload, ok := parseAnthropicSSEField(dataLine, "data")
 		if !ok {
+			continue
+		}
+
+		if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload)); ok {
+			upstreamErr = parsed
 			continue
 		}
 
@@ -421,8 +430,9 @@ func (s *GatewayService) handleResponsesBufferedStreamingResponse(
 	}
 
 	if finalResp == nil {
-		writeResponsesError(c, http.StatusBadGateway, "server_error", "Upstream stream ended without a response")
-		return nil, fmt.Errorf("upstream stream ended without response")
+		status, errCode, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)
+		writeResponsesError(c, status, errCode, message)
+		return nil, fmt.Errorf("upstream stream ended without response: %s", message)
 	}
 
 	// Update usage from accumulated delta

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -370,7 +370,7 @@ func (s *GatewayService) handleResponsesBufferedStreamingResponse(
 			continue
 		}
 
-		if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload)); ok {
+		if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), s.cfg); ok {
 			upstreamErr = parsed
 			continue
 		}
@@ -434,6 +434,11 @@ func (s *GatewayService) handleResponsesBufferedStreamingResponse(
 		writeResponsesError(c, status, errCode, message)
 		return nil, fmt.Errorf("upstream stream ended without response: %s", message)
 	}
+
+	// TK: upstream errored after partial content. Keep the tokens the client
+	// already paid for, but attribute the provider fault instead of reporting a
+	// clean success.
+	tkAnthropicBufferedPartialFailure(c, requestID, upstreamErr)
 
 	// Update usage from accumulated delta
 	if usage.InputTokens > 0 || usage.OutputTokens > 0 {

--- a/backend/internal/service/gateway_forward_as_responses_test.go
+++ b/backend/internal/service/gateway_forward_as_responses_test.go
@@ -109,7 +109,7 @@ func TestHandleResponsesBufferedStreamingResponse_RestoresNamespaceTool(t *testi
 	resp := &http.Response{Body: io.NopCloser(strings.NewReader(namespaceToolAnthropicStream()))}
 
 	svc := &GatewayService{}
-	_, err := svc.handleResponsesBufferedStreamingResponse(resp, c, "claude-fable-5", "claude-fable-5", nil, time.Now(), namespaceToolMapping())
+	_, err := svc.handleResponsesBufferedStreamingResponse(resp, c, nil, "claude-fable-5", "claude-fable-5", nil, time.Now(), namespaceToolMapping())
 	require.NoError(t, err)
 	require.Contains(t, rec.Body.String(), `"type":"function_call"`)
 	require.Contains(t, rec.Body.String(), `"name":"read_thread"`)
@@ -183,7 +183,7 @@ func TestHandleResponsesBufferedStreamingResponse_PreservesMessageStartCacheUsag
 	}
 
 	svc := &GatewayService{}
-	result, err := svc.handleResponsesBufferedStreamingResponse(resp, c, "claude-sonnet-4.5", "claude-sonnet-4.5", nil, time.Now(), apicompat.ResponsesClientToolMapping{})
+	result, err := svc.handleResponsesBufferedStreamingResponse(resp, c, nil, "claude-sonnet-4.5", "claude-sonnet-4.5", nil, time.Now(), apicompat.ResponsesClientToolMapping{})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, 12, result.Usage.InputTokens)
@@ -292,7 +292,7 @@ func TestHandleResponsesBufferedStreamingResponse_CompactSSEFormat(t *testing.T)
 	}
 
 	svc := &GatewayService{}
-	result, err := svc.handleResponsesBufferedStreamingResponse(resp, c, "claude-sonnet-4.5", "claude-sonnet-4.5", nil, time.Now(), apicompat.ResponsesClientToolMapping{})
+	result, err := svc.handleResponsesBufferedStreamingResponse(resp, c, nil, "claude-sonnet-4.5", "claude-sonnet-4.5", nil, time.Now(), apicompat.ResponsesClientToolMapping{})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, 10, result.Usage.InputTokens)

--- a/backend/internal/service/gateway_forward_as_responses_tk_content_type_test.go
+++ b/backend/internal/service/gateway_forward_as_responses_tk_content_type_test.go
@@ -64,7 +64,7 @@ func TestHandleResponsesBufferedStreamingResponse_NonStream_ReturnsApplicationJS
 	svc := &GatewayService{
 		responseHeaderFilter: responseheaders.CompileHeaderFilter(config.ResponseHeaderConfig{}),
 	}
-	result, err := svc.handleResponsesBufferedStreamingResponse(resp, c, "claude-sonnet-4.5", "claude-sonnet-4.5", nil, time.Now(), apicompat.ResponsesClientToolMapping{})
+	result, err := svc.handleResponsesBufferedStreamingResponse(resp, c, nil, "claude-sonnet-4.5", "claude-sonnet-4.5", nil, time.Now(), apicompat.ResponsesClientToolMapping{})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.False(t, result.Stream, "non-stream request must produce non-stream result")

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -695,6 +695,7 @@ type UpstreamFailoverError struct {
 	Reason                   GatewayFailureReason
 	NextAccountAction        NextAccountAction
 	ClientStatusCode         int
+	ClientErrorType          string
 	ClientMessage            string
 }
 

--- a/backend/internal/service/openai_gateway_anthropic_native_pump_test.go
+++ b/backend/internal/service/openai_gateway_anthropic_native_pump_test.go
@@ -6,6 +6,7 @@ package service
 
 import (
 	"bufio"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -28,6 +29,19 @@ func newNativeAnthropicHangTestService(intervalSec int) *OpenAIGatewayService {
 			},
 		},
 	}
+}
+
+func nativeBufferedAnthropicTestAccount() *Account {
+	return &Account{ID: 1805, Name: "native-buffered-anthropic-test", Platform: PlatformOpenAI}
+}
+
+func requireNativeBufferedTruncationCountsTowardsSLA(t *testing.T, c *gin.Context, wantIntendedStatus int) {
+	t.Helper()
+	streamErrs := GetOpsStreamErrors(c)
+	require.Len(t, streamErrs, 1)
+	require.True(t, streamErrs[0].CountTowardsSLA)
+	require.Equal(t, wantIntendedStatus, streamErrs[0].IntendedStatus)
+	require.Equal(t, "upstream_stream_truncated", streamErrs[0].Code)
 }
 
 func newHangingUpstreamResponse() (*http.Response, *io.PipeReader, *io.PipeWriter) {
@@ -142,19 +156,19 @@ func TestCCBufferedFromNativeAnthropic_HangTimesOut(t *testing.T) {
 
 	resp, pr, pw := newHangingUpstreamResponse()
 	start := time.Now()
-	_, err := svc.handleCCBufferedFromNativeAnthropic(resp, c, "glm-4.7", "glm-4.7", "glm-4.7", nil, start)
+	result, err := svc.handleCCBufferedFromNativeAnthropic(resp, c, nativeBufferedAnthropicTestAccount(), "glm-4.7", "glm-4.7", "glm-4.7", nil, start)
 	_ = pw.Close()
 	_ = pr.Close()
 
-	if err == nil || !strings.Contains(err.Error(), "stream data interval timeout") {
-		t.Fatalf("expected stream timeout error, got %v", err)
-	}
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.Contains(t, failoverErr.ClientMessage, "stream data interval timeout")
 	if elapsed := time.Since(start); elapsed > 5*time.Second {
 		t.Fatalf("handler did not respect interval bound: %v", elapsed)
 	}
-	if !strings.Contains(rec.Body.String(), "Upstream stream data interval timeout") {
-		t.Fatalf("expected 502 error body, got %q", rec.Body.String())
-	}
+	require.False(t, c.Writer.Written(), "no-content timeout must remain replayable")
 }
 
 func TestResponsesStreamingFromNativeAnthropic_HangTimesOut(t *testing.T) {
@@ -228,7 +242,7 @@ func TestCCBufferedFromNativeAnthropic_HappyPathStillConverts(t *testing.T) {
 	}()
 	defer func() { _ = pr.Close() }()
 
-	res, err := svc.handleCCBufferedFromNativeAnthropic(resp, c, "glm-4.7", "glm-4.7", "glm-4.7", nil, time.Now())
+	res, err := svc.handleCCBufferedFromNativeAnthropic(resp, c, nativeBufferedAnthropicTestAccount(), "glm-4.7", "glm-4.7", "glm-4.7", nil, time.Now())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -239,4 +253,58 @@ func TestCCBufferedFromNativeAnthropic_HappyPathStillConverts(t *testing.T) {
 	}
 	require.Equal(t, 10, res.Usage.InputTokens)
 	require.Equal(t, 5, res.Usage.OutputTokens)
+}
+
+func TestUS047_NativeBufferedIdleRoutesByContentAvailability(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("no content returns failover without writing", func(t *testing.T) {
+		svc := newNativeAnthropicHangTestService(1)
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+		resp, pr, pw := newHangingUpstreamResponse()
+
+		result, err := svc.handleCCBufferedFromNativeAnthropic(
+			resp, c, nativeBufferedAnthropicTestAccount(), "glm-4.7", "glm-4.7", "glm-4.7", nil, time.Now(),
+		)
+		_ = pw.Close()
+		_ = pr.Close()
+
+		require.Nil(t, result)
+		var failoverErr *UpstreamFailoverError
+		require.True(t, errors.As(err, &failoverErr))
+		require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+		require.False(t, c.Writer.Written())
+	})
+
+	t.Run("partial content returns 200 and marks truncation", func(t *testing.T) {
+		svc := newNativeAnthropicHangTestService(1)
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+		resp, pr, pw := newHangingUpstreamResponse()
+		go func() {
+			_, _ = pw.Write([]byte(strings.Join([]string{
+				"event: message_start",
+				`data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"glm-4.7","usage":{"input_tokens":10}}}`,
+				"",
+				"event: content_block_start",
+				`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"partial"}}`,
+				"",
+			}, "\n")))
+		}()
+
+		result, err := svc.handleCCBufferedFromNativeAnthropic(
+			resp, c, nativeBufferedAnthropicTestAccount(), "glm-4.7", "glm-4.7", "glm-4.7", nil, time.Now(),
+		)
+		_ = pw.Close()
+		_ = pr.Close()
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Contains(t, rec.Body.String(), "partial")
+		requireNativeBufferedTruncationCountsTowardsSLA(t, c, http.StatusBadGateway)
+	})
 }

--- a/backend/internal/service/openai_gateway_chat_completions_anthropic_native.go
+++ b/backend/internal/service/openai_gateway_chat_completions_anthropic_native.go
@@ -138,7 +138,7 @@ func (s *OpenAIGatewayService) forwardChatCompletionsViaNativeAnthropic(
 	if clientStream {
 		return s.handleCCStreamingFromNativeAnthropic(resp, c, originalModel, billingModel, upstreamModel, reasoningEffort, startTime, includeUsage)
 	}
-	return s.handleCCBufferedFromNativeAnthropic(resp, c, originalModel, billingModel, upstreamModel, reasoningEffort, startTime)
+	return s.handleCCBufferedFromNativeAnthropic(resp, c, account, originalModel, billingModel, upstreamModel, reasoningEffort, startTime)
 }
 
 // handleCCBufferedFromNativeAnthropic reads Anthropic SSE events, assembles the
@@ -146,6 +146,7 @@ func (s *OpenAIGatewayService) forwardChatCompletionsViaNativeAnthropic(
 func (s *OpenAIGatewayService) handleCCBufferedFromNativeAnthropic(
 	resp *http.Response,
 	c *gin.Context,
+	account *Account,
 	originalModel string,
 	billingModel string,
 	upstreamModel string,
@@ -163,6 +164,7 @@ func (s *OpenAIGatewayService) handleCCBufferedFromNativeAnthropic(
 
 	var finalResp *apicompat.AnthropicResponse
 	var usage ClaudeUsage
+	streamCompleted := false
 	// TK: terminal Anthropic `error` events are not modelled by
 	// apicompat.AnthropicStreamEvent; capture them so the fallthrough below can
 	// attribute the failure upstream instead of to the gateway.
@@ -181,23 +183,20 @@ func (s *OpenAIGatewayService) handleCCBufferedFromNativeAnthropic(
 			)
 		}
 	}
-	onIdle := func() (*OpenAIForwardResult, error) {
-		_ = resp.Body.Close()
-		logger.L().Warn("openai cc via native anthropic buffered: data interval timeout",
-			zap.String("request_id", requestID),
-			zap.Duration("interval", streamInterval),
-		)
-		writeChatCompletionsError(c, http.StatusBadGateway, "server_error", "Upstream stream data interval timeout")
-		return nil, fmt.Errorf("stream data interval timeout")
-	}
-
 	for {
 		line, rerr := pump.next()
 		if rerr != nil {
 			if errors.Is(rerr, errAnthropicNativeStreamIdle) {
-				return onIdle()
+				_ = resp.Body.Close()
+				logger.L().Warn("openai cc via native anthropic buffered: data interval timeout",
+					zap.String("request_id", requestID),
+					zap.Duration("interval", streamInterval),
+				)
+				upstreamErr = tkAnthropicBufferedSyntheticFailure("stream_timeout", "Upstream stream data interval timeout")
+			} else if !errors.Is(rerr, io.EOF) {
+				logReadErr(rerr)
+				upstreamErr = tkAnthropicBufferedSyntheticFailure("stream_read_error", "Upstream stream read failed before response completion")
 			}
-			logReadErr(rerr)
 			break
 		}
 		// SSE 规范允许 `event:xxx`（冒号后无空格）：Kimi 等 Anthropic 兼容上游
@@ -209,9 +208,16 @@ func (s *OpenAIGatewayService) handleCCBufferedFromNativeAnthropic(
 		dataLine, rerr := pump.next()
 		if rerr != nil {
 			if errors.Is(rerr, errAnthropicNativeStreamIdle) {
-				return onIdle()
+				_ = resp.Body.Close()
+				logger.L().Warn("openai cc via native anthropic buffered: data interval timeout",
+					zap.String("request_id", requestID),
+					zap.Duration("interval", streamInterval),
+				)
+				upstreamErr = tkAnthropicBufferedSyntheticFailure("stream_timeout", "Upstream stream data interval timeout")
+			} else if !errors.Is(rerr, io.EOF) {
+				logReadErr(rerr)
+				upstreamErr = tkAnthropicBufferedSyntheticFailure("stream_read_error", "Upstream stream read failed before response completion")
 			}
-			logReadErr(rerr)
 			break
 		}
 		payload, ok := extractOpenAISSEDataLine(dataLine)
@@ -221,7 +227,7 @@ func (s *OpenAIGatewayService) handleCCBufferedFromNativeAnthropic(
 
 		if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), s.cfg); ok {
 			upstreamErr = parsed
-			continue
+			break
 		}
 
 		var event apicompat.AnthropicStreamEvent
@@ -241,6 +247,10 @@ func (s *OpenAIGatewayService) handleCCBufferedFromNativeAnthropic(
 				finalResp.StopReason = apicompat.AnthropicStopReasonPtr(event.Delta.StopReason)
 			}
 		}
+		if tkAnthropicBufferedEventCompletesMessage(&event) {
+			streamCompleted = true
+			break
+		}
 		if event.Type == "content_block_start" && event.ContentBlock != nil && finalResp != nil {
 			finalResp.Content = append(finalResp.Content, *event.ContentBlock)
 		}
@@ -259,16 +269,18 @@ func (s *OpenAIGatewayService) handleCCBufferedFromNativeAnthropic(
 		}
 	}
 
-	if finalResp == nil {
-		status, errType, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)
-		writeChatCompletionsError(c, status, errType, message)
-		return nil, fmt.Errorf("upstream stream ended without response: %s", message)
+	if !streamCompleted && upstreamErr == nil {
+		upstreamErr = tkAnthropicBufferedSyntheticFailure("stream_incomplete", "Upstream stream ended before response completion")
 	}
-
-	// TK: upstream errored after partial content. Keep the tokens the client
-	// already paid for, but attribute the provider fault instead of reporting a
-	// clean success.
-	tkAnthropicBufferedPartialFailure(c, requestID, upstreamErr)
+	if upstreamErr != nil {
+		if !tkAnthropicBufferedHasUsableContent(finalResp) {
+			return nil, s.tkAnthropicBufferedFailoverError(c, account, resp, requestID, upstreamModel, upstreamErr)
+		}
+		tkAnthropicBufferedPartialFailure(c, account, requestID, upstreamErr)
+	}
+	if finalResp == nil {
+		return nil, s.tkAnthropicBufferedFailoverError(c, account, resp, requestID, upstreamModel, nil)
+	}
 
 	if usage.InputTokens > 0 || usage.OutputTokens > 0 {
 		finalResp.Usage = apicompat.AnthropicUsage{

--- a/backend/internal/service/openai_gateway_chat_completions_anthropic_native.go
+++ b/backend/internal/service/openai_gateway_chat_completions_anthropic_native.go
@@ -163,6 +163,10 @@ func (s *OpenAIGatewayService) handleCCBufferedFromNativeAnthropic(
 
 	var finalResp *apicompat.AnthropicResponse
 	var usage ClaudeUsage
+	// TK: terminal Anthropic `error` events are not modelled by
+	// apicompat.AnthropicStreamEvent; capture them so the fallthrough below can
+	// attribute the failure upstream instead of to the gateway.
+	var upstreamErr *tkAnthropicBufferedUpstreamError
 
 	// 读间隔上限：上游挂住 SSE 时中止组装（缓冲路径尚未提交响应头，可回 502）。
 	streamInterval := s.anthropicNativeStreamInterval()
@@ -215,6 +219,11 @@ func (s *OpenAIGatewayService) handleCCBufferedFromNativeAnthropic(
 			continue
 		}
 
+		if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload)); ok {
+			upstreamErr = parsed
+			continue
+		}
+
 		var event apicompat.AnthropicStreamEvent
 		if err := json.Unmarshal([]byte(payload), &event); err != nil {
 			continue
@@ -251,8 +260,9 @@ func (s *OpenAIGatewayService) handleCCBufferedFromNativeAnthropic(
 	}
 
 	if finalResp == nil {
-		writeChatCompletionsError(c, http.StatusBadGateway, "server_error", "Upstream stream ended without a response")
-		return nil, fmt.Errorf("upstream stream ended without response")
+		status, errType, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)
+		writeChatCompletionsError(c, status, errType, message)
+		return nil, fmt.Errorf("upstream stream ended without response: %s", message)
 	}
 
 	if usage.InputTokens > 0 || usage.OutputTokens > 0 {

--- a/backend/internal/service/openai_gateway_chat_completions_anthropic_native.go
+++ b/backend/internal/service/openai_gateway_chat_completions_anthropic_native.go
@@ -219,7 +219,7 @@ func (s *OpenAIGatewayService) handleCCBufferedFromNativeAnthropic(
 			continue
 		}
 
-		if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload)); ok {
+		if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), s.cfg); ok {
 			upstreamErr = parsed
 			continue
 		}
@@ -264,6 +264,11 @@ func (s *OpenAIGatewayService) handleCCBufferedFromNativeAnthropic(
 		writeChatCompletionsError(c, status, errType, message)
 		return nil, fmt.Errorf("upstream stream ended without response: %s", message)
 	}
+
+	// TK: upstream errored after partial content. Keep the tokens the client
+	// already paid for, but attribute the provider fault instead of reporting a
+	// clean success.
+	tkAnthropicBufferedPartialFailure(c, requestID, upstreamErr)
 
 	if usage.InputTokens > 0 || usage.OutputTokens > 0 {
 		finalResp.Usage = apicompat.AnthropicUsage{

--- a/backend/internal/service/openai_gateway_responses_anthropic_native.go
+++ b/backend/internal/service/openai_gateway_responses_anthropic_native.go
@@ -221,7 +221,7 @@ func (s *OpenAIGatewayService) handleResponsesBufferedFromNativeAnthropic(
 			continue
 		}
 
-		if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload)); ok {
+		if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), s.cfg); ok {
 			upstreamErr = parsed
 			continue
 		}
@@ -266,6 +266,11 @@ func (s *OpenAIGatewayService) handleResponsesBufferedFromNativeAnthropic(
 		writeResponsesError(c, status, errCode, message)
 		return nil, fmt.Errorf("upstream stream ended without response: %s", message)
 	}
+
+	// TK: upstream errored after partial content. Keep the tokens the client
+	// already paid for, but attribute the provider fault instead of reporting a
+	// clean success.
+	tkAnthropicBufferedPartialFailure(c, requestID, upstreamErr)
 
 	if usage.InputTokens > 0 || usage.OutputTokens > 0 {
 		finalResp.Usage = apicompat.AnthropicUsage{

--- a/backend/internal/service/openai_gateway_responses_anthropic_native.go
+++ b/backend/internal/service/openai_gateway_responses_anthropic_native.go
@@ -166,6 +166,10 @@ func (s *OpenAIGatewayService) handleResponsesBufferedFromNativeAnthropic(
 
 	var finalResp *apicompat.AnthropicResponse
 	var usage ClaudeUsage
+	// TK: terminal Anthropic `error` events are not modelled by
+	// apicompat.AnthropicStreamEvent; capture them so the fallthrough below can
+	// attribute the failure upstream instead of to the gateway.
+	var upstreamErr *tkAnthropicBufferedUpstreamError
 
 	// 读间隔上限：上游挂住 SSE 时中止组装（缓冲路径尚未提交响应头，可回 502）。
 	streamInterval := s.anthropicNativeStreamInterval()
@@ -217,6 +221,11 @@ func (s *OpenAIGatewayService) handleResponsesBufferedFromNativeAnthropic(
 			continue
 		}
 
+		if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload)); ok {
+			upstreamErr = parsed
+			continue
+		}
+
 		var event apicompat.AnthropicStreamEvent
 		if err := json.Unmarshal([]byte(payload), &event); err != nil {
 			continue
@@ -253,8 +262,9 @@ func (s *OpenAIGatewayService) handleResponsesBufferedFromNativeAnthropic(
 	}
 
 	if finalResp == nil {
-		writeResponsesError(c, http.StatusBadGateway, "server_error", "Upstream stream ended without a response")
-		return nil, fmt.Errorf("upstream stream ended without response")
+		status, errCode, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)
+		writeResponsesError(c, status, errCode, message)
+		return nil, fmt.Errorf("upstream stream ended without response: %s", message)
 	}
 
 	if usage.InputTokens > 0 || usage.OutputTokens > 0 {

--- a/backend/internal/service/openai_gateway_responses_anthropic_native.go
+++ b/backend/internal/service/openai_gateway_responses_anthropic_native.go
@@ -140,7 +140,7 @@ func (s *OpenAIGatewayService) forwardResponsesViaNativeAnthropic(
 	if clientStream {
 		return s.handleResponsesStreamingFromNativeAnthropic(resp, c, originalModel, billingModel, upstreamModel, reasoningEffort, startTime, clientToolMapping)
 	}
-	return s.handleResponsesBufferedFromNativeAnthropic(resp, c, originalModel, billingModel, upstreamModel, reasoningEffort, startTime, clientToolMapping)
+	return s.handleResponsesBufferedFromNativeAnthropic(resp, c, account, originalModel, billingModel, upstreamModel, reasoningEffort, startTime, clientToolMapping)
 }
 
 // handleResponsesBufferedFromNativeAnthropic reads Anthropic SSE events, assembles
@@ -148,6 +148,7 @@ func (s *OpenAIGatewayService) forwardResponsesViaNativeAnthropic(
 func (s *OpenAIGatewayService) handleResponsesBufferedFromNativeAnthropic(
 	resp *http.Response,
 	c *gin.Context,
+	account *Account,
 	originalModel string,
 	billingModel string,
 	upstreamModel string,
@@ -166,6 +167,7 @@ func (s *OpenAIGatewayService) handleResponsesBufferedFromNativeAnthropic(
 
 	var finalResp *apicompat.AnthropicResponse
 	var usage ClaudeUsage
+	streamCompleted := false
 	// TK: terminal Anthropic `error` events are not modelled by
 	// apicompat.AnthropicStreamEvent; capture them so the fallthrough below can
 	// attribute the failure upstream instead of to the gateway.
@@ -184,23 +186,20 @@ func (s *OpenAIGatewayService) handleResponsesBufferedFromNativeAnthropic(
 			)
 		}
 	}
-	onIdle := func() (*OpenAIForwardResult, error) {
-		_ = resp.Body.Close()
-		logger.L().Warn("openai responses via native anthropic buffered: data interval timeout",
-			zap.String("request_id", requestID),
-			zap.Duration("interval", streamInterval),
-		)
-		writeResponsesError(c, http.StatusBadGateway, "server_error", "Upstream stream data interval timeout")
-		return nil, fmt.Errorf("stream data interval timeout")
-	}
-
 	for {
 		line, rerr := pump.next()
 		if rerr != nil {
 			if errors.Is(rerr, errAnthropicNativeStreamIdle) {
-				return onIdle()
+				_ = resp.Body.Close()
+				logger.L().Warn("openai responses via native anthropic buffered: data interval timeout",
+					zap.String("request_id", requestID),
+					zap.Duration("interval", streamInterval),
+				)
+				upstreamErr = tkAnthropicBufferedSyntheticFailure("stream_timeout", "Upstream stream data interval timeout")
+			} else if !errors.Is(rerr, io.EOF) {
+				logReadErr(rerr)
+				upstreamErr = tkAnthropicBufferedSyntheticFailure("stream_read_error", "Upstream stream read failed before response completion")
 			}
-			logReadErr(rerr)
 			break
 		}
 		// SSE 规范允许 `event:xxx`（冒号后无空格）：Kimi 等上游返回紧凑格式。
@@ -211,9 +210,16 @@ func (s *OpenAIGatewayService) handleResponsesBufferedFromNativeAnthropic(
 		dataLine, rerr := pump.next()
 		if rerr != nil {
 			if errors.Is(rerr, errAnthropicNativeStreamIdle) {
-				return onIdle()
+				_ = resp.Body.Close()
+				logger.L().Warn("openai responses via native anthropic buffered: data interval timeout",
+					zap.String("request_id", requestID),
+					zap.Duration("interval", streamInterval),
+				)
+				upstreamErr = tkAnthropicBufferedSyntheticFailure("stream_timeout", "Upstream stream data interval timeout")
+			} else if !errors.Is(rerr, io.EOF) {
+				logReadErr(rerr)
+				upstreamErr = tkAnthropicBufferedSyntheticFailure("stream_read_error", "Upstream stream read failed before response completion")
 			}
-			logReadErr(rerr)
 			break
 		}
 		payload, ok := extractOpenAISSEDataLine(dataLine)
@@ -223,7 +229,7 @@ func (s *OpenAIGatewayService) handleResponsesBufferedFromNativeAnthropic(
 
 		if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), s.cfg); ok {
 			upstreamErr = parsed
-			continue
+			break
 		}
 
 		var event apicompat.AnthropicStreamEvent
@@ -243,6 +249,10 @@ func (s *OpenAIGatewayService) handleResponsesBufferedFromNativeAnthropic(
 				finalResp.StopReason = apicompat.AnthropicStopReasonPtr(event.Delta.StopReason)
 			}
 		}
+		if tkAnthropicBufferedEventCompletesMessage(&event) {
+			streamCompleted = true
+			break
+		}
 		if event.Type == "content_block_start" && event.ContentBlock != nil && finalResp != nil {
 			finalResp.Content = append(finalResp.Content, *event.ContentBlock)
 		}
@@ -261,16 +271,18 @@ func (s *OpenAIGatewayService) handleResponsesBufferedFromNativeAnthropic(
 		}
 	}
 
-	if finalResp == nil {
-		status, errCode, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)
-		writeResponsesError(c, status, errCode, message)
-		return nil, fmt.Errorf("upstream stream ended without response: %s", message)
+	if !streamCompleted && upstreamErr == nil {
+		upstreamErr = tkAnthropicBufferedSyntheticFailure("stream_incomplete", "Upstream stream ended before response completion")
 	}
-
-	// TK: upstream errored after partial content. Keep the tokens the client
-	// already paid for, but attribute the provider fault instead of reporting a
-	// clean success.
-	tkAnthropicBufferedPartialFailure(c, requestID, upstreamErr)
+	if upstreamErr != nil {
+		if !tkAnthropicBufferedHasUsableContent(finalResp) {
+			return nil, s.tkAnthropicBufferedFailoverError(c, account, resp, requestID, upstreamModel, upstreamErr)
+		}
+		tkAnthropicBufferedPartialFailure(c, account, requestID, upstreamErr)
+	}
+	if finalResp == nil {
+		return nil, s.tkAnthropicBufferedFailoverError(c, account, resp, requestID, upstreamModel, nil)
+	}
 
 	if usage.InputTokens > 0 || usage.OutputTokens > 0 {
 		finalResp.Usage = apicompat.AnthropicUsage{

--- a/docs/approved/anthropic-buffered-stream-failure-contract.md
+++ b/docs/approved/anthropic-buffered-stream-failure-contract.md
@@ -1,0 +1,71 @@
+---
+title: Anthropic Buffered Stream Failure Contract
+status: approved
+approved_by: "feng (conversation approval, 2026-08-24)"
+approved_at: 2026-08-24
+authors: [agent]
+created: 2026-08-24
+related_stories: [US-047]
+---
+
+# Anthropic Buffered Stream Failure Contract
+
+## 目标
+
+修复 OpenAI Chat Completions / Responses 转 Anthropic 上游时，非流式客户端由 SSE 缓冲组装响应的失败语义。上游虽然返回 HTTP 200，但可能在 SSE 内发送 `error`、中途 EOF、读错误或数据间隔超时；这些都必须进入既有账号健康、failover 和 Ops 归因链路，不能伪装成网关内部故障或干净成功。
+
+## 行为矩阵
+
+| 上游结果 | 客户端行为 | 调度与健康 | Ops |
+| --- | --- | --- | --- |
+| 完整终止事件 | 返回正常 HTTP 200 | 不 failover | 不记录失败 |
+| 尚无可用内容时出现 `error` | 当前账号尝试失败；failover 耗尽后返回映射后的真实错误 | 复用既有账号健康与 failover | 记录 provider、账号和事件原因 |
+| 尚无可用内容时超时、读错误或未完整 EOF | 当前账号尝试失败；failover 耗尽后返回 502 | 复用既有账号健康与 failover | 记录 provider、账号和中断类型 |
+| 已有可用内容后出现 `error`、超时、读错误或未完整 EOF | 保留部分 HTTP 200，不重放 | 不 failover，避免重复计费和回答漂移 | 标记 `stream_truncated`，计入 SLA |
+| 只有 `message_start`、没有内容，随后失败 | 视为“尚无可用内容” | failover | 不得返回空 HTTP 200 |
+
+“可用内容”指已组装出至少一个 Anthropic content block；只有 `message_start` 不算可用内容。完整终止以 `message_delta.stop_reason` 或 `message_stop` 为准。
+
+## 错误映射
+
+failover 耗尽后保留上游消息，并按现有 OpenAI-compatible 错误表面返回：
+
+| Anthropic error type | 对客 HTTP | 对客错误类型 |
+| --- | --- | --- |
+| `invalid_request_error` | 400 | `invalid_request_error` |
+| `authentication_error` / `permission_error` | 502 | `upstream_error` |
+| `not_found_error` | 404 | `not_found_error` |
+| `request_too_large` | 413 | `request_too_large` |
+| `rate_limit_error` | 429 | `rate_limit_error` |
+| `overloaded_error` | 503 | `overloaded_error` |
+| 未知服务端错误 | 502 | `server_error` |
+
+错误事件、超时和未完整 EOF 均不得在 service 层提前写响应；service 返回 `UpstreamFailoverError`，由现有 handler 在账号切换耗尽后统一写最终响应。部分内容路径除外：它已经产生可计费内容，仍返回单次尝试的部分结果。
+
+## Ops 与账号身份
+
+每个新增 upstream event 必须填写：
+
+- `Platform`
+- `AccountID`
+- `AccountName`
+- `UpstreamStatusCode`
+- `UpstreamRequestID`
+- `Kind`、`Reason`、`Message`
+
+这样平台级 `skip_monitoring` 规则、账号排障、provider SLA 和 failover attempt 链才使用同一份事实。原始错误 payload 仍只在 `log_upstream_error_body` 开启时持久化到 detail；failover 内存对象可携带经过上游错误读取上限约束的错误体，用于最终映射与透传规则。
+
+## 范围
+
+本次覆盖四条缓冲组装路径：Anthropic 平台的 Chat Completions / Responses，以及国产供应商 native-Anthropic 的 Chat Completions / Responses。
+
+不修改流式客户端已经提交响应后的重放策略，不新增配置开关，不修改数据库或前端字段。现有 sentinel 继续锚住单一 owner 与四个调用点。
+
+## 验证
+
+- `message_start -> error` 必须进入 failover，不能返回空 200。
+- error-only、空流、未完整 EOF、读错误和 native idle timeout 在无内容时返回 `UpstreamFailoverError`。
+- 同类故障发生在已有 content block 之后时保留 200，并带 `CountTowardsSLA=true` 的 stream failure。
+- 404 / 413 的错误类型不再落成 `server_error`。
+- upstream event 带完整平台和账号身份。
+- 完整流不产生 upstream event 或 stream failure。

--- a/docs/superpowers/plans/2026-08-24-anthropic-buffered-stream-failure.md
+++ b/docs/superpowers/plans/2026-08-24-anthropic-buffered-stream-failure.md
@@ -1,0 +1,136 @@
+# Anthropic Buffered Stream Failure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make all four buffered Anthropic SSE assembly paths fail over before content, preserve and mark partial content, and return accurate final error contracts.
+
+**Architecture:** Keep parsing, completion-state classification, Ops event construction, and client error mapping in `gateway_anthropic_buffered_error_tk.go`. Pass the selected account into the four buffered assemblers so the shared owner can write complete attempt identity. Return `UpstreamFailoverError` before any client response is committed; let existing handler loops perform health processing, account switching, and exhausted-response writing.
+
+**Tech Stack:** Go 1.26.6, Gin, `bufio.Scanner`, existing `UpstreamFailoverError`, existing Ops context and sentinel checks.
+
+**Spec:** `docs/approved/anthropic-buffered-stream-failure-contract.md`
+
+## Global Constraints
+
+- Do not retry after a content block has been assembled.
+- Do not write a response in service code before returning a failover error.
+- Preserve the partial HTTP 200 response and mark it towards SLA.
+- Every new Ops upstream event includes platform, account ID, and account name.
+- Raw persisted detail remains gated by `log_upstream_error_body`.
+- No new feature flag, schema, route, or frontend contract.
+
+---
+
+### Task 1: Pin failure classification with RED tests
+
+**Files:**
+- Modify: `backend/internal/service/gateway_anthropic_buffered_error_tk_test.go`
+- Modify: `backend/internal/service/openai_gateway_anthropic_native_pump_test.go`
+
+**Interfaces:**
+- Consumes: existing four buffered assembly functions and `UpstreamFailoverError`.
+- Produces: failing `TestUS047_*` regression tests for no-content failover, partial-content preservation, incomplete EOF, timeout, identity, and error type mapping.
+
+- [x] **Step 1: Write failing tests**
+
+Add tests that pass a real `Account{ID, Name, Platform}`, assert `errors.As` for no-content failures, assert recorder remains unwritten before failover exhaustion, and assert partial responses stay HTTP 200 with one SLA-counted stream failure.
+
+- [x] **Step 2: Run tests to verify RED**
+
+Run: `cd backend && GOTOOLCHAIN=go1.26.6 go test -tags=unit ./internal/service -run 'TestUS047_' -count=1`
+
+Expected: FAIL because buffered handlers currently write errors directly, treat `message_start` as success, omit account identity, and do not classify incomplete EOF/idle by content availability.
+
+### Task 2: Return failover errors before content and preserve partial content
+
+**Files:**
+- Modify: `backend/internal/service/gateway_anthropic_buffered_error_tk.go`
+- Modify: `backend/internal/service/gateway_forward_as_chat_completions.go`
+- Modify: `backend/internal/service/gateway_forward_as_responses.go`
+- Modify: `backend/internal/service/openai_gateway_chat_completions_anthropic_native.go`
+- Modify: `backend/internal/service/openai_gateway_responses_anthropic_native.go`
+- Modify: `backend/internal/service/gateway_service.go`
+
+**Interfaces:**
+- Consumes: `Account`, `UpstreamFailoverError`, `MarkOpsStreamFailure`, service-specific account-health helpers.
+- Produces: shared normalized failure state, complete Ops events, `ClientErrorType` on failover errors, and four account-aware buffered assemblers.
+
+- [x] **Step 1: Implement the minimal shared state**
+
+Track terminal completion separately from `finalResp`, retain a bounded in-memory error payload, and classify failure by whether at least one content block exists.
+
+- [x] **Step 2: Implement no-content failover**
+
+Build an `UpstreamFailoverError` carrying semantic upstream status, response body/headers, `ClientStatusCode`, `ClientErrorType`, and `ClientMessage`. Run the same account-health side effects used by ordinary upstream failures. Do not write to `gin.Context` response output.
+
+- [x] **Step 3: Implement partial-content truncation**
+
+For error, timeout, read error, or incomplete EOF after a content block, record `stream_truncated`, call `MarkOpsStreamFailure`, and continue the existing response conversion without replay.
+
+- [x] **Step 4: Run focused tests to verify GREEN**
+
+Run: `cd backend && GOTOOLCHAIN=go1.26.6 go test -tags=unit ./internal/service -run 'TestUS047_|TestTKAnthropicBufferedError_|TestCCBufferedFromNativeAnthropic_' -count=1`
+
+Expected: PASS.
+
+### Task 3: Preserve final error type at failover exhaustion
+
+**Files:**
+- Modify: `backend/internal/handler/gateway_handler.go`
+- Modify: `backend/internal/handler/gateway_handler_responses.go`
+- Modify: `backend/internal/handler/openai_gateway_handler.go`
+- Test: `backend/internal/handler/gateway_anthropic_buffered_failover_tk_test.go`
+
+**Interfaces:**
+- Consumes: `UpstreamFailoverError.ClientErrorType`.
+- Produces: handler exhausted paths that use the supplied error type when `ClientStatusCode` is set, falling back to existing mappings for all old callers.
+
+- [x] **Step 1: Write handler regression tests**
+
+Assert 404 emits `not_found_error`, 413 emits `request_too_large`, and existing errors without `ClientErrorType` preserve their previous mapping.
+
+- [x] **Step 2: Run tests to verify RED**
+
+Run: `cd backend && GOTOOLCHAIN=go1.26.6 go test -tags=unit ./internal/handler -run 'TestUS047_' -count=1`
+
+Expected: FAIL because exhausted handlers currently hard-code `api_error` / `server_error` for custom client statuses.
+
+- [x] **Step 3: Implement minimal handler support**
+
+Use trimmed `ClientErrorType` when present; retain each handler's current default when absent.
+
+- [x] **Step 4: Run handler tests to verify GREEN**
+
+Run: `cd backend && GOTOOLCHAIN=go1.26.6 go test -tags=unit ./internal/handler -run 'TestUS047_|Test.*FailoverExhausted' -count=1`
+
+Expected: PASS.
+
+### Task 4: Update sentinel, PR evidence, and verify the branch
+
+**Files:**
+- Modify: `scripts/sentinels/gateway-tk.json`
+- Modify: PR #1805 body through `gh pr edit` only after local commit and push approval.
+
+**Interfaces:**
+- Consumes: final shared helper and four call-site signatures.
+- Produces: upstream-merge mechanical anchors and fresh review evidence.
+
+- [x] **Step 1: Update sentinel literals**
+
+Pin the account-aware helper calls, no-content failover construction, partial truncation hook, and focused `TestUS047_*` tests.
+
+- [x] **Step 2: Run focused and package tests**
+
+Run: `cd backend && GOTOOLCHAIN=go1.26.6 go test -tags=unit ./internal/service/... ./internal/handler/... ./internal/pkg/apicompat/... -count=1`
+
+- [x] **Step 3: Run full mechanical gate**
+
+Run: `GOTOOLCHAIN=go1.26.6 PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
+
+- [x] **Step 4: Re-run xj-review pipeline**
+
+Run `pipeline find`, verify every R-001..R-007 outcome, then run `adversarial-verify` and `dedup`. The result must contain zero medium-or-higher findings.
+
+- [ ] **Step 5: Commit locally**
+
+Commit with a high-risk approval anchor and `no-web-impact`, then run the xj-review push gate. Do not push when the gate returns `verdict=halt`; present the committed diff for explicit approval.

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6939,8 +6939,10 @@
     {
       "path": "backend/internal/service/gateway_anthropic_buffered_error_tk.go",
       "must_contain": [
-        "func tkParseAnthropicBufferedSSEError(payload []byte) (*tkAnthropicBufferedUpstreamError, bool)",
+        "func tkParseAnthropicBufferedSSEError(payload []byte, cfg *config.Config) (*tkAnthropicBufferedUpstreamError, bool)",
         "func tkAnthropicBufferedFailure(",
+        "func tkAnthropicBufferedPartialFailure(",
+        "func tkRecordAnthropicBufferedUpstreamError(",
         "setOpsUpstreamError(c, upstreamErr.UpstreamStatus, upstreamErr.Message, upstreamErr.Detail)",
         "appendOpsUpstreamError(c, OpsUpstreamErrorEvent{"
       ],
@@ -6949,32 +6951,36 @@
     {
       "path": "backend/internal/service/gateway_forward_as_chat_completions.go",
       "must_contain": [
-        "if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload)); ok {",
-        "status, errType, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)"
+        "if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), s.cfg); ok {",
+        "status, errType, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)",
+        "tkAnthropicBufferedPartialFailure(c, requestID, upstreamErr)"
       ],
       "rationale": "Anthropic-platform CC buffered path must capture terminal upstream `error` events and attribute the no-message fallthrough upstream. This is the path that produced the prod incident. Dropping either hook compiles clean and reverts to an opaque 502 that clients retry against."
     },
     {
       "path": "backend/internal/service/gateway_forward_as_responses.go",
       "must_contain": [
-        "if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload)); ok {",
-        "status, errCode, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)"
+        "if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), s.cfg); ok {",
+        "status, errCode, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)",
+        "tkAnthropicBufferedPartialFailure(c, requestID, upstreamErr)"
       ],
       "rationale": "Anthropic-platform Responses buffered path shares the buffered-assembly defect with the CC path; same silent-revert risk on upstream merge."
     },
     {
       "path": "backend/internal/service/openai_gateway_chat_completions_anthropic_native.go",
       "must_contain": [
-        "if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload)); ok {",
-        "status, errType, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)"
+        "if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), s.cfg); ok {",
+        "status, errType, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)",
+        "tkAnthropicBufferedPartialFailure(c, requestID, upstreamErr)"
       ],
       "rationale": "CN native-Anthropic CC buffered path (api_protocol=anthropic upstreams) shares the same assembly loop and the same misattribution risk."
     },
     {
       "path": "backend/internal/service/openai_gateway_responses_anthropic_native.go",
       "must_contain": [
-        "if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload)); ok {",
-        "status, errCode, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)"
+        "if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), s.cfg); ok {",
+        "status, errCode, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)",
+        "tkAnthropicBufferedPartialFailure(c, requestID, upstreamErr)"
       ],
       "rationale": "CN native-Anthropic Responses buffered path shares the same assembly loop and the same misattribution risk."
     }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6935,6 +6935,48 @@
         "func TestResolveCodexFingerprintIDs_DeviceModeInstallationCappedAt3(t *testing.T)"
       ],
       "rationale": "Focused regression: same session stays in one bucket, and one OAuth account cannot emit more than 3 device-mode installation IDs."
+    },
+    {
+      "path": "backend/internal/service/gateway_anthropic_buffered_error_tk.go",
+      "must_contain": [
+        "func tkParseAnthropicBufferedSSEError(payload []byte) (*tkAnthropicBufferedUpstreamError, bool)",
+        "func tkAnthropicBufferedFailure(",
+        "setOpsUpstreamError(c, upstreamErr.UpstreamStatus, upstreamErr.Message, upstreamErr.Detail)",
+        "appendOpsUpstreamError(c, OpsUpstreamErrorEvent{"
+      ],
+      "rationale": "Single owner for 'buffered Anthropic SSE assembly produced no message'. apicompat.AnthropicStreamEvent does not model terminal `error` events, so all four buffered assembly loops used to drop them, return a bare 502, and record no upstream context — classifyOpsErrorLog then booked the upstream fault as error_phase=internal / error_owner=platform / error_source=gateway (prod 2026-08-24: 124 rows). The setOpsUpstreamError + appendOpsUpstreamError pair is what flips attribution to provider; losing either one silently restores gateway-owned SLA pollution while still compiling."
+    },
+    {
+      "path": "backend/internal/service/gateway_forward_as_chat_completions.go",
+      "must_contain": [
+        "if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload)); ok {",
+        "status, errType, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)"
+      ],
+      "rationale": "Anthropic-platform CC buffered path must capture terminal upstream `error` events and attribute the no-message fallthrough upstream. This is the path that produced the prod incident. Dropping either hook compiles clean and reverts to an opaque 502 that clients retry against."
+    },
+    {
+      "path": "backend/internal/service/gateway_forward_as_responses.go",
+      "must_contain": [
+        "if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload)); ok {",
+        "status, errCode, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)"
+      ],
+      "rationale": "Anthropic-platform Responses buffered path shares the buffered-assembly defect with the CC path; same silent-revert risk on upstream merge."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_chat_completions_anthropic_native.go",
+      "must_contain": [
+        "if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload)); ok {",
+        "status, errType, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)"
+      ],
+      "rationale": "CN native-Anthropic CC buffered path (api_protocol=anthropic upstreams) shares the same assembly loop and the same misattribution risk."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_responses_anthropic_native.go",
+      "must_contain": [
+        "if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload)); ok {",
+        "status, errCode, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)"
+      ],
+      "rationale": "CN native-Anthropic Responses buffered path shares the same assembly loop and the same misattribution risk."
     }
   ]
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6940,50 +6940,97 @@
       "path": "backend/internal/service/gateway_anthropic_buffered_error_tk.go",
       "must_contain": [
         "func tkParseAnthropicBufferedSSEError(payload []byte, cfg *config.Config) (*tkAnthropicBufferedUpstreamError, bool)",
+        "func tkAnthropicBufferedHasUsableContent(finalResp *apicompat.AnthropicResponse) bool",
+        "func tkAnthropicBufferedEventCompletesMessage(event *apicompat.AnthropicStreamEvent) bool",
         "func tkAnthropicBufferedFailure(",
+        "func (s *GatewayService) tkAnthropicBufferedFailoverError(",
+        "func (s *OpenAIGatewayService) tkAnthropicBufferedFailoverError(",
         "func tkAnthropicBufferedPartialFailure(",
         "func tkRecordAnthropicBufferedUpstreamError(",
         "setOpsUpstreamError(c, upstreamErr.UpstreamStatus, upstreamErr.Message, upstreamErr.Detail)",
-        "appendOpsUpstreamError(c, OpsUpstreamErrorEvent{",
+        "appendOpsUpstreamError(c, event)",
+        "event.AccountID = account.ID",
+        "ClientErrorType:   tkAnthropicBufferedClientErrType(upstreamErr.ErrType)",
         "MarkOpsStreamFailure("
       ],
-      "rationale": "Single owner for 'buffered Anthropic SSE assembly produced no message'. apicompat.AnthropicStreamEvent does not model terminal `error` events, so all four buffered assembly loops used to drop them, return a bare 502, and record no upstream context — classifyOpsErrorLog then booked the upstream fault as error_phase=internal / error_owner=platform / error_source=gateway (prod 2026-08-24: 124 rows). The setOpsUpstreamError + appendOpsUpstreamError pair is what flips attribution to provider; losing either one silently restores gateway-owned SLA pollution while still compiling. tkAnthropicBufferedPartialFailure additionally calls MarkOpsStreamFailure: upstream context alone on a sub-400 wire status routes to logOpsRecoveredUpstream, which deliberately keeps recovered attempts outside request SLA — correct for a retry that succeeded, wrong for a truncated answer. Dropping that call compiles clean and silently lets truncated responses escape SLA again."
+      "rationale": "Single owner for buffered Anthropic SSE completion and failure semantics. A HTTP 200 stream can still terminate through an error frame, read failure, idle timeout, or incomplete EOF. Before any content block this owner returns an account-aware UpstreamFailoverError without committing the response; after content it preserves the partial response and marks stream_truncated toward SLA to avoid replay and duplicate billing. Completion detection, client error type mapping, provider/account attribution, and both Gateway/OpenAI account-health wrappers must remain centralized or an upstream merge can silently restore empty 200s, gateway-owned SLA pollution, or missing failover."
     },
     {
       "path": "backend/internal/service/gateway_forward_as_chat_completions.go",
       "must_contain": [
         "if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), s.cfg); ok {",
-        "status, errType, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)",
-        "tkAnthropicBufferedPartialFailure(c, requestID, upstreamErr)"
+        "if tkAnthropicBufferedEventCompletesMessage(&event) {",
+        "streamCompleted = true\n\t\t\tbreak",
+        "if !tkAnthropicBufferedHasUsableContent(finalResp) {",
+        "s.tkAnthropicBufferedFailoverError(c, account, resp, requestID, mappedModel, upstreamErr)",
+        "tkAnthropicBufferedPartialFailure(c, account, requestID, upstreamErr)"
       ],
-      "rationale": "Anthropic-platform CC buffered path must capture terminal upstream `error` events and attribute the no-message fallthrough upstream. This is the path that produced the prod incident. Dropping either hook compiles clean and reverts to an opaque 502 that clients retry against."
+      "rationale": "Anthropic-platform CC buffered path must capture every terminal failure, distinguish message_start-only from usable content, enter account failover before response commit, and preserve+mark partial content. Dropping a hook compiles cleanly but restores empty 200s, direct 502s, or replay of billable partial answers."
     },
     {
       "path": "backend/internal/service/gateway_forward_as_responses.go",
       "must_contain": [
         "if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), s.cfg); ok {",
-        "status, errCode, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)",
-        "tkAnthropicBufferedPartialFailure(c, requestID, upstreamErr)"
+        "if tkAnthropicBufferedEventCompletesMessage(&event) {",
+        "streamCompleted = true\n\t\t\tbreak",
+        "if !tkAnthropicBufferedHasUsableContent(finalResp) {",
+        "s.tkAnthropicBufferedFailoverError(c, account, resp, requestID, mappedModel, upstreamErr)",
+        "tkAnthropicBufferedPartialFailure(c, account, requestID, upstreamErr)"
       ],
-      "rationale": "Anthropic-platform Responses buffered path shares the buffered-assembly defect with the CC path; same silent-revert risk on upstream merge."
+      "rationale": "Anthropic-platform Responses buffered path shares the same completion, failover-before-write, and partial-truncation contract as Chat Completions."
     },
     {
       "path": "backend/internal/service/openai_gateway_chat_completions_anthropic_native.go",
       "must_contain": [
         "if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), s.cfg); ok {",
-        "status, errType, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)",
-        "tkAnthropicBufferedPartialFailure(c, requestID, upstreamErr)"
+        "if tkAnthropicBufferedEventCompletesMessage(&event) {",
+        "streamCompleted = true\n\t\t\tbreak",
+        "if !tkAnthropicBufferedHasUsableContent(finalResp) {",
+        "s.tkAnthropicBufferedFailoverError(c, account, resp, requestID, upstreamModel, upstreamErr)",
+        "tkAnthropicBufferedPartialFailure(c, account, requestID, upstreamErr)"
       ],
-      "rationale": "CN native-Anthropic CC buffered path (api_protocol=anthropic upstreams) shares the same assembly loop and the same misattribution risk."
+      "rationale": "Native-Anthropic CC buffered path shares the same completion, failover-before-write, and partial-truncation contract, including idle timeout handling."
     },
     {
       "path": "backend/internal/service/openai_gateway_responses_anthropic_native.go",
       "must_contain": [
         "if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), s.cfg); ok {",
-        "status, errCode, message := tkAnthropicBufferedFailure(c, requestID, upstreamErr)",
-        "tkAnthropicBufferedPartialFailure(c, requestID, upstreamErr)"
+        "if tkAnthropicBufferedEventCompletesMessage(&event) {",
+        "streamCompleted = true\n\t\t\tbreak",
+        "if !tkAnthropicBufferedHasUsableContent(finalResp) {",
+        "s.tkAnthropicBufferedFailoverError(c, account, resp, requestID, upstreamModel, upstreamErr)",
+        "tkAnthropicBufferedPartialFailure(c, account, requestID, upstreamErr)"
       ],
-      "rationale": "CN native-Anthropic Responses buffered path shares the same assembly loop and the same misattribution risk."
+      "rationale": "Native-Anthropic Responses buffered path shares the same completion, failover-before-write, and partial-truncation contract, including idle timeout handling."
+    },
+    {
+      "path": "backend/internal/handler/gateway_anthropic_buffered_failover_tk_test.go",
+      "must_contain": [
+        "TestUS047_GatewayFailoverExhaustedPreservesClientErrorType",
+        "TestUS047_ResponsesFailoverExhaustedPreservesClientErrorType",
+        "TestUS047_OpenAIFailoverExhaustedPreservesClientErrorType",
+        "TestUS047_EmptyClientErrorTypeKeepsLegacyDefaults"
+      ],
+      "rationale": "Final exhausted handlers are separate protocol surfaces. These regressions pin 404 not_found_error and 413 request_too_large propagation while preserving the legacy default for older failover producers that do not set ClientErrorType."
+    },
+    {
+      "path": "backend/internal/service/gateway_anthropic_buffered_error_tk_test.go",
+      "must_contain": [
+        "TestUS047_MessageStartThenErrorReturnsFailover",
+        "TestUS047_PartialContentThenErrorPreservesResponse",
+        "TestUS047_IncompleteEOFRoutesByContentAvailability",
+        "TestUS047_ScannerReadErrorRoutesByContentAvailability",
+        "TestUS047_CompletionBeforeReadErrorRemainsSuccessful",
+        "TestUS047_ClientErrorTypeMapping"
+      ],
+      "rationale": "US-047 behavior anchors for error frames, message_start-only/incomplete EOF, partial-content truncation, account attribution, and final client error mapping."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_anthropic_native_pump_test.go",
+      "must_contain": [
+        "TestUS047_NativeBufferedIdleRoutesByContentAvailability"
+      ],
+      "rationale": "Native-Anthropic idle timeout must remain failover-safe before content and preserve+mark partial content after the first content block."
     }
   ]
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6944,9 +6944,10 @@
         "func tkAnthropicBufferedPartialFailure(",
         "func tkRecordAnthropicBufferedUpstreamError(",
         "setOpsUpstreamError(c, upstreamErr.UpstreamStatus, upstreamErr.Message, upstreamErr.Detail)",
-        "appendOpsUpstreamError(c, OpsUpstreamErrorEvent{"
+        "appendOpsUpstreamError(c, OpsUpstreamErrorEvent{",
+        "MarkOpsStreamFailure("
       ],
-      "rationale": "Single owner for 'buffered Anthropic SSE assembly produced no message'. apicompat.AnthropicStreamEvent does not model terminal `error` events, so all four buffered assembly loops used to drop them, return a bare 502, and record no upstream context — classifyOpsErrorLog then booked the upstream fault as error_phase=internal / error_owner=platform / error_source=gateway (prod 2026-08-24: 124 rows). The setOpsUpstreamError + appendOpsUpstreamError pair is what flips attribution to provider; losing either one silently restores gateway-owned SLA pollution while still compiling."
+      "rationale": "Single owner for 'buffered Anthropic SSE assembly produced no message'. apicompat.AnthropicStreamEvent does not model terminal `error` events, so all four buffered assembly loops used to drop them, return a bare 502, and record no upstream context — classifyOpsErrorLog then booked the upstream fault as error_phase=internal / error_owner=platform / error_source=gateway (prod 2026-08-24: 124 rows). The setOpsUpstreamError + appendOpsUpstreamError pair is what flips attribution to provider; losing either one silently restores gateway-owned SLA pollution while still compiling. tkAnthropicBufferedPartialFailure additionally calls MarkOpsStreamFailure: upstream context alone on a sub-400 wire status routes to logOpsRecoveredUpstream, which deliberately keeps recovered attempts outside request SLA — correct for a retry that succeeded, wrong for a truncated answer. Dropping that call compiles clean and silently lets truncated responses escape SLA again."
     },
     {
       "path": "backend/internal/service/gateway_forward_as_chat_completions.go",


### PR DESCRIPTION
## 摘要

- 修复 Anthropic 上游虽然返回 HTTP 200、但 SSE 内部随后报错、超时、读取失败或提前 EOF 时的错误处理。
- 尚未生成可用 content block 时，不再返回空 200 或由 service 直接写模糊 502，而是返回 `UpstreamFailoverError`，进入现有账号健康处理和账号切换。
- 已生成部分内容后失败时，不重放请求；保留部分 HTTP 200，同时记录 `stream_truncated` 并计入 SLA，避免重复计费和回答漂移。
- 收到 `message_delta.stop_reason` 或 `message_stop` 后立即视为完成，后续连接异常不再把完整答案误判成截断。
- failover 耗尽后保留真实错误契约，例如 404 `not_found_error`、413 `request_too_large`，并记录平台、账号 ID、账号名称和上游请求 ID。

## 设计

四条缓冲组装路径共用 `backend/internal/service/gateway_anthropic_buffered_error_tk.go` 作为单一 owner：

- Anthropic Chat Completions
- Anthropic Responses
- native-Anthropic Chat Completions
- native-Anthropic Responses

页面级 handler 只负责 failover 耗尽后的协议响应；解析、完成态、可用内容判断、账号健康处理、Ops 归因和错误映射集中在共享 owner。关键 owner、四个调用点和聚焦测试均已写入 `scripts/sentinels/gateway-tk.json`。

`upstream-touch-guarded`：所有修改的上游形状关键调用点均有 sentinel 和回归测试保护。

## 契约

- 无 content block：切换账号；全部账号失败后返回映射后的真实错误。
- 已有 content block：保留部分结果，不切换账号，记录 SLA 截断失败。
- 只有 `message_start`：不算可用内容，失败时必须切换账号，不能返回空 200。
- 完整终止：`message_delta.stop_reason` 或 `message_stop` 任一出现即完成。
- 不新增配置、数据库字段、路由或前端契约。

审批基线：`docs/approved/anthropic-buffered-stream-failure-contract.md`

## 风险

- 无内容故障会多尝试账号，因此最终失败请求的延迟和上游调用次数可能增加。
- 部分内容失败仍返回 HTTP 200，调用方可能看到不完整答案；这是避免自动重放导致双扣费的明确取舍。
- 以前被隐藏的截断失败现在会计入 provider SLA，报表中的失败数可能上升，但反映的是更真实的数据。
- 高风险点集中在四条缓冲组装路径，已由 US-047 测试、完整 package unit tests 和 sentinel 覆盖。

`no-web-impact`：本次仅调整后端既有错误处理、调度与 Ops 归因；没有新增 API 字段、枚举、路由或前端展示需求。

## 验证

- `GOTOOLCHAIN=go1.26.6 go test -tags=unit ./internal/service/... ./internal/handler/... ./internal/pkg/apicompat/... -count=1`：通过。
- `GOTOOLCHAIN=go1.26.6 PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：通过。
- `python3 scripts/sentinels/check-gateway-tk.py --quiet`：通过，742/742 anchors intact。
- Story quality：43 stories，0 issues。
- `$xj-review #1805`：高风险 `full_conformance` 审查收敛，零 medium+ finding。

## 提交

- `0cb70c95f` fix(gateway): attribute buffered Anthropic SSE error events upstream
- `c2984edd0` chore(sentinels): pin buffered Anthropic upstream-attribution hooks
- `9071cd1dc` fix(gateway): address R-001..R-004 - attribute truncated buffered streams
- `1e97cb341` fix(gateway): count truncated buffered Anthropic streams towards SLA (R-005)
- `6349715d1` fix(gateway): fail over incomplete Anthropic buffered streams

最新提交：`6349715d1`
