### PR TITLE
fix(release): 恢复合并后的发布安全

### DIFF
--- a/backend/internal/service/cn_providers_test.go
+++ b/backend/internal/service/cn_providers_test.go
@@ -184,6 +184,7 @@ func TestCNProviderResponseIndicatesInsufficientBalance(t *testing.T) {
 		`{"error":{"message":"余额不足"}}`,
 		`{"error":{"message":"Insufficient balance"}}`,
 		`{"code":"insufficient_credit"}`,
+		`{"error":{"type":"insufficient_quota"}}`,
 		`"balance is not enough"`,
 		`"no enough balance"`,
 	}

--- a/backend/internal/service/gateway_anthropic_buffered_error_tk.go
+++ b/backend/internal/service/gateway_anthropic_buffered_error_tk.go
@@ -138,6 +138,7 @@ func tkAnthropicBufferedFailure(
 			"Upstream stream ended without a response",
 		)
 	}
+	upstreamErr = tkNormalizeAnthropicBufferedUpstreamError(upstreamErr)
 	tkRecordAnthropicBufferedUpstreamError(c, account, requestID, upstreamErr.Kind, upstreamErr)
 
 	var headers http.Header
@@ -157,6 +158,17 @@ func tkAnthropicBufferedFailure(
 		ClientMessage:     upstreamErr.Message,
 		NextAccountAction: NextAccountRetry,
 	}
+}
+
+func tkNormalizeAnthropicBufferedUpstreamError(
+	upstreamErr *tkAnthropicBufferedUpstreamError,
+) *tkAnthropicBufferedUpstreamError {
+	if upstreamErr == nil || !cnProviderResponseIndicatesInsufficientBalance(upstreamErr.Payload) {
+		return upstreamErr
+	}
+	semanticErr := *upstreamErr
+	semanticErr.UpstreamStatus = http.StatusPaymentRequired
+	return &semanticErr
 }
 
 func (s *GatewayService) tkAnthropicBufferedFailoverError(

--- a/backend/internal/service/gateway_anthropic_buffered_error_tk_test.go
+++ b/backend/internal/service/gateway_anthropic_buffered_error_tk_test.go
@@ -229,6 +229,85 @@ func TestTKAnthropicBufferedError_NativeResponsesPathAttributesUpstream(t *testi
 	requireUpstreamAttributed(t, c, http.StatusUnauthorized)
 }
 
+func TestTKAnthropicBufferedError_CloudwiseGatewaySSEQuotaCoolsExactModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	repo := &rateLimitAccountRepoStub{}
+	rateLimits := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	svc := &GatewayService{rateLimitService: rateLimits}
+	account := &Account{
+		ID:          94,
+		Name:        "cloudwise-anthropic",
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Credentials: map[string]any{
+			"base_url": "https://api.cloudwise.ai/api",
+		},
+	}
+	resp := newBufferedErrorUpstreamResponse(
+		anthropicErrorOnlySSE("insufficient_quota", "Quota exhausted"),
+	)
+
+	result, err := svc.handleCCBufferedFromAnthropic(
+		resp, c, account, "claude-opus-4-8", "claude-opus-4-8", nil, time.Now(),
+	)
+
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusPaymentRequired, failoverErr.StatusCode)
+	require.Zero(t, repo.setErrorCalls, "CloudWise model exhaustion must not disable the whole account")
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	require.Equal(t, "claude-opus-4-8", repo.modelRateLimitCalls[0].scope)
+	require.Equal(t, tkCloudwiseModelBalanceCooldownReason, repo.modelRateLimitCalls[0].reason)
+}
+
+func TestTKAnthropicBufferedError_CloudwiseOpenAISSEQuotaCoolsExactModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	repo := &rateLimitAccountRepoStub{}
+	rateLimits := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	svc := &OpenAIGatewayService{rateLimitService: rateLimits}
+	rateLimits.SetAccountRuntimeBlocker(svc)
+	account := &Account{
+		ID:          95,
+		Name:        "cloudwise-openai",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Credentials: map[string]any{
+			"base_url": "https://api.cloudwise.ai/api",
+		},
+	}
+	resp := newBufferedErrorUpstreamResponse(
+		anthropicErrorOnlySSE("insufficient_quota", "Quota exhausted"),
+	)
+
+	result, err := svc.handleCCBufferedFromNativeAnthropic(
+		resp, c, account, "claude-opus-4-8", "claude-opus-4-8", "claude-opus-4-8", nil, time.Now(),
+	)
+
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusPaymentRequired, failoverErr.StatusCode)
+	require.False(t, svc.isOpenAIAccountRuntimeBlocked(account),
+		"CloudWise exact-model cooldown must leave sibling models schedulable")
+	require.Zero(t, repo.setErrorCalls, "CloudWise model exhaustion must not disable the whole account")
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	require.Equal(t, "claude-opus-4-8", repo.modelRateLimitCalls[0].scope)
+	require.Equal(t, tkCloudwiseModelBalanceCooldownReason, repo.modelRateLimitCalls[0].reason)
+}
+
 // An empty-but-200 stream has no error event to parse. It is still an upstream
 // protocol fault, so it must not be booked as a gateway-internal error either.
 func TestTKAnthropicBufferedError_EmptyStreamStillAttributedUpstream(t *testing.T) {

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -242,21 +242,6 @@ func (s *GatewayService) ForwardAsChatCompletions(
 		result, handleErr = s.handleCCBufferedFromAnthropic(resp, c, account, originalModel, mappedModel, reasoningEffort, startTime)
 	}
 
-	if !clientStream && handleErr != nil {
-		var sseErr *sseStreamErrorEventError
-		if errors.As(handleErr, &sseErr) {
-			semanticStatus := http.StatusBadGateway
-			body := []byte(sseErr.RawData)
-			if cnProviderResponseIndicatesInsufficientBalance(body) {
-				semanticStatus = http.StatusPaymentRequired
-				if s.rateLimitService != nil {
-					s.rateLimitService.HandleUpstreamError(ctx, account, semanticStatus, resp.Header, body, mappedModel)
-				}
-			}
-			return nil, s.sseStreamErrorFailover(c, account, resp, sseErr, semanticStatus)
-		}
-	}
-
 	return result, handleErr
 }
 
@@ -321,8 +306,7 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 		line := scanner.Text()
 		// SSE 规范允许 `event:xxx`（冒号后无空格）：Kimi 等 Anthropic 兼容上游
 		// 返回紧凑格式，严格匹配 "event: " 会丢弃全部事件（#4653 同根因）。
-		eventName, ok := extractOpenAISSEEventLine(line)
-		if !ok {
+		if _, ok := extractOpenAISSEEventLine(line); !ok {
 			continue
 		}
 
@@ -334,9 +318,6 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 			continue
 		}
 		observeOpenAIResponsesEvent(c, []byte(payload))
-		if eventName == "error" {
-			return nil, &sseStreamErrorEventError{RawData: payload}
-		}
 
 		if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), s.cfg); ok {
 			upstreamErr = parsed

--- a/backend/internal/service/gateway_forward_as_chat_completions_test.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_test.go
@@ -117,7 +117,7 @@ func TestHandleCCBufferedFromAnthropic_PreservesMessageStartCacheUsageAndReasoni
 	require.Equal(t, "high", *result.ReasoningEffort)
 }
 
-func TestHandleCCBufferedFromAnthropic_EventErrorReturnsTypedFailure(t *testing.T) {
+func TestHandleCCBufferedFromAnthropic_InsufficientBalanceReturnsAttributed402Failover(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
 
@@ -132,14 +132,27 @@ func TestHandleCCBufferedFromAnthropic_EventErrorReturnsTypedFailure(t *testing.
 		Header: http.Header{"x-request-id": []string{"rid_cc_buffered_error"}},
 		Body:   io.NopCloser(strings.NewReader(upstreamBody)),
 	}
+	account := &Account{
+		ID:          93,
+		Name:        "anthropic-buffered-error",
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Credentials: map[string]any{
+			"base_url": "https://cloudwise.example/api",
+		},
+	}
 
 	svc := &GatewayService{}
-	result, err := svc.handleCCBufferedFromAnthropic(resp, c, "claude-opus-4-8", "claude-opus-4-8", nil, time.Now())
+	result, err := svc.handleCCBufferedFromAnthropic(resp, c, account, "claude-opus-4-8", "claude-opus-4-8", nil, time.Now())
 	require.Nil(t, result)
-	var streamErr *sseStreamErrorEventError
-	require.ErrorAs(t, err, &streamErr)
-	require.Contains(t, streamErr.RawData, "Insufficient balance")
-	require.Empty(t, rec.Body.String(), "typed upstream failure must be handled by the failover loop, not committed as a final 502 here")
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusPaymentRequired, failoverErr.StatusCode)
+	require.Contains(t, string(failoverErr.ResponseBody), "Insufficient balance")
+	requireUpstreamAttributed(t, c, http.StatusPaymentRequired)
+	require.Empty(t, rec.Body.String(), "buffered upstream failure must remain uncommitted so a healthy account can serve the request")
 }
 
 func TestForwardAsChatCompletions_BufferedBalanceSSEErrorBecomes402Failover(t *testing.T) {

--- a/backend/internal/service/ratelimit_cn_providers.go
+++ b/backend/internal/service/ratelimit_cn_providers.go
@@ -44,6 +44,7 @@ func cnProviderResponseIndicatesInsufficientBalance(body []byte) bool {
 	return strings.Contains(s, "余额不足") ||
 		strings.Contains(s, "insufficient balance") ||
 		strings.Contains(s, "insufficient_credit") ||
+		strings.Contains(s, "insufficient_quota") ||
 		strings.Contains(s, "balance is not enough") ||
 		strings.Contains(s, "no enough balance")
 }

--- a/ops/stage0/deploy_via_ssm_bluegreen.sh
+++ b/ops/stage0/deploy_via_ssm_bluegreen.sh
@@ -642,6 +642,13 @@ write_active_color() {
   log "active-color=${color}"
 }
 
+commit_cutover_state() {
+  local color="$1"
+  CUTOVER_COMMITTED=1
+  write_active_color "${color}"
+  record_cutover
+}
+
 read_active_color() {
   if [[ -r "${ACTIVE_FILE}" ]]; then
     sed -n '1p' "${ACTIVE_FILE}" | tr -d '[:space:]'
@@ -677,9 +684,7 @@ ensure_legacy_cutover() {
   wait_ready tokenkey-blue
 
   write_caddy_for_color blue
-  record_cutover
-  CUTOVER_COMMITTED=1
-  write_active_color blue
+  commit_cutover_state blue
   install_bluegreen_systemd_unit
 
   drain_container tokenkey
@@ -731,9 +736,7 @@ deploy_target_color() {
   fi
 
   write_caddy_for_color "${target}"
-  record_cutover
-  CUTOVER_COMMITTED=1
-  write_active_color "${target}"
+  commit_cutover_state "${target}"
   install_bluegreen_systemd_unit
 
   drain_container "${active_container}"

--- a/ops/stage0/test_deploy_via_ssm_bluegreen.py
+++ b/ops/stage0/test_deploy_via_ssm_bluegreen.py
@@ -187,6 +187,88 @@ target_is_reusable tokenkey-green {shlex.quote(expected_image)}
     return proc.returncode, proc.stdout + proc.stderr
 
 
+def _extract_shell_function(remote: str, name: str) -> str:
+    start = remote.index(f"{name}() {{")
+    end = remote.index("\n}\n\n", start) + len("\n}\n")
+    return remote[start:end]
+
+
+def _run_commit_cutover_state(remote: str, color: str) -> subprocess.CompletedProcess[str]:
+    try:
+        function = _extract_shell_function(remote, "commit_cutover_state")
+    except ValueError:
+        return subprocess.CompletedProcess(
+            args=["bash"],
+            returncode=127,
+            stdout="",
+            stderr="commit_cutover_state is missing",
+        )
+    script = f"""{function}
+write_active_color() {{ printf 'active:%s:%s\\n' "$CUTOVER_COMMITTED" "$1"; }}
+record_cutover() {{ printf 'record:%s\\n' "$CUTOVER_COMMITTED"; }}
+CUTOVER_COMMITTED=0
+commit_cutover_state {shlex.quote(color)}
+printf 'final:%s\\n' "$CUTOVER_COMMITTED"
+"""
+    return subprocess.run(
+        ["bash"],
+        input=script,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _run_cutover_path(remote: str, function_name: str) -> subprocess.CompletedProcess[str]:
+    function = _extract_shell_function(remote, function_name)
+    common = """
+log() { :; }
+die() { printf 'die:%s\n' "$*"; return 1; }
+sudo() { return 0; }
+backup_env() { :; }
+env_set() { :; }
+write_bluegreen_compose() { :; }
+compose_bg() { :; }
+wait_healthy() { :; }
+wait_ready() { :; }
+install_bluegreen_systemd_unit() { :; }
+write_caddy_for_color() { printf 'caddy:%s\n' "$1"; }
+commit_cutover_state() { CUTOVER_COMMITTED=1; printf 'commit:%s\n' "$1"; }
+record_cutover() { printf 'raw-record\n'; }
+write_active_color() { printf 'raw-active:%s\n' "$1"; }
+drain_container() { printf 'drain:%s\n' "$1"; }
+TARGET_CONTAINER=""
+CUTOVER_COMMITTED=0
+"""
+    if function_name == "ensure_legacy_cutover":
+        setup = """
+read_active_color() { :; }
+container_image() { printf 'ghcr.io/youxuanxue/sub2api:1.8.98\n'; }
+env_get() { printf 'ghcr.io/youxuanxue/sub2api:1.8.98\n'; }
+ensure_legacy_cutover
+"""
+    else:
+        setup = """
+read_active_color() { printf 'blue\n'; }
+other_color() { printf 'green\n'; }
+color_container() { printf 'tokenkey-%s\n' "$1"; }
+container_image() { printf 'ghcr.io/youxuanxue/sub2api:1.8.98\n'; }
+image_repo() { printf 'ghcr.io/youxuanxue/sub2api\n'; }
+env_get() { printf 'ghcr.io/youxuanxue/sub2api:1.8.98\n'; }
+target_is_reusable() { return 0; }
+TAG=1.8.99
+TELEMETRY_ARCHIVE_ENABLED=""
+deploy_target_color
+"""
+    return subprocess.run(
+        ["bash"],
+        input=function + common + setup,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
 class BlueGreenRenderTest(unittest.TestCase):
     def test_rejects_lightsail_edge_ids(self) -> None:
         proc, params, remote = _render(_EDGE_IID, env_extra={"EDGE_ID": "us2"})
@@ -266,18 +348,31 @@ class BlueGreenRenderTest(unittest.TestCase):
         self.assertNotIn('removed failed target ${TARGET_CONTAINER}', remote)
         self.assertIn("last-cutover-at", remote)
 
-    def test_records_target_cutover_before_draining_previous_color(self) -> None:
+    def test_commit_cutover_state_persists_live_state_in_safe_order(self) -> None:
         proc, _, remote = _render()
         self.assertEqual(proc.returncode, 0, msg=proc.stderr)
         assert remote is not None
-        target_start = remote.index("deploy_target_color() {")
-        target_end = remote.index("\n}\n\nprune_images()", target_start)
-        target = remote[target_start:target_end]
-        caddy = target.index('write_caddy_for_color "${target}"')
-        cutover = target.index("record_cutover")
-        drain = target.index('drain_container "${active_container}"')
-        self.assertLess(caddy, cutover)
-        self.assertLess(cutover, drain)
+        committed = _run_commit_cutover_state(remote, "green")
+        self.assertEqual(committed.returncode, 0, msg=committed.stderr)
+        self.assertEqual(
+            committed.stdout.splitlines(),
+            ["active:1:green", "record:1", "final:1"],
+        )
+
+    def test_legacy_and_regular_cutovers_share_committed_state_owner(self) -> None:
+        proc, _, remote = _render()
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        assert remote is not None
+
+        cases = [
+            ("ensure_legacy_cutover", ["caddy:blue", "commit:blue", "drain:tokenkey"]),
+            ("deploy_target_color", ["caddy:green", "commit:green", "drain:tokenkey-blue"]),
+        ]
+        for function_name, expected in cases:
+            with self.subTest(function_name=function_name):
+                cutover = _run_cutover_path(remote, function_name)
+                self.assertEqual(cutover.returncode, 0, msg=cutover.stderr)
+                self.assertEqual(cutover.stdout.splitlines(), expected)
 
     def test_exports_remote_cutover_timestamp_to_github_output(self) -> None:
         proc, github_output = _run_with_fake_aws(

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1323,14 +1323,13 @@
       "rationale": "Gateway Anthropic-backed /v1/chat/completions non-stream path (handleCCBufferedFromAnthropic) shares the upstream #1311 Content-Type leak root cause and must explicitly override Content-Type after WriteFilteredHeaders so the converted chat.completion JSON body is not labeled text/event-stream. Also the call site wiring the gemini-native image aspect-ratio injection (tkInjectGeminiImageAspectRatio, gateway_forward_as_chat_completions_tk_image.go) into the OpenAI-compat → Anthropic forward, after enforceCacheControlLimit and before buildUpstreamRequest — the companion compiling alone would not catch a dropped call site, so the one-line hook is anchored here separately. Anthropic passthrough relays must use buildAnthropicCompatUpstreamRequest for the upstream /v1/messages hop after CC→Anthropic conversion."
     },
     {
-      "path": "backend/internal/service/gateway_forward_as_chat_completions.go",
+      "path": "backend/internal/service/gateway_forward_as_chat_completions_test.go",
       "must_contain": [
-        "if eventName == \"error\" {",
-        "return nil, &sseStreamErrorEventError{RawData: payload}",
-        "cnProviderResponseIndicatesInsufficientBalance(body)",
-        "s.sseStreamErrorFailover(c, account, resp, sseErr, semanticStatus)"
+        "TestHandleCCBufferedFromAnthropic_InsufficientBalanceReturnsAttributed402Failover",
+        "TestForwardAsChatCompletions_BufferedBalanceSSEErrorBecomes402Failover",
+        "requireUpstreamAttributed(t, c, http.StatusPaymentRequired)"
       ],
-      "rationale": "The buffered Chat Completions → Anthropic SSE path must preserve upstream event:error frames as typed failover evidence. Without these anchors a balance-exhausted relay returns HTTP 200 plus event:error, the converter ignores it, and the user receives the misleading terminal 502 'Upstream stream ended without a response'. The balance semantic must map to 402 so existing account-standing policy can stop scheduling the exhausted account."
+      "rationale": "Merged regression for the buffered Chat Completions → Anthropic SSE path: an insufficient-balance error frame must enter the shared US-047 UpstreamFailoverError owner, retain provider/account attribution, map to semantic 402, and stay uncommitted so the handler can try another account. This pins the combined #1805/#1807 contract without restoring a second typed-error bypass around the shared buffered owner."
     },
     {
       "path": "backend/internal/service/gateway_forward_as_responses_tk_content_type_test.go",
@@ -6997,8 +6996,12 @@
         "func tkAnthropicBufferedHasUsableContent(finalResp *apicompat.AnthropicResponse) bool",
         "func tkAnthropicBufferedEventCompletesMessage(event *apicompat.AnthropicStreamEvent) bool",
         "func tkAnthropicBufferedFailure(",
+        "upstreamErr = tkNormalizeAnthropicBufferedUpstreamError(upstreamErr)",
+        "func tkNormalizeAnthropicBufferedUpstreamError(",
         "func (s *GatewayService) tkAnthropicBufferedFailoverError(",
         "func (s *OpenAIGatewayService) tkAnthropicBufferedFailoverError(",
+        "cnProviderResponseIndicatesInsufficientBalance(upstreamErr.Payload)",
+        "semanticErr.UpstreamStatus = http.StatusPaymentRequired",
         "func tkAnthropicBufferedPartialFailure(",
         "func tkRecordAnthropicBufferedUpstreamError(",
         "setOpsUpstreamError(c, upstreamErr.UpstreamStatus, upstreamErr.Message, upstreamErr.Detail)",
@@ -7007,7 +7010,16 @@
         "ClientErrorType:   tkAnthropicBufferedClientErrType(upstreamErr.ErrType)",
         "MarkOpsStreamFailure("
       ],
-      "rationale": "Single owner for buffered Anthropic SSE completion and failure semantics. A HTTP 200 stream can still terminate through an error frame, read failure, idle timeout, or incomplete EOF. Before any content block this owner returns an account-aware UpstreamFailoverError without committing the response; after content it preserves the partial response and marks stream_truncated toward SLA to avoid replay and duplicate billing. Completion detection, client error type mapping, provider/account attribution, and both Gateway/OpenAI account-health wrappers must remain centralized or an upstream merge can silently restore empty 200s, gateway-owned SLA pollution, or missing failover."
+      "rationale": "Single owner for buffered Anthropic SSE completion and failure semantics. A HTTP 200 stream can still terminate through an error frame, read failure, idle timeout, or incomplete EOF. Before any content block this owner returns an account-aware UpstreamFailoverError without committing the response; after content it preserves the partial response and marks stream_truncated toward SLA to avoid replay and duplicate billing. Insufficient-balance payloads are normalized to semantic 402 inside the same owner so CloudWise can cool only the mapped model without reintroducing a parallel error path. Completion detection, client error type mapping, provider/account attribution, and both Gateway/OpenAI account-health wrappers must remain centralized or an upstream merge can silently restore empty 200s, gateway-owned SLA pollution, whole-account disablement, or missing failover."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_cn_providers.go",
+      "must_contain": [
+        "func cnProviderResponseIndicatesInsufficientBalance(body []byte) bool",
+        "strings.Contains(s, \"insufficient balance\")",
+        "strings.Contains(s, \"insufficient_quota\")"
+      ],
+      "rationale": "The shared insufficient-balance detector feeds buffered Anthropic semantic 402 normalization. Both human-readable balance messages and the OpenAI-compatible insufficient_quota code must remain recognized or CloudWise SSE failures fall back to 500 and skip exact-model cooldown."
     },
     {
       "path": "backend/internal/service/gateway_forward_as_chat_completions.go",
@@ -7075,9 +7087,11 @@
         "TestUS047_IncompleteEOFRoutesByContentAvailability",
         "TestUS047_ScannerReadErrorRoutesByContentAvailability",
         "TestUS047_CompletionBeforeReadErrorRemainsSuccessful",
-        "TestUS047_ClientErrorTypeMapping"
+        "TestUS047_ClientErrorTypeMapping",
+        "TestTKAnthropicBufferedError_CloudwiseGatewaySSEQuotaCoolsExactModel",
+        "TestTKAnthropicBufferedError_CloudwiseOpenAISSEQuotaCoolsExactModel"
       ],
-      "rationale": "US-047 behavior anchors for error frames, message_start-only/incomplete EOF, partial-content truncation, account attribution, and final client error mapping."
+      "rationale": "US-047 behavior anchors for error frames, message_start-only/incomplete EOF, partial-content truncation, account attribution, final client error mapping, and both Gateway/OpenAI CloudWise SSE paths reaching semantic 402 exact-model cooldown without whole-account disablement."
     },
     {
       "path": "backend/internal/service/openai_gateway_anthropic_native_pump_test.go",


### PR DESCRIPTION
## 摘要
- 统一蓝绿切流提交状态顺序：Caddy reload 成功后再标记 committed、写 active-color、记录时间并 drain 旧容器。
- 恢复 Anthropic buffered SSE 的共享失败 owner，余额不足统一映射为 402，并贯通 CloudWise 精确模型 5 小时冷却。
- 补齐合并回归测试与 sentinel 锚点，防止后续 upstream merge 静默回退。

## 风险
- 高：涉及生产蓝绿切流状态与 gateway failover/账号冷却语义；已通过独立 full-conformance 复审。
- no-web-impact

## 验证
- `GOTOOLCHAIN=go1.26.6 go test -tags=unit ./internal/service -count=1`
- `GOTOOLCHAIN=go1.26.6 go test -tags=unit ./internal/handler -run TestUS047_ -count=1`
- `python3 -m unittest ops.stage0.test_deploy_via_ssm_bluegreen`（15/15）
- `PREFLIGHT_BASE=origin/main GOTOOLCHAIN=go1.26.6 bash scripts/preflight.sh`
- `git diff --check`

## 提交
- `521489697` fix(release): restore post-merge rollout safety
- 最新提交：`521489697`