### PR TITLE
chore(ci): 缩短默认流水线关键路径

### DIFF
--- a/.github/actions/go-rolling-cache/action.yml
+++ b/.github/actions/go-rolling-cache/action.yml
@@ -28,14 +28,34 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Go module cache
+    - name: Restore Go module cache (non-main writer)
+      if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-gomod-${{ hashFiles('backend/go.sum') }}
+        restore-keys: ${{ runner.os }}-gomod-
+
+    - name: Go module cache (main writer)
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: actions/cache@v4
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-gomod-${{ hashFiles('backend/go.sum') }}
         restore-keys: ${{ runner.os }}-gomod-
 
-    - name: Go build/test cache (rolling, ${{ inputs.prefix }})
+    - name: Restore Go build/test cache (non-main writer, ${{ inputs.prefix }})
+      if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.cache/go-build
+        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
+        restore-keys: |
+          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.sum') }}-
+          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-
+
+    - name: Go build/test cache (rolling main writer, ${{ inputs.prefix }})
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: actions/cache@v4
       with:
         path: ~/.cache/go-build

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -34,7 +34,46 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.classify.outputs.backend }}
+      frontend: ${{ steps.classify.outputs.frontend }}
+      deploy: ${{ steps.classify.outputs.deploy }}
+      ops: ${{ steps.classify.outputs.ops }}
+      contracts: ${{ steps.classify.outputs.contracts }}
+      all: ${{ steps.classify.outputs.all }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 64
+      - name: Classify changed surfaces
+        id: classify
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "schedule" ] || [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            python3 scripts/ci/changed-surfaces.py --all --github-output "$GITHUB_OUTPUT" </dev/null
+          elif [ "$EVENT_NAME" = "push" ]; then
+            if [ -z "${BEFORE_SHA:-}" ] || [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
+              python3 scripts/ci/changed-surfaces.py --all --github-output "$GITHUB_OUTPUT" </dev/null
+            else
+              git fetch --no-tags origin "$BEFORE_SHA" --depth=64
+              git diff --name-only -z "$BEFORE_SHA" HEAD |
+                python3 scripts/ci/changed-surfaces.py --null --github-output "$GITHUB_OUTPUT"
+            fi
+          else
+            git fetch --no-tags origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}" --depth=64
+            git diff --name-only -z "origin/${BASE_REF}...HEAD" |
+              python3 scripts/ci/changed-surfaces.py --null --github-output "$GITHUB_OUTPUT"
+          fi
+
   shell:
+    needs: changes
+    if: needs.changes.outputs.all == 'true' || needs.changes.outputs.deploy == 'true'
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v6
@@ -47,15 +86,29 @@ jobs:
           /bin/sh deploy/test-caddyfile-cache.sh
 
   preflight:
-    if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'ci'))
+    needs: changes
+    if: always() && (github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'ci')))
     # Mechanical gate for process / quality rules from dev-rules submodule.
     # See CLAUDE.md § 10 and dev-rules/rules/dev-rules-convention.mdc.
     runs-on: ubuntu-latest
     steps:
+      - name: Require changed-surface classification
+        if: needs.changes.result != 'success'
+        run: exit 1
       - uses: actions/checkout@v6
         with:
           fetch-depth: 64
           submodules: recursive
+      - name: CI orchestration contract tests
+        run: |
+          python3 -m unittest \
+            scripts.test_preflight_ci_lint_skip \
+            scripts.checks.test_release_cache_key_parity \
+            scripts.checks.test_go_rolling_cache_policy \
+            scripts.test_preflight_ci_handoffs \
+            scripts.test_ci_gate_handoffs \
+            scripts.ci.test_changed_surfaces \
+            scripts.test_backend_ci_routing
       # Preflight runs `go test` for QA evidence dataset validation; backend/go.mod
       # replaces new-api with ../../new-api — same sibling checkout as test/lint jobs.
       - uses: ./.github/actions/cache-and-checkout-new-api
@@ -78,6 +131,11 @@ jobs:
           # Keep local/full preflight strict, but avoid re-running that slow Go
           # fixture inside the CI preflight job on main pushes.
           PREFLIGHT_SKIP_PROMPT_FIXTURE_GATEWAY: "1"
+          # Keep the required preflight check authoritative: skip slow contracts
+          # only when the changed-surface classifier proves they are unrelated.
+          PREFLIGHT_SKIP_SLOW_OPS_CONTRACTS: ${{ needs.changes.outputs.all != 'true' && needs.changes.outputs.ops != 'true' && '1' || '0' }}
+          PREFLIGHT_SKIP_MAIN_ANCESTRY: "1"
+          PREFLIGHT_SKIP_AGENT_CONTRACT: ${{ needs.changes.outputs.all != 'true' && needs.changes.outputs.contracts != 'true' && '1' || '0' }}
         run: |
           if [ -x scripts/preflight.sh ]; then
             ./scripts/preflight.sh
@@ -135,7 +193,8 @@ jobs:
           echo "ssot-delta-gate: ok (no catalog-surface paths changed)"
 
   test-unit:
-    if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'ci'))
+    needs: changes
+    if: (github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'ci'))) && (needs.changes.outputs.all == 'true' || needs.changes.outputs.backend == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -163,7 +222,8 @@ jobs:
         run: python3 ops/anthropic/probe_prompt_surfaces.py --check-fixture-gateway
 
   test-integration:
-    if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'ci'))
+    needs: changes
+    if: (github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'ci'))) && (needs.changes.outputs.all == 'true' || needs.changes.outputs.backend == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -186,7 +246,8 @@ jobs:
         run: make test-integration
 
   frontend:
-    if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'ci'))
+    needs: changes
+    if: (github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'ci'))) && (needs.changes.outputs.all == 'true' || needs.changes.outputs.frontend == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -209,7 +270,8 @@ jobs:
         run: make test-frontend
 
   golangci-lint:
-    if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'ci'))
+    needs: changes
+    if: (github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'ci'))) && (needs.changes.outputs.all == 'true' || needs.changes.outputs.backend == 'true')
     permissions:
       contents: read
       pull-requests: read
@@ -243,7 +305,8 @@ jobs:
           only-new-issues: false
 
   backend-security:
-    if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'schedule' && github.event.schedule == '0 3 * * 1') || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'security'))
+    needs: changes
+    if: (github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'schedule' && github.event.schedule == '0 3 * * 1') || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'security'))) && (needs.changes.outputs.all == 'true' || needs.changes.outputs.backend == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -287,7 +350,8 @@ jobs:
           govulncheck ./...
 
   frontend-security:
-    if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'schedule' && github.event.schedule == '0 3 * * 1') || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'security'))
+    needs: changes
+    if: (github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'schedule' && github.event.schedule == '0 3 * * 1') || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'security'))) && (needs.changes.outputs.all == 'true' || needs.changes.outputs.frontend == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -332,74 +396,6 @@ jobs:
         run: |
           CURRENT_PIN="$(tr -d '[:space:]' < .new-api-ref)"
           bash scripts/upstream/bump-new-api.sh "$CURRENT_PIN"
-
-  # Warm the cross-arch (amd64+arm64) Go build cache that release.yml consumes.
-  #
-  # WHY THIS JOB EXISTS: release.yml is triggered by `tag push`, so it runs on
-  # `refs/tags/vX.Y.Z`. GitHub Actions scopes cache restore to the current ref
-  # plus the DEFAULT BRANCH only — a cache saved on one tag ref is invisible to
-  # the next tag's run. The "rolling" cache release.yml saved on its own tag ref
-  # was therefore NEVER restored across releases (verified: every release logged
-  # `Cache not found for input keys: Linux-go-release-...`), so every release
-  # cold-compiled the full arm64 package set (~4m, ~79% of the GoReleaser step).
-  #
-  # Saving the same-keyed cache HERE — on `main`, the default branch — makes it
-  # readable from every tag-triggered release run. release.yml now restores it
-  # (restore-only) and only recompiles changed packages + relinks.
-  #
-  # Runs only on push to main (where the save lands on the default-branch ref);
-  # PR runs are pointless because their cache is PR-ref-scoped and release can't
-  # read it.
-  warm-release-cache:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/cache-and-checkout-new-api
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: backend/go.mod
-          check-latest: false
-          # The rolling cache below owns GOCACHE + GOMODCACHE; setup-go's
-          # go.sum-keyed cache is immutable and would never refresh the arm64
-          # cross-compile objects (same reasoning as release.yml).
-          cache: false
-      # Rolling cache: a run_id-unique SAVE key always re-saves at post-job; the
-      # restore-keys seed from the previous main warm cache so the build is
-      # incremental, not cold. Key prefix is IDENTICAL to release.yml's
-      # restore-keys so release restores exactly this entry. Go's cache is
-      # content-addressed, so a stale entry is unused, never wrong.
-      - name: Rolling Go build cache (amd64 + arm64 cross-compile)
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-release-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-go-release-${{ hashFiles('backend/go.sum') }}-
-            ${{ runner.os }}-go-release-
-      - name: Verify Go version
-        run: |
-          expected=$(awk '/^go /{print $2; exit}' backend/go.mod)
-          go version | grep -Fq "go${expected}"
-      # Compile cmd/server for BOTH release arches to populate the cache.
-      # Flags mirror .goreleaser.yaml (CGO_ENABLED=0, linux) — but WITHOUT
-      # `-tags=embed`, so no frontend dist/ is required (embed_off.go satisfies
-      # `//go:build !embed`). The embed-gated files are a handful of tiny
-      # packages that recompile during release; deps + stdlib + all relay/
-      # service/handler objects — the ~79% bulk — are cached identically.
-      - name: Warm cross-arch Go build cache
-        working-directory: backend
-        env:
-          CGO_ENABLED: '0'
-          GOOS: linux
-        run: |
-          for arch in amd64 arm64; do
-            echo "::group::go build linux/${arch}"
-            GOARCH="${arch}" go build -o /dev/null ./cmd/server
-            echo "::endgroup::"
-          done
 
   compile-smoke:
     if: (github.event_name == 'schedule' && github.event.schedule == '17 9 * * TUE') || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'weekly-smoke'))

--- a/.github/workflows/main-ancestry-guard.yml
+++ b/.github/workflows/main-ancestry-guard.yml
@@ -28,15 +28,15 @@ name: Main Ancestry Guard
 #      that commit is tagged. This is the v1.3.0 incident (CLAUDE.md §9.2)
 #      and the PR #312 re-occurrence pattern.
 #
-# Companion preflight check `scripts/checks/main-ancestry-anchor.py` runs
-# locally and in CI on every PR; together with this workflow they cover
-# both prevention (this gate, at PR-merge time) and detection (preflight,
-# at every commit / push). A green check here is a hard prerequisite for
-# merging — branch protection on `main` should require this status.
+# The PR job prevents an orphan merge. A separate push job below detects any
+# direct rewrite of main without forcing the heavyweight backend preflight to
+# deepen its shallow checkout by thousands of commits.
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    branches: [main]
+  push:
     branches: [main]
 
 permissions:
@@ -45,6 +45,7 @@ permissions:
 
 jobs:
   main-ancestry-guard:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       # fetch-depth: 0 ensures PR base is reachable locally — GitHub Actions
@@ -200,3 +201,14 @@ jobs:
             --title "$PR_TITLE" \
             --body "$PR_BODY" \
             --commits-range "$BASE..$HEAD"
+
+  main-ancestry-anchor:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Verify immutable main ancestry anchor
+        run: python3 scripts/checks/main-ancestry-anchor.py

--- a/.github/workflows/warm-release-cache-main.yml
+++ b/.github/workflows/warm-release-cache-main.yml
@@ -1,0 +1,61 @@
+name: Warm Release Cache
+
+# Release tags can restore caches from the default branch, but not from older
+# tag refs. Keep the cross-arch cache warm on main only when backend build
+# inputs change; this is acceleration work, not a required CI correctness gate.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'backend/**/*.go'
+      - 'backend/go.mod'
+      - 'backend/go.sum'
+      - '.new-api-ref'
+      - '.goreleaser.yaml'
+      - '.github/workflows/warm-release-cache-main.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: warm-release-cache-main
+  cancel-in-progress: true
+
+jobs:
+  warm-release-cache:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/cache-and-checkout-new-api
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: backend/go.mod
+          check-latest: false
+          cache: false
+      - name: Rolling Go build cache (amd64 + arm64 cross-compile)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-release-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-go-release-${{ hashFiles('backend/go.sum') }}-
+            ${{ runner.os }}-go-release-
+      - name: Verify Go version
+        run: |
+          expected=$(awk '/^go /{print $2; exit}' backend/go.mod)
+          go version | grep -Fq "go${expected}"
+      - name: Warm cross-arch Go build cache
+        working-directory: backend
+        env:
+          CGO_ENABLED: '0'
+          GOOS: linux
+        run: |
+          for arch in amd64 arm64; do
+            echo "::group::go build linux/${arch}"
+            GOARCH="${arch}" go build -o /dev/null ./cmd/server
+            echo "::endgroup::"
+          done

--- a/.preflight/local-lint.conf
+++ b/.preflight/local-lint.conf
@@ -1,2 +1,4 @@
 # Mirror backend-ci.yml golangci-lint job (v2.9 via backend/Makefile).
-cd backend && make lint
+# GitHub Actions already owns the same full lint in its dedicated job; local
+# preflight remains strict so developers still get the gate before commit.
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then :; else cd backend && make lint; fi

--- a/scripts/checks/release-cache-key-parity.py
+++ b/scripts/checks/release-cache-key-parity.py
@@ -6,8 +6,8 @@ files that MUST agree, or the optimization silently reverts (release goes back
 to cold-compiling arm64 ~4m every time, with NO error — exactly the failure
 mode that went unnoticed for weeks before #576):
 
-  * .github/workflows/backend-ci.yml  — `warm-release-cache` job SAVES the cache
-    on `main` (the default branch) with `actions/cache@v4`.
+  * .github/workflows/warm-release-cache-main.yml — `warm-release-cache` SAVES
+    the cache on `main` (the default branch) with `actions/cache@v4`.
   * .github/workflows/release.yml     — RESTORES it on the tag ref with
     `actions/cache/restore@v4` (restore-only; saving here would re-create the
     dead tag-scoped caches #576 removed).
@@ -34,7 +34,7 @@ import sys
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 
-BACKEND_CI = REPO_ROOT / ".github" / "workflows" / "backend-ci.yml"
+WARM_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "warm-release-cache-main.yml"
 RELEASE = REPO_ROOT / ".github" / "workflows" / "release.yml"
 
 # The shared cache-key prefix both files must agree on, verbatim (GitHub
@@ -83,7 +83,7 @@ def main() -> int:
 
     errors = 0
 
-    for path in (BACKEND_CI, RELEASE):
+    for path in (WARM_WORKFLOW, RELEASE):
         if not path.exists():
             _fail(args.quiet, f"{path.relative_to(REPO_ROOT)} not found")
             errors += 1
@@ -91,14 +91,14 @@ def main() -> int:
     if errors:
         return 1
 
-    ci_text = BACKEND_CI.read_text()
+    ci_text = WARM_WORKFLOW.read_text()
     rel_text = RELEASE.read_text()
 
     # Invariant 1: shared key prefix present in BOTH files.
     if SHARED_KEY_PREFIX not in ci_text:
         _fail(
             args.quiet,
-            f"backend-ci.yml missing the shared cache-key prefix '{SHARED_KEY_PREFIX}'. "
+            f"warm-release-cache-main.yml missing the shared cache-key prefix '{SHARED_KEY_PREFIX}'. "
             "The warm-release-cache job must key on it so release.yml can restore the entry.",
         )
         errors += 1
@@ -118,7 +118,7 @@ def main() -> int:
     if ci_action != SAVE_ACTION:
         _fail(
             args.quiet,
-            f"backend-ci.yml go-release cache step must use '{SAVE_ACTION}' (it SAVES the warm "
+            f"warm-release-cache-main.yml go-release cache step must use '{SAVE_ACTION}' (it SAVES the warm "
             f"cache on main); found '{ci_action}'.",
         )
         errors += 1

--- a/scripts/checks/test_go_rolling_cache_policy.py
+++ b/scripts/checks/test_go_rolling_cache_policy.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Contract tests for the shared Go cache write policy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+import yaml
+
+
+ACTION = Path(__file__).resolve().parents[2] / ".github" / "actions" / "go-rolling-cache" / "action.yml"
+MAIN_WRITER_IF = "github.event_name == 'push' && github.ref == 'refs/heads/main'"
+NON_MAIN_IF = "github.event_name != 'push' || github.ref != 'refs/heads/main'"
+
+
+class GoRollingCachePolicyTest(unittest.TestCase):
+    def test_only_main_push_steps_can_save_caches(self) -> None:
+        steps = yaml.safe_load(ACTION.read_text(encoding="utf-8"))["runs"]["steps"]
+        saving = [step for step in steps if step.get("uses") == "actions/cache@v4"]
+        self.assertEqual(len(saving), 2)
+        self.assertTrue(all(step.get("if") == MAIN_WRITER_IF for step in saving))
+
+    def test_non_main_events_restore_but_never_save_both_cache_layers(self) -> None:
+        steps = yaml.safe_load(ACTION.read_text(encoding="utf-8"))["runs"]["steps"]
+        restore_only = [step for step in steps if step.get("uses") == "actions/cache/restore@v4"]
+        self.assertEqual(len(restore_only), 2)
+        self.assertTrue(all(step.get("if") == NON_MAIN_IF for step in restore_only))
+        restored_paths = {step["with"]["path"] for step in restore_only}
+        self.assertEqual(restored_paths, {"~/go/pkg/mod", "~/.cache/go-build"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/checks/test_release_cache_key_parity.py
+++ b/scripts/checks/test_release_cache_key_parity.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Repository-level behavior tests for the release cache warm workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_CI = REPO_ROOT / ".github" / "workflows" / "backend-ci.yml"
+WARM_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "warm-release-cache-main.yml"
+
+
+def load_workflow(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def workflow_on(workflow: dict) -> dict:
+    return workflow.get("on") or workflow.get(True) or {}
+
+
+class ReleaseCacheWorkflowTest(unittest.TestCase):
+    def test_default_ci_does_not_wait_for_release_cache_warming(self) -> None:
+        jobs = load_workflow(BACKEND_CI)["jobs"]
+        self.assertNotIn("warm-release-cache", jobs)
+
+    def test_warm_workflow_runs_only_for_main_backend_build_inputs(self) -> None:
+        workflow = load_workflow(WARM_WORKFLOW)
+        push = workflow_on(workflow)["push"]
+        self.assertEqual(push["branches"], ["main"])
+        self.assertEqual(
+            set(push["paths"]),
+            {
+                "backend/**/*.go",
+                "backend/go.mod",
+                "backend/go.sum",
+                ".new-api-ref",
+                ".goreleaser.yaml",
+                ".github/workflows/warm-release-cache-main.yml",
+            },
+        )
+        job = workflow["jobs"]["warm-release-cache"]
+        self.assertEqual(job.get("if"), "github.ref == 'refs/heads/main'")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/changed-surfaces.py
+++ b/scripts/ci/changed-surfaces.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Classify changed paths into the expensive CI surfaces they can affect."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Iterable
+
+
+KEYS = ("backend", "frontend", "deploy", "ops", "contracts", "all")
+
+CONTRACT_FILES = {
+    "backend/internal/domain/constants.go",
+    "backend/internal/server/router.go",
+    "docs/agent_integration.md",
+    "scripts/export_agent_contract.py",
+    "scripts/export_agent_contract_routes.go",
+    "scripts/test_export_agent_contract.py",
+    "ops/pricing/modelops.py",
+    "ops/pricing/manage-account-model-mapping-runtime.py",
+    "ops/archive/data_layer_archive_cleanup_hold.py",
+    "ops/archive/data_layer_archive_prod_export.py",
+    "ops/archive/data_layer_archive_promote_batch.py",
+    "ops/archive/data_layer_archive_closeout.py",
+    "ops/migration/usage_logs_daily_partition.py",
+}
+
+NEUTRAL_TOP_LEVEL = {
+    ".gitignore",
+    ".gitattributes",
+    ".main-ancestry-anchor",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "DEPRECATIONS.md",
+    "LICENSE",
+    "README.md",
+}
+
+
+def _starts(path: str, prefixes: Iterable[str]) -> bool:
+    return any(path.startswith(prefix) for prefix in prefixes)
+
+
+def classify(paths: Iterable[str]) -> dict[str, bool]:
+    result = {key: False for key in KEYS}
+    for raw_path in paths:
+        path = raw_path.replace("\\", "/")
+        if not path:
+            continue
+
+        if path == ".github/workflows/backend-ci.yml" or _starts(
+            path,
+            (".github/actions/", "scripts/ci/"),
+        ):
+            result["all"] = True
+            continue
+
+        matched = False
+
+        if path == ".new-api-ref" or _starts(path, ("backend/",)):
+            result["backend"] = True
+            matched = True
+
+        if _starts(path, ("frontend/",)):
+            result["frontend"] = True
+            matched = True
+
+        if path == "backend/internal/domain/constants.go":
+            result["frontend"] = True
+
+        if _starts(path, ("deploy/", "ops/stage0/", "ops/lightsail/")) or (
+            path.startswith(".github/workflows/")
+            and Path(path).name.startswith(("deploy-", "edge-", "ops-stage0-", "warm-image-stage0"))
+        ):
+            result["deploy"] = True
+            matched = True
+
+        if _starts(
+            path,
+            ("ops/qa/", "ops/archive/", "ops/stage0/", "backend/internal/observability/qa/"),
+        ) or path == "scripts/checks/data-layer-archive-ssot.py":
+            result["ops"] = True
+            matched = True
+
+        if path in CONTRACT_FILES or _starts(path, ("backend/internal/server/routes/",)):
+            result["contracts"] = True
+            matched = True
+
+        if path == "scripts/preflight.sh":
+            result["ops"] = True
+            result["contracts"] = True
+            matched = True
+
+        if matched:
+            continue
+
+        if (
+            path in NEUTRAL_TOP_LEVEL
+            or _starts(
+                path,
+                (
+                    ".cache/",
+                    "docs/",
+                    ".cursor/",
+                    ".testing/",
+                    "dev-rules/",
+                    "ops/",
+                    "scripts/checks/",
+                    "scripts/sentinels/",
+                ),
+            )
+            or path.endswith((".md", ".txt"))
+        ):
+            continue
+
+        result["all"] = True
+
+    return result
+
+
+def _read_paths(null_delimited: bool) -> list[str]:
+    if null_delimited:
+        return [item.decode("utf-8") for item in sys.stdin.buffer.read().split(b"\0") if item]
+    return [line.rstrip("\n") for line in sys.stdin]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--all", action="store_true", help="mark every expensive surface as required")
+    parser.add_argument("--null", action="store_true", help="read NUL-delimited paths from stdin")
+    parser.add_argument("--github-output", type=Path, help="append boolean outputs to this GitHub output file")
+    args = parser.parse_args(argv)
+
+    result = {key: True for key in KEYS} if args.all else classify(_read_paths(args.null))
+    if args.github_output:
+        with args.github_output.open("a", encoding="utf-8") as output:
+            for key in KEYS:
+                output.write(f"{key}={'true' if result[key] else 'false'}\n")
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_changed_surfaces.py
+++ b/scripts/ci/test_changed_surfaces.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Behavior tests for CI changed-surface classification."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+MODULE_PATH = Path(__file__).resolve().parent / "changed-surfaces.py"
+SPEC = importlib.util.spec_from_file_location("changed_surfaces", MODULE_PATH)
+assert SPEC and SPEC.loader
+changed_surfaces = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(changed_surfaces)
+
+
+class ChangedSurfacesTest(unittest.TestCase):
+    def test_backend_go_change_runs_backend_jobs_only(self) -> None:
+        self.assertEqual(
+            changed_surfaces.classify(["backend/internal/service/account_service.go"]),
+            {
+                "backend": True,
+                "frontend": False,
+                "deploy": False,
+                "ops": False,
+                "contracts": False,
+                "all": False,
+            },
+        )
+
+    def test_frontend_change_runs_frontend_jobs_only(self) -> None:
+        self.assertEqual(
+            changed_surfaces.classify(["frontend/src/views/admin/Accounts.vue"]),
+            {
+                "backend": False,
+                "frontend": True,
+                "deploy": False,
+                "ops": False,
+                "contracts": False,
+                "all": False,
+            },
+        )
+
+    def test_deploy_change_runs_deploy_jobs_only(self) -> None:
+        self.assertEqual(
+            changed_surfaces.classify(["deploy/tests/docker-runtime-resources-test.sh"]),
+            {
+                "backend": False,
+                "frontend": False,
+                "deploy": True,
+                "ops": False,
+                "contracts": False,
+                "all": False,
+            },
+        )
+
+    def test_route_change_runs_backend_and_contract_jobs(self) -> None:
+        self.assertEqual(
+            changed_surfaces.classify(["backend/internal/server/routes/user.go"]),
+            {
+                "backend": True,
+                "frontend": False,
+                "deploy": False,
+                "ops": False,
+                "contracts": True,
+                "all": False,
+            },
+        )
+
+    def test_ops_contract_change_runs_backend_and_ops_contracts(self) -> None:
+        self.assertEqual(
+            changed_surfaces.classify(["backend/internal/observability/qa/bundle/service.go"]),
+            {
+                "backend": True,
+                "frontend": False,
+                "deploy": False,
+                "ops": True,
+                "contracts": False,
+                "all": False,
+            },
+        )
+
+    def test_docs_only_change_keeps_expensive_jobs_off(self) -> None:
+        self.assertEqual(
+            changed_surfaces.classify(["docs/runbook.md"]),
+            {
+                "backend": False,
+                "frontend": False,
+                "deploy": False,
+                "ops": False,
+                "contracts": False,
+                "all": False,
+            },
+        )
+
+    def test_cache_snapshot_change_keeps_expensive_jobs_off(self) -> None:
+        self.assertEqual(
+            changed_surfaces.classify([".cache/anthropic/cc-triage.json"]),
+            {
+                "backend": False,
+                "frontend": False,
+                "deploy": False,
+                "ops": False,
+                "contracts": False,
+                "all": False,
+            },
+        )
+
+    def test_backend_sentinel_does_not_escalate_a_backend_change_to_all_surfaces(self) -> None:
+        self.assertEqual(
+            changed_surfaces.classify(
+                [
+                    "backend/internal/service/gateway_usage_billing.go",
+                    "scripts/sentinels/gateway-tk.json",
+                ]
+            ),
+            {
+                "backend": True,
+                "frontend": False,
+                "deploy": False,
+                "ops": False,
+                "contracts": False,
+                "all": False,
+            },
+        )
+
+    def test_mixed_change_combines_surfaces(self) -> None:
+        self.assertEqual(
+            changed_surfaces.classify(["backend/go.mod", "frontend/pnpm-lock.yaml"]),
+            {
+                "backend": True,
+                "frontend": True,
+                "deploy": False,
+                "ops": False,
+                "contracts": False,
+                "all": False,
+            },
+        )
+
+    def test_ci_infrastructure_change_runs_everything(self) -> None:
+        result = changed_surfaces.classify([".github/actions/go-rolling-cache/action.yml"])
+        self.assertEqual(
+            result,
+            {
+                "backend": False,
+                "frontend": False,
+                "deploy": False,
+                "ops": False,
+                "contracts": False,
+                "all": True,
+            },
+        )
+
+    def test_unknown_path_fails_safe_by_running_everything(self) -> None:
+        result = changed_surfaces.classify(["unexpected/new-surface.bin"])
+        self.assertEqual(
+            result,
+            {
+                "backend": False,
+                "frontend": False,
+                "deploy": False,
+                "ops": False,
+                "contracts": False,
+                "all": True,
+            },
+        )
+
+    def test_whitespace_in_a_git_path_is_not_normalized_into_a_known_surface(self) -> None:
+        result = changed_surfaces.classify([" backend/internal/service/account_service.go"])
+        self.assertEqual(
+            result,
+            {
+                "backend": False,
+                "frontend": False,
+                "deploy": False,
+                "ops": False,
+                "contracts": False,
+                "all": True,
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -121,6 +121,14 @@ case "${PREFLIGHT_FAST:-}" in 1|true|yes|TRUE|YES) _preflight_fast=1 ;; esac
 if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ] && [ "${PREFLIGHT_FAST:-}" != "0" ]; then
     _preflight_fast=1
 fi
+_preflight_skip_slow_ops=0
+case "${PREFLIGHT_SKIP_SLOW_OPS_CONTRACTS:-}" in
+    1|true|yes|TRUE|YES) _preflight_skip_slow_ops=1 ;;
+esac
+_preflight_skip_main_ancestry=0
+case "${PREFLIGHT_SKIP_MAIN_ANCESTRY:-}" in
+    1|true|yes|TRUE|YES) _preflight_skip_main_ancestry=1 ;;
+esac
 
 # ---- TK: background-job helpers ----------------------------------------------
 # The most expensive sub2api gates (QA go test, the unittest-discover suites,
@@ -212,7 +220,7 @@ export PREFLIGHT_BASE="${template_base:-origin/main}"
 _qa_bundle_gate_run() {
     cd backend && go test -tags=unit -v ./internal/observability/qa/bundle ./internal/observability/qa
 }
-if command -v python3 >/dev/null 2>&1 && command -v go >/dev/null 2>&1; then
+if [ "$_preflight_skip_slow_ops" -ne 1 ] && command -v python3 >/dev/null 2>&1 && command -v go >/dev/null 2>&1; then
     _bg_spawn qa_bundle _qa_bundle_gate_run
 fi
 if command -v python3 >/dev/null 2>&1; then
@@ -247,11 +255,13 @@ _bg_spawn ssm_parse bash ./scripts/checks/check-stage0-ssm-host-parse.sh
 # deleted-ref base and scans colocated Python tests outside tests/ directories.
 _dev_preflight_template="./dev-rules/templates/preflight.sh"
 if ! grep -q 'check_deleted_file_refs.py --base' "$_dev_preflight_template" 2>/dev/null || \
-   ! grep -q 'check_existence_only_tests.py --glob' "$_dev_preflight_template" 2>/dev/null; then
+   ! grep -q 'check_existence_only_tests.py --glob' "$_dev_preflight_template" 2>/dev/null || \
+   [ "${PREFLIGHT_SKIP_AGENT_CONTRACT:-}" = "1" ]; then
     _dev_preflight_template="$(mktemp "${TMPDIR:-/tmp}/preflight-dev-rules.XXXXXX")"
     sed \
         -e 's|check_deleted_file_refs\.py >|check_deleted_file_refs.py --base "${PREFLIGHT_BASE:-origin/main}" >|' \
         -e 's|"$PYTHON_BIN" dev-rules/scripts/check_existence_only_tests\.py >|"$PYTHON_BIN" -W ignore::SyntaxWarning dev-rules/scripts/check_existence_only_tests.py --glob "test_*.py" --glob "*_test.py" --glob "**/test_*.py" --glob "**/*_test.py" >|' \
+        -e 's|^if \[ -f scripts/export_agent_contract\.py \]; then$|if [ "${PREFLIGHT_SKIP_AGENT_CONTRACT:-}" = "1" ]; then skip "unchanged CI surface; required preflight gate not needed"; elif [ -f scripts/export_agent_contract.py ]; then|' \
         ./dev-rules/templates/preflight.sh > "$_dev_preflight_template"
     chmod +x "$_dev_preflight_template"
 fi
@@ -1329,7 +1339,9 @@ fi
 # ---- sub2api: QA Phase 1 closeout + Phase 2 baseline ops -------------------
 echo ""
 echo "=== sub2api: QA Phase 1 closeout + Phase 2 baseline ==="
-if ! command -v python3 >/dev/null 2>&1; then
+if [ "$_preflight_skip_slow_ops" -eq 1 ]; then
+    echo "  skip: unchanged CI surface; required preflight gate not needed"
+elif ! command -v python3 >/dev/null 2>&1; then
     echo "  FAIL: python3 not on PATH (required by QA phase ops scripts)"
     errors=$((errors + 1))
 elif ! python3 -m py_compile ./ops/qa/edge_phase1_closeout.py ./ops/qa/prod_phase2_baseline.py; then
@@ -1346,7 +1358,9 @@ fi
 # authorization test in verbose output so a rename/deletion cannot pass vacuously.
 echo ""
 echo "=== sub2api: QA Bundle service/worker contract ==="
-if ! command -v go >/dev/null 2>&1; then
+if [ "$_preflight_skip_slow_ops" -eq 1 ]; then
+    echo "  skip: unchanged CI surface; required preflight gate not needed"
+elif ! command -v go >/dev/null 2>&1; then
     echo "  FAIL: go not on PATH (required to run QA Bundle contract tests)"
     errors=$((errors + 1))
 elif ! _bg_spawned qa_bundle; then
@@ -1636,7 +1650,9 @@ fi
 # ---- sub2api: nonprod archive/restore rehearsal ----------------------------
 echo ""
 echo "=== sub2api: nonprod archive/restore rehearsal ==="
-if ! command -v python3 >/dev/null 2>&1; then
+if [ "$_preflight_skip_slow_ops" -eq 1 ]; then
+    echo "  skip: unchanged CI surface; required preflight gate not needed"
+elif ! command -v python3 >/dev/null 2>&1; then
     echo "  FAIL: python3 not on PATH (required for archive rehearsal tests)"
     errors=$((errors + 1))
 elif ! python3 ./ops/archive/test_data_layer_archive_rehearsal.py >/dev/null 2>&1; then
@@ -1994,7 +2010,9 @@ fi
 # at PR-merge time (PR.base must be ancestor of PR.head).
 echo ""
 echo "=== sub2api: main ancestry anchor ==="
-if ! command -v python3 >/dev/null 2>&1; then
+if [ "$_preflight_skip_main_ancestry" -eq 1 ]; then
+    echo "  skip: owned by lightweight Main Ancestry Guard push job"
+elif ! command -v python3 >/dev/null 2>&1; then
     echo "  FAIL: python3 not on PATH (required to read .main-ancestry-anchor)"
     errors=$((errors + 1))
 elif [ "$_preflight_fast" = "1" ]; then

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Behavior contract for expensive-job routing in backend-ci.yml."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+import yaml
+
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "backend-ci.yml"
+
+
+class BackendCIRoutingTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.jobs = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+
+    def test_changes_job_exports_all_surface_decisions(self) -> None:
+        outputs = self.jobs["changes"]["outputs"]
+        self.assertEqual(set(outputs), {"backend", "frontend", "deploy", "ops", "contracts", "all"})
+
+    def test_expensive_jobs_depend_on_the_matching_surface(self) -> None:
+        expected = {
+            "shell": "deploy",
+            "test-unit": "backend",
+            "test-integration": "backend",
+            "golangci-lint": "backend",
+            "backend-security": "backend",
+            "frontend": "frontend",
+            "frontend-security": "frontend",
+        }
+        for job_name, surface in expected.items():
+            with self.subTest(job=job_name):
+                job = self.jobs[job_name]
+                needs = job.get("needs")
+                self.assertIn("changes", [needs] if isinstance(needs, str) else needs)
+                condition = job.get("if", "")
+                self.assertIn(f"needs.changes.outputs.{surface} == 'true'", condition)
+                self.assertIn("needs.changes.outputs.all == 'true'", condition)
+
+    def test_required_preflight_owns_path_conditioned_contract_gates(self) -> None:
+        preflight = self.jobs["preflight"]
+        self.assertEqual(preflight.get("needs"), "changes")
+        self.assertIn("always()", preflight.get("if", ""))
+        run_preflight = next(
+            step for step in preflight["steps"] if step.get("name") == "Run preflight"
+        )
+        env = run_preflight["env"]
+        self.assertIn("needs.changes.outputs.ops", env["PREFLIGHT_SKIP_SLOW_OPS_CONTRACTS"])
+        self.assertIn("needs.changes.outputs.contracts", env["PREFLIGHT_SKIP_AGENT_CONTRACT"])
+
+    def test_preflight_job_runs_ci_orchestration_contracts(self) -> None:
+        matching_steps = [
+            step
+            for step in self.jobs["preflight"]["steps"]
+            if step.get("name") == "CI orchestration contract tests"
+        ]
+        self.assertEqual(len(matching_steps), 1)
+        step = matching_steps[0]
+        command = step.get("run", "")
+        expected_modules = {
+            "scripts.test_preflight_ci_lint_skip",
+            "scripts.checks.test_release_cache_key_parity",
+            "scripts.checks.test_go_rolling_cache_policy",
+            "scripts.test_preflight_ci_handoffs",
+            "scripts.test_ci_gate_handoffs",
+            "scripts.ci.test_changed_surfaces",
+            "scripts.test_backend_ci_routing",
+        }
+        for module in expected_modules:
+            with self.subTest(module=module):
+                self.assertIn(module, command)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_ci_gate_handoffs.py
+++ b/scripts/test_ci_gate_handoffs.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Workflow behavior tests for ancestry and agent-contract handoffs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_CI = REPO_ROOT / ".github" / "workflows" / "backend-ci.yml"
+ANCESTRY = REPO_ROOT / ".github" / "workflows" / "main-ancestry-guard.yml"
+
+
+def load_workflow(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def workflow_on(workflow: dict) -> dict:
+    return workflow.get("on") or workflow.get(True) or {}
+
+
+class CIGateHandoffTest(unittest.TestCase):
+    def test_required_preflight_routes_expensive_gate_implementations(self) -> None:
+        workflow = load_workflow(BACKEND_CI)
+        run_preflight = next(
+            step
+            for step in workflow["jobs"]["preflight"]["steps"]
+            if step.get("name") == "Run preflight"
+        )
+        self.assertEqual(run_preflight["env"]["PREFLIGHT_SKIP_MAIN_ANCESTRY"], "1")
+        skip_expression = run_preflight["env"]["PREFLIGHT_SKIP_AGENT_CONTRACT"]
+        self.assertIn("needs.changes.outputs.contracts", skip_expression)
+        self.assertIn("needs.changes.outputs.all", skip_expression)
+
+    def test_main_push_ancestry_detection_uses_a_lightweight_full_history_job(self) -> None:
+        workflow = load_workflow(ANCESTRY)
+        self.assertEqual(workflow_on(workflow)["push"]["branches"], ["main"])
+        job = workflow["jobs"]["main-ancestry-anchor"]
+        checkout = next(step for step in job["steps"] if step.get("uses") == "actions/checkout@v6")
+        self.assertEqual(checkout["with"]["fetch-depth"], 0)
+        self.assertNotIn("submodules", checkout["with"])
+        commands = "\n".join(step.get("run", "") for step in job["steps"])
+        self.assertIn("python3 scripts/checks/main-ancestry-anchor.py", commands)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_preflight_ci_handoffs.py
+++ b/scripts/test_preflight_ci_handoffs.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Workflow behavior tests for changed-surface routing of slow ops contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_CI = REPO_ROOT / ".github" / "workflows" / "backend-ci.yml"
+
+
+def load_workflow(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+class PreflightCIHandoffTest(unittest.TestCase):
+    def test_required_preflight_runs_slow_ops_only_for_matching_surfaces(self) -> None:
+        workflow = load_workflow(BACKEND_CI)
+        run_preflight = next(
+            step
+            for step in workflow["jobs"]["preflight"]["steps"]
+            if step.get("name") == "Run preflight"
+        )
+        skip_expression = run_preflight["env"]["PREFLIGHT_SKIP_SLOW_OPS_CONTRACTS"]
+        self.assertIn("needs.changes.outputs.ops", skip_expression)
+        self.assertIn("needs.changes.outputs.all", skip_expression)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_preflight_ci_lint_skip.py
+++ b/scripts/test_preflight_ci_lint_skip.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Behavior tests for the local-lint command consumed by preflight."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LINT_CONFIG = REPO_ROOT / ".preflight" / "local-lint.conf"
+
+
+def configured_command() -> str:
+    commands = [
+        line.strip()
+        for line in LINT_CONFIG.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    if len(commands) != 1:
+        raise AssertionError(f"expected exactly one local lint command, got {commands!r}")
+    return commands[0]
+
+
+def run_configured_command(*, github_actions: bool) -> bool:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        (root / "backend").mkdir()
+        fake_bin = root / "bin"
+        fake_bin.mkdir()
+        marker = root / "make-called"
+        fake_make = fake_bin / "make"
+        fake_make.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            f"touch {marker!s}\n",
+            encoding="utf-8",
+        )
+        fake_make.chmod(0o755)
+        env = os.environ.copy()
+        env["PATH"] = f"{fake_bin}:{env['PATH']}"
+        if github_actions:
+            env["GITHUB_ACTIONS"] = "true"
+        else:
+            env.pop("GITHUB_ACTIONS", None)
+        result = subprocess.run(
+            ["bash", "-c", configured_command()],
+            cwd=root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self_message = result.stdout + result.stderr
+        if result.returncode != 0:
+            raise AssertionError(self_message)
+        return marker.exists()
+
+
+class PreflightCILintSkipTest(unittest.TestCase):
+    def test_github_actions_does_not_run_duplicate_lint(self) -> None:
+        self.assertFalse(run_configured_command(github_actions=True))
+
+    def test_local_preflight_still_runs_lint(self) -> None:
+        self.assertTrue(run_configured_command(github_actions=False))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

- 按变更表面路由 backend、frontend、deploy、ops、contracts 等 CI 任务，避免文档、缓存与 sentinel 等改动触发无关重项。
- GitHub Actions 的 preflight 跳过重复 `make lint`，本地 preflight 保留完整 lint。
- PR/非 main 的 Go rolling cache 改为 restore-only；main push 独立预热 release cache。
- 将 main ancestry 检查拆为轻量 full-history job，并用契约测试固定任务交接、缓存策略与路由行为。

## 风险

- 主要风险是 changed-surface 分类遗漏导致应运行的任务被跳过；通过默认保守回退、required preflight 动态执行重项及路由契约测试约束。
- release cache 写入仅允许 main push，避免 PR 并发污染缓存；缓存 key parity 由机械检查保证。
- 不修改业务代码、公共 API、数据结构或部署状态。

## 验证

- `python3 -m unittest scripts.test_preflight_ci_lint_skip scripts.checks.test_release_cache_key_parity scripts.checks.test_go_rolling_cache_policy scripts.test_preflight_ci_handoffs scripts.test_ci_gate_handoffs scripts.ci.test_changed_surfaces scripts.test_backend_ci_routing`（25 项通过）
- `GOTOOLCHAIN=go1.26.6 PREFLIGHT_BASE=origin/main ./scripts/preflight.sh`（通过）
- `git diff origin/main...HEAD --check`（通过）

## 提交

- `96c457175 chore(ci): reduce default pipeline critical path`

最新提交：`96c457175`
