### PR TITLE
test(ci): remove external and backoff waits from unit tests

### DIFF
--- a/backend/internal/handler/failover_loop.go
+++ b/backend/internal/handler/failover_loop.go
@@ -24,6 +24,8 @@ type TempUnscheduler interface {
 // FailoverAction 表示 failover 错误处理后的下一步动作
 type FailoverAction int
 
+type failoverSleeper func(context.Context, time.Duration) bool
+
 const (
 	// FailoverContinue 继续循环（同账号重试或切换账号，调用方统一 continue）
 	FailoverContinue FailoverAction = iota
@@ -130,6 +132,7 @@ type FailoverState struct {
 	LastFailoverErr       *service.UpstreamFailoverError
 	ForceCacheBilling     bool
 	hasBoundSession       bool
+	sleeper               failoverSleeper
 
 	// profitVetoedAccountIDs 记录被分组利润门终检否决的账号，是 FailedAccountIDs
 	// 的子集。之所以单独维护：HandleSelectionExhausted 的 503 退避分支会清空
@@ -143,13 +146,28 @@ type FailoverState struct {
 
 // NewFailoverState 创建 failover 状态
 func NewFailoverState(maxSwitches int, hasBoundSession bool) *FailoverState {
+	return newFailoverState(maxSwitches, hasBoundSession, sleepWithContext)
+}
+
+func newFailoverState(maxSwitches int, hasBoundSession bool, sleeper failoverSleeper) *FailoverState {
+	if sleeper == nil {
+		sleeper = sleepWithContext
+	}
 	return &FailoverState{
 		MaxSwitches:            maxSwitches,
 		FailedAccountIDs:       make(map[int64]struct{}),
 		SameAccountRetryCount:  make(map[int64]int),
 		hasBoundSession:        hasBoundSession,
+		sleeper:                sleeper,
 		profitVetoedAccountIDs: make(map[int64]struct{}),
 	}
+}
+
+func (s *FailoverState) sleep(ctx context.Context, delay time.Duration) bool {
+	if s.sleeper == nil {
+		return sleepWithContext(ctx, delay)
+	}
+	return s.sleeper(ctx, delay)
 }
 
 // RecordProfitVeto 记录一次分组利润门终检否决：把账号加入排除列表（同时登记到
@@ -244,7 +262,7 @@ func (s *FailoverState) HandleFailoverError(
 			zap.Int("same_account_retry_max", sameAccountRetryLimit),
 			zap.Duration("retry_delay", retryDelay),
 		)
-		if !sleepWithContext(ctx, retryDelay) {
+		if !s.sleep(ctx, retryDelay) {
 			return FailoverCanceled
 		}
 		s.SameAccountRetryCount[accountID]++
@@ -279,7 +297,7 @@ func (s *FailoverState) HandleFailoverError(
 	// Antigravity 平台换号线性递增延时
 	if platform == service.PlatformAntigravity {
 		delay := time.Duration(s.SwitchCount-1) * time.Second
-		if !sleepWithContext(ctx, delay) {
+		if !s.sleep(ctx, delay) {
 			return FailoverCanceled
 		}
 	}
@@ -324,7 +342,7 @@ func (s *FailoverState) HandleSelectionExhausted(ctx context.Context, thinPoolEx
 			zap.Int("switch_count", s.SwitchCount),
 			zap.Int("max_switches", s.MaxSwitches),
 		)
-		if !sleepWithContext(ctx, singleAccountBackoffDelay) {
+		if !s.sleep(ctx, singleAccountBackoffDelay) {
 			return FailoverCanceled
 		}
 		logger.FromContext(ctx).Warn("gateway.failover_single_account_retry",

--- a/backend/internal/handler/failover_loop_profit_veto_test.go
+++ b/backend/internal/handler/failover_loop_profit_veto_test.go
@@ -66,7 +66,7 @@ func runProfitVetoLoop(t *testing.T, fs *FailoverState, pool []int64, vetoed map
 // 「选号 → 否决 → 排除 → 选号耗尽 → 清空排除 → 睡 2s → 选号」会无限循环，
 // 因为利润否决不推进 SwitchCount，退避条件永远成立。
 func TestProfitVetoAfter503DoesNotLivelock(t *testing.T) {
-	fs := NewFailoverState(10, false)
+	fs := newFastFailoverState(10, false)
 	// 已经历一次真实 503（Antigravity 单账号分组 MODEL_CAPACITY_EXHAUSTED 是设计内路径）。
 	fs.LastFailoverErr = newTestFailoverErr(503, false, false)
 	fs.SwitchCount = 1
@@ -85,7 +85,7 @@ func TestProfitVetoAfter503DoesNotLivelock(t *testing.T) {
 // 503 退避语义：排除列表里仍有非利润否决的账号时，退避照常清空并重试，
 // 只是被利润门否决的账号不再复活。
 func TestProfitVetoKeepsBackoffUsefulForHealthyAccount(t *testing.T) {
-	fs := NewFailoverState(10, false)
+	fs := newFastFailoverState(10, false)
 	fs.LastFailoverErr = newTestFailoverErr(503, false, false)
 	fs.SwitchCount = 1
 	// 账号 1 因真实 503 被排除；账号 2 会被利润门否决。
@@ -102,7 +102,7 @@ func TestProfitVetoKeepsBackoffUsefulForHealthyAccount(t *testing.T) {
 // TestProfitVetoAttemptsCapped 钉死没有 503 参与时，大分组整池越线也会在
 // 常数步内终止，而不是把整池逐个选一遍。
 func TestProfitVetoAttemptsCapped(t *testing.T) {
-	fs := NewFailoverState(10, false)
+	fs := newFastFailoverState(10, false)
 	pool := make([]int64, 0, 64)
 	vetoed := make(map[int64]bool, 64)
 	for id := int64(1); id <= 64; id++ {
@@ -120,7 +120,7 @@ func TestProfitVetoAttemptsCapped(t *testing.T) {
 // TestRecordProfitVetoExcludesAccount 钉死 RecordProfitVeto 仍然把账号加入
 // 调度排除列表（选号入参用的就是 FailedAccountIDs）。
 func TestRecordProfitVetoExcludesAccount(t *testing.T) {
-	fs := NewFailoverState(10, false)
+	fs := newFastFailoverState(10, false)
 	require.Equal(t, FailoverContinue, fs.RecordProfitVeto(42))
 	require.Contains(t, fs.FailedAccountIDs, int64(42))
 	require.Equal(t, 1, fs.ProfitVetoCount())
@@ -129,7 +129,7 @@ func TestRecordProfitVetoExcludesAccount(t *testing.T) {
 // TestHandleSelectionExhaustedUnaffectedWithoutProfitVeto 钉死未启用利润控制的
 // 请求（无任何利润否决）走的仍是原有退避语义：清空排除列表并重试。
 func TestHandleSelectionExhaustedUnaffectedWithoutProfitVeto(t *testing.T) {
-	fs := NewFailoverState(3, false)
+	fs := newFastFailoverState(3, false)
 	fs.LastFailoverErr = newTestFailoverErr(503, false, false)
 	fs.SwitchCount = 1
 	fs.FailedAccountIDs[100] = struct{}{}

--- a/backend/internal/handler/failover_loop_test.go
+++ b/backend/internal/handler/failover_loop_test.go
@@ -141,6 +141,12 @@ func newTestFailoverErrWithBody(statusCode int, retryable bool, body []byte) *se
 	}
 }
 
+func newFastFailoverState(maxSwitches int, hasBoundSession bool) *FailoverState {
+	return newFailoverState(maxSwitches, hasBoundSession, func(context.Context, time.Duration) bool {
+		return true
+	})
+}
+
 // ---------------------------------------------------------------------------
 // NewFailoverState 测试
 // ---------------------------------------------------------------------------
@@ -231,7 +237,7 @@ func TestSleepWithContext(t *testing.T) {
 func TestHandleFailoverError_BasicSwitch(t *testing.T) {
 	t.Run("显式停止不切换账号且旧错误默认仍切换", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		stopErr := &service.UpstreamFailoverError{
 			Stage:             service.GatewayFailureStageAccountAuth,
 			Scope:             service.GatewayFailureScopeProvider,
@@ -257,7 +263,7 @@ func TestHandleFailoverError_BasicSwitch(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		err := &service.UpstreamFailoverError{
 			Stage:             service.GatewayFailureStageAccountAuth,
 			Scope:             service.GatewayFailureScopeAccount,
@@ -275,7 +281,7 @@ func TestHandleFailoverError_BasicSwitch(t *testing.T) {
 
 	t.Run("非重试错误_非Antigravity_直接切换", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		err := newTestFailoverErr(500, false, false)
 
 		action := fs.HandleFailoverError(context.Background(), mock, 100, "openai", 3, err)
@@ -291,7 +297,7 @@ func TestHandleFailoverError_BasicSwitch(t *testing.T) {
 	t.Run("非重试错误_Antigravity_第一次切换无延迟", func(t *testing.T) {
 		// switchCount 从 0→1 时，sleepFailoverDelay(ctx, 1) 的延时 = (1-1)*1s = 0
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		err := newTestFailoverErr(500, false, false)
 
 		start := time.Now()
@@ -306,23 +312,24 @@ func TestHandleFailoverError_BasicSwitch(t *testing.T) {
 	t.Run("非重试错误_Antigravity_第二次切换有1秒延迟", func(t *testing.T) {
 		// switchCount 从 1→2 时，sleepFailoverDelay(ctx, 2) 的延时 = (2-1)*1s = 1s
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		var delays []time.Duration
+		fs := newFailoverState(3, false, func(_ context.Context, delay time.Duration) bool {
+			delays = append(delays, delay)
+			return true
+		})
 		fs.SwitchCount = 1 // 模拟已切换一次
 
 		err := newTestFailoverErr(500, false, false)
-		start := time.Now()
 		action := fs.HandleFailoverError(context.Background(), mock, 200, service.PlatformAntigravity, 3, err)
-		elapsed := time.Since(start)
 
 		require.Equal(t, FailoverContinue, action)
 		require.Equal(t, 2, fs.SwitchCount)
-		require.GreaterOrEqual(t, elapsed, 800*time.Millisecond, "第二次切换延迟应约 1s")
-		require.Less(t, elapsed, 3*time.Second)
+		require.Equal(t, []time.Duration{time.Second}, delays)
 	})
 
 	t.Run("连续切换直到耗尽", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(2, false)
+		fs := newFastFailoverState(2, false)
 
 		// 第一次切换：0→1
 		err1 := newTestFailoverErr(500, false, false)
@@ -354,7 +361,7 @@ func TestHandleFailoverError_BasicSwitch(t *testing.T) {
 
 	t.Run("MaxSwitches为0时首次即耗尽", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(0, false)
+		fs := newFastFailoverState(0, false)
 		err := newTestFailoverErr(500, false, false)
 
 		action := fs.HandleFailoverError(context.Background(), mock, 100, "openai", 3, err)
@@ -371,7 +378,7 @@ func TestHandleFailoverError_BasicSwitch(t *testing.T) {
 func TestHandleFailoverError_CacheBilling(t *testing.T) {
 	t.Run("hasBoundSession为true且实际切换时设置ForceCacheBilling", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, true) // hasBoundSession=true
+		fs := newFastFailoverState(3, true) // hasBoundSession=true
 		err := newTestFailoverErr(500, false, false)
 
 		fs.HandleFailoverError(context.Background(), mock, 100, "openai", 3, err)
@@ -380,7 +387,7 @@ func TestHandleFailoverError_CacheBilling(t *testing.T) {
 
 	t.Run("同账号重试时仅凭hasBoundSession不设置ForceCacheBilling", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, true)
+		fs := newFastFailoverState(3, true)
 		err := newTestFailoverErr(400, true, false)
 
 		fs.HandleFailoverError(context.Background(), mock, 100, "openai", testSameAccountRetryLimit, err)
@@ -391,7 +398,7 @@ func TestHandleFailoverError_CacheBilling(t *testing.T) {
 
 	t.Run("OAuth deadline存在时不按普通计数切换", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, true)
+		fs := newFastFailoverState(3, true)
 		fs.SameAccountRetryCount[100] = maxSameAccountRetries
 		err := newTestFailoverErr(http.StatusTooManyRequests, true, false)
 		err.SameAccountRetryDeadline = time.Now().Add(time.Minute)
@@ -407,7 +414,7 @@ func TestHandleFailoverError_CacheBilling(t *testing.T) {
 
 	t.Run("同账号重试耗尽并实际切换时设置ForceCacheBilling", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, true)
+		fs := newFastFailoverState(3, true)
 		err := newTestFailoverErr(400, true, false)
 
 		for i := 0; i < testSameAccountRetryLimit; i++ {
@@ -422,7 +429,7 @@ func TestHandleFailoverError_CacheBilling(t *testing.T) {
 
 	t.Run("failoverErr.ForceCacheBilling为true时设置", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		err := newTestFailoverErr(500, false, true) // ForceCacheBilling=true
 
 		fs.HandleFailoverError(context.Background(), mock, 100, "openai", 3, err)
@@ -431,7 +438,7 @@ func TestHandleFailoverError_CacheBilling(t *testing.T) {
 
 	t.Run("同账号重试保留显式ForceCacheBilling", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, true)
+		fs := newFastFailoverState(3, true)
 		err := newTestFailoverErr(400, true, true)
 
 		fs.HandleFailoverError(context.Background(), mock, 100, "openai", testSameAccountRetryLimit, err)
@@ -442,7 +449,7 @@ func TestHandleFailoverError_CacheBilling(t *testing.T) {
 
 	t.Run("两者均为false时不设置", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		err := newTestFailoverErr(500, false, false)
 
 		fs.HandleFailoverError(context.Background(), mock, 100, "openai", 3, err)
@@ -451,7 +458,7 @@ func TestHandleFailoverError_CacheBilling(t *testing.T) {
 
 	t.Run("一旦设置不会被后续错误重置", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 
 		// 第一次：ForceCacheBilling=true → 设置
 		err1 := newTestFailoverErr(500, false, true)
@@ -472,26 +479,26 @@ func TestHandleFailoverError_CacheBilling(t *testing.T) {
 func TestHandleFailoverError_SameAccountRetry(t *testing.T) {
 	t.Run("第一次重试返回FailoverContinue", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		var delays []time.Duration
+		fs := newFailoverState(3, false, func(_ context.Context, delay time.Duration) bool {
+			delays = append(delays, delay)
+			return true
+		})
 		err := newTestFailoverErr(400, true, false)
 
-		start := time.Now()
 		action := fs.HandleFailoverError(context.Background(), mock, 100, "openai", 3, err)
-		elapsed := time.Since(start)
 
 		require.Equal(t, FailoverContinue, action)
 		require.Equal(t, 1, fs.SameAccountRetryCount[100])
 		require.Equal(t, 0, fs.SwitchCount, "同账号重试不应增加切换计数")
 		require.NotContains(t, fs.FailedAccountIDs, int64(100), "同账号重试不应加入失败列表")
 		require.Empty(t, mock.calls, "同账号重试期间不应调用 TempUnschedule")
-		// 验证等待了 sameAccountRetryDelay (500ms)
-		require.GreaterOrEqual(t, elapsed, 400*time.Millisecond)
-		require.Less(t, elapsed, 2*time.Second)
+		require.Equal(t, []time.Duration{sameAccountRetryDelay}, delays)
 	})
 
 	t.Run("达到最大重试次数前均返回FailoverContinue", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		err := newTestFailoverErr(400, true, false)
 
 		for i := 1; i <= 3; i++ {
@@ -505,7 +512,7 @@ func TestHandleFailoverError_SameAccountRetry(t *testing.T) {
 
 	t.Run("超过最大重试次数后触发TempUnschedule并切换", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		err := newTestFailoverErr(400, true, false)
 
 		for i := 0; i < 3; i++ {
@@ -527,7 +534,7 @@ func TestHandleFailoverError_SameAccountRetry(t *testing.T) {
 
 	t.Run("不同账号独立跟踪重试次数", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(5, false)
+		fs := newFastFailoverState(5, false)
 		err := newTestFailoverErr(400, true, false)
 
 		// 账号 100 第一次重试
@@ -544,7 +551,7 @@ func TestHandleFailoverError_SameAccountRetry(t *testing.T) {
 
 	t.Run("重试耗尽后再次遇到同账号_直接切换", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(5, false)
+		fs := newFastFailoverState(5, false)
 		err := newTestFailoverErr(400, true, false)
 
 		// 耗尽账号 100 的重试
@@ -565,7 +572,7 @@ func TestHandleFailoverError_SameAccountRetry(t *testing.T) {
 		// 回归测试：Anthropic 等路径此前硬编码同账号重试 3 次，忽略账号
 		// pool_mode_retry_count 配置。此处验证传入 retryLimit=1 时只重试 1 次即切换。
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(5, false)
+		fs := newFastFailoverState(5, false)
 		err := newTestFailoverErr(502, true, false)
 		const retryLimit = 1
 
@@ -588,7 +595,7 @@ func TestHandleFailoverError_SameAccountRetry(t *testing.T) {
 	t.Run("retryLimit为0时立即切换不重试", func(t *testing.T) {
 		// pool_mode_retry_count=0 表示关闭同账号重试（如 GPT Image 账号）。
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(5, false)
+		fs := newFastFailoverState(5, false)
 		err := newTestFailoverErr(502, true, false)
 
 		action := fs.HandleFailoverError(context.Background(), mock, 100, "openai", 0, err)
@@ -606,7 +613,7 @@ func TestHandleFailoverError_SameAccountRetry(t *testing.T) {
 func TestHandleFailoverError_TempUnschedule(t *testing.T) {
 	t.Run("非重试错误不调用TempUnschedule", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		err := newTestFailoverErr(500, false, false) // RetryableOnSameAccount=false
 
 		fs.HandleFailoverError(context.Background(), mock, 100, "openai", 3, err)
@@ -615,7 +622,7 @@ func TestHandleFailoverError_TempUnschedule(t *testing.T) {
 
 	t.Run("重试错误耗尽后调用TempUnschedule_传入正确参数", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		err := newTestFailoverErr(502, true, false)
 
 		for i := 0; i < 3; i++ {
@@ -663,7 +670,7 @@ func TestHandleFailoverError_ContextCanceled(t *testing.T) {
 
 	t.Run("Antigravity延迟期间context取消", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		fs.SwitchCount = 1 // 下一次 switchCount=2 → delay = 1s
 		err := newTestFailoverErr(500, false, false)
 
@@ -686,7 +693,7 @@ func TestHandleFailoverError_ContextCanceled(t *testing.T) {
 func TestHandleFailoverError_FailedAccountIDs(t *testing.T) {
 	t.Run("切换时添加到失败列表", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 
 		fs.HandleFailoverError(context.Background(), mock, 100, "openai", 3, newTestFailoverErr(500, false, false))
 		require.Contains(t, fs.FailedAccountIDs, int64(100))
@@ -698,7 +705,7 @@ func TestHandleFailoverError_FailedAccountIDs(t *testing.T) {
 
 	t.Run("耗尽时也添加到失败列表", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(0, false)
+		fs := newFastFailoverState(0, false)
 
 		action := fs.HandleFailoverError(context.Background(), mock, 100, "openai", 3, newTestFailoverErr(500, false, false))
 		require.Equal(t, FailoverExhausted, action)
@@ -707,7 +714,7 @@ func TestHandleFailoverError_FailedAccountIDs(t *testing.T) {
 
 	t.Run("同账号重试期间不添加到失败列表", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 
 		action := fs.HandleFailoverError(context.Background(), mock, 100, "openai", 3, newTestFailoverErr(400, true, false))
 		require.Equal(t, FailoverContinue, action)
@@ -716,7 +723,7 @@ func TestHandleFailoverError_FailedAccountIDs(t *testing.T) {
 
 	t.Run("同一账号多次切换不重复添加", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(5, false)
+		fs := newFastFailoverState(5, false)
 
 		fs.HandleFailoverError(context.Background(), mock, 100, "openai", 3, newTestFailoverErr(500, false, false))
 		fs.HandleFailoverError(context.Background(), mock, 100, "openai", 3, newTestFailoverErr(500, false, false))
@@ -731,7 +738,7 @@ func TestHandleFailoverError_FailedAccountIDs(t *testing.T) {
 func TestHandleFailoverError_LastFailoverErr(t *testing.T) {
 	t.Run("每次调用都更新LastFailoverErr", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 
 		err1 := newTestFailoverErr(500, false, false)
 		fs.HandleFailoverError(context.Background(), mock, 100, "openai", 3, err1)
@@ -744,7 +751,7 @@ func TestHandleFailoverError_LastFailoverErr(t *testing.T) {
 
 	t.Run("同账号重试时也更新LastFailoverErr", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 
 		err := newTestFailoverErr(400, true, false)
 		fs.HandleFailoverError(context.Background(), mock, 100, "openai", 3, err)
@@ -759,7 +766,7 @@ func TestHandleFailoverError_LastFailoverErr(t *testing.T) {
 func TestHandleFailoverError_IntegrationScenario(t *testing.T) {
 	t.Run("模拟完整failover流程_多账号混合重试与切换", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, true) // hasBoundSession=true
+		fs := newFastFailoverState(3, true) // hasBoundSession=true
 
 		// 1. 账号 100 遇到可重试错误，同账号重试 3 次
 		retryErr := newTestFailoverErr(400, true, false)
@@ -800,35 +807,32 @@ func TestHandleFailoverError_IntegrationScenario(t *testing.T) {
 
 	t.Run("模拟Antigravity平台完整流程", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(2, false)
+		var delays []time.Duration
+		fs := newFailoverState(2, false, func(_ context.Context, delay time.Duration) bool {
+			delays = append(delays, delay)
+			return true
+		})
 
 		err := newTestFailoverErr(500, false, false)
 
 		// 第一次切换：delay = 0s
-		start := time.Now()
 		action := fs.HandleFailoverError(context.Background(), mock, 100, service.PlatformAntigravity, 3, err)
-		elapsed := time.Since(start)
 		require.Equal(t, FailoverContinue, action)
-		require.Less(t, elapsed, 200*time.Millisecond, "第一次切换延迟为 0")
 
 		// 第二次切换：delay = 1s
-		start = time.Now()
 		action = fs.HandleFailoverError(context.Background(), mock, 200, service.PlatformAntigravity, 3, err)
-		elapsed = time.Since(start)
 		require.Equal(t, FailoverContinue, action)
-		require.GreaterOrEqual(t, elapsed, 800*time.Millisecond, "第二次切换延迟约 1s")
+		require.Equal(t, []time.Duration{0, time.Second}, delays)
 
 		// 第三次：耗尽（无延迟，因为在检查延迟之前就返回了）
-		start = time.Now()
 		action = fs.HandleFailoverError(context.Background(), mock, 300, service.PlatformAntigravity, 3, err)
-		elapsed = time.Since(start)
+		require.Equal(t, []time.Duration{0, time.Second}, delays)
 		require.Equal(t, FailoverExhausted, action)
-		require.Less(t, elapsed, 200*time.Millisecond, "耗尽时不应有延迟")
 	})
 
 	t.Run("ForceCacheBilling通过错误标志设置", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false) // hasBoundSession=false
+		fs := newFastFailoverState(3, false) // hasBoundSession=false
 
 		// 第一次：ForceCacheBilling=false
 		err1 := newTestFailoverErr(500, false, false)
@@ -854,7 +858,7 @@ func TestHandleFailoverError_IntegrationScenario(t *testing.T) {
 func TestHandleFailoverError_EdgeCases(t *testing.T) {
 	t.Run("StatusCode为0的错误也能正常处理", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		err := newTestFailoverErr(0, false, false)
 
 		action := fs.HandleFailoverError(context.Background(), mock, 100, "openai", 3, err)
@@ -863,7 +867,7 @@ func TestHandleFailoverError_EdgeCases(t *testing.T) {
 
 	t.Run("AccountID为0也能正常跟踪", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		err := newTestFailoverErr(500, true, false)
 
 		action := fs.HandleFailoverError(context.Background(), mock, 0, "openai", 3, err)
@@ -873,7 +877,7 @@ func TestHandleFailoverError_EdgeCases(t *testing.T) {
 
 	t.Run("负AccountID也能正常跟踪", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		err := newTestFailoverErr(500, true, false)
 
 		action := fs.HandleFailoverError(context.Background(), mock, -1, "openai", 3, err)
@@ -883,7 +887,7 @@ func TestHandleFailoverError_EdgeCases(t *testing.T) {
 
 	t.Run("空平台名称不触发Antigravity延迟", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		fs.SwitchCount = 1
 		err := newTestFailoverErr(500, false, false)
 
@@ -902,7 +906,7 @@ func TestHandleFailoverError_EdgeCases(t *testing.T) {
 
 func TestHandleSelectionExhausted(t *testing.T) {
 	t.Run("无LastFailoverErr时返回Exhausted", func(t *testing.T) {
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		// LastFailoverErr 为 nil
 
 		action := fs.HandleSelectionExhausted(context.Background(), false)
@@ -910,7 +914,7 @@ func TestHandleSelectionExhausted(t *testing.T) {
 	})
 
 	t.Run("非503错误返回Exhausted", func(t *testing.T) {
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		fs.LastFailoverErr = newTestFailoverErr(500, false, false)
 
 		action := fs.HandleSelectionExhausted(context.Background(), false)
@@ -918,23 +922,24 @@ func TestHandleSelectionExhausted(t *testing.T) {
 	})
 
 	t.Run("503且未耗尽_等待后返回Continue并清除失败列表", func(t *testing.T) {
-		fs := NewFailoverState(3, false)
+		var delays []time.Duration
+		fs := newFailoverState(3, false, func(_ context.Context, delay time.Duration) bool {
+			delays = append(delays, delay)
+			return true
+		})
 		fs.LastFailoverErr = newTestFailoverErr(503, false, false)
 		fs.FailedAccountIDs[100] = struct{}{}
 		fs.SwitchCount = 1
 
-		start := time.Now()
 		action := fs.HandleSelectionExhausted(context.Background(), false)
-		elapsed := time.Since(start)
 
 		require.Equal(t, FailoverContinue, action)
 		require.Empty(t, fs.FailedAccountIDs, "应清除失败账号列表")
-		require.GreaterOrEqual(t, elapsed, 1500*time.Millisecond, "应等待约 2s")
-		require.Less(t, elapsed, 5*time.Second)
+		require.Equal(t, []time.Duration{singleAccountBackoffDelay}, delays)
 	})
 
 	t.Run("classified relay capacity不重置失败列表", func(t *testing.T) {
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		fs.LastFailoverErr = &service.UpstreamFailoverError{
 			StatusCode: http.StatusServiceUnavailable,
 			Reason:     service.AntigravityRelayCapacityReason,
@@ -952,7 +957,7 @@ func TestHandleSelectionExhausted(t *testing.T) {
 	})
 
 	t.Run("503但SwitchCount已超过MaxSwitches_返回Exhausted", func(t *testing.T) {
-		fs := NewFailoverState(2, false)
+		fs := newFastFailoverState(2, false)
 		fs.LastFailoverErr = newTestFailoverErr(503, false, false)
 		fs.SwitchCount = 3 // > MaxSwitches(2)
 
@@ -965,7 +970,7 @@ func TestHandleSelectionExhausted(t *testing.T) {
 	})
 
 	t.Run("503但context已取消_返回Canceled", func(t *testing.T) {
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		fs.LastFailoverErr = newTestFailoverErr(503, false, false)
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -979,10 +984,30 @@ func TestHandleSelectionExhausted(t *testing.T) {
 		require.Less(t, elapsed, 100*time.Millisecond, "应立即返回")
 	})
 
+	t.Run("503退避期间context取消_保留失败列表", func(t *testing.T) {
+		fs := NewFailoverState(3, false)
+		fs.LastFailoverErr = newTestFailoverErr(503, false, false)
+		fs.FailedAccountIDs[100] = struct{}{}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(30 * time.Millisecond)
+			cancel()
+		}()
+
+		start := time.Now()
+		action := fs.HandleSelectionExhausted(ctx, false)
+		elapsed := time.Since(start)
+
+		require.Equal(t, FailoverCanceled, action)
+		require.Less(t, elapsed, 100*time.Millisecond, "取消后不应继续等待 2s")
+		require.Contains(t, fs.FailedAccountIDs, int64(100), "取消的退避不应重置排除列表")
+	})
+
 	t.Run("context已取消_非503也返回Canceled而非Exhausted", func(t *testing.T) {
 		// #4257 核心场景：客户端断开后选号失败源于 context canceled，
 		// 不应被当成账号耗尽转成 502。
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		fs.LastFailoverErr = newTestFailoverErr(520, false, false)
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -993,7 +1018,7 @@ func TestHandleSelectionExhausted(t *testing.T) {
 	})
 
 	t.Run("context已取消_无LastFailoverErr也返回Canceled", func(t *testing.T) {
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -1003,7 +1028,7 @@ func TestHandleSelectionExhausted(t *testing.T) {
 	})
 
 	t.Run("503且SwitchCount等于MaxSwitches_仍可重试", func(t *testing.T) {
-		fs := NewFailoverState(2, false)
+		fs := newFastFailoverState(2, false)
 		fs.LastFailoverErr = newTestFailoverErr(503, false, false)
 		fs.SwitchCount = 2 // == MaxSwitches，条件是 <=，仍可重试
 
@@ -1014,22 +1039,24 @@ func TestHandleSelectionExhausted(t *testing.T) {
 	// TK thin-pool guard:薄池仅因 failover 排除排空时（service.ErrThinPoolAllExcluded），
 	// 即使 LastFailoverErr 不是 503（典型为流内 502 或为 nil），也应退避重试该唯一账号。
 	t.Run("thinPool排除_无503_仍退避重试并清除失败列表", func(t *testing.T) {
-		fs := NewFailoverState(3, false)
+		var delays []time.Duration
+		fs := newFailoverState(3, false, func(_ context.Context, delay time.Duration) bool {
+			delays = append(delays, delay)
+			return true
+		})
 		fs.LastFailoverErr = newTestFailoverErr(502, false, false) // 流内 SSE 包成 502
 		fs.FailedAccountIDs[100] = struct{}{}
 		fs.SwitchCount = 1
 
-		start := time.Now()
 		action := fs.HandleSelectionExhausted(context.Background(), true)
-		elapsed := time.Since(start)
 
 		require.Equal(t, FailoverContinue, action)
 		require.Empty(t, fs.FailedAccountIDs, "薄池重试应清除排除列表，让唯一账号可再次被选中")
-		require.GreaterOrEqual(t, elapsed, 1500*time.Millisecond, "应退避约 2s")
+		require.Equal(t, []time.Duration{singleAccountBackoffDelay}, delays)
 	})
 
 	t.Run("thinPool排除_LastFailoverErr为nil_仍退避重试", func(t *testing.T) {
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		// LastFailoverErr 为 nil（首轮就排空的极端情形）
 		fs.FailedAccountIDs[100] = struct{}{}
 		fs.SwitchCount = 0
@@ -1040,7 +1067,7 @@ func TestHandleSelectionExhausted(t *testing.T) {
 	})
 
 	t.Run("thinPool排除_SwitchCount超过MaxSwitches_仍受上限约束返回Exhausted", func(t *testing.T) {
-		fs := NewFailoverState(2, false)
+		fs := newFastFailoverState(2, false)
 		fs.LastFailoverErr = newTestFailoverErr(502, false, false)
 		fs.SwitchCount = 3 // > MaxSwitches(2)
 
@@ -1063,7 +1090,7 @@ func TestHandleFailoverError_SameAccountRetryLimit_DrivenByParameter(t *testing.
 		// limit=0 是运维通过 UI 显式选择"不原地重试"的语义（i18n hint:
 		// "0 = 不原地重试"）。不做隐式升值，否则违反 UI 承诺。
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		err := newTestFailoverErr(503, true, false)
 
 		action := fs.HandleFailoverError(context.Background(), mock, 100, "anthropic", 0, err)
@@ -1074,7 +1101,7 @@ func TestHandleFailoverError_SameAccountRetryLimit_DrivenByParameter(t *testing.
 
 	t.Run("limit=负数_当作0处理_直接切账号", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		err := newTestFailoverErr(503, true, false)
 
 		action := fs.HandleFailoverError(context.Background(), mock, 100, "anthropic", -5, err)
@@ -1085,7 +1112,7 @@ func TestHandleFailoverError_SameAccountRetryLimit_DrivenByParameter(t *testing.
 
 	t.Run("limit=1_只retry一次_第二次切账号", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		err := newTestFailoverErr(503, true, false)
 
 		// 第一次：retry
@@ -1103,7 +1130,7 @@ func TestHandleFailoverError_SameAccountRetryLimit_DrivenByParameter(t *testing.
 
 	t.Run("limit=5_前5次retry_第6次切账号_pool_mode上限对所有平台一致", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		err := newTestFailoverErr(429, true, false)
 
 		for i := 1; i <= 5; i++ {
@@ -1122,7 +1149,7 @@ func TestHandleFailoverError_SameAccountRetryLimit_DrivenByParameter(t *testing.
 
 	t.Run("limit参数对非retryable错误无影响", func(t *testing.T) {
 		mock := &mockTempUnscheduler{}
-		fs := NewFailoverState(3, false)
+		fs := newFastFailoverState(3, false)
 		err := newTestFailoverErr(500, false, false) // RetryableOnSameAccount=false
 
 		action := fs.HandleFailoverError(context.Background(), mock, 100, "openai", 10, err)
@@ -1138,7 +1165,7 @@ func TestHandleFailoverError_SameAccountRetryLimit_DrivenByParameter(t *testing.
 
 func TestHandleFailoverError_Forbidden403FailFast(t *testing.T) {
 	t.Run("403_空body_立即FailoverExhausted且不切账号不unschedule", func(t *testing.T) {
-		fs := NewFailoverState(5, false)
+		fs := newFastFailoverState(5, false)
 		mock := &mockTempUnscheduler{}
 		err := newTestFailoverErrWithBody(403, false, nil)
 
@@ -1151,7 +1178,7 @@ func TestHandleFailoverError_Forbidden403FailFast(t *testing.T) {
 	})
 
 	t.Run("403_非JSON_HTML页面_FailoverExhausted", func(t *testing.T) {
-		fs := NewFailoverState(5, false)
+		fs := newFastFailoverState(5, false)
 		mock := &mockTempUnscheduler{}
 		body := []byte("<html><body>403 Forbidden</body></html>")
 		err := newTestFailoverErrWithBody(403, false, body)
@@ -1164,7 +1191,7 @@ func TestHandleFailoverError_Forbidden403FailFast(t *testing.T) {
 	})
 
 	t.Run("403_非anthropicJSON_FailoverExhausted", func(t *testing.T) {
-		fs := NewFailoverState(5, false)
+		fs := newFastFailoverState(5, false)
 		mock := &mockTempUnscheduler{}
 		body := []byte(`{"foo":"bar"}`)
 		err := newTestFailoverErrWithBody(403, false, body)
@@ -1175,7 +1202,7 @@ func TestHandleFailoverError_Forbidden403FailFast(t *testing.T) {
 	})
 
 	t.Run("403_anthropicJSON_走原failover路径切账号", func(t *testing.T) {
-		fs := NewFailoverState(5, false)
+		fs := newFastFailoverState(5, false)
 		mock := &mockTempUnscheduler{}
 		body := []byte(`{"type":"error","error":{"type":"forbidden","message":"x"}}`)
 		err := newTestFailoverErrWithBody(403, false, body)
@@ -1188,7 +1215,7 @@ func TestHandleFailoverError_Forbidden403FailFast(t *testing.T) {
 	})
 
 	t.Run("403_openaiJSON_走原failover路径切账号", func(t *testing.T) {
-		fs := NewFailoverState(5, false)
+		fs := newFastFailoverState(5, false)
 		mock := &mockTempUnscheduler{}
 		body := []byte(`{"error":{"message":"key revoked","type":"invalid_request_error","code":"invalid_api_key"}}`)
 		err := newTestFailoverErrWithBody(403, false, body)
@@ -1199,7 +1226,7 @@ func TestHandleFailoverError_Forbidden403FailFast(t *testing.T) {
 	})
 
 	t.Run("403_geminiJSON_走原failover路径切账号", func(t *testing.T) {
-		fs := NewFailoverState(5, false)
+		fs := newFastFailoverState(5, false)
 		mock := &mockTempUnscheduler{}
 		body := []byte(`{"error":{"code":403,"message":"Permission denied","status":"PERMISSION_DENIED"}}`)
 		err := newTestFailoverErrWithBody(403, false, body)
@@ -1210,7 +1237,7 @@ func TestHandleFailoverError_Forbidden403FailFast(t *testing.T) {
 	})
 
 	t.Run("403_tokenkeyInsufficientBalanceJSON_走原failover路径切账号", func(t *testing.T) {
-		fs := NewFailoverState(5, false)
+		fs := newFastFailoverState(5, false)
 		mock := &mockTempUnscheduler{}
 		body := []byte(`{"code":"INSUFFICIENT_BALANCE","message":"Insufficient account balance"}`)
 		err := newTestFailoverErrWithBody(403, true, body)
@@ -1226,7 +1253,7 @@ func TestHandleFailoverError_Forbidden403FailFast(t *testing.T) {
 	})
 
 	t.Run("非403_不触发fail-fast", func(t *testing.T) {
-		fs := NewFailoverState(5, false)
+		fs := newFastFailoverState(5, false)
 		mock := &mockTempUnscheduler{}
 		err := newTestFailoverErrWithBody(401, false, nil)
 
@@ -1240,7 +1267,7 @@ func TestHandleFailoverError_Forbidden403FailFast(t *testing.T) {
 		// R-001 regression: anthropic stream-error event used to be wrapped
 		// as fake-403 (empty body). Now wrapped as 502 so it does not collide
 		// with the 403 fail-fast judgment.
-		fs := NewFailoverState(5, false)
+		fs := newFastFailoverState(5, false)
 		mock := &mockTempUnscheduler{}
 		err := newTestFailoverErrWithBody(502, false, nil)
 

--- a/backend/internal/service/antigravity_gateway_retry.go
+++ b/backend/internal/service/antigravity_gateway_retry.go
@@ -566,7 +566,7 @@ urlFallbackLoop:
 				}
 				if attempt < antigravityMaxRetries {
 					logger.LegacyPrintf("service.antigravity_gateway", "%s status=request_failed retry=%d/%d error=%v", p.prefix, attempt, antigravityMaxRetries, err)
-					if !sleepAntigravityBackoffWithContext(p.ctx, attempt) {
+					if !s.waitRetryBackoff(p.ctx, attempt) {
 						logger.LegacyPrintf("service.antigravity_gateway", "%s status=context_canceled_during_backoff", p.prefix)
 						return nil, p.ctx.Err()
 					}
@@ -640,7 +640,7 @@ urlFallbackLoop:
 							Detail:             getUpstreamDetail(respBody),
 						})
 						logger.LegacyPrintf("service.antigravity_gateway", "%s status=%d retry=%d/%d body=%s", p.prefix, resp.StatusCode, attempt, antigravityMaxRetries, truncateForLog(respBody, 200))
-						if !sleepAntigravityBackoffWithContext(p.ctx, attempt) {
+						if !s.waitRetryBackoff(p.ctx, attempt) {
 							logger.LegacyPrintf("service.antigravity_gateway", "%s status=context_canceled_during_backoff", p.prefix)
 							return nil, p.ctx.Err()
 						}
@@ -675,7 +675,7 @@ urlFallbackLoop:
 							Detail:             getUpstreamDetail(respBody),
 						})
 						logger.LegacyPrintf("service.antigravity_gateway", "%s status=%d retry=%d/%d body=%s", p.prefix, resp.StatusCode, attempt, antigravityMaxRetries, truncateForLog(respBody, 500))
-						if !sleepAntigravityBackoffWithContext(p.ctx, attempt) {
+						if !s.waitRetryBackoff(p.ctx, attempt) {
 							logger.LegacyPrintf("service.antigravity_gateway", "%s status=context_canceled_during_backoff", p.prefix)
 							return nil, p.ctx.Err()
 						}

--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -129,6 +129,14 @@ type AntigravityGatewayService struct {
 	cache             GatewayCache // 用于模型级限流时清除粘性会话绑定
 	schedulerSnapshot *SchedulerSnapshotService
 	internal500Cache  Internal500CounterCache // INTERNAL 500 渐进惩罚计数器
+	retryBackoff      func(context.Context, int) bool
+}
+
+func (s *AntigravityGatewayService) waitRetryBackoff(ctx context.Context, attempt int) bool {
+	if s != nil && s.retryBackoff != nil {
+		return s.retryBackoff(ctx, attempt)
+	}
+	return sleepAntigravityBackoffWithContext(ctx, attempt)
 }
 
 func (s *AntigravityGatewayService) upstreamErrorBodyReadLimit() int64 {

--- a/backend/internal/service/antigravity_rate_limit_test.go
+++ b/backend/internal/service/antigravity_rate_limit_test.go
@@ -127,7 +127,13 @@ func TestAntigravityRetryLoop_NoURLFallback_UsesConfiguredBaseURL(t *testing.T) 
 	}
 
 	var handleErrorCalled bool
-	svc := &AntigravityGatewayService{}
+	var backoffAttempts []int
+	svc := &AntigravityGatewayService{
+		retryBackoff: func(_ context.Context, attempt int) bool {
+			backoffAttempts = append(backoffAttempts, attempt)
+			return true
+		},
+	}
 	result, err := svc.antigravityRetryLoop(antigravityRetryLoopParams{
 		prefix:         "[test]",
 		ctx:            context.Background(),
@@ -151,6 +157,7 @@ func TestAntigravityRetryLoop_NoURLFallback_UsesConfiguredBaseURL(t *testing.T) 
 	require.Equal(t, http.StatusTooManyRequests, result.resp.StatusCode)
 	require.True(t, handleErrorCalled)
 	require.Len(t, upstream.calls, antigravityMaxRetries)
+	require.Equal(t, []int{1, 2}, backoffAttempts)
 	for _, callURL := range upstream.calls {
 		require.True(t, strings.HasPrefix(callURL, prod))
 	}

--- a/backend/internal/service/gemini_oauth_service.go
+++ b/backend/internal/service/gemini_oauth_service.go
@@ -51,12 +51,13 @@ const (
 )
 
 type GeminiOAuthService struct {
-	sessionStore *geminicli.SessionStore
-	proxyRepo    ProxyRepository
-	oauthClient  GeminiOAuthClient
-	codeAssist   GeminiCliCodeAssistClient
-	driveClient  geminicli.DriveClient
-	cfg          *config.Config
+	sessionStore                   *geminicli.SessionStore
+	proxyRepo                      ProxyRepository
+	oauthClient                    GeminiOAuthClient
+	codeAssist                     GeminiCliCodeAssistClient
+	driveClient                    geminicli.DriveClient
+	resourceManagerProjectResolver func(context.Context, string, string) (string, error)
+	cfg                            *config.Config
 }
 
 type GeminiOAuthCapabilities struct {
@@ -72,12 +73,13 @@ func NewGeminiOAuthService(
 	cfg *config.Config,
 ) *GeminiOAuthService {
 	return &GeminiOAuthService{
-		sessionStore: geminicli.NewSessionStore(),
-		proxyRepo:    proxyRepo,
-		oauthClient:  oauthClient,
-		codeAssist:   codeAssist,
-		driveClient:  driveClient,
-		cfg:          cfg,
+		sessionStore:                   geminicli.NewSessionStore(),
+		proxyRepo:                      proxyRepo,
+		oauthClient:                    oauthClient,
+		codeAssist:                     codeAssist,
+		driveClient:                    driveClient,
+		resourceManagerProjectResolver: fetchProjectIDFromResourceManager,
+		cfg:                            cfg,
 	}
 }
 
@@ -962,7 +964,7 @@ func (s *GeminiOAuthService) fetchProjectID(ctx context.Context, accessToken, pr
 			logger.LegacyPrintf("service.gemini_oauth", "[GeminiOAuth] User has tier (%s) but no cloudaicompanionProject, trying Cloud Resource Manager...", registeredTierID)
 
 			// Try to get project from Cloud Resource Manager
-			fallback, fbErr := fetchProjectIDFromResourceManager(ctx, accessToken, proxyURL)
+			fallback, fbErr := s.resolveProjectIDFromResourceManager(ctx, accessToken, proxyURL)
 			if fbErr == nil && strings.TrimSpace(fallback) != "" {
 				logger.LegacyPrintf("service.gemini_oauth", "[GeminiOAuth] Found project from Cloud Resource Manager: %s", fallback)
 				return strings.TrimSpace(fallback), tierID, nil
@@ -991,7 +993,7 @@ func (s *GeminiOAuthService) fetchProjectID(ctx context.Context, accessToken, pr
 		resp, err := s.codeAssist.OnboardUser(ctx, accessToken, proxyURL, req)
 		if err != nil {
 			// If Code Assist onboarding fails (e.g. INVALID_ARGUMENT), fallback to Cloud Resource Manager projects.
-			fallback, fbErr := fetchProjectIDFromResourceManager(ctx, accessToken, proxyURL)
+			fallback, fbErr := s.resolveProjectIDFromResourceManager(ctx, accessToken, proxyURL)
 			if fbErr == nil && strings.TrimSpace(fallback) != "" {
 				return strings.TrimSpace(fallback), tierID, nil
 			}
@@ -1009,7 +1011,7 @@ func (s *GeminiOAuthService) fetchProjectID(ctx context.Context, accessToken, pr
 				}
 			}
 
-			fallback, fbErr := fetchProjectIDFromResourceManager(ctx, accessToken, proxyURL)
+			fallback, fbErr := s.resolveProjectIDFromResourceManager(ctx, accessToken, proxyURL)
 			if fbErr == nil && strings.TrimSpace(fallback) != "" {
 				return strings.TrimSpace(fallback), tierID, nil
 			}
@@ -1018,7 +1020,7 @@ func (s *GeminiOAuthService) fetchProjectID(ctx context.Context, accessToken, pr
 		time.Sleep(2 * time.Second)
 	}
 
-	fallback, fbErr := fetchProjectIDFromResourceManager(ctx, accessToken, proxyURL)
+	fallback, fbErr := s.resolveProjectIDFromResourceManager(ctx, accessToken, proxyURL)
 	if fbErr == nil && strings.TrimSpace(fallback) != "" {
 		return strings.TrimSpace(fallback), tierID, nil
 	}
@@ -1026,6 +1028,14 @@ func (s *GeminiOAuthService) fetchProjectID(ctx context.Context, accessToken, pr
 		return "", tierID, fmt.Errorf("loadCodeAssist failed (%v) and onboardUser timeout after %d attempts", loadErr, maxAttempts)
 	}
 	return "", tierID, fmt.Errorf("onboardUser timeout after %d attempts", maxAttempts)
+}
+
+func (s *GeminiOAuthService) resolveProjectIDFromResourceManager(ctx context.Context, accessToken, proxyURL string) (string, error) {
+	resolver := s.resourceManagerProjectResolver
+	if resolver == nil {
+		resolver = fetchProjectIDFromResourceManager
+	}
+	return resolver(ctx, accessToken, proxyURL)
 }
 
 type googleCloudProject struct {

--- a/backend/internal/service/gemini_oauth_service_test.go
+++ b/backend/internal/service/gemini_oauth_service_test.go
@@ -1207,6 +1207,17 @@ func TestGeminiOAuthService_RefreshAccountToken_CodeAssist_NoProjectID_FailsEmpt
 
 	svc := NewGeminiOAuthService(&mockGeminiProxyRepo{}, client, codeAssist, nil, &config.Config{})
 	defer svc.Stop()
+	resolverCalls := 0
+	svc.resourceManagerProjectResolver = func(ctx context.Context, accessToken, proxyURL string) (string, error) {
+		resolverCalls++
+		if accessToken != "at" {
+			t.Fatalf("Resource Manager resolver access token 不匹配: got=%q", accessToken)
+		}
+		if proxyURL != "" {
+			t.Fatalf("Resource Manager resolver proxy URL 应为空: got=%q", proxyURL)
+		}
+		return "", fmt.Errorf("resource manager unavailable")
+	}
 
 	account := &Account{
 		Platform: PlatformGemini,
@@ -1223,6 +1234,9 @@ func TestGeminiOAuthService_RefreshAccountToken_CodeAssist_NoProjectID_FailsEmpt
 	}
 	if !strings.Contains(err.Error(), "project_id") {
 		t.Fatalf("错误信息应包含 project_id: got=%q", err.Error())
+	}
+	if resolverCalls != 1 {
+		t.Fatalf("Resource Manager resolver 应调用 1 次: got=%d", resolverCalls)
 	}
 }
 

--- a/backend/internal/service/grok_credential_failure_test.go
+++ b/backend/internal/service/grok_credential_failure_test.go
@@ -1112,6 +1112,8 @@ func TestGetRequestCredentialLockHeldTimeoutDoesNotQuarantineAccount(t *testing.
 			repo := tt.buildRepo(account)
 			cache := &grokTokenCacheForProviderTest{lockResult: false}
 			provider := NewGrokTokenProvider(repo, cache)
+			provider.refreshLockWaitTimeout = 10 * time.Millisecond
+			provider.refreshLockPollInterval = time.Millisecond
 			provider.SetRefreshAPI(NewOAuthRefreshAPI(repo, cache), &tokenRefresherStub{})
 			svc := &OpenAIGatewayService{accountRepo: repo, grokTokenProvider: provider}
 			c, _ := gin.CreateTestContext(httptest.NewRecorder())

--- a/backend/internal/service/grok_token_provider.go
+++ b/backend/internal/service/grok_token_provider.go
@@ -27,12 +27,14 @@ var (
 type GrokTokenCache = GeminiTokenCache
 
 type GrokTokenProvider struct {
-	accountRepo      AccountRepository
-	tokenCache       GrokTokenCache
-	refreshAPI       *OAuthRefreshAPI
-	executor         OAuthRefreshExecutor
-	refreshPolicy    ProviderRefreshPolicy
-	tempUnschedCache TempUnschedCache
+	accountRepo             AccountRepository
+	tokenCache              GrokTokenCache
+	refreshAPI              *OAuthRefreshAPI
+	executor                OAuthRefreshExecutor
+	refreshPolicy           ProviderRefreshPolicy
+	tempUnschedCache        TempUnschedCache
+	refreshLockWaitTimeout  time.Duration
+	refreshLockPollInterval time.Duration
 }
 
 func NewGrokTokenProvider(
@@ -231,7 +233,16 @@ func (p *GrokTokenProvider) GetAccessTokenForManualTest(ctx context.Context, acc
 }
 
 func (p *GrokTokenProvider) waitForRefreshedToken(ctx context.Context, account *Account, cacheKey string) (string, error) {
-	waitCtx, cancel := context.WithTimeout(ctx, grokRefreshLockWaitTimeout)
+	waitTimeout := p.refreshLockWaitTimeout
+	if waitTimeout <= 0 {
+		waitTimeout = grokRefreshLockWaitTimeout
+	}
+	pollInterval := p.refreshLockPollInterval
+	if pollInterval <= 0 {
+		pollInterval = grokRefreshLockPollInterval
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, waitTimeout)
 	defer cancel()
 
 	initialToken := strings.TrimSpace(account.GetGrokAccessToken())
@@ -239,7 +250,7 @@ func (p *GrokTokenProvider) waitForRefreshedToken(ctx context.Context, account *
 	selectedProxyID := cloneGrokProxyID(account.ProxyID)
 	sawAuthoritativeState := false
 	var lastAccountReadErr error
-	ticker := time.NewTicker(grokRefreshLockPollInterval)
+	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 
 	for {

--- a/backend/internal/service/openai_ws_protocol_forward_test.go
+++ b/backend/internal/service/openai_ws_protocol_forward_test.go
@@ -31,6 +31,12 @@ type httpUpstreamSequenceRecorder struct {
 	callCount int
 }
 
+func configureOpenAIWSFastRetryForTest(cfg *config.Config) {
+	cfg.Gateway.OpenAIWS.RetryBackoffInitialMS = 1
+	cfg.Gateway.OpenAIWS.RetryBackoffMaxMS = 2
+	cfg.Gateway.OpenAIWS.RetryJitterRatio = 0
+}
+
 func (u *httpUpstreamSequenceRecorder) Do(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
@@ -750,6 +756,7 @@ func TestOpenAIGatewayService_Forward_WSv2StreamEarlyCloseFallbackHTTP(t *testin
 	cfg.Gateway.OpenAIWS.APIKeyEnabled = true
 	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
 	cfg.Gateway.OpenAIWS.FallbackCooldownSeconds = 1
+	configureOpenAIWSFastRetryForTest(cfg)
 
 	svc := &OpenAIGatewayService{
 		cfg:              cfg,
@@ -832,6 +839,7 @@ func TestOpenAIGatewayService_Forward_WSv2RetryFiveTimesThenFallbackHTTP(t *test
 	cfg.Gateway.OpenAIWS.APIKeyEnabled = true
 	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
 	cfg.Gateway.OpenAIWS.FallbackCooldownSeconds = 1
+	configureOpenAIWSFastRetryForTest(cfg)
 
 	svc := &OpenAIGatewayService{
 		cfg:              cfg,
@@ -910,9 +918,7 @@ func TestOpenAIGatewayService_Forward_WSv2PolicyViolationFastFallbackHTTP(t *tes
 	cfg.Gateway.OpenAIWS.APIKeyEnabled = true
 	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
 	cfg.Gateway.OpenAIWS.FallbackCooldownSeconds = 1
-	cfg.Gateway.OpenAIWS.RetryBackoffInitialMS = 1
-	cfg.Gateway.OpenAIWS.RetryBackoffMaxMS = 2
-	cfg.Gateway.OpenAIWS.RetryJitterRatio = 0
+	configureOpenAIWSFastRetryForTest(cfg)
 
 	svc := &OpenAIGatewayService{
 		cfg:              cfg,
@@ -997,6 +1003,7 @@ func TestOpenAIGatewayService_Forward_WSv2ConnectionLimitReachedRetryThenFallbac
 	cfg.Gateway.OpenAIWS.APIKeyEnabled = true
 	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
 	cfg.Gateway.OpenAIWS.FallbackCooldownSeconds = 1
+	configureOpenAIWSFastRetryForTest(cfg)
 
 	svc := &OpenAIGatewayService{
 		cfg:              cfg,

--- a/backend/internal/service/token_refresh_service_test.go
+++ b/backend/internal/service/token_refresh_service_test.go
@@ -495,6 +495,9 @@ func TestTokenRefreshService_RefreshWithRetry_Antigravity(t *testing.T) {
 		ID:       8,
 		Platform: PlatformAntigravity,
 		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			"privacy_mode": AntigravityPrivacySet,
+		},
 	}
 	refresher := &tokenRefresherStub{
 		credentials: map[string]any{


### PR DESCRIPTION
## 摘要

- 保留上一轮 Gemini OAuth / Antigravity 测试离线化，继续消除 Unit 内剩余的真实等待瓶颈。
- OpenAI WS 重连测试使用 1–2ms 的确定性测试退避，仍断言完整重连次数与失败语义。
- Grok refresh-lock 与 Antigravity retry 使用实例级私有测试 seam；生产 nil/zero 值仍走原 2s 轮询和指数退避。
- Handler failover 测试改为断言请求的 500ms / 1s / 2s delay，不再按墙钟真实等待；真实 context 取消 smoke 保留。

## 风险

- 不修改公共 API、生产默认等待、重试次数、错误映射或 failover 状态机。
- 所有 seam 均为实例私有字段，不使用 package-level 可变状态；聚焦 race 测试已通过。
- Handler 取消路径同时覆盖同账号重试和 selection backoff，确保测试加速未绕过生产取消语义。
- Web impact: none
- sentinel-registry-reviewed
- upstream-touch-trivial

## 验证

- `go test -tags=unit ./internal/service -count=1`：通过，独立运行 package 耗时 145.447 秒；上一轮同机为 163.456 秒，再降约 18 秒。
- `go test -tags=unit ./internal/handler -count=1`：通过，package 耗时 10.800 秒；本轮消除至少 33.5 秒固定墙钟等待。
- `go test -tags=unit ./... -count=1`：最终树完整 backend unit suite 通过。
- 聚焦 service / handler `go test -race`：通过。
- `PREFLIGHT_FAST=1 ./scripts/preflight.sh`：最终树通过；本地 Docker 不可用的 Caddy 语法检查由 CI 执行。
- 最新 PR CI 全绿：Unit 5分12秒（上一轮 5分29秒，缩短 17 秒，约 5.2%）；Preflight 1分57秒；Integration 2分25秒；golangci-lint 3分05秒。
- Unit 仍比此前 main 对照 5分05秒慢 7 秒，说明 GitHub runner/cache 波动仍大；本轮可重复的确定收益主要来自移除约 51.5 秒串行测试墙钟等待。
- 独立只读代码审查：无 Critical / Important / Minor finding，结论 Ready to merge。
- 完整本地 preflight 的既有 Ent 生成漂移可在干净 `origin/main` 复现；本 PR 未修改 `backend/ent/schema` 或生成文件。

## 提交

- `7c594cb07 test(ci): keep OAuth unit tests offline`
- `11d1d7843 test(ci): remove remaining unit backoff waits`
- 最新提交：`11d1d7843`
