### PR TITLE
chore(ci): stop rerunning unit packages in integration

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -122,6 +122,8 @@ jobs:
           go-version-file: backend/go.mod
           check-latest: false
           cache: false
+      - name: Integration package discovery contract tests
+        run: python3 -m unittest scripts.ci.test_integration_packages
       - uses: ./.github/actions/go-rolling-cache
         with:
           prefix: preflight

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -60,7 +60,9 @@ test-unit:
 	go test -tags=unit ./...
 
 test-integration:
-	go test -tags=integration ./...
+	@packages="$$(python3 ../scripts/ci/integration-packages.py --root .)" || exit $$?; \
+	printf 'integration packages:\n%s\n' "$$packages"; \
+	go test -tags=integration $$packages
 
 lint: ensure-golangci-lint
 	$(GOLANGCI_LINT) run ./... $(GOLANGCI_LINT_FAST_ARGS)

--- a/scripts/ci/integration-packages.py
+++ b/scripts/ci/integration-packages.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""List Go packages that gain test files when the integration tag is enabled."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+
+def _go_list(root: Path, tags: str | None = None) -> dict[str, dict[str, object]]:
+    command = ["go", "list", "-json"]
+    if tags:
+        command.append(f"-tags={tags}")
+    command.append("./...")
+    result = subprocess.run(
+        command,
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "go list failed")
+
+    packages: dict[str, dict[str, object]] = {}
+    decoder = json.JSONDecoder()
+    offset = 0
+    while offset < len(result.stdout):
+        while offset < len(result.stdout) and result.stdout[offset].isspace():
+            offset += 1
+        if offset >= len(result.stdout):
+            break
+        package, offset = decoder.raw_decode(result.stdout, offset)
+        packages[str(package["ImportPath"])] = package
+    return packages
+
+
+def integration_packages(root: Path) -> list[str]:
+    root = root.resolve()
+    baseline = _go_list(root)
+    tagged = _go_list(root, "integration")
+    selected: list[str] = []
+    for import_path, package in tagged.items():
+        baseline_package = baseline.get(import_path, {})
+        baseline_tests = set(baseline_package.get("TestGoFiles", [])) | set(
+            baseline_package.get("XTestGoFiles", [])
+        )
+        tagged_tests = set(package.get("TestGoFiles", [])) | set(
+            package.get("XTestGoFiles", [])
+        )
+        if not tagged_tests - baseline_tests:
+            continue
+        relative = Path(str(package["Dir"])).resolve().relative_to(root)
+        selected.append("." if relative == Path(".") else f"./{relative.as_posix()}")
+    return sorted(selected)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args(argv)
+    try:
+        packages = integration_packages(args.root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"integration package discovery failed: {exc}", file=sys.stderr)
+        return 1
+    if not packages:
+        print("no integration-tagged test packages found", file=sys.stderr)
+        return 1
+    print("\n".join(packages))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_integration_packages.py
+++ b/scripts/ci/test_integration_packages.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Behavior tests for integration test package discovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parent / "integration-packages.py"
+
+
+class IntegrationPackagesTest(unittest.TestCase):
+    def test_lists_only_packages_that_gain_tests_from_the_integration_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "go.mod").write_text("module example.com/integrationfixture\n\ngo 1.26\n")
+            self._write_package(root, "plain", "plain_test.go", "", "TestPlain")
+            self._write_package(
+                root,
+                "repository",
+                "repository_integration_test.go",
+                "//go:build integration\n\n",
+                "TestRepositoryIntegration",
+            )
+            self._write_package(
+                root,
+                "routes",
+                "routes_integration_test.go",
+                "//go:build integration && (linux || darwin)\n\n",
+                "TestRoutesIntegration",
+            )
+            self._write_package(
+                root,
+                "negated",
+                "negated_test.go",
+                "//go:build !integration\n\n",
+                "TestNegated",
+            )
+
+            result = subprocess.run(
+                ["python3", str(SCRIPT), "--root", str(root)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.splitlines(), ["./repository", "./routes"])
+
+    def test_fails_when_no_integration_tagged_tests_exist(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "go.mod").write_text("module example.com/plainfixture\n\ngo 1.26\n")
+            self._write_package(root, "plain", "plain_test.go", "", "TestPlain")
+
+            result = subprocess.run(
+                ["python3", str(SCRIPT), "--root", str(root)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("no integration-tagged test packages found", result.stderr)
+
+    @staticmethod
+    def _write_package(
+        root: Path,
+        package: str,
+        test_file: str,
+        build_constraint: str,
+        test_name: str,
+    ) -> None:
+        package_dir = root / package
+        package_dir.mkdir(parents=True, exist_ok=True)
+        (package_dir / f"{package}.go").write_text(
+            f"package {package}\n", encoding="utf-8"
+        )
+        (package_dir / test_file).write_text(
+            build_constraint
+            + textwrap.dedent(
+                f"""
+                package {package}
+
+                import "testing"
+
+                func {test_name}(t *testing.T) {{}}
+                """
+            ),
+            encoding="utf-8",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -10,6 +10,7 @@ import yaml
 
 
 WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "backend-ci.yml"
+BACKEND_MAKEFILE = Path(__file__).resolve().parents[1] / "backend" / "Makefile"
 
 
 class BackendCIRoutingTest(unittest.TestCase):
@@ -71,6 +72,33 @@ class BackendCIRoutingTest(unittest.TestCase):
         for module in expected_modules:
             with self.subTest(module=module):
                 self.assertIn(module, command)
+
+    def test_go_dependent_integration_contract_runs_after_pinned_setup(self) -> None:
+        steps = self.jobs["preflight"]["steps"]
+        orchestration = next(
+            step for step in steps if step.get("name") == "CI orchestration contract tests"
+        )
+        self.assertNotIn("scripts.ci.test_integration_packages", orchestration.get("run", ""))
+
+        setup_index = next(
+            index for index, step in enumerate(steps) if step.get("uses") == "actions/setup-go@v6"
+        )
+        contract_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("name") == "Integration package discovery contract tests"
+        )
+        self.assertGreater(contract_index, setup_index)
+        self.assertIn(
+            "scripts.ci.test_integration_packages",
+            steps[contract_index].get("run", ""),
+        )
+
+    def test_integration_target_uses_discovered_owner_packages(self) -> None:
+        makefile = BACKEND_MAKEFILE.read_text(encoding="utf-8")
+        target = makefile.split("test-integration:\n", 1)[1].split("\n\n", 1)[0]
+        self.assertIn("integration-packages.py", target)
+        self.assertNotIn("go test -tags=integration ./...", target)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 摘要

- 通过普通与 `integration` build tag 下的 `go list` 测试文件差集，自动发现真正拥有 integration 测试的 package。
- `make test-integration` 仅执行发现出的 owner packages，不再重复运行只有 unit 测试的 package。
- 将依赖 Go 的 discovery 契约测试放到 pinned `actions/setup-go@v6` 之后，并增加 workflow 顺序守卫。

## 风险

- `no-web-impact`：仅调整 CI 测试发现与执行范围，不影响 Web、运行时业务逻辑或公共契约。
- discovery 为空或 `go list` 失败时保持 fail closed，避免 integration 检查静默跳过。
- `internal/observability/qa/archive` 依赖 Docker/testcontainers；本机无可用 Docker daemon，但同一 HEAD 的 GitHub Actions `test-integration` 已通过。

## 验证

- `GOTOOLCHAIN=go1.26.6 PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：通过。
- `python3 -m unittest scripts.ci.test_integration_packages scripts.test_backend_ci_routing -v`：8 个测试通过。
- 实际发现 6 个 integration owner packages。
- 非 Docker owners 的 `go test -tags=integration`：全部通过。
- GitHub Actions：`preflight`、`test-unit`、`test-integration`、`golangci-lint`、security 与 frontend checks 全部通过。
- 独立只读复审：Critical / Important / Minor 均为 0。

## 提交

- `0628d1af0 chore(ci): stop rerunning unit packages in integration`
- 最新提交：`0628d1af0`