### PR TITLE
chore(ci): 升级 cache action 到 Node 24 runtime

### DIFF
--- a/.github/actions/cache-and-checkout-new-api/action.yml
+++ b/.github/actions/cache-and-checkout-new-api/action.yml
@@ -11,7 +11,7 @@ runs:
       run: echo "sha=$(tr -d '[:space:]' < "${GITHUB_WORKSPACE}/.new-api-ref")" >> "$GITHUB_OUTPUT"
 
     - name: Restore cached new-api sibling
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: .cache/new-api
         key: new-api-${{ steps.new-api-pin.outputs.sha }}

--- a/.github/actions/go-rolling-cache/action.yml
+++ b/.github/actions/go-rolling-cache/action.yml
@@ -30,7 +30,7 @@ runs:
   steps:
     - name: Restore Go module cache (non-main writer)
       if: github.event_name != 'push' || github.ref != 'refs/heads/main'
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-gomod-${{ hashFiles('backend/go.sum') }}
@@ -38,7 +38,7 @@ runs:
 
     - name: Go module cache (main writer)
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-gomod-${{ hashFiles('backend/go.sum') }}
@@ -46,7 +46,7 @@ runs:
 
     - name: Restore Go build/test cache (non-main writer, ${{ inputs.prefix }})
       if: github.event_name != 'push' || github.ref != 'refs/heads/main'
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       with:
         path: ~/.cache/go-build
         key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
@@ -56,7 +56,7 @@ runs:
 
     - name: Go build/test cache (rolling main writer, ${{ inputs.prefix }})
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cache/go-build
         key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -103,6 +103,7 @@ jobs:
         run: |
           python3 -m unittest \
             scripts.test_preflight_ci_lint_skip \
+            scripts.checks.test_cache_action_runtime \
             scripts.checks.test_release_cache_key_parity \
             scripts.checks.test_go_rolling_cache_policy \
             scripts.test_preflight_ci_handoffs \

--- a/.github/workflows/edge-health-watch.yml
+++ b/.github/workflows/edge-health-watch.yml
@@ -65,7 +65,7 @@ jobs:
           fi
 
       - name: Restore previous state key
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: .edge-health-state
           key: edge-health-watch-state-${{ github.run_id }}
@@ -112,7 +112,7 @@ jobs:
       - name: Save state key
         # Not on dry-run: a dry-run must not advance the dedup state (see Decide step).
         if: inputs.dry_run != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: .edge-health-state
           key: edge-health-watch-state-${{ github.run_id }}

--- a/.github/workflows/ops-pgdump-restore-canary.yml
+++ b/.github/workflows/ops-pgdump-restore-canary.yml
@@ -75,7 +75,7 @@ jobs:
           aws-region: ${{ env.TARGET_REGION }}
 
       - name: Restore per-target alert state
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: .pgdump-canary-state/${{ env.TARGET_ID }}
           key: pgdump-restore-canary-${{ env.TARGET_ID }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -135,7 +135,7 @@ jobs:
 
       - name: Save per-target alert state
         if: always() && steps.alert_delivery.outcome == 'success'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: .pgdump-canary-state/${{ env.TARGET_ID }}
           key: pgdump-restore-canary-${{ env.TARGET_ID }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
       # Release runs on a tag ref (`refs/tags/vX.Y.Z`). GitHub Actions scopes
       # cache restore to the current ref + the DEFAULT BRANCH only, so a cache
       # SAVED here (on the tag ref) is invisible to the next tag's release — the
-      # old `actions/cache@v4` save was pure dead weight (every release logged
+      # the old cache saver was pure dead weight (every release logged
       # `Cache not found` and cold-compiled arm64 from scratch, ~4m). The warm
       # cache is now produced by the `warm-release-cache` job in backend-ci.yml
       # on push to `main` (the default branch), which IS readable from tag runs.
@@ -173,7 +173,7 @@ jobs:
       # stale entry (e.g. after a .new-api-ref bump) is simply unused, never
       # wrong — release recompiles only changed packages + relinks.
       - name: Restore cross-arch Go build cache (warmed on main)
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/warm-release-cache-main.yml
+++ b/.github/workflows/warm-release-cache-main.yml
@@ -35,7 +35,7 @@ jobs:
           check-latest: false
           cache: false
       - name: Rolling Go build cache (amd64 + arm64 cross-compile)
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cache/go-build

--- a/scripts/checks/release-cache-key-parity.py
+++ b/scripts/checks/release-cache-key-parity.py
@@ -7,9 +7,9 @@ to cold-compiling arm64 ~4m every time, with NO error — exactly the failure
 mode that went unnoticed for weeks before #576):
 
   * .github/workflows/warm-release-cache-main.yml — `warm-release-cache` SAVES
-    the cache on `main` (the default branch) with `actions/cache@v4`.
+    the cache on `main` (the default branch) with `actions/cache@v6`.
   * .github/workflows/release.yml     — RESTORES it on the tag ref with
-    `actions/cache/restore@v4` (restore-only; saving here would re-create the
+    `actions/cache/restore@v6` (restore-only; saving here would re-create the
     dead tag-scoped caches #576 removed).
 
 The two invariants that, if broken, silently kill the speed-up:
@@ -18,8 +18,8 @@ The two invariants that, if broken, silently kill the speed-up:
      `<runner.os>-go-release-<hashFiles(backend/go.sum)>`. Rename it in one file
      only and release's restore-keys never match the warm cache again.
   2. DIRECTIONALITY — backend-ci's go-release step uses the SAVING action
-     (`actions/cache@v4`); release's uses the RESTORE-ONLY action
-     (`actions/cache/restore@v4`). Re-adding a saver to release.yml resurrects
+     (`actions/cache@v6`); release's uses the RESTORE-ONLY action
+     (`actions/cache/restore@v6`). Re-adding a saver to release.yml resurrects
      the per-tag-ref dead caches.
 
 Same doctrine as scripts/checks/merge-gate-parity.py: a soft "keep these two in
@@ -44,8 +44,8 @@ SHARED_KEY_PREFIX = "${{ runner.os }}-go-release-${{ hashFiles('backend/go.sum')
 # Marker substring that identifies a go-release cache key line in either file.
 KEY_MARKER = "go-release"
 
-SAVE_ACTION = "actions/cache@v4"
-RESTORE_ACTION = "actions/cache/restore@v4"
+SAVE_ACTION = "actions/cache@v6"
+RESTORE_ACTION = "actions/cache/restore@v6"
 
 
 def _fail(quiet: bool, msg: str) -> None:

--- a/scripts/checks/test_cache_action_runtime.py
+++ b/scripts/checks/test_cache_action_runtime.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Contract tests for the GitHub Actions cache runtime major."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GITHUB_DIR = REPO_ROOT / ".github"
+CACHE_ACTION = re.compile(
+    r"actions/cache(?P<variant>/(?:restore|save))?@v(?P<major>\d+)"
+)
+REQUIRED_MAJOR = "6"
+
+
+class CacheActionRuntimeTest(unittest.TestCase):
+    def test_all_direct_cache_actions_use_node24_runtime_major(self) -> None:
+        matches: list[tuple[Path, int, str]] = []
+        outdated: list[str] = []
+
+        workflow_files = sorted(GITHUB_DIR.rglob("*.yml")) + sorted(
+            GITHUB_DIR.rglob("*.yaml")
+        )
+        for path in workflow_files:
+            for line_number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), start=1
+            ):
+                for match in CACHE_ACTION.finditer(line):
+                    action = match.group(0)
+                    matches.append((path, line_number, action))
+                    if match.group("major") != REQUIRED_MAJOR:
+                        relative = path.relative_to(REPO_ROOT)
+                        outdated.append(f"{relative}:{line_number}: {action}")
+
+        self.assertTrue(matches, "expected at least one direct actions/cache reference")
+        self.assertEqual(
+            outdated,
+            [],
+            "direct cache actions must use v6 (Node 24 runtime):\n"
+            + "\n".join(outdated),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/checks/test_go_rolling_cache_policy.py
+++ b/scripts/checks/test_go_rolling_cache_policy.py
@@ -17,13 +17,13 @@ NON_MAIN_IF = "github.event_name != 'push' || github.ref != 'refs/heads/main'"
 class GoRollingCachePolicyTest(unittest.TestCase):
     def test_only_main_push_steps_can_save_caches(self) -> None:
         steps = yaml.safe_load(ACTION.read_text(encoding="utf-8"))["runs"]["steps"]
-        saving = [step for step in steps if step.get("uses") == "actions/cache@v4"]
+        saving = [step for step in steps if step.get("uses") == "actions/cache@v6"]
         self.assertEqual(len(saving), 2)
         self.assertTrue(all(step.get("if") == MAIN_WRITER_IF for step in saving))
 
     def test_non_main_events_restore_but_never_save_both_cache_layers(self) -> None:
         steps = yaml.safe_load(ACTION.read_text(encoding="utf-8"))["runs"]["steps"]
-        restore_only = [step for step in steps if step.get("uses") == "actions/cache/restore@v4"]
+        restore_only = [step for step in steps if step.get("uses") == "actions/cache/restore@v6"]
         self.assertEqual(len(restore_only), 2)
         self.assertTrue(all(step.get("if") == NON_MAIN_IF for step in restore_only))
         restored_paths = {step["with"]["path"] for step in restore_only}

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -2933,6 +2933,17 @@ else
     echo "  ok: release/warm cache key prefix + directionality in sync"
 fi
 
+echo ""
+echo "=== sub2api: GitHub cache action Node runtime ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required by cache action runtime contract)"
+    errors=$((errors + 1))
+elif ! python3 -m unittest scripts.checks.test_cache_action_runtime >/dev/null; then
+    errors=$((errors + 1))
+else
+    echo "  ok: all direct actions/cache references use the Node 24 runtime major"
+fi
+
 # ---- sub2api: pnpm audit owner contract -------------------------------------
 # Project installs stay on pnpm 9, while security audit uses a pinned pnpm 11
 # owner because npm retired the quick-audit endpoint used by pnpm 9/10.


### PR DESCRIPTION
## 摘要

- 将 workflow 与 composite action 中直接使用的 `actions/cache`、`actions/cache/restore`、`actions/cache/save` 统一升级到 v6。
- 保持缓存 key、路径以及 main-write / PR-restore-only 方向不变。
- 新增仓库级契约测试，阻止低于 v6 的 cache action 引用重新进入，并接入 required preflight。

## 风险

- 风险限于 GitHub Actions cache runtime 主版本升级，不修改业务代码、公共契约、缓存数据格式或发布流程语义。
- 已核对 release、rolling Go cache、edge health 与 pgdump canary 的 restore/save 方向保持原样。
- `sentinel-registry-reviewed`：本次只替换既有 workflow action runtime，不新增或改变 TokenKey load-bearing 业务语义，无需新增 sentinel anchor。

## 验证

- CI orchestration 契约测试：26 项通过。
- GitHub Actions YAML：36 个文件解析通过。
- `GOTOOLCHAIN=go1.26.6 PREFLIGHT_BASE=origin/main ./scripts/preflight.sh`：通过。
- `git diff origin/main...HEAD --check`：通过。

## 提交

- `d1904ffce chore(ci): upgrade cache actions to node24 runtime`

最新提交：`d1904ffce`
