### PR TITLE
fix(pricing): drop .qianfan scoped owners from global registry

### DIFF
--- a/backend/internal/service/billing_service_tk_qianfan.go
+++ b/backend/internal/service/billing_service_tk_qianfan.go
@@ -1,53 +1,24 @@
 package service
 
-import "strings"
-
-const tkQianfanOverlayPricingSuffix = ".qianfan"
-
-// tkDeepSeekPeakValleyExcludedModels are overlay owners on Baidu Qianfan list
-// pricing, not DeepSeek official direct-API peak-valley windows.
+// tkDeepSeekPeakValleyExcludedModels are registry owners priced from Baidu
+// Qianfan's published list rather than DeepSeek's direct API. Qianfan bills one
+// flat rate with no time-of-day component, so the DeepSeek peak-valley policy in
+// _config.deepseek_peak_valley must not double their output price during the
+// 09:00-12:00 / 14:00-18:00 Asia/Shanghai windows. Without this list they would
+// be caught by that policy's model_contains ["deepseek"] matcher and overbilled
+// 2x for half the working day.
+//
+// Membership rule: an id belongs here only when its sole registry owner IS a
+// Qianfan price. An id that bills from a DeepSeek official owner does NOT belong
+// here, even when Qianfan also serves it — that includes dated aliases such as
+// deepseek-v4-flash-0731, which resolves to the deepseek-v4-flash owner and is
+// therefore subject to the official peak windows.
+//
+// These three ids have no DeepSeek official equivalent (Qianfan-exclusive SKUs),
+// so the registry is their only legitimate global owner and this exclusion is
+// what keeps that owner's flat rate flat.
 var tkDeepSeekPeakValleyExcludedModels = map[string]struct{}{
-	"deepseek-v3.2":          {},
-	"deepseek-v3.2-think":    {},
-	"deepseek-v4-flash-0731": {},
-}
-
-// tkQianfanScopedOverlayModels are client-facing model ids that share a global
-// overlay owner but bill at Baidu Qianfan list rates when served from account 90.
-var tkQianfanScopedOverlayModels = map[string]struct{}{
-	"deepseek-v4-pro":   {},
-	"deepseek-v4-flash": {},
-	"glm-5":             {},
-	"glm-5.1":           {},
-	"glm-5.2":           {},
-	"kimi-k2.6":         {},
-}
-
-// tkQianfanScopedBillingModel maps billing to the Qianfan overlay owner when the
-// serving account is Baidu Qianfan (ch46). Public catalog and GetModelPricing
-// keep the global owner; only usage billing on account 90 switches keys.
-func tkQianfanScopedBillingModel(model string, account *Account) string {
-	model = strings.TrimSpace(model)
-	if model == "" || account == nil || !isNewAPIQianfanAccount(account) {
-		return model
-	}
-	if _, ok := tkQianfanScopedOverlayModels[model]; !ok {
-		return model
-	}
-	scoped := model + tkQianfanOverlayPricingSuffix
-	if tkOverlayModelPricing(scoped) != nil {
-		return scoped
-	}
-	return model
-}
-
-func tkMapQianfanScopedBillingModels(models []string, account *Account) []string {
-	if len(models) == 0 || account == nil {
-		return models
-	}
-	out := make([]string, len(models))
-	for i, model := range models {
-		out[i] = tkQianfanScopedBillingModel(model, account)
-	}
-	return out
+	"deepseek-v3.2":       {},
+	"deepseek-v3.2-think": {},
+	"deepseek-ocr":        {},
 }

--- a/backend/internal/service/billing_service_tk_qianfan_test.go
+++ b/backend/internal/service/billing_service_tk_qianfan_test.go
@@ -9,8 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The `.qianfan` suffix owners are gone: a per-account commercial price is a
-// SCOPED override (channel_model_pricing), not a second global registry key.
+// The `.qianfan` suffix owners are gone: user-facing billing is intentionally
+// independent of the upstream account that serves the request. Shared client ids
+// use the single global owner; provider/account cost differences belong to profit
+// reporting, not ActualCost. channel_model_pricing remains a customer commercial
+// scope and must not be used as a proxy for a serving-account price.
 // See docs/approved/pricing-serving-single-source-of-truth.md §1.
 func TestTkQianfanScopedOverlayKeysAreRemoved(t *testing.T) {
 	t.Parallel()
@@ -24,7 +27,7 @@ func TestTkQianfanScopedOverlayKeysAreRemoved(t *testing.T) {
 		"kimi-k2.6.qianfan",
 	} {
 		require.Nil(t, overlay[key],
-			"%s must not exist: a per-account price belongs in channel_model_pricing, not the global registry", key)
+			"%s must not exist: shared ids use one global user price regardless of serving account", key)
 	}
 }
 

--- a/backend/internal/service/billing_service_tk_qianfan_test.go
+++ b/backend/internal/service/billing_service_tk_qianfan_test.go
@@ -6,37 +6,99 @@ import (
 	"testing"
 	"time"
 
-	newapiconstant "github.com/QuantumNous/new-api/constant"
-	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
-	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 	"github.com/stretchr/testify/require"
 )
 
-func TestTkQianfanScopedBillingModel(t *testing.T) {
+// The `.qianfan` suffix owners are gone: a per-account commercial price is a
+// SCOPED override (channel_model_pricing), not a second global registry key.
+// See docs/approved/pricing-serving-single-source-of-truth.md §1.
+func TestTkQianfanScopedOverlayKeysAreRemoved(t *testing.T) {
 	t.Parallel()
-	qianfan := &Account{
-		Platform:    PlatformNewAPI,
-		Type:        AccountTypeAPIKey,
-		ChannelType: newapiconstant.ChannelTypeBaiduV2,
-		Credentials: map[string]any{
-			"base_url": newapiintegration.QianfanBaseURL,
-		},
+	overlay := loadTKPricingOverlay()
+	for _, key := range []string{
+		"deepseek-v4-pro.qianfan",
+		"deepseek-v4-flash.qianfan",
+		"glm-5.qianfan",
+		"glm-5.1.qianfan",
+		"glm-5.2.qianfan",
+		"kimi-k2.6.qianfan",
+	} {
+		require.Nil(t, overlay[key],
+			"%s must not exist: a per-account price belongs in channel_model_pricing, not the global registry", key)
 	}
-	official := &Account{
-		Platform:    PlatformNewAPI,
-		Type:        AccountTypeAPIKey,
-		ChannelType: newapiconstant.ChannelTypeDeepSeek,
-		Credentials: map[string]any{
-			"base_url": "https://api.deepseek.com",
-		},
+}
+
+// The dated Qianfan flash SKU is the same upstream model as the official
+// deepseek-v4-flash (the official price page itself names it V4-Flash-0731), so
+// it is an ALIAS, not an owner. It must resolve through the family matcher to
+// the official owner rather than carry a duplicate price row.
+func TestTkQianfanDatedFlashResolvesToOfficialFlashOwner(t *testing.T) {
+	t.Parallel()
+	overlay := loadTKPricingOverlay()
+	require.Nil(t, overlay["deepseek-v4-flash-0731"],
+		"dated SKU must not be its own registry owner")
+
+	svc := newTestBillingService()
+	dated, err := svc.GetModelPricing("deepseek-v4-flash-0731")
+	require.NoError(t, err, "dated alias must stay priced (else the priced-serving gate 404s it)")
+	official, err := svc.GetModelPricing("deepseek-v4-flash")
+	require.NoError(t, err)
+
+	require.InDelta(t, official.InputPricePerToken, dated.InputPricePerToken, 1e-15)
+	require.InDelta(t, official.OutputPricePerToken, dated.OutputPricePerToken, 1e-15)
+}
+
+// Peak-valley now applies to the dated alias exactly as it does to the official
+// owner it bills from: the alias no longer has a Qianfan price row to protect.
+func TestTkDeepSeekPeakValleyAppliesToDatedFlashAlias(t *testing.T) {
+	t.Parallel()
+	policy := loadTkDeepSeekPeakValleyPolicy()
+	require.NotNil(t, policy)
+
+	require.True(t, tkDeepSeekPeakValleyAppliesWithPolicy(policy, "deepseek-v4-flash-0731", PricingSourceLiteLLM),
+		"dated alias bills from the official owner, so official peak windows must apply")
+
+	// Windows are evaluated in the policy timezone (Asia/Shanghai), NOT the
+	// process timezone — build the instant there so the case is a real peak.
+	shanghai, err := time.LoadLocation("Asia/Shanghai")
+	require.NoError(t, err)
+	peak := time.Date(2026, 7, 21, 10, 0, 0, 0, shanghai)
+	require.InDelta(t, policy.PeakMultiplier, tkDeepSeekPeakMultiplierAtWithPolicy(policy, peak), 1e-12,
+		"10:00 Asia/Shanghai must land inside the 09:00-12:00 window")
+
+	base := &ModelPricing{InputPricePerToken: 0.0015, OutputPricePerToken: 0.0045}
+	scaled := tkApplyDeepSeekPeakValleyPricing("deepseek-v4-flash-0731", base, peak, PricingSourceLiteLLM)
+	require.InDelta(t, base.InputPricePerToken*policy.PeakMultiplier, scaled.InputPricePerToken, 1e-12)
+	require.InDelta(t, base.OutputPricePerToken*policy.PeakMultiplier, scaled.OutputPricePerToken, 1e-12)
+}
+
+// Qianfan-ONLY owners (no official DeepSeek equivalent) keep their registry row
+// AND keep their peak-valley exemption: Qianfan list pricing has no peak window,
+// so applying the official 2x multiplier to them would overbill.
+func TestTkQianfanOnlyDeepSeekOwnersStayPeakExempt(t *testing.T) {
+	t.Parallel()
+	policy := loadTkDeepSeekPeakValleyPolicy()
+	require.NotNil(t, policy)
+	overlay := loadTKPricingOverlay()
+
+	for _, model := range []string{"deepseek-v3.2", "deepseek-v3.2-think", "deepseek-ocr"} {
+		require.NotNil(t, overlay[model], "%s is a Qianfan-only owner and must keep its row", model)
+		require.False(t, tkDeepSeekPeakValleyAppliesWithPolicy(policy, model, PricingSourceLiteLLM),
+			"%s is priced from the Qianfan list, which has no peak window", model)
 	}
 
-	require.Equal(t, "deepseek-v4-pro.qianfan", tkQianfanScopedBillingModel("deepseek-v4-pro", qianfan))
-	require.Equal(t, "deepseek-v4-flash.qianfan", tkQianfanScopedBillingModel("deepseek-v4-flash", qianfan))
-	require.Equal(t, "glm-5.2.qianfan", tkQianfanScopedBillingModel("glm-5.2", qianfan))
-	require.Equal(t, "kimi-k2.6.qianfan", tkQianfanScopedBillingModel("kimi-k2.6", qianfan))
-	require.Equal(t, "deepseek-v4-pro", tkQianfanScopedBillingModel("deepseek-v4-pro", official))
-	require.Equal(t, "deepseek-v3.2", tkQianfanScopedBillingModel("deepseek-v3.2", qianfan))
+	// A real in-window instant (policy timezone, not the process timezone), so
+	// "unchanged" proves the exemption rather than merely missing the window.
+	shanghai, err := time.LoadLocation("Asia/Shanghai")
+	require.NoError(t, err)
+	at := time.Date(2026, 7, 21, 10, 0, 0, 0, shanghai)
+	require.InDelta(t, policy.PeakMultiplier, tkDeepSeekPeakMultiplierAtWithPolicy(policy, at), 1e-12,
+		"fixture instant must be inside a peak window for this exemption test to mean anything")
+
+	base := &ModelPricing{InputPricePerToken: 0.002, OutputPricePerToken: 0.003}
+	scaled := tkApplyDeepSeekPeakValleyPricing("deepseek-v3.2", base, at, PricingSourceLiteLLM)
+	require.InDelta(t, base.InputPricePerToken, scaled.InputPricePerToken, 1e-12)
+	require.InDelta(t, base.OutputPricePerToken, scaled.OutputPricePerToken, 1e-12)
 }
 
 func TestTkQianfanOverlay_DeepSeekV32UsesTieredIntervals(t *testing.T) {
@@ -62,34 +124,6 @@ func TestTkQianfanOverlay_ThinkSKUUsesIntervalOutputNotFlatThinkingRate(t *testi
 	require.InDelta(t, 8.955223880597015e-07, *entry.Intervals[1].OutputPrice, 1e-15)
 }
 
-func TestTkQianfanScopedBillingModel_UsesQianfanRatesInCost(t *testing.T) {
-	t.Parallel()
-	svc := newTestBillingService()
-	qianfan := &Account{
-		Platform:    PlatformNewAPI,
-		Type:        AccountTypeAPIKey,
-		ChannelType: newapiconstant.ChannelTypeBaiduV2,
-		Credentials: map[string]any{
-			"base_url": newapiintegration.QianfanBaseURL,
-		},
-	}
-	billingModel := tkQianfanScopedBillingModel("deepseek-v4-pro", qianfan)
-	require.Equal(t, "deepseek-v4-pro.qianfan", billingModel)
-
-	qianfanOwner := loadTKPricingOverlay()["deepseek-v4-pro.qianfan"]
-	officialOwner := loadTKPricingOverlay()["deepseek-v4-pro"]
-	require.NotNil(t, qianfanOwner)
-	require.NotNil(t, officialOwner)
-	require.Greater(t, qianfanOwner.InputCostPerToken, officialOwner.InputCostPerToken)
-	require.Greater(t, qianfanOwner.OutputCostPerToken, officialOwner.OutputCostPerToken)
-
-	pricing, err := svc.GetModelPricing(billingModel)
-	require.NoError(t, err)
-	officialPricing, err := svc.GetModelPricing("deepseek-v4-pro")
-	require.NoError(t, err)
-	require.Greater(t, pricing.InputPricePerToken, officialPricing.InputPricePerToken)
-}
-
 func TestTkQianfanOverlay_EmbeddingModelsUseEmbeddingMode(t *testing.T) {
 	t.Parallel()
 	for _, model := range []string{
@@ -108,18 +142,4 @@ func TestTkQianfanOverlay_EmbeddingModelsUseEmbeddingMode(t *testing.T) {
 			require.Zero(t, entry.OutputCostPerToken)
 		})
 	}
-}
-
-func TestTkQianfanScopedBillingModel_ExcludesDeepSeekPeakValley(t *testing.T) {
-	t.Parallel()
-	policy := loadTkDeepSeekPeakValleyPolicy()
-	require.NotNil(t, policy)
-	require.False(t, tkDeepSeekPeakValleyAppliesWithPolicy(policy, "deepseek-v4-pro.qianfan", PricingSourceLiteLLM))
-
-	at := time.Date(2026, 7, 21, 10, 0, 0, 0, timezone.Location())
-	base := &ModelPricing{InputPricePerToken: 0.012, OutputPricePerToken: 0.024}
-	scaled := tkApplyDeepSeekPeakValleyPricing("deepseek-v4-pro.qianfan", base, at, PricingSourceLiteLLM)
-	require.InDelta(t, base.InputPricePerToken, scaled.InputPricePerToken, 1e-12)
-	require.InDelta(t, base.OutputPricePerToken, scaled.OutputPricePerToken, 1e-12)
-	require.False(t, tkDeepSeekPeakValleyAppliesWithPolicy(policy, "deepseek-v3.2-think", PricingSourceLiteLLM))
 }

--- a/backend/internal/service/gateway_usage_billing.go
+++ b/backend/internal/service/gateway_usage_billing.go
@@ -816,7 +816,6 @@ func (s *GatewayService) recordUsageCore(ctx context.Context, input *recordUsage
 	// 通用兜底（与 OpenAI 路径的 usageBillingModelCandidates 语义对齐）：
 	// 选定模型查不到任何价格时回退到实际转发的具体模型。已定价流量不受影响。
 	billingModel = s.billableModelWithFallback(ctx, apiKey, billingModel, result.UpstreamModel, result.Model)
-	billingModel = tkQianfanScopedBillingModel(billingModel, account)
 
 	// 确定 RequestedModel（渠道映射前的原始模型）
 	requestedModel := result.Model

--- a/backend/internal/service/openai_account_scheduler_tk_newapi_test.go
+++ b/backend/internal/service/openai_account_scheduler_tk_newapi_test.go
@@ -136,6 +136,42 @@ func TestUS008_NewAPIGroup_Scheduler_PicksNewAPIAccount(t *testing.T) {
 	require.Equal(t, openAIAccountScheduleLayerLoadBalance, decision.Layer)
 }
 
+func TestQianfanDatedFlashAliasSelectsAgentPlanAndSkipsDeepSeekAccount(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(19)
+	const model = "deepseek-v4-flash-0731"
+
+	deepSeek := newAPIAccount(39, 43)
+	deepSeek.Type = AccountTypeAPIKey
+	deepSeek.Priority = 0
+	deepSeek.Credentials = map[string]any{
+		"model_mapping": map[string]any{
+			"deepseek-v4-flash": "deepseek-v4-flash",
+			"deepseek-v4-pro":   "deepseek-v4-pro",
+		},
+	}
+	agentPlan := newAPIAccount(88, 45)
+	agentPlan.Type = AccountTypeAPIKey
+	agentPlan.Priority = 10
+	agentPlan.Credentials = map[string]any{
+		"model_mapping": map[string]any{
+			model: "deepseek-v4-flash",
+		},
+	}
+
+	svc, _ := newAPISchedFixture(t, groupID, PlatformNewAPI, []*Account{deepSeek, agentPlan})
+	selection, _, err := svc.SelectAccountWithScheduler(
+		ctx, &groupID, "", "", model, nil, OpenAIUpstreamTransportAny, false,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, int64(88), selection.Account.ID,
+		"account 39 has higher priority but lacks the dated alias; only account 88 may receive it")
+	require.Equal(t, "deepseek-v4-flash", selection.Account.GetModelMapping()[model])
+}
+
 // US-008 AC-002 / US-012 AC-001 (scheduler tier): newapi group with an empty
 // candidate pool MUST return an error (no fallback to openai accounts).
 //

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -206,7 +206,6 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 		result.UpstreamModel,
 		result.Model,
 	)
-	billingModels = tkMapQianfanScopedBillingModels(billingModels, account)
 	billingModels = s.filterCNProviderBillingModelCandidates(ctx, account, apiKey, billingModels)
 	serviceTier := ""
 	if result.ServiceTier != nil {

--- a/backend/internal/service/pricing_service_tk_overlay_test.go
+++ b/backend/internal/service/pricing_service_tk_overlay_test.go
@@ -87,18 +87,19 @@ func TestTKPricingOverlay_DeepSeekOfficialIdleSSOTAndAliases(t *testing.T) {
 		require.Equal(t, flash.MaxOutputTokens, entry.MaxOutputTokens, alias)
 	}
 
-	// Baidu Qianfan scoped price variants were removed: a per-account commercial
-	// override is not a global-registry fact. Every account serving these client
-	// ids now bills from the single official owner above, and the official
-	// peak-valley policy applies uniformly. A future Qianfan-specific rate is a
-	// channel_model_pricing scope, never a suffixed registry key.
+	// Baidu Qianfan serving-account price variants were removed by policy: every
+	// account serving these shared client ids bills users from the single official
+	// owner above, and the official peak-valley policy applies uniformly. Upstream
+	// procurement differences belong to provider-cost/profit reporting. They must
+	// not return as suffixed registry keys or be approximated through the customer-
+	// scoped channel_model_pricing resolver.
 	for _, removed := range []string{
 		"deepseek-v4-flash.qianfan",
 		"deepseek-v4-pro.qianfan",
 		"deepseek-v4-flash-0731",
 	} {
 		require.Nil(t, overlay[removed],
-			"%s must not come back as a registry key; scoped overrides belong in channel_model_pricing", removed)
+			"%s must not come back: shared ids use one global user price across serving accounts", removed)
 	}
 }
 

--- a/backend/internal/service/pricing_service_tk_overlay_test.go
+++ b/backend/internal/service/pricing_service_tk_overlay_test.go
@@ -87,17 +87,19 @@ func TestTKPricingOverlay_DeepSeekOfficialIdleSSOTAndAliases(t *testing.T) {
 		require.Equal(t, flash.MaxOutputTokens, entry.MaxOutputTokens, alias)
 	}
 
-	qianfanFlash := overlay["deepseek-v4-flash.qianfan"]
-	require.NotNil(t, qianfanFlash)
-	require.InDelta(t, tkCNYPerMTokToUSDPerToken(1), qianfanFlash.InputCostPerToken, 1e-15)
-	require.InDelta(t, tkCNYPerMTokToUSDPerToken(2), qianfanFlash.OutputCostPerToken, 1e-15)
-	require.NotEqual(t, flash.InputCostPerToken, qianfanFlash.InputCostPerToken)
-
-	qianfanPro := overlay["deepseek-v4-pro.qianfan"]
-	require.NotNil(t, qianfanPro)
-	require.InDelta(t, tkCNYPerMTokToUSDPerToken(12), qianfanPro.InputCostPerToken, 1e-15)
-	require.InDelta(t, tkCNYPerMTokToUSDPerToken(24), qianfanPro.OutputCostPerToken, 1e-15)
-	require.NotEqual(t, pro.InputCostPerToken, qianfanPro.InputCostPerToken)
+	// Baidu Qianfan scoped price variants were removed: a per-account commercial
+	// override is not a global-registry fact. Every account serving these client
+	// ids now bills from the single official owner above, and the official
+	// peak-valley policy applies uniformly. A future Qianfan-specific rate is a
+	// channel_model_pricing scope, never a suffixed registry key.
+	for _, removed := range []string{
+		"deepseek-v4-flash.qianfan",
+		"deepseek-v4-pro.qianfan",
+		"deepseek-v4-flash-0731",
+	} {
+		require.Nil(t, overlay[removed],
+			"%s must not come back as a registry key; scoped overrides belong in channel_model_pricing", removed)
+	}
 }
 
 func TestTKPricingOverlay_FillsMoonshotChinaModels(t *testing.T) {

--- a/backend/internal/service/pricing_tk_deepseek_peak.go
+++ b/backend/internal/service/pricing_tk_deepseek_peak.go
@@ -79,9 +79,6 @@ func tkDeepSeekPeakValleyAppliesWithPolicy(policy *tkDeepSeekPeakValleyPolicy, m
 		return false
 	}
 	lower := strings.ToLower(strings.TrimSpace(model))
-	if strings.HasSuffix(lower, tkQianfanOverlayPricingSuffix) {
-		return false
-	}
 	if _, excluded := tkDeepSeekPeakValleyExcludedModels[lower]; excluded {
 		return false
 	}

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -1366,22 +1366,6 @@
     "supports_tool_choice": true,
     "supports_vision": false
   },
-  "deepseek-v4-flash.qianfan": {
-    "litellm_provider": "deepseek",
-    "mode": "chat",
-    "input_cost_per_token": 1.492537313432836e-07,
-    "output_cost_per_token": 2.985074626865672e-07,
-    "source": "Baidu Qianfan console 按量后付费, captured 2026-08-07: DeepSeek-V4-Flash ¥0.001/¥0.002 per 1k in/out; CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
-    "supported_endpoints": [
-      "/v1/chat/completions"
-    ],
-    "supports_function_calling": true,
-    "supports_native_streaming": true,
-    "supports_reasoning": true,
-    "supports_system_messages": true,
-    "supports_tool_choice": true,
-    "supports_vision": false
-  },
   "deepseek-v3.2": {
     "litellm_provider": "deepseek",
     "mode": "chat",
@@ -1442,22 +1426,6 @@
       }
     ]
   },
-  "deepseek-v4-flash-0731": {
-    "litellm_provider": "deepseek",
-    "mode": "chat",
-    "input_cost_per_token": 1.492537313432836e-07,
-    "output_cost_per_token": 2.985074626865672e-07,
-    "source": "Baidu Qianfan console 按量后付费, captured 2026-08-07: DeepSeek-V4-Flash-0731 ¥0.001/¥0.002 per 1k in/out; CNY/USD=6.7. Serving via account 90 ch46 only.",
-    "supported_endpoints": [
-      "/v1/chat/completions"
-    ],
-    "supports_function_calling": true,
-    "supports_native_streaming": true,
-    "supports_reasoning": true,
-    "supports_system_messages": true,
-    "supports_tool_choice": true,
-    "supports_vision": false
-  },
   "deepseek-v4-pro": {
     "litellm_provider": "deepseek",
     "mode": "chat",
@@ -1480,22 +1448,6 @@
     "supports_parallel_function_calling": true,
     "supports_reasoning": true,
     "supports_response_schema": true,
-    "supports_system_messages": true,
-    "supports_tool_choice": true,
-    "supports_vision": false
-  },
-  "deepseek-v4-pro.qianfan": {
-    "litellm_provider": "deepseek",
-    "mode": "chat",
-    "input_cost_per_token": 1.791044776119403e-06,
-    "output_cost_per_token": 3.582089552238806e-06,
-    "source": "Baidu Qianfan console 按量后付费, captured 2026-08-07: DeepSeek-V4-Pro ¥0.012/¥0.024 per 1k in/out; CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
-    "supported_endpoints": [
-      "/v1/chat/completions"
-    ],
-    "supports_function_calling": true,
-    "supports_native_streaming": true,
-    "supports_reasoning": true,
     "supports_system_messages": true,
     "supports_tool_choice": true,
     "supports_vision": false
@@ -9974,82 +9926,6 @@
         "output_cost_per_token": 2.686567164179104e-06
       }
     ]
-  },
-  "glm-5.qianfan": {
-    "litellm_provider": "zhipu",
-    "mode": "chat",
-    "input_cost_per_token": 5.970149253731343e-07,
-    "output_cost_per_token": 2.686567164179104e-06,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: input ¥0.004–0.006 / output ¥0.018–0.022 per 1k (tiers ≤32k/>32k); overlay intervals by input tokens; CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
-    "supported_endpoints": [
-      "/v1/chat/completions"
-    ],
-    "supports_reasoning": false,
-    "supports_vision": false,
-    "intervals": [
-      {
-        "min_tokens": 0,
-        "max_tokens": 32000,
-        "input_cost_per_token": 5.970149253731343e-07,
-        "output_cost_per_token": 2.686567164179104e-06
-      },
-      {
-        "min_tokens": 32000,
-        "max_tokens": null,
-        "input_cost_per_token": 8.955223880597015e-07,
-        "output_cost_per_token": 3.2835820895522387e-06
-      }
-    ]
-  },
-  "glm-5.1.qianfan": {
-    "litellm_provider": "zhipu",
-    "mode": "chat",
-    "input_cost_per_token": 8.955223880597015e-07,
-    "output_cost_per_token": 3.582089552238806e-06,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: input ¥0.006–0.008 / output ¥0.024–0.028 per 1k (tiers ≤32k/>32k); overlay intervals by input tokens; CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
-    "supported_endpoints": [
-      "/v1/chat/completions"
-    ],
-    "supports_reasoning": false,
-    "supports_vision": false,
-    "intervals": [
-      {
-        "min_tokens": 0,
-        "max_tokens": 32000,
-        "input_cost_per_token": 8.955223880597015e-07,
-        "output_cost_per_token": 3.582089552238806e-06
-      },
-      {
-        "min_tokens": 32000,
-        "max_tokens": null,
-        "input_cost_per_token": 1.1940298507462686e-06,
-        "output_cost_per_token": 4.17910447761194e-06
-      }
-    ]
-  },
-  "glm-5.2.qianfan": {
-    "litellm_provider": "zhipu",
-    "mode": "chat",
-    "input_cost_per_token": 1.1940298507462686e-06,
-    "output_cost_per_token": 4.17910447761194e-06,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.008/¥0.028 per 1k in/out; CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
-    "supported_endpoints": [
-      "/v1/chat/completions"
-    ],
-    "supports_reasoning": false,
-    "supports_vision": false
-  },
-  "kimi-k2.6.qianfan": {
-    "litellm_provider": "moonshot",
-    "mode": "chat",
-    "input_cost_per_token": 9.701492537313432e-07,
-    "output_cost_per_token": 4.029850746268657e-06,
-    "source": "Baidu Qianfan GET /v2/models pricing, captured 2026-08-07: ¥0.0065/¥0.027 per 1k in/out; CNY/USD=6.7. Billing owner for Baidu Qianfan account 90 only (see billing_service_tk_qianfan.go).",
-    "supported_endpoints": [
-      "/v1/chat/completions"
-    ],
-    "supports_reasoning": false,
-    "supports_vision": true
   },
   "grok-4.6": {
     "litellm_provider": "xai",

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -1136,6 +1136,8 @@
       "platform": "newapi",
       "model_id": "deepseek-v4-flash-0731",
       "served_on": [
+        "39",
+        "88",
         "90"
       ],
       "channel_type": 46,

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -34,7 +34,7 @@
       "price_source": "overlay",
       "price_key": "deepseek-v4-pro",
       "display": true,
-      "notes": "ds-官 account 39. Mapped by tk_022 (identity whitelist). Priced in overlay from DeepSeek official list (https://api-docs.deepseek.com/quick_start/pricing, captured 2026-08-17). Baidu Qianfan account 90 bills via overlay owner deepseek-v4-pro.qianfan at runtime (¥0.012/¥0.024 per 1k). served-via-admin-ui (model_mapping predates the tk_*.sql era / set out-of-band; A3 downgraded to WARN). Also on VolcEngine Agent Plan account 88; mapped by tk_068; probe 200 on 2026-07-30. Also on Baidu Qianfan account 90 (ch46); probe 200 on 2026-08-07. Account 90 mapping: served-via-modelops-activation."
+      "notes": "ds-官 account 39. Mapped by tk_022 (identity whitelist). Priced in overlay from DeepSeek official list (https://api-docs.deepseek.com/quick_start/pricing, captured 2026-08-17); every serving account, including Baidu Qianfan account 90, bills from the single deepseek-v4-pro owner and follows its peak-valley policy. served-via-admin-ui (model_mapping predates the tk_*.sql era / set out-of-band; A3 downgraded to WARN). Also on VolcEngine Agent Plan account 88; mapped by tk_068; probe 200 on 2026-07-30. Also on Baidu Qianfan account 90 (ch46); probe 200 on 2026-08-07. Account 90 mapping: served-via-modelops-activation."
     },
     "newapi/deepseek-v4-flash": {
       "platform": "newapi",
@@ -53,7 +53,7 @@
       "price_source": "overlay",
       "price_key": "deepseek-v4-flash",
       "display": true,
-      "notes": "ds-官 account 39. Mapped by tk_022. Priced in overlay from DeepSeek official list (https://api-docs.deepseek.com/quick_start/pricing, captured 2026-08-17). Baidu Qianfan account 90 bills via overlay owner deepseek-v4-flash.qianfan at runtime (¥0.001/¥0.002 per 1k). served-via-admin-ui (model_mapping predates the tk_*.sql era / set out-of-band; A3 downgraded to WARN). Also on VolcEngine Agent Plan account 88; mapped by tk_068; probe 200 on 2026-07-30. Also on Baidu Qianfan account 90 (ch46); probe 200 on 2026-08-07. Account 90 mapping: served-via-modelops-activation."
+      "notes": "ds-官 account 39. Mapped by tk_022. Priced in overlay from DeepSeek official list (https://api-docs.deepseek.com/quick_start/pricing, captured 2026-08-17); every serving account, including Baidu Qianfan account 90, bills from the single deepseek-v4-flash owner and follows its peak-valley policy. served-via-admin-ui (model_mapping predates the tk_*.sql era / set out-of-band; A3 downgraded to WARN). Also on VolcEngine Agent Plan account 88; mapped by tk_068; probe 200 on 2026-07-30. Also on Baidu Qianfan account 90 (ch46); probe 200 on 2026-08-07. Account 90 mapping: served-via-modelops-activation."
     },
     "newapi/deepseek-chat": {
       "platform": "newapi",

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -1145,9 +1145,9 @@
         "base_url": "https://qianfan.baidubce.com"
       },
       "price_source": "overlay",
-      "price_key": "deepseek-v4-flash-0731",
+      "price_key": "deepseek-v4-flash",
       "display": true,
-      "notes": "Baidu Qianfan account 90 only (dated flash SKU). Probe 200 on 2026-08-07. Qianfan ¥0.001/¥0.002 per 1k; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Dated flash SKU. Probe 200 on 2026-08-07 via Baidu Qianfan account 90; also served by accounts 39/88 as an alias (tk_088). Bills from the deepseek-v4-flash official owner (the same upstream model, per the DeepSeek price page), so official peak windows apply. served-via-modelops-activation."
     },
     "newapi/deepseek-v3.2": {
       "platform": "newapi",

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -1136,7 +1136,6 @@
       "platform": "newapi",
       "model_id": "deepseek-v4-flash-0731",
       "served_on": [
-        "39",
         "88",
         "90"
       ],
@@ -1149,7 +1148,7 @@
       "price_source": "overlay",
       "price_key": "deepseek-v4-flash",
       "display": true,
-      "notes": "Dated flash SKU. Probe 200 on 2026-08-07 via Baidu Qianfan account 90; also served by accounts 39/88 as an alias (tk_088). Bills from the deepseek-v4-flash official owner (the same upstream model, per the DeepSeek price page), so official peak windows apply. served-via-modelops-activation."
+      "notes": "Dated flash SKU. Probe 200 on 2026-08-07 via Baidu Qianfan account 90; also served by account 88 as an alias (tk_088; account 39 excluded while its DeepSeek path fails closed, see #1806). Bills from the deepseek-v4-flash official owner (the same upstream model, per the DeepSeek price page), so official peak windows apply. served-via-modelops-activation."
     },
     "newapi/deepseek-v3.2": {
       "platform": "newapi",

--- a/backend/migrations/tk_088_deepseek_v4_flash_0731_alias.sql
+++ b/backend/migrations/tk_088_deepseek_v4_flash_0731_alias.sql
@@ -1,10 +1,21 @@
 -- Migration: tk_088_deepseek_v4_flash_0731_alias
 --
--- Serve client id "deepseek-v4-flash-0731" from the two schedulable DeepSeek-capable
--- newapi accounts by REWRITING it onto the upstream id they actually serve:
+-- Serve client id "deepseek-v4-flash-0731" from the Ark Agent Plan account by
+-- REWRITING it onto the upstream id that account actually serves:
 --
---     account 39 "ds-官"                 (channel_type=43, api.deepseek.com)
 --     account 88 "volcengine-agent-plan" (channel_type=45, Ark /api/plan/v3)
+--
+-- Account 39 "ds-官" (channel_type=43, api.deepseek.com) is deliberately EXCLUDED.
+-- It advertises V4-Flash and would be the natural second home for this alias, but
+-- every DeepSeek request routed to it currently fails closed: 2026-08-25 00:40-01:20
+-- UTC it served 0 successes against 219 upstream 502s (upstream_status_code=null,
+-- "Upstream request failed"), the #1806 newapi CC-bridge bug. While it stayed in
+-- this alias, scheduler fan-out sent ~40% of user38's -0731 traffic to it and every
+-- one of those became a client-visible 502; the surviving ~60% on account 88 all
+-- succeeded. Adding an account here only helps if that account can serve the model,
+-- so 39 stays out until #1806 ships. The live key was removed out-of-band via
+-- ops/newapi/apply-model-mapping-live.py remove-live; this file is the source of
+-- truth that must not re-add it.
 --
 -- Why a rewrite and not an identity key: "-0731" is a Baidu-Qianfan-only dated SKU
 -- name. Probed 2026-08-24 via the admin fetch-upstream-models endpoint, DeepSeek
@@ -45,10 +56,8 @@ WITH upd AS (
         updated_at = NOW()
     WHERE platform = 'newapi'
       AND deleted_at IS NULL
-      AND (
-            (id = 39 AND channel_type = 43)
-         OR (id = 88 AND channel_type = 45)
-      )
+      AND id = 88
+      AND channel_type = 45
     RETURNING id
 )
 INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)

--- a/backend/migrations/tk_088_deepseek_v4_flash_0731_alias.sql
+++ b/backend/migrations/tk_088_deepseek_v4_flash_0731_alias.sql
@@ -39,7 +39,7 @@
 -- CloudWise prefix floor in tk_082).
 --
 -- Idempotent: jsonb || re-applies the same single key and leaves every other
--- mapping entry untouched. Guarded on id + platform + channel_type + deleted_at
+-- mapping entry untouched. Guarded on id + name + platform + channel_type + deleted_at
 -- so a renumbered account cannot be hit by accident.
 
 SET LOCAL lock_timeout = '5s';
@@ -57,6 +57,7 @@ WITH upd AS (
     WHERE platform = 'newapi'
       AND deleted_at IS NULL
       AND id = 88
+      AND name = 'volcengine-agent-plan'
       AND channel_type = 45
     RETURNING id
 )

--- a/backend/migrations/tk_088_deepseek_v4_flash_0731_alias.sql
+++ b/backend/migrations/tk_088_deepseek_v4_flash_0731_alias.sql
@@ -1,0 +1,55 @@
+-- Migration: tk_088_deepseek_v4_flash_0731_alias
+--
+-- Serve client id "deepseek-v4-flash-0731" from the two schedulable DeepSeek-capable
+-- newapi accounts by REWRITING it onto the upstream id they actually serve:
+--
+--     account 39 "ds-官"                 (channel_type=43, api.deepseek.com)
+--     account 88 "volcengine-agent-plan" (channel_type=45, Ark /api/plan/v3)
+--
+-- Why a rewrite and not an identity key: "-0731" is a Baidu-Qianfan-only dated SKU
+-- name. Probed 2026-08-24 via the admin fetch-upstream-models endpoint, DeepSeek
+-- official (ch43) advertises exactly three chat ids — deepseek-v4-flash,
+-- deepseek-v4-flash-vision-exp, deepseek-v4-pro — and none carries the -0731
+-- suffix. An identity mapping would forward an id the upstream rejects (404
+-- model-not-found surfaced as 502). The upstream truth is that -0731 IS
+-- V4-Flash: DeepSeek's own price page names the model "DeepSeek-V4-Flash-0731".
+--
+-- Billing: usage bills by the CLIENT-facing id, so these rows settle on the
+-- registry owner "deepseek-v4-flash" (official list price + the official
+-- 09:00-12:00 / 14:00-18:00 Asia/Shanghai peak window), same as any other
+-- V4-Flash request. The Qianfan-scoped price key this id used to carry was
+-- removed in the same change — see tk_pricing_overlay.json.
+--
+-- Account 90 (Qianfan, ch46) keeps its own identity mapping: Qianfan does serve
+-- the dated id verbatim. It is intentionally NOT touched here.
+--
+-- model_mapping is normally an identity whitelist; a rewriting entry is the
+-- documented exception for a vendor-specific SKU alias (same shape as the
+-- CloudWise prefix floor in tk_082).
+--
+-- Idempotent: jsonb || re-applies the same single key and leaves every other
+-- mapping entry untouched. Guarded on id + platform + channel_type + deleted_at
+-- so a renumbered account cannot be hit by accident.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+WITH upd AS (
+    UPDATE accounts
+    SET credentials = jsonb_set(
+            credentials,
+            '{model_mapping}',
+            COALESCE(credentials -> 'model_mapping', '{}'::jsonb)
+                || '{"deepseek-v4-flash-0731": "deepseek-v4-flash"}'::jsonb
+        ),
+        updated_at = NOW()
+    WHERE platform = 'newapi'
+      AND deleted_at IS NULL
+      AND (
+            (id = 39 AND channel_type = 43)
+         OR (id = 88 AND channel_type = 45)
+      )
+    RETURNING id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'account_changed', id, NULL, NULL FROM upd;

--- a/backend/migrations/tk_088_deepseek_v4_flash_0731_alias_test.go
+++ b/backend/migrations/tk_088_deepseek_v4_flash_0731_alias_test.go
@@ -1,0 +1,26 @@
+package migrations
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTK088TargetsOnlyTheVolcengineAgentPlanAccount(t *testing.T) {
+	content, err := FS.ReadFile("tk_088_deepseek_v4_flash_0731_alias.sql")
+	require.NoError(t, err)
+
+	sql := strings.Join(strings.Fields(string(content)), " ")
+	for _, guard := range []string{
+		"id = 88",
+		"name = 'volcengine-agent-plan'",
+		"platform = 'newapi'",
+		"channel_type = 45",
+		"deleted_at IS NULL",
+	} {
+		require.Contains(t, sql, guard)
+	}
+	require.NotContains(t, sql, "id = 39")
+	require.Contains(t, sql, `"deepseek-v4-flash-0731": "deepseek-v4-flash"`)
+}

--- a/docs/approved/pricing-serving-single-source-of-truth.md
+++ b/docs/approved/pricing-serving-single-source-of-truth.md
@@ -41,6 +41,27 @@ There is one editable global owner. A channel row is not a second global writer:
 applies only when the resolver selects that commercial scope. Provider/LiteLLM files may
 produce a candidate diff, but no value from them participates in effective billing.
 
+### 1.1 User billing is independent of the serving account
+
+Approved clarification (2026-08-25): the price precedence above is evaluated in the
+**customer commercial scope**, not in the upstream account that happens to serve a
+request. `channel_model_pricing` is selected from the API key's group/channel context;
+it is not a serving-account price table.
+
+For client ids with a global owner, every serving account therefore produces the same
+user-facing `ActualCost`. Differences between an upstream account's procurement price
+and the global user price belong to provider-cost / profit reporting and must not rewrite
+the billing model or alter balance, subscription, API-key quota, or rate-limit deductions.
+In particular, Qianfan account 90 uses the global owners for shared ids such as
+`deepseek-v4-pro`, `deepseek-v4-flash`, `glm-5*`, and `kimi-k2.6`; the former
+`.qianfan` registry keys and serving-account remap are deliberately retired rather than
+moved into `channel_model_pricing`.
+
+Qianfan-only ids with no equivalent global/direct-provider SKU remain legitimate global
+owners. Reintroducing user prices that vary by serving account would be a new billing
+policy and requires a separately approved serving-account-scoped primitive; it must not
+be approximated with customer-channel pricing.
+
 **Serving owner is genuinely per-account.** `Account.IsModelSupported`
 (`backend/internal/service/account.go:639`) returns `true` on an **empty** mapping —
 "无映射 = 允许所有" — for every non-antigravity platform. A populated `model_mapping` is an

--- a/ops/newapi/apply-model-mapping-live.py
+++ b/ops/newapi/apply-model-mapping-live.py
@@ -16,9 +16,11 @@ hot-apply, not a new source of truth. See the tokenkey-onboard-model skill §4.
 Subcommands
 -----------
   check      Read-only: print the account's current model_mapping keys + guard fields.
-  sync-live  Merge --add-identity / --add keys onto the account + scheduler_outbox +
-             BEFORE/AFTER verify. --dry-run previews (guard match + BEFORE + plan, no write).
-  --selftest Offline unit test of the additions/SQL building (no AWS).
+  sync-live   Merge --add-identity / --add keys onto the account + scheduler_outbox +
+              BEFORE/AFTER verify. --dry-run previews (guard match + BEFORE + plan, no write).
+  remove-live Remove --remove keys from the account + scheduler_outbox + fail-closed
+              BEFORE/AFTER verify. --dry-run previews without writing.
+  --selftest  Offline unit test of the additions/removals and SQL building (no AWS).
 
 SSM transport mirrors ops/pricing/manage-overlay-runtime.py: the shell is base64'd,
 written to a FILE on the host and bash'd from the file (NOT piped to `bash` via stdin),
@@ -55,10 +57,10 @@ _ssm_spec.loader.exec_module(_SSM)
 # quote/space that breaks the SQL literal or the jsonb key set (the audit's schema-gate,
 # applied at the one place that mutates model_mapping out-of-band).
 _ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
-# guard-tuple name: a group/account display name (may be non-ASCII, e.g. "ds-官"); reject
-# single quotes — the only char that breaks a PG string literal under
-# standard_conforming_strings (the default), so this is sufficient SQL-literal safety.
-_NAME_RE = re.compile(r"^[^']+$")
+# guard-tuple name: a group/account display name (may be non-ASCII, e.g. "ds-官").
+# It is embedded in both a PG single-quoted literal and a remote shell double-quoted
+# argument, so reject the metacharacters that can break either layer.
+_NAME_RE = re.compile(r"^[^'\"`$\\\r\n]+$")
 # platform is a fixed enum-like token (newapi/anthropic/openai/gemini/antigravity/grok);
 # validate to a strict charset so it can never break the guard's SQL string literal.
 _PLATFORM_RE = re.compile(r"^[A-Za-z0-9_-]+$")
@@ -113,6 +115,15 @@ def build_removals(remove_keys: list[str]) -> list[str]:
     if not out:
         fail("no model_mapping removals (pass --remove MODEL)")
     return sorted(out)
+
+
+def validate_guard_fields(name: str, platform: str) -> None:
+    """Reject values that cannot be embedded in both SQL and the remote shell."""
+    if not _NAME_RE.fullmatch(name):
+        fail(f"--name {name!r} contains an SQL or shell literal breaker")
+    if not _PLATFORM_RE.fullmatch(platform):
+        fail(f"--platform {platform!r} must match {_PLATFORM_RE.pattern} "
+             f"(newapi/anthropic/openai/gemini/antigravity/grok)")
 
 
 def build_merge_sql(account_id: int, name: str, platform: str, channel_type: int,
@@ -170,6 +181,55 @@ def keys_array_sql(keys: list[str]) -> str:
     return "array[" + ", ".join("'" + k + "'" for k in sorted(keys)) + "]"
 
 
+def build_remove_live_shell(
+    account_id: int,
+    name: str,
+    platform: str,
+    channel_type: int,
+    keys: list[str],
+    sql_b64: str,
+    psql: str = PSQL,
+) -> str:
+    """Build the fail-closed remote shell for one guarded mapping removal."""
+    keys_arr = keys_array_sql(keys)
+    guard = (
+        f"id={account_id} AND name='{name}' AND platform='{platform}' "
+        f"AND channel_type={channel_type}"
+    )
+    return (
+        "set -euo pipefail\n"
+        f"PSQL='{psql}'\n"
+        "echo '=== guard match (exactly 1 row required) ==='\n"
+        f"guard_count=\"$($PSQL -c \"SELECT count(*) FROM accounts WHERE {guard} "
+        "AND deleted_at IS NULL;\" </dev/null)\"\n"
+        "if [ \"$guard_count\" != \"1\" ]; then\n"
+        "  echo \"ERROR: guard matched $guard_count accounts (expected 1)\" >&2\n"
+        "  exit 1\n"
+        "fi\n"
+        "echo '=== BEFORE: which of the target keys are present? ==='\n"
+        f"$PSQL -c \"SELECT string_agg(k, ', ' ORDER BY k) FROM "
+        f"(SELECT jsonb_object_keys(credentials->'model_mapping') k FROM accounts "
+        f"WHERE {guard} AND deleted_at IS NULL) s WHERE k = ANY({keys_arr});\" </dev/null\n"
+        "echo '=== APPLY (jsonb - text[] + scheduler_outbox) ==='\n"
+        f"echo {sql_b64} | base64 -d | $PSQL\n"
+        "echo '=== AFTER: any target key still present? (must be f) ==='\n"
+        f"after_present=\"$($PSQL -c \"SELECT coalesce((credentials->'model_mapping') ?| "
+        f"{keys_arr}, false) FROM accounts WHERE {guard} AND deleted_at IS NULL;\" </dev/null)\"\n"
+        "if [ \"$after_present\" != \"f\" ]; then\n"
+        "  echo \"ERROR: target keys remain after removal (value=$after_present)\" >&2\n"
+        "  exit 1\n"
+        "fi\n"
+        "echo '=== model_mapping keys now ==='\n"
+        f"$PSQL -c \"SELECT string_agg(k, ', ' ORDER BY k) FROM "
+        f"(SELECT jsonb_object_keys(credentials->'model_mapping') k FROM accounts "
+        f"WHERE {guard} AND deleted_at IS NULL) s;\" </dev/null\n"
+        "echo '=== scheduler_outbox account_changed (last 2 min) ==='\n"
+        f"$PSQL -c \"SELECT count(*) FROM scheduler_outbox WHERE account_id={account_id} "
+        "AND event_type='account_changed' AND created_at > now() - interval '2 min';\" </dev/null\n"
+        "echo APPLY_OK\n"
+    )
+
+
 # --- SQL self-check registry (ops-sql-coverage gate; doctrine: manage-anthropic-config.py)
 # Every *_sql generator must be enumerated here (so ops/anthropic/test_ops_sql_execute.py
 # runs it against a real Postgres) or exempted with a reason. No runner-shaped symbols here.
@@ -211,11 +271,7 @@ def cmd_check(args) -> int:
 
 
 def cmd_sync_live(args) -> int:
-    if not _NAME_RE.match(args.name):
-        fail(f"--name {args.name!r} must not contain a single quote (SQL literal safety)")
-    if not _PLATFORM_RE.match(args.platform):
-        fail(f"--platform {args.platform!r} must match {_PLATFORM_RE.pattern} "
-             f"(newapi/anthropic/openai/gemini/antigravity/grok)")
+    validate_guard_fields(args.name, args.platform)
     additions = build_additions(args.add_identity or [], args.add or [])
     additions_json = json.dumps(additions, ensure_ascii=False, separators=(",", ":"))
     additions_b64 = base64.b64encode(additions_json.encode()).decode()
@@ -287,11 +343,7 @@ def cmd_remove_live(args) -> int:
     fail-closes. The companion migration in git MUST be corrected in the same change,
     or the next release re-adds the key.
     """
-    if not _NAME_RE.match(args.name):
-        fail(f"--name {args.name!r} must not contain a single quote (SQL literal safety)")
-    if not _PLATFORM_RE.match(args.platform):
-        fail(f"--platform {args.platform!r} must match {_PLATFORM_RE.pattern} "
-             f"(newapi/anthropic/openai/gemini/antigravity/grok)")
+    validate_guard_fields(args.name, args.platform)
     keys = build_removals(args.remove or [])
     keys_arr = keys_array_sql(keys)
     print(f"account {args.account_id} ({args.name}, {args.platform}, ct={args.channel_type})"
@@ -321,22 +373,13 @@ def cmd_remove_live(args) -> int:
     remove_sql = build_remove_sql(args.account_id, args.name, args.platform,
                                   args.channel_type, keys)
     sql_b64 = base64.b64encode(remove_sql.encode()).decode()
-    shell = (
-        "set -uo pipefail\n"
-        f"PSQL='{PSQL}'\n"
-        + guard_and_before
-        + "echo '=== APPLY (jsonb - text[] + scheduler_outbox) ==='\n"
-        f"echo {sql_b64} | base64 -d | $PSQL && echo APPLY_OK\n"
-        "echo '=== AFTER: any target key still present? (expect f) ==='\n"
-        f"$PSQL -c \"SELECT coalesce((credentials->'model_mapping') ?| {keys_arr}, false) "
-        f"FROM accounts WHERE id={args.account_id} AND deleted_at IS NULL;\" </dev/null\n"
-        "echo '=== model_mapping keys now ==='\n"
-        f"$PSQL -c \"SELECT string_agg(k, ', ' ORDER BY k) FROM "
-        f"(SELECT jsonb_object_keys(credentials->'model_mapping') k FROM accounts "
-        f"WHERE id={args.account_id} AND deleted_at IS NULL) s;\" </dev/null\n"
-        "echo '=== scheduler_outbox account_changed (last 2 min) ==='\n"
-        f"$PSQL -c \"SELECT count(*) FROM scheduler_outbox WHERE account_id={args.account_id} "
-        f"AND event_type='account_changed' AND created_at > now() - interval '2 min';\" </dev/null\n"
+    shell = build_remove_live_shell(
+        args.account_id,
+        args.name,
+        args.platform,
+        args.channel_type,
+        keys,
+        sql_b64,
     )
     out = _SSM.run_shell_b64(inst, base64.b64encode(shell.encode()).decode(),
                              f"model_mapping remove-live acct {args.account_id}")
@@ -365,11 +408,12 @@ def _selftest() -> int:
     # keys array literal
     if keys_array_sql(["b", "a"]) != "array['a', 'b']":
         failures.append("keys_array_sql wrong/ordering")
-    # guard-field validation regexes reject the SQL-literal escape char (injection gate)
-    if _PLATFORM_RE.match("newapi'; DROP") or not _PLATFORM_RE.match("newapi"):
+    # Guard-field validation rejects both SQL and remote-shell literal breakers.
+    if _PLATFORM_RE.fullmatch("newapi'; DROP") or not _PLATFORM_RE.fullmatch("newapi"):
         failures.append("_PLATFORM_RE wrong (must reject quotes, accept newapi)")
-    if _NAME_RE.match("Qwen'; x") or not _NAME_RE.match("ds-官"):
-        failures.append("_NAME_RE wrong (must reject quotes, accept non-ASCII)")
+    if any(_NAME_RE.fullmatch(bad) for bad in ("Qwen'; x", 'Qwen"x', "Qwen$(id)", "Qwen`id`")) \
+            or not _NAME_RE.fullmatch("ds-官"):
+        failures.append("_NAME_RE wrong (must reject SQL/shell breakers, accept non-ASCII)")
     # merge SQL shape: guard tuple + jsonb || + scheduler_outbox + decode
     sql = build_merge_sql(60, "Qwen", "newapi", 17, "QQ==")
     for needle in ("id = 60", "name = 'Qwen'", "platform = 'newapi'", "channel_type = 17",
@@ -405,7 +449,7 @@ def _selftest() -> int:
         for f in failures:
             print(f"  - {f}")
         return 1
-    print("selftest ok: additions / id-validation / keys-array / merge-SQL shape")
+    print("selftest ok: additions / removals / validation / keys-array / SQL shape")
     return 0
 
 

--- a/ops/newapi/apply-model-mapping-live.py
+++ b/ops/newapi/apply-model-mapping-live.py
@@ -96,6 +96,25 @@ def build_additions(add_identity: list[str], add_pairs: list[str]) -> dict:
     return out
 
 
+def build_removals(remove_keys: list[str]) -> list[str]:
+    """Validated, de-duplicated, sorted model_mapping keys to DELETE.
+
+    Same _ID_RE gate as the additions path: a key this tool writes into the `- text[]`
+    literal can never carry a quote or space that breaks the SQL literal.
+    """
+    out: set[str] = set()
+    for m in remove_keys:
+        m = m.strip()
+        if not m:
+            continue
+        if not _ID_RE.match(m):
+            fail(f"--remove {m!r} is not a valid model id ({_ID_RE.pattern})")
+        out.add(m)
+    if not out:
+        fail("no model_mapping removals (pass --remove MODEL)")
+    return sorted(out)
+
+
 def build_merge_sql(account_id: int, name: str, platform: str, channel_type: int,
                     additions_b64: str) -> str:
     """Idempotent guard-protected jsonb || merge + scheduler_outbox, additions decoded in PG.
@@ -109,6 +128,33 @@ def build_merge_sql(account_id: int, name: str, platform: str, channel_type: int
         "  SET credentials = jsonb_set(credentials, '{model_mapping}',\n"
         "        COALESCE(credentials -> 'model_mapping', '{}'::jsonb)\n"
         f"        || convert_from(decode('{additions_b64}', 'base64'), 'UTF8')::jsonb),\n"
+        "      updated_at = NOW()\n"
+        f"  WHERE id = {account_id} AND name = '{name}' AND platform = '{platform}'\n"
+        f"    AND channel_type = {channel_type} AND deleted_at IS NULL\n"
+        "  RETURNING id\n"
+        ")\n"
+        "INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)\n"
+        "SELECT 'account_changed', id, NULL, NULL FROM upd;"
+    )
+
+
+def build_remove_sql(account_id: int, name: str, platform: str, channel_type: int,
+                     keys: list[str]) -> str:
+    """Idempotent guard-protected jsonb key DELETE + scheduler_outbox.
+
+    Mirrors build_merge_sql exactly but uses jsonb `- text[]` instead of `||`, so an
+    account that must STOP serving a model id can be corrected out-of-band with the same
+    guard tuple and the same hot-reload event. Idempotent: `-` on an absent key is a
+    no-op, and every other mapping entry is left untouched.
+
+    A SINGLE data-modifying-CTE statement (atomic on its own), same as the merge path.
+    """
+    return (
+        "WITH upd AS (\n"
+        "  UPDATE accounts\n"
+        "  SET credentials = jsonb_set(credentials, '{model_mapping}',\n"
+        "        COALESCE(credentials -> 'model_mapping', '{}'::jsonb)\n"
+        f"        - {keys_array_sql(keys)}::text[]),\n"
         "      updated_at = NOW()\n"
         f"  WHERE id = {account_id} AND name = '{name}' AND platform = '{platform}'\n"
         f"    AND channel_type = {channel_type} AND deleted_at IS NULL\n"
@@ -135,6 +181,7 @@ def iter_self_check_sql() -> list[tuple[str, str]]:
     sample_b64 = base64.b64encode(b'{"qwen3.6-27b":"qwen3.6-27b"}').decode()
     return [
         ("build_merge_sql", build_merge_sql(60, "Qwen", "newapi", 17, sample_b64)),
+        ("build_remove_sql", build_remove_sql(60, "Qwen", "newapi", 17, ["qwen3.6-27b"])),
         # keys_array_sql returns a text[] fragment; wrap it in a runnable presence check.
         ("keys_array_sql", "SELECT '{}'::jsonb ?& " + keys_array_sql(["qwen3.6-27b", "qwen3-8b"])),
     ]
@@ -232,6 +279,75 @@ def cmd_sync_live(args) -> int:
     return 0
 
 
+def cmd_remove_live(args) -> int:
+    """Hot-remove model_mapping keys from ONE newapi account (inverse of sync-live).
+
+    Use when an account must STOP being scheduled for a model id — e.g. an alias was
+    mapped onto an account whose upstream does not serve it, so every routed request
+    fail-closes. The companion migration in git MUST be corrected in the same change,
+    or the next release re-adds the key.
+    """
+    if not _NAME_RE.match(args.name):
+        fail(f"--name {args.name!r} must not contain a single quote (SQL literal safety)")
+    if not _PLATFORM_RE.match(args.platform):
+        fail(f"--platform {args.platform!r} must match {_PLATFORM_RE.pattern} "
+             f"(newapi/anthropic/openai/gemini/antigravity/grok)")
+    keys = build_removals(args.remove or [])
+    keys_arr = keys_array_sql(keys)
+    print(f"account {args.account_id} ({args.name}, {args.platform}, ct={args.channel_type})"
+          f"  remove: {', '.join(keys)}")
+
+    inst = _SSM.resolve_prod_instance()
+    guard_and_before = (
+        "echo '=== guard match (1 row expected; 0 = wrong id/name/platform/channel_type) ==='\n"
+        f"$PSQL -c \"SELECT id, name, platform, channel_type FROM accounts "
+        f"WHERE id={args.account_id} AND name='{args.name}' AND platform='{args.platform}' "
+        f"AND channel_type={args.channel_type} AND deleted_at IS NULL;\" </dev/null\n"
+        "echo '=== BEFORE: which of the target keys are present? ==='\n"
+        f"$PSQL -c \"SELECT string_agg(k, ', ' ORDER BY k) FROM "
+        f"(SELECT jsonb_object_keys(credentials->'model_mapping') k FROM accounts "
+        f"WHERE id={args.account_id} AND deleted_at IS NULL) s WHERE k = ANY({keys_arr});\" "
+        "</dev/null\n"
+    )
+
+    if args.dry_run:
+        print("DRY-RUN: would jsonb `- text[]` the above keys off credentials.model_mapping + "
+              "enqueue scheduler_outbox account_changed. No write.")
+        shell = "set -uo pipefail\n" f"PSQL='{PSQL}'\n" + guard_and_before
+        print(_SSM.run_shell_b64(inst, base64.b64encode(shell.encode()).decode(),
+                                 f"model_mapping remove dry-run acct {args.account_id}"))
+        return 0
+
+    remove_sql = build_remove_sql(args.account_id, args.name, args.platform,
+                                  args.channel_type, keys)
+    sql_b64 = base64.b64encode(remove_sql.encode()).decode()
+    shell = (
+        "set -uo pipefail\n"
+        f"PSQL='{PSQL}'\n"
+        + guard_and_before
+        + "echo '=== APPLY (jsonb - text[] + scheduler_outbox) ==='\n"
+        f"echo {sql_b64} | base64 -d | $PSQL && echo APPLY_OK\n"
+        "echo '=== AFTER: any target key still present? (expect f) ==='\n"
+        f"$PSQL -c \"SELECT coalesce((credentials->'model_mapping') ?| {keys_arr}, false) "
+        f"FROM accounts WHERE id={args.account_id} AND deleted_at IS NULL;\" </dev/null\n"
+        "echo '=== model_mapping keys now ==='\n"
+        f"$PSQL -c \"SELECT string_agg(k, ', ' ORDER BY k) FROM "
+        f"(SELECT jsonb_object_keys(credentials->'model_mapping') k FROM accounts "
+        f"WHERE id={args.account_id} AND deleted_at IS NULL) s;\" </dev/null\n"
+        "echo '=== scheduler_outbox account_changed (last 2 min) ==='\n"
+        f"$PSQL -c \"SELECT count(*) FROM scheduler_outbox WHERE account_id={args.account_id} "
+        f"AND event_type='account_changed' AND created_at > now() - interval '2 min';\" </dev/null\n"
+    )
+    out = _SSM.run_shell_b64(inst, base64.b64encode(shell.encode()).decode(),
+                             f"model_mapping remove-live acct {args.account_id}")
+    print(out)
+    if "APPLY_OK" not in out:
+        fail("APPLY did not report success — inspect the output above (guard match? psql error?)")
+    print("removed. Correct the companion tk_*.sql migration in git so the next release "
+          "does not re-add these keys.")
+    return 0
+
+
 def _selftest() -> int:
     failures: list[str] = []
     # additions building
@@ -261,6 +377,29 @@ def _selftest() -> int:
                    "scheduler_outbox", "account_changed"):
         if needle not in sql:
             failures.append(f"merge SQL missing {needle!r}")
+    # removals building: validated, de-duplicated, sorted
+    if build_removals(["b", "a", "b", " "]) != ["a", "b"]:
+        failures.append("build_removals wrong (want dedup+sort, blanks skipped)")
+    for bad in (["bad'id"], ["has space"]):
+        try:
+            build_removals(bad)
+            failures.append(f"invalid remove id {bad} not rejected")
+        except SystemExit:
+            pass
+    try:
+        build_removals([])
+        failures.append("empty removals not rejected")
+    except SystemExit:
+        pass
+    # remove SQL shape: same guard tuple, but jsonb `- text[]` instead of `||`
+    rsql = build_remove_sql(39, "ds-官", "newapi", 43, ["deepseek-v4-flash-0731"])
+    for needle in ("id = 39", "name = 'ds-官'", "platform = 'newapi'", "channel_type = 43",
+                   "deleted_at IS NULL", "- array['deepseek-v4-flash-0731']::text[]",
+                   "scheduler_outbox", "account_changed"):
+        if needle not in rsql:
+            failures.append(f"remove SQL missing {needle!r}")
+    if "||" in rsql:
+        failures.append("remove SQL must not contain a jsonb || merge")
     if failures:
         print("SELFTEST FAILED:")
         for f in failures:
@@ -293,6 +432,17 @@ def main() -> int:
                    help="add non-identity mapping (repeatable)")
     s.add_argument("--dry-run", action="store_true", help="preview guard match + BEFORE; no write")
     s.set_defaults(fn=cmd_sync_live)
+
+    r = sub.add_parser("remove-live",
+                       help="hot-remove model_mapping keys from prod (inverse of sync-live)")
+    r.add_argument("--account-id", type=int, required=True)
+    r.add_argument("--name", required=True, help="guard: accounts.name (must match exactly)")
+    r.add_argument("--channel-type", type=int, required=True, help="guard: accounts.channel_type")
+    r.add_argument("--platform", default="newapi", help="guard: accounts.platform (default newapi)")
+    r.add_argument("--remove", action="append", metavar="MODEL",
+                   help="model_mapping key to delete (repeatable)")
+    r.add_argument("--dry-run", action="store_true", help="preview guard match + BEFORE; no write")
+    r.set_defaults(fn=cmd_remove_live)
 
     args = ap.parse_args()
     if not getattr(args, "fn", None):

--- a/ops/newapi/test_apply_model_mapping_live.py
+++ b/ops/newapi/test_apply_model_mapping_live.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import importlib.util
+import contextlib
+import io
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("apply-model-mapping-live.py")
+SPEC = importlib.util.spec_from_file_location("apply_model_mapping_live", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class RemoveLiveShellTest(unittest.TestCase):
+    def test_account_name_rejects_shell_and_sql_literal_breakers(self) -> None:
+        for value in ("bad'name", 'bad"name', "bad$(id)", "bad`id`", "bad\\name", "bad\nname"):
+            with self.subTest(value=value):
+                self.assertIsNone(MODULE._NAME_RE.fullmatch(value))
+        self.assertIsNotNone(MODULE._NAME_RE.fullmatch("ds-官 primary"))
+
+    def test_guard_validation_rejects_trailing_newline(self) -> None:
+        validator = getattr(MODULE, "validate_guard_fields", None)
+        self.assertTrue(callable(validator), "live mutations must share one guard validator")
+        for name, platform in (("safe\n", "newapi"), ("safe", "newapi\n")):
+            with self.subTest(name=name, platform=platform):
+                with contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+                    validator(name, platform)
+
+    def _run_shell(self, guard_count: str, after_present: str) -> subprocess.CompletedProcess[str]:
+        builder = getattr(MODULE, "build_remove_live_shell", None)
+        self.assertTrue(callable(builder), "remove-live must expose a testable shell builder")
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_psql = Path(tmp) / "psql"
+            fake_psql.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+args="$*"
+if [[ "$args" == *"SELECT count(*) FROM accounts"* ]]; then
+  printf '%s\\n' "$FAKE_GUARD_COUNT"
+elif [[ "$args" == *"credentials->'model_mapping') ?|"* ]]; then
+  printf '%s\\n' "$FAKE_AFTER_PRESENT"
+elif [[ "$args" == *"SELECT string_agg"* ]]; then
+  printf '\\n'
+else
+  cat >/dev/null
+  printf 'INSERT 0 1\\n'
+fi
+""",
+                encoding="utf-8",
+            )
+            fake_psql.chmod(0o755)
+            shell = builder(
+                account_id=39,
+                name="ds-官",
+                platform="newapi",
+                channel_type=43,
+                keys=["deepseek-v4-flash-0731"],
+                sql_b64="U0VMRUNUIDE7",
+                psql=str(fake_psql),
+            )
+            env = os.environ | {
+                "FAKE_GUARD_COUNT": guard_count,
+                "FAKE_AFTER_PRESENT": after_present,
+            }
+            return subprocess.run(
+                ["bash"],
+                input=shell,
+                text=True,
+                capture_output=True,
+                env=env,
+                check=False,
+            )
+
+    def test_wrong_guard_fails_before_apply(self) -> None:
+        result = self._run_shell(guard_count="0", after_present="f")
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertNotIn("APPLY_OK", result.stdout)
+        self.assertIn("guard matched 0 accounts", result.stderr)
+
+    def test_failed_postcondition_does_not_report_success(self) -> None:
+        result = self._run_shell(guard_count="1", after_present="t")
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertNotIn("APPLY_OK", result.stdout)
+        self.assertIn("target keys remain after removal", result.stderr)
+
+    def test_verified_removal_reports_success(self) -> None:
+        result = self._run_shell(guard_count="1", after_present="f")
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("APPLY_OK", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -2556,6 +2556,23 @@ elif ! python3 ./scripts/checks/ops-sql-coverage.py; then
     errors=$((errors + 1))
 fi
 
+# ---- sub2api: newapi live mapping mutation contract -------------------------
+# The real-Postgres SQL gate proves generated statements parse and execute, but
+# the remote-shell wrapper owns the fail-closed guard and postcondition contract.
+# Keep that operator-facing success signal under an offline behavioral test.
+echo ""
+echo "=== sub2api: newapi live mapping mutation contract ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required for newapi live mapping mutation tests)"
+    errors=$((errors + 1))
+elif ! python3 -m unittest ops/newapi/test_apply_model_mapping_live.py -q; then
+    echo "  FAIL: newapi live mapping mutation tests failed"
+    echo "        — run: python3 -m unittest ops/newapi/test_apply_model_mapping_live.py -v"
+    errors=$((errors + 1))
+else
+    echo "  ok: newapi live mapping mutation guard and postcondition contract"
+fi
+
 # ---- sub2api: ops/deploy SQL soft-delete filter ------------------------------
 # Hand-written operational SQL (psql in ops/ + deploy/ .sh/.py/.sql) bypasses Ent's
 # soft-delete interceptor; a query over a soft-delete table (accounts/users/groups

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2923,34 +2923,35 @@
       "path": "backend/internal/service/openai_gateway_usage.go",
       "must_contain": [
         "isOpenAIVideoUsageResult(result)",
-        "tkTryCalculateOpenAIVideoUsageCost",
-        "tkMapQianfanScopedBillingModels(billingModels, account)"
+        "tkTryCalculateOpenAIVideoUsageCost"
       ],
-      "rationale": "Injection wiring from upstream-owned RecordUsage/calculateOpenAIRecordUsageCost into TK settlement companions. VideoSubmit billing must stay on the video path; Qianfan account 90 must remap shared DeepSeek overlay ids to .qianfan billing owners before candidate resolution."
+      "rationale": "Injection wiring from upstream-owned RecordUsage/calculateOpenAIRecordUsageCost into TK settlement companions. VideoSubmit billing must stay on the video path."
     },
     {
       "path": "backend/internal/service/gateway_usage_billing.go",
       "must_contain": [
-        "tkQianfanScopedBillingModel(billingModel, account)"
+        "billableModelWithFallback(ctx, apiKey, billingModel, result.UpstreamModel, result.Model)"
       ],
-      "rationale": "Anthropic/generic RecordUsage funnel must switch shared DeepSeek models to .qianfan overlay owners when served from Baidu Qianfan account 90; dropping the call site restores official DeepSeek list pricing on a Qianfan channel."
+      "rationale": "Anthropic/generic RecordUsage funnel must keep the TK unpriced-alias fallback: a selected billing model with no registry price falls back to the concretely forwarded model instead of silently settling $0. (Per-account .qianfan remap removed 2026-08-24: a per-account commercial price is a scoped channel_model_pricing override, not a second global registry owner — see docs/approved/pricing-serving-single-source-of-truth.md.)"
     },
     {
       "path": "backend/internal/service/billing_service_tk_qianfan.go",
       "must_contain": [
-        "tkQianfanScopedBillingModel",
-        "tkMapQianfanScopedBillingModels",
-        "tkQianfanOverlayPricingSuffix"
+        "var tkDeepSeekPeakValleyExcludedModels = map[string]struct{}{",
+        "\"deepseek-v3.2\"",
+        "\"deepseek-ocr\""
       ],
-      "rationale": "Per-account Qianfan billing key remap for deepseek-v4-pro/flash while public catalog keeps global DeepSeek owners. Companion isolates upstream gateway insertions to one-liners."
+      "rationale": "Qianfan-exclusive DeepSeek SKUs (no official equivalent) must stay exempt from _config.deepseek_peak_valley: Qianfan lists one flat rate, so the official 2x peak window would overbill them for half the working day. Dropping an id from this map silently doubles its output price 09:00-12:00 / 14:00-18:00 Asia/Shanghai."
     },
     {
       "path": "backend/internal/service/billing_service_tk_qianfan_test.go",
       "must_contain": [
-        "TestTkQianfanScopedBillingModel_UsesQianfanRatesInCost",
-        "TestTkQianfanScopedBillingModel_ExcludesDeepSeekPeakValley"
+        "TestTkQianfanScopedOverlayKeysAreRemoved",
+        "TestTkQianfanDatedFlashResolvesToOfficialFlashOwner",
+        "TestTkDeepSeekPeakValleyAppliesToDatedFlashAlias",
+        "TestTkQianfanOnlyDeepSeekOwnersStayPeakExempt"
       ],
-      "rationale": "Focused regressions: Qianfan account remap and guard against applying DeepSeek official peak-valley multiplier to .qianfan overlay billing keys."
+      "rationale": "Focused regressions for the 2026-08-24 scoped-price removal: the .qianfan suffix owners stay out of the global registry, the dated flash alias resolves to the official owner (and is therefore subject to official peak windows), and Qianfan-exclusive owners keep their flat rate."
     },
     {
       "path": "backend/internal/service/account_model_mapping_preset_tk_qianfan_test.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2932,7 +2932,7 @@
       "must_contain": [
         "billableModelWithFallback(ctx, apiKey, billingModel, result.UpstreamModel, result.Model)"
       ],
-      "rationale": "Anthropic/generic RecordUsage funnel must keep the TK unpriced-alias fallback: a selected billing model with no registry price falls back to the concretely forwarded model instead of silently settling $0. (Per-account .qianfan remap removed 2026-08-24: a per-account commercial price is a scoped channel_model_pricing override, not a second global registry owner — see docs/approved/pricing-serving-single-source-of-truth.md.)"
+      "rationale": "Anthropic/generic RecordUsage funnel must keep the TK unpriced-alias fallback: a selected billing model with no registry price falls back to the concretely forwarded model instead of silently settling $0. (Per-account .qianfan remap removed: shared ids intentionally use one global user price regardless of serving account; provider-cost differences stay in profit reporting, and customer-scoped channel_model_pricing is not a serving-account substitute — see docs/approved/pricing-serving-single-source-of-truth.md §1.1.)"
     },
     {
       "path": "backend/internal/service/billing_service_tk_qianfan.go",
@@ -2951,7 +2951,7 @@
         "TestTkDeepSeekPeakValleyAppliesToDatedFlashAlias",
         "TestTkQianfanOnlyDeepSeekOwnersStayPeakExempt"
       ],
-      "rationale": "Focused regressions for the 2026-08-24 scoped-price removal: the .qianfan suffix owners stay out of the global registry, the dated flash alias resolves to the official owner (and is therefore subject to official peak windows), and Qianfan-exclusive owners keep their flat rate."
+      "rationale": "Focused regressions for the global-user-price decision: shared ids stay independent of the serving account and the .qianfan suffix owners stay out of the registry; the dated flash alias resolves to the official owner (and is therefore subject to official peak windows), while Qianfan-exclusive owners keep their flat rate."
     },
     {
       "path": "backend/internal/service/account_model_mapping_preset_tk_qianfan_test.go",


### PR DESCRIPTION
## 摘要

本 PR 删除 Qianfan 账号级 `.qianfan` 定价 owner，并将
`deepseek-v4-flash-0731` 收敛为 `deepseek-v4-flash` 的客户端别名。

删除的 registry key：

- `deepseek-v4-pro.qianfan`
- `deepseek-v4-flash.qianfan`
- `glm-5.qianfan`
- `glm-5.1.qianfan`
- `glm-5.2.qianfan`
- `kimi-k2.6.qianfan`
- 独立 owner `deepseek-v4-flash-0731`

`deepseek-v4-flash-0731` 继续作为可服务的客户端 id，但统一解析并计费到
`deepseek-v4-flash`。`deepseek-v3.2`、`deepseek-v3.2-think`、
`deepseek-ocr` 没有对应的官方共享 SKU，因此继续保留 Qianfan registry owner
和 peak-valley 豁免。

## 设计

2026-08-25 人工批准采用统一用户计费方案：对于已有 global owner 的共享模型，
用户侧 `ActualCost` 不随实际 serving account 变化。上游账号采购成本差异只进入
provider-cost / profit 核算，不改写用户余额、订阅额度、API Key quota 或 rate-limit
扣减。

`channel_model_pricing` 的作用域是 API Key group/channel 所代表的客户商业渠道，
不是 serving-account price table，不能作为账号 90 价格的替代实现。因此原有
`.qianfan` suffix owner 和按账号 90 改写 billing model 的逻辑是明确退役，而不是
迁移到 `channel_model_pricing`。

该决策已固化到
`docs/approved/pricing-serving-single-source-of-truth.md` §1.1，并由 focused unit
tests 与 gateway sentinel 阻止未来重新引入账号级用户价格。

## 迁移

`tk_088_deepseek_v4_flash_0731_alias.sql` 仅更新账号 88
`volcengine-agent-plan`：

```text
deepseek-v4-flash-0731 -> deepseek-v4-flash
```

账号 39 `ds-官` 被明确排除。2026-08-25 的线上证据显示其 DeepSeek 路径持续产生
最终 502，因此此前热更新加入的 alias 已移除；migration 不会在发布时重新加回。
SQL 对账号身份、channel type 和 soft-delete 状态有保护，并保持幂等。

## 风险

- 统一 global user price 是有意的计费政策变化。按过去 30 天历史流量重算，用户
  `ActualCost` 合计约增加 `$10.56`；其中 `deepseek-v4-pro` 约减少 `$0.9705`。
- 当前账号 90 为 `status=error`、欠费且不可调度，因此没有即时前向计费暴露；
  将来恢复调度后，共享模型会按本次批准的 global price 计费。
- `deepseek-v4-flash-0731` 已通过账号 88 的定向线上探测并返回 HTTP 200。账号 88
  曾出现间歇性基础模型 502，属于需要继续监控的上游运营风险，目前没有证据表明
  是 alias 映射回归。
- 无 Web surface 变化。

## 验证

- focused Qianfan pricing unit tests：通过。
- gateway TK sentinel：通过。
- 使用仓库固定的 Go 1.26.6 运行完整 `scripts/preflight.sh`：通过。
- registry、catalog-serving、migration safety、SSOT、lint、安全检查：通过。
- 新 HEAD 推送后继续等待 GitHub CI 全绿。

## 提交

- `3be51e066` fix(pricing): remove .qianfan scoped price owners from the global registry
- `2545b7c93` fix(catalog): declare accounts 39/88 in the 0731 served_on
- `7087581d5` fix(newapi): drop the 0731 alias from account 39 while its DeepSeek path fails closed
- `6462dc42a` fix(newapi): address R-001..R-004 production guards
- `f688fe7f4` docs(pricing): approve global billing across serving accounts

最新提交：f688fe7f4

no-web-impact

sentinel-registry-reviewed

ai
