### PR TITLE
fix(newapi): route inbound /v1/chat/completions through the bridge

### DIFF
--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -69,6 +69,18 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		return nil, err
 	}
 
+	// TK: bridge-eligible newapi accounts are relayed by the adaptor, which reads
+	// the account's own channel base URL and key. This must stay ahead of every
+	// OpenAI-shaped fallback below: those resolve their upstream from
+	// OpenAI-family accessors that return "" for platform=newapi, which #1800's
+	// guard then refuses (ErrForeignCredentialOfficialOpenAIFallback) — a hard
+	// 502 for a perfectly healthy account. Mirrors tkTryRouteForwardAsAnthropic.
+	if result, handled, err := s.tkTryRouteChatCompletionsViaNewAPIBridge(
+		ctx, c, account, body, promptCacheKey, defaultMappedModel,
+	); handled {
+		return result, err
+	}
+
 	if account.Platform == PlatformGrok {
 		if account.IsGrokOAuth() {
 			if eligible, reason := grokChatResponsesBridgeEligibility(body); eligible {

--- a/backend/internal/service/openai_gateway_chat_completions_tk_newapi_bridge.go
+++ b/backend/internal/service/openai_gateway_chat_completions_tk_newapi_bridge.go
@@ -1,0 +1,101 @@
+package service
+
+// TK: newapi bridge ownership for inbound /v1/chat/completions.
+//
+// Same defect class as the /v1/messages leak fixed in #1800, one endpoint over.
+//
+// Every OpenAI-shaped forwarder below ForwardAsChatCompletions resolves its
+// upstream through OpenAI-family accessors (nativeOpenAIBaseURLForAccount ->
+// Account.GetOpenAIBaseURL), which return "" for platform=newapi: a newapi
+// channel is neither IsOpenAI nor IsCNProvider. Before #1800 the caller turned
+// that "" into https://api.openai.com and POSTed the channel's real credential
+// (DeepSeek, DashScope, Ark, ...) to OpenAI, which answers "Incorrect API key
+// provided" — a routing defect that reads like a dead credential. #1800 added
+// the fail-closed guard in openAIChatCompletionsTargetURL, so the same request
+// now returns ErrForeignCredentialOfficialOpenAIFallback instead of leaking.
+//
+// That guard is the last line of defense, not the fix. #1800 closed the
+// /v1/messages path by giving bridge-eligible newapi accounts to
+// ForwardAsAnthropicDispatched before any OpenAI-shaped fallback could claim
+// them. /v1/chat/completions never got the same treatment:
+// ForwardAsChatCompletionsDispatched existed with zero callers — unwired dead
+// code, exactly as ForwardAsAnthropicDispatched had been.
+//
+// Prod consequence (2026-08-24, prod on 1.8.172): account 39 "ds-官"
+// (platform=newapi, channel_type=43, base_url=https://api.deepseek.com,
+// status=active, schedulable=true, zero Redis load) failed 100% of
+// /v1/chat/completions requests in ~35ms — far too fast for any network round
+// trip, because no request was ever sent. Gateway logs carried one line per
+// failure:
+//
+//	handler/openai_chat_completions.go  openai_chat_completions.forward_failed
+//	account_id=39 model=deepseek-v4-pro
+//	error="refusing to send foreign account credential to api.openai.com:
+//	       account has no resolved base_url"
+//
+// The group that account served had no other member, so every failure emptied
+// the pool and the next request fast-failed with routing 429 "No available
+// accounts for platform newapi" — 614 of those in one 30-minute window, all on
+// one API key, all one model. Two hours earlier (pre-1.8.172) the same account
+// produced "Upstream authentication failed" instead: the leak had been live and
+// quiet for as long as this path existed, and #1800 only made it loud.
+//
+// The admin account test passed against the same account throughout, because
+// dispatchNewAPIAccountTestChatCompletions goes through the bridge and reads the
+// channel's own base URL. Same account, same endpoint name, two resolvers.
+//
+// This file restores the #1800 invariant for the Chat Completions entry: a
+// bridge-eligible newapi account is relayed by the adaptor, which reads that
+// account's channel base URL and key, and never reaches a resolver that can
+// return "".
+
+import (
+	"context"
+
+	"github.com/gin-gonic/gin"
+)
+
+// newAPIBridgeOwnsChatCompletions reports whether inbound /v1/chat/completions
+// for this account must relay through the NewAPI adaptor bridge.
+//
+// Mirrors newAPIBridgeOwnsAnthropicMessages (the #1800 predicate) so both entry
+// points share one rule: platform must be newapi, and the account must be
+// bridge-eligible for the Chat Completions capability.
+//
+// Accounts that are NOT bridge-eligible are deliberately left alone. The
+// VolcEngine Agent Plan carve-out in ShouldDispatchToNewAPIBridge returns false
+// so its /api/plan/v3 endpoint keeps TokenKey's native path (the upstream
+// adaptor would append its own /api/v3 suffix); such accounts already resolve a
+// base URL through nativeOpenAIBaseURLForAccount's agent-plan branch and are
+// unaffected by this predicate.
+func (s *OpenAIGatewayService) newAPIBridgeOwnsChatCompletions(account *Account) bool {
+	if account == nil || account.Platform != PlatformNewAPI {
+		return false
+	}
+	return s.ShouldDispatchToNewAPIBridge(account, BridgeEndpointChatCompletions)
+}
+
+// tkTryRouteChatCompletionsViaNewAPIBridge claims bridge-eligible newapi
+// accounts for the adaptor before any OpenAI-shaped forwarder can.
+//
+// Returns handled=false for every other account so the caller proceeds with its
+// existing routing chain unchanged.
+//
+// No recursion: ForwardAsChatCompletionsDispatched falls back to
+// ForwardAsChatCompletions only when ShouldDispatchToNewAPIBridge is false,
+// while this function is entered only when it is true. Same argument as #1800's
+// newAPIBridgeOwnsAnthropicMessages.
+func (s *OpenAIGatewayService) tkTryRouteChatCompletionsViaNewAPIBridge(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	promptCacheKey string,
+	defaultMappedModel string,
+) (*OpenAIForwardResult, bool, error) {
+	if !s.newAPIBridgeOwnsChatCompletions(account) {
+		return nil, false, nil
+	}
+	result, err := s.ForwardAsChatCompletionsDispatched(ctx, c, account, body, promptCacheKey, defaultMappedModel)
+	return result, true, err
+}

--- a/backend/internal/service/openai_gateway_chat_completions_tk_newapi_bridge_test.go
+++ b/backend/internal/service/openai_gateway_chat_completions_tk_newapi_bridge_test.go
@@ -1,0 +1,156 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression for the 2026-08-24 prod incident: inbound /v1/chat/completions for a
+// bridge-eligible newapi account must be owned by the NewAPI adaptor.
+//
+// Same defect class as #1800 (/v1/messages), one endpoint over. account 39
+// "ds-官" (platform=newapi, channel_type=43 DeepSeek, base_url set, status
+// active, schedulable, zero load) failed 100% of requests in ~35ms because every
+// OpenAI-shaped forwarder resolves its upstream from OpenAI-family accessors
+// that return "" for platform=newapi, and #1800's guard then correctly refuses
+// to default that "" to api.openai.com. The account was healthy; the routing was
+// wrong. Its group had no other member, so each failure emptied the pool and the
+// next request fast-failed with routing 429 "No available accounts".
+
+func newapiDeepSeekAccountForBridgeTest() *Account {
+	return &Account{
+		ID:          39,
+		Name:        "ds-官",
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeDeepSeek,
+		Credentials: map[string]any{
+			"api_key":  "sk-deepseek-not-an-openai-key",
+			"base_url": "https://api.deepseek.com",
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+}
+
+// The prod account, reconstructed: without bridge ownership its upstream cannot
+// be resolved at all, which is why the request died before any network I/O.
+func TestNewAPIDeepSeekChatCompletionsWouldFailClosedWithoutBridge(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+	account := newapiDeepSeekAccountForBridgeTest()
+
+	// The credential is real and wire-bound; only the destination was wrong.
+	require.Equal(t, "sk-deepseek-not-an-openai-key", account.GetOpenAIProtocolAPIKey())
+	require.False(t, AccountUsesOfficialOpenAIUpstream(account))
+	require.False(t, OfficialOpenAIFallbackAllowed(account),
+		"a newapi channel credential must never be allowed to default to api.openai.com")
+
+	// This is the exact prod failure: the OpenAI-shaped resolver has nothing to
+	// resolve, so #1800's guard refuses the request.
+	_, err := svc.openAIChatCompletionsTargetURL(account)
+	require.ErrorIs(t, err, ErrForeignCredentialOfficialOpenAIFallback,
+		"the OpenAI-shaped path cannot serve this account; the bridge must own it")
+}
+
+// Primary fix: the account above is claimed by the bridge before any
+// OpenAI-shaped fallback can reach it.
+func TestNewAPIBridgeOwnsChatCompletionsForDeepSeek(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+
+	require.True(t, svc.newAPIBridgeOwnsChatCompletions(newapiDeepSeekAccountForBridgeTest()),
+		"inbound /v1/chat/completions for a bridge-eligible newapi account must relay through the adaptor")
+
+	// Ali/DashScope channels ride the same rule — this is not DeepSeek-specific.
+	require.True(t, svc.newAPIBridgeOwnsChatCompletions(&Account{
+		ID:          78,
+		Name:        "Qwen-4",
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeAli,
+		Credentials: map[string]any{"api_key": "sk-dashscope", "base_url": "https://dashscope.aliyuncs.com"},
+	}))
+}
+
+// Non-newapi accounts keep their existing routing untouched.
+func TestNewAPIBridgeOwnsChatCompletionsLeavesOtherPlatformsAlone(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+
+	require.False(t, svc.newAPIBridgeOwnsChatCompletions(nil))
+
+	require.False(t, svc.newAPIBridgeOwnsChatCompletions(&Account{
+		ID:          76,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Credentials: map[string]any{"api_key": "sk-openai"},
+	}), "an OpenAI api-key account must keep the OpenAI-shaped path")
+
+	require.False(t, svc.newAPIBridgeOwnsChatCompletions(&Account{
+		ID:       71,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+	}))
+
+	// A newapi row with no channel type cannot enter the bridge; #1800's
+	// fail-closed guard remains its only protection, which is correct.
+	require.False(t, svc.newAPIBridgeOwnsChatCompletions(&Account{
+		ID:          61,
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: 0,
+		Credentials: map[string]any{"api_key": "sk-x", "base_url": "https://dashscope.aliyuncs.com"},
+	}))
+}
+
+// The VolcEngine Agent Plan carve-out must survive: its /api/plan/v3 endpoint is
+// a direct OpenAI-compatible upstream and stays on TokenKey's native path, since
+// the upstream adaptor would append its own /api/v3 suffix.
+//
+// This is load-bearing for the incident's own workaround: account 88 was added
+// to the affected group as a stopgap and serves traffic through the native path.
+// Claiming it for the bridge here would break the mitigation.
+func TestNewAPIBridgeDoesNotClaimVolcEngineAgentPlan(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+
+	agentPlan := &Account{
+		ID:          88,
+		Name:        "volcengine-agent-plan",
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeVolcEngine,
+		Credentials: map[string]any{
+			"api_key":  "ark-key",
+			"base_url": "https://ark.cn-beijing.volces.com/api/plan/v3",
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	require.True(t, isNewAPIVolcEngineAgentPlanAccount(agentPlan),
+		"test fixture must reproduce the agent-plan shape")
+	require.False(t, svc.newAPIBridgeOwnsChatCompletions(agentPlan),
+		"agent plan must keep the native path; the adaptor would append /api/v3")
+
+	// And it resolves an upstream on the native path, which is why it works.
+	targetURL, err := svc.openAIChatCompletionsTargetURL(agentPlan)
+	require.NoError(t, err)
+	require.Contains(t, targetURL, "ark.cn-beijing.volces.com")
+}
+
+// The routing helper reports handled=false for accounts it does not own, so the
+// caller's existing chain proceeds unchanged.
+func TestTKTryRouteChatCompletionsViaNewAPIBridgeSkipsUnownedAccounts(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+
+	result, handled, err := svc.tkTryRouteChatCompletionsViaNewAPIBridge(
+		nil, nil,
+		&Account{ID: 76, Platform: PlatformOpenAI, Type: AccountTypeAPIKey},
+		[]byte(`{"model":"gpt-5","messages":[]}`), "", "",
+	)
+	require.False(t, handled, "an unowned account must fall through to the existing routing chain")
+	require.NoError(t, err)
+	require.Nil(t, result)
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6935,6 +6935,13 @@
         "func TestResolveCodexFingerprintIDs_DeviceModeInstallationCappedAt3(t *testing.T)"
       ],
       "rationale": "Focused regression: same session stays in one bucket, and one OAuth account cannot emit more than 3 device-mode installation IDs."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_chat_completions.go",
+      "must_contain": [
+        "if result, handled, err := s.tkTryRouteChatCompletionsViaNewAPIBridge("
+      ],
+      "rationale": "Ordering anchor, mirroring the newAPIBridgeOwnsAnthropicMessages entry for openai_gateway_messages_tk.go. The newapi bridge claim must stay the FIRST routing branch in ForwardAsChatCompletions, ahead of the Grok / adaptive / Anthropic-protocol / raw-CC fallbacks. Any of those reached first resolves an empty upstream for platform=newapi and turns a healthy account into a hard 502. Position is the invariant here, not mere presence."
     }
   ]
 }

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -834,6 +834,26 @@
         "ErrForeignCredentialOfficialOpenAIFallback"
       ],
       "rationale": "Behavior regressions for the Qwen credential-leak fix: inbound /v1/messages for a bridge-eligible newapi account is owned by the NewAPI adaptor (not an OpenAI-shaped fallback), a foreign credential with no OpenAI-resolvable base fails closed instead of reaching api.openai.com, and an OpenAI api-key account still resolves the official host. Deleting these tests would let an upstream merge restore either leak with a green build."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_chat_completions_tk_newapi_bridge.go",
+      "must_contain": [
+        "func (s *OpenAIGatewayService) newAPIBridgeOwnsChatCompletions(account *Account) bool",
+        "func (s *OpenAIGatewayService) tkTryRouteChatCompletionsViaNewAPIBridge(",
+        "s.ShouldDispatchToNewAPIBridge(account, BridgeEndpointChatCompletions)",
+        "s.ForwardAsChatCompletionsDispatched(ctx, c, account, body, promptCacheKey, defaultMappedModel)"
+      ],
+      "rationale": "Chat Completions counterpart of the #1800 /v1/messages leak fix. Every OpenAI-shaped forwarder under ForwardAsChatCompletions resolves its upstream via nativeOpenAIBaseURLForAccount, which returns \"\" for platform=newapi; before #1800 that \"\" became api.openai.com and leaked the channel credential, and after #1800 it fails closed with ErrForeignCredentialOfficialOpenAIFallback. Either outcome is wrong for a healthy account. Prod 2026-08-24 on 1.8.172: account 39 (channel_type=43 DeepSeek) failed 100% of chat requests in ~35ms with no request sent, emptying its group and producing 614 routing-429 in one 30-minute window. This predicate is what keeps bridge-eligible newapi accounts on the adaptor, which reads their own channel base URL and key."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_chat_completions_tk_newapi_bridge_test.go",
+      "must_contain": [
+        "TestNewAPIDeepSeekChatCompletionsWouldFailClosedWithoutBridge",
+        "TestNewAPIBridgeOwnsChatCompletionsForDeepSeek",
+        "TestNewAPIBridgeDoesNotClaimVolcEngineAgentPlan",
+        "ErrForeignCredentialOfficialOpenAIFallback"
+      ],
+      "rationale": "Regression tests pinning the prod-observed shape: the DeepSeek channel account fails closed without the bridge, the bridge claims it with the fix, and the VolcEngine Agent Plan carve-out is NOT claimed (its /api/plan/v3 endpoint must keep TokenKey's native path or the upstream adaptor appends its own /api/v3 suffix)."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Inbound `/v1/chat/completions` for a **bridge-eligible newapi account** now relays through
the NewAPI adaptor instead of falling into an OpenAI-shaped forwarder that cannot resolve
its upstream. Same defect class as the `/v1/messages` leak fixed in #1800, one endpoint over.

`ForwardAsChatCompletionsDispatched` already existed with **zero callers** — unwired dead
code, exactly as `ForwardAsAnthropicDispatched` had been before #1800.

## Root cause

Every OpenAI-shaped forwarder under `ForwardAsChatCompletions` resolves its upstream via
`nativeOpenAIBaseURLForAccount` → `Account.GetOpenAIBaseURL()`, which returns `""` for
`platform=newapi` (a newapi channel is neither `IsOpenAI` nor `IsCNProvider`).

- **Before #1800**: the caller turned `""` into `https://api.openai.com` and POSTed the
  channel's real credential there. Upstream answered `Incorrect API key provided` — a
  routing defect that reads like a dead credential.
- **After #1800**: `openAIChatCompletionsTargetURL` fails closed with
  `ErrForeignCredentialOfficialOpenAIFallback`. The leak is stopped, but a healthy account
  now hard-fails.

That guard is the last line of defense, not the fix. #1800 closed `/v1/messages` by giving
bridge-eligible newapi accounts to the dispatcher *before* any OpenAI-shaped fallback could
claim them. `/v1/chat/completions` never got the same treatment.

## Production evidence (2026-08-24, prod on 1.8.172)

Account 39 `ds-官` — `platform=newapi`, `channel_type=43`,
`base_url=https://api.deepseek.com`, `status=active`, `schedulable=true`,
`rate_limited_at`/`overload_until`/`error_message` all empty, Redis `conc=0 rpm_now=0` —
failed **100%** of `/v1/chat/completions` requests in **~35ms**. Far too fast for any network
round trip to `api.deepseek.com`, because no request was ever sent. One log line per failure:

```
handler/openai_chat_completions.go  openai_chat_completions.forward_failed
account_id=39 api_key_id=216 group_id=11 model=deepseek-v4-pro stream=false
error="refusing to send foreign account credential to api.openai.com:
       account has no resolved base_url"
```

99 such lines in 40 minutes; **0** `newapi_bridge_dispatch` lines in the same window.

The group that account served had no other member, so every failure emptied the pool and the
next request fast-failed with routing 429 `No available accounts for platform "newapi"` —
**614** of those in one 30-minute window, all on one API key, all one model. A control group
confirms the mechanism: the same model succeeded 169× on a different account that happens to
hit `nativeOpenAIBaseURLForAccount`'s agent-plan carve-out and therefore resolves a base URL.

Two hours earlier (pre-cutover) the same account produced `Upstream authentication failed`
instead — the 401 from OpenAI rejecting a DeepSeek key. **The leak had been live and quiet
for as long as this path existed; #1800 only made it loud.**

Throughout the incident the **admin account test passed** against that same account, because
`dispatchNewAPIAccountTestChatCompletions` goes through the bridge and reads the channel's own
base URL. Same account, same endpoint name, two resolvers — which is why the account looked
healthy from the console while every production request failed.

## Change

One TK-owned file plus a 12-line insertion:

- `openai_gateway_chat_completions_tk_newapi_bridge.go` (new) — `newAPIBridgeOwnsChatCompletions`
  mirrors #1800's `newAPIBridgeOwnsAnthropicMessages`, and
  `tkTryRouteChatCompletionsViaNewAPIBridge` delegates to the existing dispatcher.
- `openai_gateway_chat_completions.go` — the claim runs as the **first** routing branch, ahead
  of every OpenAI-shaped fallback. Pure insertion, no line removed.

**No recursion**: `ForwardAsChatCompletionsDispatched` falls back to `ForwardAsChatCompletions`
only when `ShouldDispatchToNewAPIBridge` is `false`, while the new branch is entered only when
it is `true`. Same argument as #1800.

**No new routing logic**: `ShouldDispatchToNewAPIBridge` and the dispatcher both already
existed and are used by embeddings / images / video. This wires Chat Completions to them.

## Risk

This touches the routing decision at the top of the **main Chat Completions entry point**,
which carries all CC traffic. Stated plainly rather than downplayed. What bounds it:

- The predicate is `platform == newapi` **and** bridge-eligible. Every other platform
  (`openai`, `anthropic`, `gemini`, `grok`, CN providers, Kiro, adaptive accounts) takes an
  early `return nil, false, nil` and reaches its existing chain byte-for-byte unchanged.
- The VolcEngine Agent Plan carve-out inside `ShouldDispatchToNewAPIBridge` returns `false`,
  so agent-plan accounts keep TokenKey's native path — deliberately preserved, and pinned by
  a test.
- Newapi rows that cannot enter the bridge (e.g. `channel_type` unset) still hit #1800's
  fail-closed guard rather than leaking.
- Pure-insertion diff, so an upstream merge cannot silently revert it.

Reviewers may reasonably want this behind a kill switch. Note the bridge already has one
(`newapi_bridge_enabled`): with it off, `accountUsesNewAPIAdaptorBridge` returns `false`,
the new branch never fires, and behavior returns to today's.

## Testing

- `go build ./...` and `go vet ./...` clean.
- 5 new tests, all passing: bridge ownership for a DeepSeek channel account; the fail-closed
  reproduction proving what the fix prevents; other platforms untouched; agent-plan carve-out
  preserved; unowned accounts pass through with `handled=false`.
- #1800's own leak tests still pass unchanged.
- `go test -tags=unit` green across `internal/service`, `internal/handler{,/admin,/dto,/quotaview}`,
  `internal/relay/bridge`, `internal/engine`.
- Sentinel anchors added to both registries, mirroring #1800's choice of mechanical anchors
  over a review marker: `newapi.json` pins the predicate, the dispatcher delegation and the
  test names; `gateway-tk.json` pins the call site's **position** as the first branch, since
  ordering is load-bearing here, not incidental. `check-newapi.py` 90/90,
  `check-gateway-tk.py` 735/735, registry-update-gate ok.
- `upstream-override-marker` passes as a pure-insertion diff.

### Not verified locally

- **`scripts/preflight.sh` reports one unrelated failure**: "ent generated code is stale".
  Regenerating rewrites `json.RawMessage` → `jsontext.Value` across 7 `backend/ent/` files this
  PR does not touch — an artifact of a local Go 1.27 stdlib against `go.mod`'s 1.26.6 pin.
  Verified pre-existing: a pristine `origin/main` checkout with none of these changes produces
  the identical diff, and CI's preflight passes the same gate. No `ent/` file is in this PR.
- **Production verification is partial.** An operator added a second account to the affected
  group during the incident, which stopped the 429 storm and restored throughput, but that
  account reaches a *different provider* and only works because it hits the agent-plan
  carve-out. It masks the defect rather than fixing it; the broken account continues to fail
  100%. This PR has not itself been exercised against production traffic.

no-web-impact — no frontend or contract change. This alters which internal forwarder handles
a request; no API shape, response field, error code, or config surface changes. No file under
`frontend/` is touched.

ai
