### PR TITLE
fix(gateway): fail over relay failures without disabling healthy models

### DIFF
--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -259,7 +259,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 					accountReleaseFunc()
 				}
 			}()
-			return h.gatewayService.ForwardAsChatCompletions(c.Request.Context(), c, account, forwardBody, promptCacheKey, dispatchMappedModel)
+			return h.gatewayService.ForwardAsChatCompletionsDispatched(c.Request.Context(), c, account, forwardBody, promptCacheKey, dispatchMappedModel)
 		}()
 		var cyberBlockBodyChat []byte
 		if service.GetOpsCyberPolicy(c) != nil {

--- a/backend/internal/service/account_incident_notifier_tk.go
+++ b/backend/internal/service/account_incident_notifier_tk.go
@@ -124,6 +124,8 @@ func classifyIncident(reason string, until time.Time, kind AccountIncidentKind) 
 		// G4(#600)模型维度 cooldown：单模型类(如 opus)打穿 5h/7d 用量窗口,只冷却该模型类,
 		// 账号其它模型仍可调度。不能复用兜底的"账号临时冷却"——那会误报成整账号下线。
 		return incidentClass{true, IncidentKindTemporaryCooldown, "429_model_class", "模型类限流冷却（账号其它模型仍可调度）", "单模型类(如 opus)用量窗口耗尽;账号其它模型不受影响,关注是否反复触发"}
+	case "402_cloudwise_model_balance":
+		return incidentClass{true, IncidentKindTemporaryCooldown, "402_cloudwise_model_balance", "CloudWise 模型余额冷却（账号其它模型仍可调度）", "该模型的 CloudWise 独立余额池返回 402;等待 5h 冷却结束或检查模型额度,账号其它模型不受影响"}
 	}
 	// 未知 reason: 显式 kind 优先,缺省再看 until。
 	k := kind

--- a/backend/internal/service/account_incident_notifier_tk_test.go
+++ b/backend/internal/service/account_incident_notifier_tk_test.go
@@ -139,6 +139,16 @@ func TestClassifyIncident(t *testing.T) {
 	}
 }
 
+func TestClassifyIncident_CloudwiseModelBalance402IsModelScopedCooldown(t *testing.T) {
+	got := classifyIncident("402_cloudwise_model_balance", time.Now().Add(5*time.Hour), IncidentKindUnknown)
+
+	require.True(t, got.alert)
+	require.Equal(t, IncidentKindTemporaryCooldown, got.kind)
+	require.Equal(t, "402_cloudwise_model_balance", got.reasonClass)
+	require.Contains(t, got.kindZh, "模型")
+	require.Contains(t, got.advice, "其它模型")
+}
+
 func TestFormatAlertTime(t *testing.T) {
 	t.Parallel()
 	utc := time.Date(2026, 6, 5, 10, 31, 34, 0, time.UTC)

--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -46,7 +46,7 @@ func (s *GatewayService) shouldRetryUpstreamError(account *Account, statusCode i
 // shouldFailoverUpstreamError determines whether an upstream error should trigger account failover.
 func (s *GatewayService) shouldFailoverUpstreamError(statusCode int) bool {
 	switch statusCode {
-	case 401, 403, 424, 429, 529:
+	case 401, 402, 403, 424, 429, 529:
 		// 424: CloudWise-class relays wrap their upstream outage as Failed
 		// Dependency + server_error. Prod 2026-08-21 #94 returned terminal
 		// 424s while kiro still served after 429 failover.

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -242,6 +242,21 @@ func (s *GatewayService) ForwardAsChatCompletions(
 		result, handleErr = s.handleCCBufferedFromAnthropic(resp, c, originalModel, mappedModel, reasoningEffort, startTime)
 	}
 
+	if !clientStream && handleErr != nil {
+		var sseErr *sseStreamErrorEventError
+		if errors.As(handleErr, &sseErr) {
+			semanticStatus := http.StatusBadGateway
+			body := []byte(sseErr.RawData)
+			if cnProviderResponseIndicatesInsufficientBalance(body) {
+				semanticStatus = http.StatusPaymentRequired
+				if s.rateLimitService != nil {
+					s.rateLimitService.HandleUpstreamError(ctx, account, semanticStatus, resp.Header, body, mappedModel)
+				}
+			}
+			return nil, s.sseStreamErrorFailover(c, account, resp, sseErr, semanticStatus)
+		}
+	}
+
 	return result, handleErr
 }
 
@@ -300,7 +315,8 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 		line := scanner.Text()
 		// SSE 规范允许 `event:xxx`（冒号后无空格）：Kimi 等 Anthropic 兼容上游
 		// 返回紧凑格式，严格匹配 "event: " 会丢弃全部事件（#4653 同根因）。
-		if _, ok := extractOpenAISSEEventLine(line); !ok {
+		eventName, ok := extractOpenAISSEEventLine(line)
+		if !ok {
 			continue
 		}
 
@@ -312,6 +328,9 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 			continue
 		}
 		observeOpenAIResponsesEvent(c, []byte(payload))
+		if eventName == "error" {
+			return nil, &sseStreamErrorEventError{RawData: payload}
+		}
 
 		var event apicompat.AnthropicStreamEvent
 		if err := json.Unmarshal([]byte(payload), &event); err != nil {

--- a/backend/internal/service/gateway_forward_as_chat_completions_test.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_test.go
@@ -5,6 +5,7 @@ package service
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -19,6 +20,25 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
+
+type ccAnthropicSSEErrorUpstream struct {
+	body string
+}
+
+func (u *ccAnthropicSSEErrorUpstream) Do(*http.Request, string, int64, int) (*http.Response, error) {
+	return nil, fmt.Errorf("unexpected Do call")
+}
+
+func (u *ccAnthropicSSEErrorUpstream) DoWithTLS(*http.Request, string, int64, int, *tlsfingerprint.Profile) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream"},
+			"x-request-id": []string{"rid_cc_sse_error"},
+		},
+		Body: io.NopCloser(strings.NewReader(u.body)),
+	}, nil
+}
 
 func TestExtractCCReasoningEffortFromBody(t *testing.T) {
 	t.Parallel()
@@ -95,6 +115,73 @@ func TestHandleCCBufferedFromAnthropic_PreservesMessageStartCacheUsageAndReasoni
 	require.Equal(t, 3, result.Usage.CacheCreationInputTokens)
 	require.NotNil(t, result.ReasoningEffort)
 	require.Equal(t, "high", *result.ReasoningEffort)
+}
+
+func TestHandleCCBufferedFromAnthropic_EventErrorReturnsTypedFailure(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	upstreamBody := strings.Join([]string{
+		`event: error`,
+		`data: {"type":"error","error":{"type":"api_error","message":"Insufficient balance"}}`,
+		``,
+	}, "\n")
+	resp := &http.Response{
+		Header: http.Header{"x-request-id": []string{"rid_cc_buffered_error"}},
+		Body:   io.NopCloser(strings.NewReader(upstreamBody)),
+	}
+
+	svc := &GatewayService{}
+	result, err := svc.handleCCBufferedFromAnthropic(resp, c, "claude-opus-4-8", "claude-opus-4-8", nil, time.Now())
+	require.Nil(t, result)
+	var streamErr *sseStreamErrorEventError
+	require.ErrorAs(t, err, &streamErr)
+	require.Contains(t, streamErr.RawData, "Insufficient balance")
+	require.Empty(t, rec.Body.String(), "typed upstream failure must be handled by the failover loop, not committed as a final 502 here")
+}
+
+func TestForwardAsChatCompletions_BufferedBalanceSSEErrorBecomes402Failover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"hi"}],"max_tokens":32,"stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &ccAnthropicSSEErrorUpstream{body: strings.Join([]string{
+		`event: error`,
+		`data: {"type":"error","error":{"type":"api_error","message":"Insufficient balance"}}`,
+		``,
+	}, "\n")}
+	svc := &GatewayService{
+		cfg:                 &config.Config{},
+		httpUpstream:        upstream,
+		tlsFPProfileService: &TLSFingerprintProfileService{},
+	}
+	account := &Account{
+		ID:          94,
+		Name:        "cloudwise",
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "test-key",
+			"base_url": "https://cloudwise.example/api",
+		},
+	}
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, nil)
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr), "SSE event:error must re-enter the account failover loop")
+	require.Equal(t, http.StatusPaymentRequired, failoverErr.StatusCode)
+	require.Contains(t, string(failoverErr.ResponseBody), "Insufficient balance")
+	require.Empty(t, rec.Body.String(), "failover must remain uncommitted so a healthy account can serve the request")
 }
 
 // Kimi 等 Anthropic 兼容上游返回 SSE 紧凑格式（冒号后无空格），CC 桥此前按

--- a/backend/internal/service/gateway_forward_failover_status_test.go
+++ b/backend/internal/service/gateway_forward_failover_status_test.go
@@ -14,10 +14,17 @@ func TestGatewayShouldFailoverUpstreamError_424IsFailoverEligible(t *testing.T) 
 		"424 from CloudWise-class relays is a provider dependency failure and must leave the current account")
 }
 
+func TestGatewayShouldFailoverUpstreamError_402IsFailoverEligible(t *testing.T) {
+	svc := &GatewayService{}
+
+	assert.True(t, svc.shouldFailoverUpstreamError(http.StatusPaymentRequired),
+		"402 is an account-standing failure; the request must leave the exhausted account")
+}
+
 func TestGatewayShouldFailoverUpstreamError_ExistingCodesStillWork(t *testing.T) {
 	svc := &GatewayService{}
 
-	failoverCodes := []int{401, 403, 424, 429, 529, 500, 502, 503, 504}
+	failoverCodes := []int{401, 402, 403, 424, 429, 529, 500, 502, 503, 504}
 	for _, code := range failoverCodes {
 		assert.True(t, svc.shouldFailoverUpstreamError(code), "status %d should trigger failover", code)
 	}

--- a/backend/internal/service/openai_account_runtime_block_fastpath.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath.go
@@ -130,7 +130,9 @@ func (s *OpenAIGatewayService) handleOpenAIAccountUpstreamError(ctx context.Cont
 	shouldDisable := s.rateLimitService.HandleUpstreamError(stateCtx, account, statusCode, headers, responseBody, canonicalModel...)
 	modelTempMatched := statusCode != http.StatusUnauthorized && tempUnschedulableModel(stateCtx, nil) != "" &&
 		len(matchTempUnschedulableRules(account, statusCode, responseBody)) > 0
-	if shouldDisable && !modelTempMatched {
+	cloudwiseModelBalanceMatched := len(canonicalModel) > 0 &&
+		tkIsCloudwiseModelBalance402(account, statusCode, responseBody, canonicalModel[0])
+	if shouldDisable && !modelTempMatched && !cloudwiseModelBalanceMatched {
 		s.BlockAccountScheduling(account, time.Time{}, "upstream_disable")
 	}
 	// Pool-mode retryable upstream errors are already bounded by the request-local

--- a/backend/internal/service/openai_gateway_bridge_dispatch_test.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_test.go
@@ -50,6 +50,16 @@ func TestOpenAIShouldDispatchToNewAPIBridge(t *testing.T) {
 			want:     true,
 		},
 		{
+			name: "deepseek newapi chat endpoint",
+			account: &Account{
+				Type:        AccountTypeAPIKey,
+				ChannelType: newapiconstant.ChannelTypeDeepSeek,
+				Platform:    domain.PlatformNewAPI,
+			},
+			endpoint: BridgeEndpointChatCompletions,
+			want:     true,
+		},
+		{
 			name: "volcengine Agent Plan uses native OpenAI path",
 			account: &Account{
 				Type:        AccountTypeAPIKey,

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -392,6 +392,13 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 		return true
 	}
 
+	// CloudWise model pools are independent. Handle their model-balance 402
+	// before pool-mode and custom-error-code early exits so every CloudWise
+	// account shape persists the same exact-model five-hour cooldown.
+	if s.tkTryCloudwiseModelBalanceCooldown(ctx, account, statusCode, responseBody, firstRequestedModel(requestedModel)) {
+		return true
+	}
+
 	// 池模式默认不标记本地账号状态；但管理员显式配置的临时不可调度规则优先。
 	// 401 保留现有认证错误语义，不在这里改变池模式的认证处理。
 	if account.IsPoolMode() && !customErrorCodesEnabled && account.Platform != PlatformAnthropic {

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -394,14 +394,17 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 
 	// CloudWise model pools are independent. Handle their model-balance 402
 	// before pool-mode and custom-error-code early exits so every CloudWise
-	// account shape persists the same exact-model five-hour cooldown.
-	if s.tkTryCloudwiseModelBalanceCooldown(ctx, account, statusCode, responseBody, firstRequestedModel(requestedModel)) {
+	// account shape persists the same exact-model five-hour cooldown. If the
+	// model scope cannot be persisted, bypass those early exits and retain the
+	// conservative account-level 402 fallback.
+	cloudwiseModelBalance402 := tkIsCloudwiseModelBalance402Response(account, statusCode, responseBody)
+	if cloudwiseModelBalance402 && s.tkTryCloudwiseModelBalanceCooldown(ctx, account, statusCode, responseBody, firstRequestedModel(requestedModel)) {
 		return true
 	}
 
 	// 池模式默认不标记本地账号状态；但管理员显式配置的临时不可调度规则优先。
 	// 401 保留现有认证错误语义，不在这里改变池模式的认证处理。
-	if account.IsPoolMode() && !customErrorCodesEnabled && account.Platform != PlatformAnthropic {
+	if account.IsPoolMode() && !customErrorCodesEnabled && account.Platform != PlatformAnthropic && !cloudwiseModelBalance402 {
 		if statusCode != http.StatusUnauthorized && s.tryTempUnschedulable(ctx, account, statusCode, responseBody) {
 			return true
 		}
@@ -412,7 +415,7 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 	// apikey 类型账号：检查自定义错误码配置
 	// 如果启用且错误码不在列表中，则不处理（不停止调度、不标记限流/过载）
 	planGatedModel := isOpenAIOAuthAccount(account) && isOpenAICodexPlanGatedModelError(statusCode, responseBody)
-	if !planGatedModel && !account.ShouldHandleErrorCode(statusCode) && account.Platform != PlatformAnthropic {
+	if !cloudwiseModelBalance402 && !planGatedModel && !account.ShouldHandleErrorCode(statusCode) && account.Platform != PlatformAnthropic {
 		slog.Info("account_error_code_skipped", "account_id", account.ID, "status_code", statusCode)
 		return false
 	}

--- a/backend/internal/service/ratelimit_service_tk_cloudwise_402.go
+++ b/backend/internal/service/ratelimit_service_tk_cloudwise_402.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	tkCloudwiseModelBalanceCooldownReason = "cloudwise_model_insufficient_balance_402"
+	tkCloudwiseModelBalanceCooldown       = 5 * time.Hour
+)
+
+func tkIsCloudwiseModelBalance402(account *Account, statusCode int, responseBody []byte, requestedModel string) bool {
+	if account == nil || statusCode != http.StatusPaymentRequired || !isCloudwiseRelayAccount(account) {
+		return false
+	}
+	if strings.TrimSpace(requestedModel) == "" {
+		return false
+	}
+	body := strings.ToLower(strings.TrimSpace(string(responseBody)))
+	return strings.Contains(body, "insufficient balance") || strings.Contains(body, "insufficient_quota")
+}
+
+func (s *RateLimitService) tkTryCloudwiseModelBalanceCooldown(
+	ctx context.Context,
+	account *Account,
+	statusCode int,
+	responseBody []byte,
+	requestedModel string,
+) bool {
+	if s == nil || s.accountRepo == nil || !tkIsCloudwiseModelBalance402(account, statusCode, responseBody, requestedModel) {
+		return false
+	}
+	scopeKey := strings.TrimSpace(account.GetMappedModel(requestedModel))
+	if scopeKey == "" {
+		return false
+	}
+
+	resetAt := time.Now().Add(tkCloudwiseModelBalanceCooldown)
+	if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, scopeKey, resetAt, tkCloudwiseModelBalanceCooldownReason); err != nil {
+		slog.Warn("cloudwise_model_balance_rate_limit_failed",
+			"account_id", account.ID,
+			"model", scopeKey,
+			"error", err)
+		return false
+	}
+	s.notifyAccountSchedulingBlocked(account, resetAt, "402_cloudwise_model_balance", scopeKey)
+	slog.Info("cloudwise_model_balance_rate_limited",
+		"account_id", account.ID,
+		"model", scopeKey,
+		"reset_at", resetAt,
+		"reset_in", time.Until(resetAt).Truncate(time.Second))
+	return true
+}

--- a/backend/internal/service/ratelimit_service_tk_cloudwise_402.go
+++ b/backend/internal/service/ratelimit_service_tk_cloudwise_402.go
@@ -13,15 +13,17 @@ const (
 	tkCloudwiseModelBalanceCooldown       = 5 * time.Hour
 )
 
-func tkIsCloudwiseModelBalance402(account *Account, statusCode int, responseBody []byte, requestedModel string) bool {
+func tkIsCloudwiseModelBalance402Response(account *Account, statusCode int, responseBody []byte) bool {
 	if account == nil || statusCode != http.StatusPaymentRequired || !isCloudwiseRelayAccount(account) {
-		return false
-	}
-	if strings.TrimSpace(requestedModel) == "" {
 		return false
 	}
 	body := strings.ToLower(strings.TrimSpace(string(responseBody)))
 	return strings.Contains(body, "insufficient balance") || strings.Contains(body, "insufficient_quota")
+}
+
+func tkIsCloudwiseModelBalance402(account *Account, statusCode int, responseBody []byte, requestedModel string) bool {
+	return strings.TrimSpace(requestedModel) != "" &&
+		tkIsCloudwiseModelBalance402Response(account, statusCode, responseBody)
 }
 
 func (s *RateLimitService) tkTryCloudwiseModelBalanceCooldown(

--- a/backend/internal/service/ratelimit_service_tk_cloudwise_402_test.go
+++ b/backend/internal/service/ratelimit_service_tk_cloudwise_402_test.go
@@ -1,0 +1,211 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRateLimitService_CloudwiseInsufficientBalance402_CoolsExactModelForFiveHours(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	account := &Account{
+		ID:          94,
+		Name:        "cloudwise",
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Credentials: map[string]any{
+			"base_url": "https://api.cloudwise.ai/api",
+		},
+	}
+
+	startedAt := time.Now()
+	shouldFailover := svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusPaymentRequired,
+		http.Header{},
+		[]byte(`{"error":{"message":"Insufficient balance","type":"insufficient_quota"}}`),
+		"claude-opus-4-8",
+	)
+
+	require.True(t, shouldFailover, "current request must leave the exhausted account/model")
+	require.Zero(t, repo.setErrorCalls, "CloudWise model balance must not disable the whole account")
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	call := repo.modelRateLimitCalls[0]
+	require.Equal(t, int64(94), call.accountID)
+	require.Equal(t, "claude-opus-4-8", call.scope)
+	require.Equal(t, "cloudwise_model_insufficient_balance_402", call.reason)
+	require.WithinDuration(t, startedAt.Add(5*time.Hour), call.resetAt, time.Second)
+
+	account.Extra = map[string]any{
+		modelRateLimitsKey: map[string]any{
+			call.scope: map[string]any{
+				"rate_limit_reset_at": call.resetAt.Format(time.RFC3339),
+				"reason":              call.reason,
+			},
+		},
+	}
+	require.False(t, account.IsSchedulableForModelWithContext(context.Background(), "claude-opus-4-8"))
+	require.True(t, account.IsSchedulableForModelWithContext(context.Background(), "claude-sonnet-4-6"),
+		"exact-model cooldown must leave sibling CloudWise models schedulable")
+}
+
+func TestOpenAIGateway_CloudwiseInsufficientBalance402_DoesNotRuntimeBlockWholeAccount(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	rateLimits := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	gateway := &OpenAIGatewayService{rateLimitService: rateLimits}
+	rateLimits.SetAccountRuntimeBlocker(gateway)
+	account := &Account{
+		ID:          95,
+		Name:        "cloudwise-openai",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Credentials: map[string]any{
+			"base_url": "https://api.cloudwise.ai/api",
+		},
+	}
+	body := []byte(`{"error":{"message":"Insufficient balance","type":"insufficient_quota"}}`)
+
+	shouldFailover := gateway.handleOpenAIAccountUpstreamError(
+		context.Background(),
+		account,
+		http.StatusPaymentRequired,
+		http.Header{},
+		body,
+		"claude-opus-4-8",
+	)
+
+	require.True(t, shouldFailover)
+	require.False(t, gateway.isOpenAIAccountRuntimeBlocked(account),
+		"CloudWise 402 must isolate the model without blocking sibling models on the account")
+	require.Zero(t, repo.setErrorCalls)
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	require.Equal(t, "claude-opus-4-8", repo.modelRateLimitCalls[0].scope)
+}
+
+func TestRateLimitService_CloudwisePoolMode402_StillCoolsExactModel(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	account := &Account{
+		ID:          96,
+		Name:        "cloudwise-pool",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Credentials: map[string]any{
+			"base_url":  "https://api.cloudwise.ai/api",
+			"pool_mode": true,
+		},
+	}
+
+	shouldFailover := svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusPaymentRequired,
+		http.Header{},
+		[]byte(`{"error":{"message":"Insufficient balance","type":"insufficient_quota"}}`),
+		"claude-opus-4-8",
+	)
+
+	require.True(t, shouldFailover)
+	require.Zero(t, repo.setErrorCalls)
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	require.Equal(t, "claude-opus-4-8", repo.modelRateLimitCalls[0].scope)
+}
+
+func TestRateLimitService_CloudwiseInsufficientBalance402_UsesMappedModelScope(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	account := &Account{
+		ID:          97,
+		Name:        "cloudwise-mapped",
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Credentials: map[string]any{
+			"base_url": "https://api.cloudwise.ai/api",
+			"model_mapping": map[string]any{
+				"claude-opus-latest": "claude-opus-4-8",
+			},
+		},
+	}
+
+	shouldFailover := svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusPaymentRequired,
+		http.Header{},
+		[]byte(`{"error":{"message":"Insufficient balance","type":"insufficient_quota"}}`),
+		"claude-opus-latest",
+	)
+
+	require.True(t, shouldFailover)
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	require.Equal(t, "claude-opus-4-8", repo.modelRateLimitCalls[0].scope,
+		"write key must match the mapped-model key consulted by scheduling")
+}
+
+func TestRateLimitService_Cloudwise402WithoutModel_KeepsAccountLevelFallback(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	account := &Account{
+		ID:       98,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://api.cloudwise.ai/api",
+		},
+	}
+
+	shouldDisable := svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusPaymentRequired,
+		http.Header{},
+		[]byte(`{"error":{"message":"Insufficient balance","type":"insufficient_quota"}}`),
+	)
+
+	require.True(t, shouldDisable)
+	require.Empty(t, repo.modelRateLimitCalls)
+	require.Equal(t, 1, repo.setErrorCalls,
+		"without a model key the safe fallback remains whole-account disable")
+}
+
+func TestRateLimitService_NonCloudwise402_KeepsAccountLevelBehavior(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	account := &Account{
+		ID:       99,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://api.anthropic.com",
+		},
+	}
+
+	shouldDisable := svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusPaymentRequired,
+		http.Header{},
+		[]byte(`{"error":{"message":"Insufficient balance","type":"insufficient_quota"}}`),
+		"claude-opus-4-8",
+	)
+
+	require.True(t, shouldDisable)
+	require.Empty(t, repo.modelRateLimitCalls)
+	require.Equal(t, 1, repo.setErrorCalls)
+}

--- a/backend/internal/service/ratelimit_service_tk_cloudwise_402_test.go
+++ b/backend/internal/service/ratelimit_service_tk_cloudwise_402_test.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -123,6 +124,82 @@ func TestRateLimitService_CloudwisePoolMode402_StillCoolsExactModel(t *testing.T
 	require.Zero(t, repo.setErrorCalls)
 	require.Len(t, repo.modelRateLimitCalls, 1)
 	require.Equal(t, "claude-opus-4-8", repo.modelRateLimitCalls[0].scope)
+}
+
+func TestRateLimitService_Cloudwise402FallbackBypassesPoolAndCustomEarlyExits(t *testing.T) {
+	tests := []struct {
+		name        string
+		credentials map[string]any
+		model       []string
+		writeErr    error
+		wantWrites  int
+	}{
+		{
+			name: "pool mode model cooldown write failure",
+			credentials: map[string]any{
+				"base_url":  "https://api.cloudwise.ai/api",
+				"pool_mode": true,
+			},
+			model:      []string{"claude-opus-4-8"},
+			writeErr:   errors.New("write failed"),
+			wantWrites: 1,
+		},
+		{
+			name: "custom error code miss after model cooldown write failure",
+			credentials: map[string]any{
+				"base_url":                   "https://api.cloudwise.ai/api",
+				"custom_error_codes_enabled": true,
+				"custom_error_codes":         []any{float64(http.StatusTooManyRequests)},
+			},
+			model:      []string{"claude-opus-4-8"},
+			writeErr:   errors.New("write failed"),
+			wantWrites: 1,
+		},
+		{
+			name: "pool mode without model context",
+			credentials: map[string]any{
+				"base_url":  "https://api.cloudwise.ai/api",
+				"pool_mode": true,
+			},
+		},
+		{
+			name: "custom error code miss without model context",
+			credentials: map[string]any{
+				"base_url":                   "https://api.cloudwise.ai/api",
+				"custom_error_codes_enabled": true,
+				"custom_error_codes":         []any{float64(http.StatusTooManyRequests)},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &rateLimitAccountRepoStub{modelRateLimitErr: tt.writeErr}
+			svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+			account := &Account{
+				ID:          100,
+				Name:        "cloudwise-fallback",
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Status:      StatusActive,
+				Schedulable: true,
+				Credentials: tt.credentials,
+			}
+
+			shouldDisable := svc.HandleUpstreamError(
+				context.Background(),
+				account,
+				http.StatusPaymentRequired,
+				http.Header{},
+				[]byte(`{"error":{"message":"Insufficient balance","type":"insufficient_quota"}}`),
+				tt.model...,
+			)
+
+			require.True(t, shouldDisable, "failed or impossible model cooldown must fail closed")
+			require.Len(t, repo.modelRateLimitCalls, tt.wantWrites)
+			require.Equal(t, 1, repo.setErrorCalls, "fallback must disable the whole account")
+		})
+	}
 }
 
 func TestRateLimitService_CloudwiseInsufficientBalance402_UsesMappedModelScope(t *testing.T) {

--- a/backend/internal/service/ratelimit_service_tk_incident.go
+++ b/backend/internal/service/ratelimit_service_tk_incident.go
@@ -10,7 +10,7 @@ import (
 // cooldown reasons only persist model_rate_limits and incident telemetry.
 func isWholeAccountRuntimeBlockReason(reason string) bool {
 	switch strings.TrimSpace(reason) {
-	case "429_codex_metered", "429_model_class", "429_mirror_class_downstream_empty", "429_openai_mirror_downstream_empty":
+	case "402_cloudwise_model_balance", "429_codex_metered", "429_model_class", "429_mirror_class_downstream_empty", "429_openai_mirror_downstream_empty":
 		return false
 	default:
 		return true

--- a/docs/approved/prod-user-visible-failure-hotfix-2026-08-24.md
+++ b/docs/approved/prod-user-visible-failure-hotfix-2026-08-24.md
@@ -1,0 +1,98 @@
+---
+title: Prod user-visible failure hotfix — Anthropic SSE and NewAPI chat dispatch
+status: approved
+approved_by: user (chat confirmation 2026-08-24)
+approved_at: 2026-08-24
+authors: [agent]
+created: 2026-08-24
+related_incidents: ["prod user_visible_failure_count 66 at 2026-08-24T07:21:18Z"]
+---
+
+# Prod user-visible failure hotfix — 2026-08-24
+
+## Goal
+
+Eliminate the two gateway defects behind the August 24 production alert:
+
+1. A buffered Chat Completions request converted to Anthropic SSE must treat an
+   upstream `event:error` frame as an account failover signal instead of
+   returning `Upstream stream ended without a response`.
+2. Inbound `/v1/chat/completions` selected onto a bridge-eligible `newapi`
+   account must enter the existing NewAPI bridge dispatcher. A foreign channel
+   credential must never fall through to the official OpenAI host.
+
+## Approved containment
+
+- Keep accounts #94, #72, #57, and #60 unschedulable until their relevant probes
+  are green after rollout. Account #60 was added by explicit chat confirmation
+  after the same pre-dispatch NewAPI defect recurred on its ch17 pool.
+- Account #94 may be restored after rollout only after the observed
+  `claude-opus-4-8` CloudWise 402 has been persisted as an exact-model 5h
+  cooldown. Restoring the production account remains a separately confirmed
+  write operation.
+- Do not delete accounts, rewrite credentials, restart production, or deploy as
+  part of containment.
+
+## Design
+
+### NewAPI Chat Completions ownership
+
+The production handler calls `ForwardAsChatCompletionsDispatched`, the existing
+Tier-1 owner for channel-type-aware relay. The dispatcher remains the sole
+owner of bridge eligibility, sticky injection, model rewriting, credential
+binding, relay error penalties, and native fallback.
+
+The handler must not copy `platform == newapi` or `channel_type > 0` predicates.
+
+### Anthropic buffered SSE errors
+
+The buffered Chat Completions → Anthropic path recognizes an SSE `event:error`
+frame before attempting to assemble a response. It reuses the existing typed
+SSE failover path and preserves the upstream error payload for ops evidence and
+account policy handling.
+
+An upstream HTTP 402 joins the Gateway failover status SSOT so another eligible
+account can serve the current request.
+
+CloudWise is a narrow exception to the generic account-standing policy. Direct
+probes of account #94 on 2026-08-24 showed `claude-opus-4-8` returning
+`402 Insufficient balance` while the same API key successfully served
+`claude-sonnet-4-6`, `claude-sonnet-5`, GLM, and MiniMax. A CloudWise 402 whose
+body contains `Insufficient balance` or `insufficient_quota` therefore writes an
+exact mapped-model entry in `account.extra.model_rate_limits` with a fixed 5h
+reset. It must not write an Anthropic model-class key or disable/block the whole
+account. Missing model context, a failed model-cooldown write, non-CloudWise
+accounts, and other 402 bodies retain the conservative account-level fallback.
+
+## Required tests
+
+- Handler-selected channel type 17 account enters the NewAPI chat dispatcher.
+- Handler-selected channel type 41 account enters the same dispatcher.
+- DeepSeek channel type 43 remains bridge-eligible on Chat Completions; live
+  account-test evidence showed the account/model itself was healthy while the
+  pre-fix production handler sent normal traffic to `/v1/responses`.
+- Buffered Anthropic SSE `event:error` returns a typed failover error and does
+  not emit the generic empty-stream 502.
+- HTTP 402 is failover-eligible and reaches the existing account penalty path.
+- CloudWise `Insufficient balance` 402 writes an exact mapped-model 5h cooldown,
+  including pool-mode accounts, without setting account `error`.
+- The OpenAI-compatible CloudWise path does not create a whole-account runtime
+  block after persisting the model cooldown.
+- Sibling CloudWise models remain schedulable; missing model context and
+  non-CloudWise 402 responses keep the account-level fallback.
+- Existing native OpenAI, Anthropic, and Agent Plan exceptions remain green.
+
+## Non-goals
+
+- No deployment without a separate confirmation.
+- No schema, API response schema, pricing, billing, or scheduler algorithm
+  changes.
+- No broad rewrite of the SSE parsers.
+- Probe-reserved resources remain in the current alert metric for this hotfix;
+  metric separation is a follow-up and must not hide real gateway failures.
+
+## Rollback
+
+- Code rollback: revert the hotfix release.
+- Containment rollback: restore `schedulable=true` individually only after the
+  account-specific probe passes; #94 also requires upstream balance recovery.

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1275,6 +1275,13 @@
       "rationale": "GatewayService.Forward must intercept CloudWise non-claude /v1/messages before anthropic APIKey passthrough, otherwise #94 glm/kimi/minimax/deepseek stay on native messages."
     },
     {
+      "path": "backend/internal/service/gateway_forward.go",
+      "must_contain": [
+        "case 401, 402, 403, 424, 429, 529:"
+      ],
+      "rationale": "Gateway upstream failover status truth must include HTTP 402. A payment-required or exhausted-balance account is an account-standing failure, not a client request error; leaving 402 out keeps the dead account selected and turns every request into a final 502 instead of switching to a healthy account."
+    },
+    {
       "path": "backend/internal/service/gateway_tokensea_anthropic_relay_test.go",
       "must_contain": [
         "TestAnthropicTokenseaRelayFloorMapsShortNamesToWireIDs",
@@ -1314,6 +1321,16 @@
         "buildAnthropicCompatUpstreamRequest"
       ],
       "rationale": "Gateway Anthropic-backed /v1/chat/completions non-stream path (handleCCBufferedFromAnthropic) shares the upstream #1311 Content-Type leak root cause and must explicitly override Content-Type after WriteFilteredHeaders so the converted chat.completion JSON body is not labeled text/event-stream. Also the call site wiring the gemini-native image aspect-ratio injection (tkInjectGeminiImageAspectRatio, gateway_forward_as_chat_completions_tk_image.go) into the OpenAI-compat → Anthropic forward, after enforceCacheControlLimit and before buildUpstreamRequest — the companion compiling alone would not catch a dropped call site, so the one-line hook is anchored here separately. Anthropic passthrough relays must use buildAnthropicCompatUpstreamRequest for the upstream /v1/messages hop after CC→Anthropic conversion."
+    },
+    {
+      "path": "backend/internal/service/gateway_forward_as_chat_completions.go",
+      "must_contain": [
+        "if eventName == \"error\" {",
+        "return nil, &sseStreamErrorEventError{RawData: payload}",
+        "cnProviderResponseIndicatesInsufficientBalance(body)",
+        "s.sseStreamErrorFailover(c, account, resp, sseErr, semanticStatus)"
+      ],
+      "rationale": "The buffered Chat Completions → Anthropic SSE path must preserve upstream event:error frames as typed failover evidence. Without these anchors a balance-exhausted relay returns HTTP 200 plus event:error, the converter ignores it, and the user receives the misleading terminal 502 'Upstream stream ended without a response'. The balance semantic must map to 402 so existing account-standing policy can stop scheduling the exhausted account."
     },
     {
       "path": "backend/internal/service/gateway_forward_as_responses_tk_content_type_test.go",
@@ -3060,6 +3077,7 @@
         "func (n *TKAccountIncidentNotifier) NotifyAccountIncident(",
         "func classifyIncident(",
         "case \"429_model_class\":",
+        "case \"402_cloudwise_model_balance\":",
         "func (n *TKAccountIncidentNotifier) NotifyAccountRecovered(",
         "func (n *TKAccountIncidentNotifier) trackActive(",
         "func (n *TKAccountIncidentNotifier) pruneStaleActive(",
@@ -3068,7 +3086,14 @@
         "func (n *TKAccountIncidentNotifier) temporaryDigestEnabled() bool",
         "cls.kind == IncidentKindTemporaryCooldown && !n.temporaryDigestEnabled()"
       ],
-      "rationale": "账号失效 → 飞书告警的核心实现（TK-only，无上游对应）。NotifyAccountIncident 按 classifyIncident 的派生形态分流：永久失效（status=error 终态）即时单条 P0；临时冷却（429/529/...自愈）写聚合 buffer 由后台 ticker flush 成低频摘要，保住信噪比不刷屏。classifyIncident 把底层 reason 字符串映射成 (形态, 去重类, 中文文案, 运营建议)。`case \"429_model_class\"` 是 G4(#600)模型维度 cooldown 的专属分类——缺它会落兜底\"账号临时冷却\"，把 opus-only 冷却误报成整账号下线。**恢复通知（事件驱动）**：trackActive 登记活跃事件台账；NotifyAccountRecovered 在真实清除事件(ClearRateLimit/RecoverAccountState)时对此前告警过的账号发即时绿卡（`green` header），永久+临时两类都发；pruneStaleActive 静默修剪纯定时器到期(无 clear 事件)的陈旧条目、**不发卡**(按设计:定时器到期不播报)。删掉任一 anchor 会让恢复链路断裂或模型类告警回到误报兜底。整文件易在大重构/上游合并中被整体误删——删掉等于告警链路断裂。**自愈摘要 opt-in 默认关（PR#730 起，gate 由 #730 修正）**：temporaryDigestEnabled + NotifyAccountIncident 里 `cls.kind == IncidentKindTemporaryCooldown && !n.temporaryDigestEnabled()` 的早返门把 529/429/temp 自愈类摘要改成默认静默。enable 现在看显式 bool `feishu.account_incident_digest_enabled`（默认 false）——绝不能复用 `account_incident_digest_seconds>0`，后者被 normalizeOpsFeishuAlertConfig 的 0→600 回填使其永不为 0，曾让 #730 的“默认关”被悄悄打开（gate 恒真）；seconds 现在只表示 flush 间隔。上游合并/重构若删掉该门会让自愈类摘要回到默认刷屏，淹没真故障 P0。"
+      "rationale": "账号失效 → 飞书告警的核心实现（TK-only，无上游对应）。NotifyAccountIncident 按 classifyIncident 的派生形态分流：永久失效（status=error 终态）即时单条 P0；临时冷却（429/529/...自愈）写聚合 buffer 由后台 ticker flush 成低频摘要，保住信噪比不刷屏。classifyIncident 把底层 reason 字符串映射成 (形态, 去重类, 中文文案, 运营建议)。`case \"429_model_class\"` 与 `case \"402_cloudwise_model_balance\"` 是模型维度 cooldown 的专属分类——缺失会落兜底\"账号临时冷却\"，把模型专属冷却误报成整账号下线。**恢复通知（事件驱动）**：trackActive 登记活跃事件台账；NotifyAccountRecovered 在真实清除事件(ClearRateLimit/RecoverAccountState)时对此前告警过的账号发即时绿卡（`green` header），永久+临时两类都发；pruneStaleActive 静默修剪纯定时器到期(无 clear 事件)的陈旧条目、**不发卡**(按设计:定时器到期不播报)。删掉任一 anchor 会让恢复链路断裂或模型类告警回到误报兜底。整文件易在大重构/上游合并中被整体误删——删掉等于告警链路断裂。**自愈摘要 opt-in 默认关（PR#730 起，gate 由 #730 修正）**：temporaryDigestEnabled + NotifyAccountIncident 里 `cls.kind == IncidentKindTemporaryCooldown && !n.temporaryDigestEnabled()` 的早返门把 529/429/temp 自愈类摘要改成默认静默。enable 现在看显式 bool `feishu.account_incident_digest_enabled`（默认 false）——绝不能复用 `account_incident_digest_seconds>0`，后者被 normalizeOpsFeishuAlertConfig 的 0→600 回填使其永不为 0，曾让 #730 的“默认关”被悄悄打开（gate 恒真）；seconds 现在只表示 flush 间隔。上游合并/重构若删掉该门会让自愈类摘要回到默认刷屏，淹没真故障 P0。"
+    },
+    {
+      "path": "backend/internal/service/account_incident_notifier_tk_test.go",
+      "must_contain": [
+        "TestClassifyIncident_CloudwiseModelBalance402IsModelScopedCooldown"
+      ],
+      "rationale": "CloudWise model-balance 402 must stay classified as a temporary model-scoped cooldown with sibling-model guidance, not the generic whole-account cooldown fallback."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_incident.go",
@@ -3076,7 +3101,8 @@
         "func (s *RateLimitService) SetAccountIncidentNotifier(",
         "func (s *RateLimitService) notifyAccountIncident(",
         "func (s *RateLimitService) notifyAccountRecovered(",
-        "func isWholeAccountRuntimeBlockReason(reason string) bool"
+        "func isWholeAccountRuntimeBlockReason(reason string) bool",
+        "402_cloudwise_model_balance"
       ],
       "rationale": "把 AccountIncidentNotifier 注入 RateLimitService 的 glue：wire ProvideTKAccountIncidentNotifier 在构造后调 SetAccountIncidentNotifier 回填，挂钩点（ratelimit_service.go）经 notifyAccountIncident 转发。notifyAccountRecovered 是恢复绿卡的转发包装，由 notifyAccountSchedulingBlockCleared(ClearRateLimit/RecoverAccountState 真实清除事件)调用。isWholeAccountRuntimeBlockReason is the SSOT predicate for whether notifyAccountSchedulingBlocked also writes the in-memory whole-account runtime blocker (model-scoped 429 reasons excluded).删掉会让挂钩行编译失败或静默 no-op，账号失效/恢复告警链路断裂。"
     },
@@ -3604,8 +3630,29 @@
       "rationale": "G4 model-dimension cooldown companion. Anthropic OAuth accounts share a unified 5h/7d window across model classes. The model-scoped cooldown is ONLY correct for a genuine per-class sub-bucket limit; an account-wide unified window (anthropic-ratelimit-unified-{5h,7d}-* with NO class suffix) is shared and blocks every class even when that class's own sub-bucket is allowed (direct upstream probe edge-us3 account a1, 2026-06-06: unified-7d-status=rejected returned 429 to a sonnet request while unified-7d_sonnet-status=allowed). The 'if result.window == anthropicUnifiedWindow5h || ...7d' guard makes tkTryAnthropicModelScopedCooldown DECLINE (return false -> caller does account-level SetRateLimited) for account-wide windows, so all classes are cooled; model-scoping survives only for window=='' (per-class sub-bucket). Losing that guard re-introduces the bug where a 7d-exhausted account leaves haiku falsely schedulable and unmarked. Losing tkTryAnthropicModelScopedCooldown / tkAnthropicModelClass on an upstream merge would silently re-introduce the original account-level amplification; this sentinel catches both. The same file also hosts the OpenAI/Codex analog tkTryOpenAICodexModelScopedCooldown: a ChatGPT account's per-model metered sub-window (e.g. gpt-5.3-codex-spark, the /wham/usage additional_rate_limits family) can hit 100% (429 usage_limit_reached) while the account-wide 5h/7d window is healthy; cooling the whole account there idles healthy capacity and empties the pool ('刷不出 codex 额度'). It narrows such a 429 to the mapped model scope (honored by modelRateLimitKeysForRequest's GetMappedModel key, no read-side change) when tkIsOpenAICodexMeteredModel; account-wide exhaustion is owned solely by calculateOpenAI429ResetTime (general window >=100% → whole account, the only fact-based account-wide signal — no inferred sub-100% threshold). Losing these on a merge reverts codex to account-level amplification."
     },
     {
+      "path": "backend/internal/service/ratelimit_service_tk_cloudwise_402.go",
+      "must_contain": [
+        "func tkIsCloudwiseModelBalance402(",
+        "func (s *RateLimitService) tkTryCloudwiseModelBalanceCooldown(",
+        "tkCloudwiseModelBalanceCooldown       = 5 * time.Hour",
+        "SetModelRateLimit(ctx, account.ID, scopeKey, resetAt, tkCloudwiseModelBalanceCooldownReason)"
+      ],
+      "rationale": "CloudWise model-balance 402 owner. Prod account #94 proved the same API key could serve Sonnet/GLM/MiniMax while claude-opus-4-8 returned 402 insufficient_quota, so the failure is an independent model pool rather than whole-account standing. This helper narrowly matches CloudWise base URLs plus the observed balance markers, resolves the scheduler's exact mapped-model key, and persists a fixed 5h model_rate_limits cooldown. Removing it restores whole-account SetError amplification and unnecessarily idles healthy sibling models."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_cloudwise_402_test.go",
+      "must_contain": [
+        "TestRateLimitService_CloudwiseInsufficientBalance402_CoolsExactModelForFiveHours",
+        "TestOpenAIGateway_CloudwiseInsufficientBalance402_DoesNotRuntimeBlockWholeAccount",
+        "TestRateLimitService_CloudwisePoolMode402_StillCoolsExactModel",
+        "TestRateLimitService_Cloudwise402WithoutModel_KeepsAccountLevelFallback"
+      ],
+      "rationale": "Regression coverage for CloudWise 402 isolation: exact model receives the 5h cooldown, sibling models stay schedulable, OpenAI-compatible runtime blocking remains model-scoped, pool-mode cannot bypass the policy, and absent model context keeps the conservative account-level fallback."
+    },
+    {
       "path": "backend/internal/service/ratelimit_service.go",
       "must_contain": [
+        "if s.tkTryCloudwiseModelBalanceCooldown(ctx, account, statusCode, responseBody, firstRequestedModel(requestedModel)) {",
         "if len(requestedModel) > 0 && s.tkTryAnthropicModelScopedCooldown(ctx, account, requestedModel[0], result) {",
         "if len(requestedModel) > 0 && s.tkTryOpenAICodexModelScopedCooldown(ctx, account, requestedModel[0], resetTime) {",
         "rateLimitSet := s.handle429(ctx, account, headers, responseBody, requestedModel...)"
@@ -6897,9 +6944,11 @@
     {
       "path": "backend/internal/service/openai_account_runtime_block_fastpath.go",
       "must_contain": [
-        "HandleOpenAIImageCapabilityLoss400(stateCtx, account, statusCode, responseBody)"
+        "HandleOpenAIImageCapabilityLoss400(stateCtx, account, statusCode, responseBody)",
+        "cloudwiseModelBalanceMatched := len(canonicalModel) > 0 &&",
+        "!modelTempMatched && !cloudwiseModelBalanceMatched"
       ],
-      "rationale": "Gateway error fastpath must cool openai:image_generation on capability-loss 400 without blocking the whole account."
+      "rationale": "Gateway error fastpath must cool openai:image_generation on capability-loss 400 without blocking the whole account. The same boundary must recognize a successfully persisted CloudWise model-balance 402 and skip the whole-account in-memory runtime block while still returning shouldDisable=true so the current request fails over. Losing that guard makes the durable model scope ineffective until process restart because healthy sibling models remain hidden behind an account-wide runtime block."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_account_capability_400.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -491,9 +491,9 @@
         "SetTempUnschedulable(ctx, account.ID, until, reason)",
         ") ResetAnthropicUpstreamErrorCounter(",
         "ResetAnthropicCooldownTier",
-        "if account.IsPoolMode() && !customErrorCodesEnabled && account.Platform != PlatformAnthropic {",
+        "if account.IsPoolMode() && !customErrorCodesEnabled && account.Platform != PlatformAnthropic && !cloudwiseModelBalance402 {",
         "planGatedModel := isOpenAIOAuthAccount(account) && isOpenAICodexPlanGatedModelError(statusCode, responseBody)",
-        "if !planGatedModel && !account.ShouldHandleErrorCode(statusCode) && account.Platform != PlatformAnthropic {",
+        "if !cloudwiseModelBalance402 && !planGatedModel && !account.ShouldHandleErrorCode(statusCode) && account.Platform != PlatformAnthropic {",
         "s.ResetAnthropicUpstreamErrorCounter(ctx, accountID)",
         "s.tkDisableIfOAuth401OnValidToken(ctx, authAccount, upstreamMsg)",
         "oauth_401_immediate_disable",
@@ -3632,6 +3632,7 @@
     {
       "path": "backend/internal/service/ratelimit_service_tk_cloudwise_402.go",
       "must_contain": [
+        "func tkIsCloudwiseModelBalance402Response(",
         "func tkIsCloudwiseModelBalance402(",
         "func (s *RateLimitService) tkTryCloudwiseModelBalanceCooldown(",
         "tkCloudwiseModelBalanceCooldown       = 5 * time.Hour",
@@ -3645,19 +3646,23 @@
         "TestRateLimitService_CloudwiseInsufficientBalance402_CoolsExactModelForFiveHours",
         "TestOpenAIGateway_CloudwiseInsufficientBalance402_DoesNotRuntimeBlockWholeAccount",
         "TestRateLimitService_CloudwisePoolMode402_StillCoolsExactModel",
+        "TestRateLimitService_Cloudwise402FallbackBypassesPoolAndCustomEarlyExits",
         "TestRateLimitService_Cloudwise402WithoutModel_KeepsAccountLevelFallback"
       ],
-      "rationale": "Regression coverage for CloudWise 402 isolation: exact model receives the 5h cooldown, sibling models stay schedulable, OpenAI-compatible runtime blocking remains model-scoped, pool-mode cannot bypass the policy, and absent model context keeps the conservative account-level fallback."
+      "rationale": "Regression coverage for CloudWise 402 isolation: exact model receives the 5h cooldown, sibling models stay schedulable, OpenAI-compatible runtime blocking remains model-scoped, pool/custom early exits cannot bypass either the model cooldown or its fail-closed account fallback, and absent model context keeps the conservative account-level fallback."
     },
     {
       "path": "backend/internal/service/ratelimit_service.go",
       "must_contain": [
-        "if s.tkTryCloudwiseModelBalanceCooldown(ctx, account, statusCode, responseBody, firstRequestedModel(requestedModel)) {",
+        "cloudwiseModelBalance402 := tkIsCloudwiseModelBalance402Response(",
+        "s.tkTryCloudwiseModelBalanceCooldown(ctx, account, statusCode, responseBody, firstRequestedModel(requestedModel))",
+        "account.Platform != PlatformAnthropic && !cloudwiseModelBalance402",
+        "if !cloudwiseModelBalance402 && !planGatedModel",
         "if len(requestedModel) > 0 && s.tkTryAnthropicModelScopedCooldown(ctx, account, requestedModel[0], result) {",
         "if len(requestedModel) > 0 && s.tkTryOpenAICodexModelScopedCooldown(ctx, account, requestedModel[0], resetTime) {",
         "rateLimitSet := s.handle429(ctx, account, headers, responseBody, requestedModel...)"
       ],
-      "rationale": "G4 injection point in the upstream-shaped handle429 / case-429 dispatch. The Anthropic per-window (5h/7d) branch must try the (account x model class) cooldown BEFORE the account-level SetRateLimited fallback, and the dispatch must thread requestedModel into handle429. The OpenAI/Codex body path (usage_limit_reached) must likewise try tkTryOpenAICodexModelScopedCooldown BEFORE the whole-account SetRateLimited so a spark per-model sub-limit 429 (account-wide window healthy) is narrowed to the model. An upstream merge that rewrites the 429 path or drops the requestedModel passthrough would silently revert both G4 (Anthropic) and the codex spark cooldown back to account-level amplification; this sentinel anchors both calls and the threading."
+      "rationale": "G4 injection point in the upstream-shaped error dispatch. CloudWise model-balance 402 must try the exact-model cooldown before pool/custom early exits, while a failed write or missing model bypasses those exits and reaches the conservative account-level 402 fallback. The Anthropic per-window (5h/7d) branch must try the (account x model class) cooldown BEFORE the account-level SetRateLimited fallback, and the dispatch must thread requestedModel into handle429. The OpenAI/Codex body path (usage_limit_reached) must likewise try tkTryOpenAICodexModelScopedCooldown BEFORE the whole-account SetRateLimited so a spark per-model sub-limit 429 (account-wide window healthy) is narrowed to the model. An upstream merge that rewrites these paths or drops the requestedModel passthrough would silently restore whole-account amplification or fail-open CloudWise scheduling; this sentinel anchors the calls, fallbacks, and threading."
     },
     {
       "path": "backend/internal/service/model_rate_limit.go",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -573,6 +573,16 @@
       "rationale": "Chat-completions handler must preserve the NewAPIRelayError's real upstream status (402/429/...) to the client instead of masking it as 502 'Upstream request failed'. The load-bearing call lives INSIDE the non-failover error branch (mirroring the /v1/responses handler); the file contains a SECOND textually-identical call further down that is only reachable on the image-partial-result path, so a bare single-line needle would still pass after a merge dropped the reachable branch. The needle therefore pins the comment tail + if-line contiguous to the in-branch site; a merge that drops it reverts every newapi chat bridge error to an opaque 502 (the 2026-06-11 DeepSeek incident shape, 6946 masked 402s)."
     },
     {
+      "path": "backend/internal/handler/openai_chat_completions.go",
+      "must_contain": [
+        "return h.gatewayService.ForwardAsChatCompletionsDispatched(c.Request.Context(), c, account, forwardBody, promptCacheKey, dispatchMappedModel)"
+      ],
+      "must_not_contain": [
+        "return h.gatewayService.ForwardAsChatCompletions(c.Request.Context(), c, account, forwardBody, promptCacheKey, dispatchMappedModel)"
+      ],
+      "rationale": "The production /v1/chat/completions handler must enter the existing NewAPI bridge dispatcher. Calling the native forwarder directly bypasses channel_type-aware ownership and can send a DashScope/Vertex credential toward the official OpenAI path. This is the load-bearing call-site half of the account #72/#57 regression; service-level bridge tests alone cannot detect an unwired production entrypoint."
+    },
+    {
       "path": "backend/internal/service/ratelimit_service.go",
       "must_contain": [
         "s.notifyAccountSchedulingBlocked(account, time.Time{}, \"auth_error\", errorMsg)"


### PR DESCRIPTION
## 摘要

- 将 `/v1/chat/completions` 的 NewAPI 账号统一接入现有 dispatcher，避免外部渠道凭证误落到官方 OpenAI 路径。
- 识别 Anthropic buffered SSE 的 `event:error`，保留上游错误并进入账号 failover；HTTP 402 加入统一 failover 状态集合。
- 对 CloudWise `402 Insufficient balance / insufficient_quota` 写入“账号 × 精确映射模型”的 5h `model_rate_limits`，不再停用整账号；pool mode 与 OpenAI runtime fastpath 同步生效，健康的兄弟模型仍可调度。
- 模型冷却写入失败或缺少模型上下文时绕过 pool/custom 早退，继续执行保守的账号级 fail-closed 回退。
- 更新模型级冷却告警文案、聚焦回归测试及 gateway/newapi sentinel 锚点。审批基线：`docs/approved/prod-user-visible-failure-hotfix-2026-08-24.md`。

## 风险

- 高风险：触达核心网关 failover、账号错误策略和调度可用性。CloudWise 特例仅匹配 CloudWise base URL、HTTP 402 及已观测余额错误标记；模型冷却成功时仅隔离精确映射模型，失败或无法写入时停调账号，避免继续调度已耗尽资源。
- `no-web-impact`：无 Web 页面、公共 API schema、数据库 schema、计费或价格变更。
- 本 PR 不部署、不恢复 prod 账号 #94，也不执行任何生产写操作。

## 验证

- `GOTOOLCHAIN=go1.26.6 go test -tags=unit ./internal/service -run '^(TestRateLimitService_Cloudwise402FallbackBypassesPoolAndCustomEarlyExits|TestRateLimitService_Cloudwise.*402|TestOpenAIGateway_Cloudwise.*402)' -count=1`：PASS；新增 fallback 用例已完成 RED → GREEN。
- `GOTOOLCHAIN=go1.26.6 go test -tags=unit ./internal/service -count=1`：PASS（174.025s）。
- `PREFLIGHT_BASE=origin/main GOTOOLCHAIN=go1.26.6 bash scripts/preflight.sh`：PASS，新鲜证据对应 `3f8bf2013`。
- `xj-review` 高风险 `full_conformance`：本地 `merge-ready`，零 medium+ finding；推送后继续等待新 HEAD CI。
- 线上只读复核：prod #94 在 2026-08-24 07:18:50Z–07:22:20Z 出现 124 次空流 502，随后在 07:22:26Z–07:23:07Z 出现 675 次 `Insufficient balance` 402；账号当前仍为 active/schedulable 且 `model_rate_limits={}`，符合本修复要消除的重复命中形态。

## 提交

- `6c90c65d7 fix(gateway): fail over relay failures without disabling healthy models`
- `3f8bf2013 fix(gateway): fail closed on CloudWise cooldown write errors`

最新提交：3f8bf2013
