### PR TITLE
fix(gateway): restore protocol cutover fallback

### DIFF
--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -283,7 +283,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 				h.gatewayService.ValidateProtocolEndpoint,
 				service.ProtocolExecutors{
 					NonGoverned: func(executionCtx context.Context, _ protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
-						return h.gatewayService.ForwardAsChatCompletions(executionCtx, c, account, prepareBody(request), promptCacheKey, dispatchMappedModel)
+						return h.gatewayService.ForwardAsChatCompletionsDispatched(executionCtx, c, account, prepareBody(request), promptCacheKey, dispatchMappedModel)
 					},
 					ChatIdentity: func(executionCtx context.Context, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
 						service.SetActualOpenAIUpstreamEndpoint(c, protocolPlanEndpoint(plan.Endpoint()))

--- a/backend/internal/handler/openai_chat_completions_legacy_protocol_fallback_test.go
+++ b/backend/internal/handler/openai_chat_completions_legacy_protocol_fallback_test.go
@@ -1,0 +1,106 @@
+//go:build unit
+
+package handler
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	middleware "github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestOpenAIChatCompletionsCutoverDisabledKeepsNewAPILegacyDispatcher(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	var upstreamPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamPath = r.URL.Path
+		require.Equal(t, "Bearer dashscope-key", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"chatcmpl-legacy","object":"chat.completion","model":"qwen3.7-max","choices":[{"index":0,"message":{"role":"assistant","content":"OK"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+	}))
+	defer upstream.Close()
+
+	groupID := int64(18)
+	group := &service.Group{ID: groupID, Hydrated: true, Platform: service.PlatformNewAPI, Status: service.StatusActive}
+	account := service.Account{
+		ID:          60,
+		Name:        "Qwen",
+		Platform:    service.PlatformNewAPI,
+		Type:        service.AccountTypeAPIKey,
+		Status:      service.StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		ChannelType: newapiconstant.ChannelTypeAli,
+		Credentials: map[string]any{
+			"api_key":  "dashscope-key",
+			"base_url": upstream.URL,
+			"model_mapping": map[string]any{
+				"client-qwen": "qwen3.7-max",
+			},
+		},
+	}
+	accountRepo := &openAIWSFailoverHandlerAccountRepoStub{accounts: []service.Account{account}}
+	cfg := &config.Config{RunMode: config.RunModeSimple}
+	cfg.Default.RateMultiplier = 1
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	cfg.Gateway.MaxAccountSwitches = 1
+	schedulerSnapshot := service.NewSchedulerSnapshotService(
+		&fakeSchedulerCache{accounts: []*service.Account{&account}},
+		nil,
+		accountRepo,
+		&fakeGroupRepo{group: group},
+		cfg,
+	)
+	wrongNativePath := &openAIHTTPPassthroughFailoverUpstream{}
+	billingCache := service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, cfg, nil)
+	defer billingCache.Stop()
+	gateway := service.NewOpenAIGatewayService(
+		accountRepo, nil, nil, nil, nil, nil, nil, cfg, schedulerSnapshot, nil,
+		service.NewBillingService(cfg, nil), nil, billingCache, wrongNativePath,
+		&service.DeferredService{}, nil, nil, nil, nil, nil, nil, nil,
+	)
+	cache := &concurrencyCacheMock{
+		acquireUserSlotFn:    func(context.Context, int64, int, string) (bool, error) { return true, nil },
+		acquireAccountSlotFn: func(context.Context, int64, int, string) (bool, error) { return true, nil },
+	}
+	h := NewOpenAIGatewayHandler(
+		gateway,
+		service.NewConcurrencyService(cache),
+		billingCache,
+		&service.APIKeyService{},
+		nil, nil, nil, nil,
+		cfg,
+	)
+	// Deliberately leave protocolRouter nil: this is the CutoverReady=false path.
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", strings.NewReader(
+		`{"model":"client-qwen","messages":[{"role":"user","content":"hello"}],"stream":false}`,
+	))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set(string(middleware.ContextKeyAPIKey), &service.APIKey{
+		ID: 1806, GroupID: &groupID,
+		User:  &service.User{ID: 1706, Status: service.StatusActive},
+		Group: group,
+	})
+	c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{UserID: 1706, Concurrency: 1})
+
+	h.ChatCompletions(c)
+
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	require.Equal(t, "/compatible-mode/v1/chat/completions", upstreamPath)
+	require.Equal(t, "OK", gjson.GetBytes(recorder.Body.Bytes(), "choices.0.message.content").String())
+	require.Empty(t, wrongNativePath.calls(), "legacy fallback must not leak the NewAPI credential into the native OpenAI path")
+}

--- a/backend/internal/handler/openai_gateway_count_tokens.go
+++ b/backend/internal/handler/openai_gateway_count_tokens.go
@@ -148,6 +148,9 @@ func (h *OpenAIGatewayHandler) ResponsesInputTokens(c *gin.Context) {
 		account,
 		h.gatewayService.ValidateProtocolEndpoint,
 		service.ProtocolExecutors{
+			NonGoverned: func(executionCtx context.Context, _ protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
+				return nil, h.gatewayService.ForwardResponsesInputTokens(executionCtx, c, account, request.Body())
+			},
 			ResponsesIdentity: func(executionCtx context.Context, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
 				if plan.ResponsesPath() != protocolrouter.ResponsesPathInputTokens {
 					return nil, protocolrouter.ErrStalePlan

--- a/backend/internal/handler/openai_responses_input_tokens_legacy_protocol_fallback_test.go
+++ b/backend/internal/handler/openai_responses_input_tokens_legacy_protocol_fallback_test.go
@@ -1,0 +1,90 @@
+//go:build unit
+
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
+	middleware "github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestResponsesInputTokensCutoverDisabledKeepsLegacyExecutor(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	groupID := int64(18)
+	group := &service.Group{ID: groupID, Hydrated: true, Platform: service.PlatformNewAPI, Status: service.StatusActive}
+	account := service.Account{
+		ID:          72,
+		Name:        "Qwen",
+		Platform:    service.PlatformNewAPI,
+		Type:        service.AccountTypeAPIKey,
+		Status:      service.StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		ChannelType: newapiconstant.ChannelTypeAli,
+		Credentials: map[string]any{
+			"api_key":  "dashscope-key",
+			"base_url": "https://dashscope.aliyuncs.com",
+			"model_mapping": map[string]any{
+				"client-qwen": "qwen3.7-max",
+			},
+		},
+		Extra: map[string]any{
+			openai_compat.ExtraKeyResponsesSupported: true,
+		},
+	}
+	accountRepo := &openAIWSFailoverHandlerAccountRepoStub{accounts: []service.Account{account}}
+	cfg := &config.Config{RunMode: config.RunModeSimple}
+	cfg.Default.RateMultiplier = 1
+	cfg.Security.URLAllowlist.Enabled = false
+	schedulerSnapshot := service.NewSchedulerSnapshotService(
+		&fakeSchedulerCache{accounts: []*service.Account{&account}},
+		nil,
+		accountRepo,
+		&fakeGroupRepo{group: group},
+		cfg,
+	)
+	billingCache := service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, cfg, nil)
+	t.Cleanup(billingCache.Stop)
+	gateway := service.NewOpenAIGatewayService(
+		accountRepo, nil, nil, nil, nil, nil, nil, cfg, schedulerSnapshot, nil,
+		service.NewBillingService(cfg, nil), nil, billingCache, nil,
+		&service.DeferredService{}, nil, nil, nil, nil, nil, nil, nil,
+	)
+	h := NewOpenAIGatewayHandler(
+		gateway,
+		service.NewConcurrencyService(nil),
+		billingCache,
+		&service.APIKeyService{},
+		nil, nil, nil, nil,
+		cfg,
+	)
+	// Deliberately leave protocolRouter nil: this is the CutoverReady=false path.
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses/input_tokens", strings.NewReader(
+		`{"model":"client-qwen","input":"hello"}`,
+	))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set(string(middleware.ContextKeyAPIKey), &service.APIKey{
+		ID: 1817, GroupID: &groupID,
+		User:  &service.User{ID: 1717, Status: service.StatusActive},
+		Group: group,
+	})
+	c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{UserID: 1717, Concurrency: 1})
+
+	h.ResponsesInputTokens(c)
+
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	require.Greater(t, gjson.GetBytes(recorder.Body.Bytes(), "input_tokens").Int(), int64(0), recorder.Body.String())
+}

--- a/backend/internal/service/account_supported_protocols.go
+++ b/backend/internal/service/account_supported_protocols.go
@@ -228,19 +228,39 @@ func protocolExactEndpoints(account *Account, resolvedModel string) (map[protoco
 	if account == nil || account.Platform != PlatformNewAPI || account.ChannelType <= 0 {
 		return nil, nil
 	}
-	in := newAPIBridgeChannelInputForModel(account, 0, "", resolvedModel).WithoutModelMapping()
 	endpoints := make(map[protocolrouter.Protocol]string, 2)
-	for protocol, format := range map[protocolrouter.Protocol]newapitypes.RelayFormat{
-		protocolrouter.ProtocolChatCompletions: newapitypes.RelayFormatOpenAI,
-		protocolrouter.ProtocolResponses:       newapitypes.RelayFormatOpenAIResponses,
+	for _, protocol := range []protocolrouter.Protocol{
+		protocolrouter.ProtocolChatCompletions,
+		protocolrouter.ProtocolResponses,
 	} {
-		endpoint, err := bridge.ResolveTextEndpoint(in, format, resolvedModel)
+		endpoint, err := protocolExactEndpoint(account, protocol, resolvedModel)
 		if err != nil {
-			return nil, fmt.Errorf("resolve newapi %s endpoint: %w", protocol, err)
+			return nil, err
 		}
 		endpoints[protocol] = endpoint
 	}
 	return endpoints, nil
+}
+
+func protocolExactEndpoint(account *Account, protocol protocolrouter.Protocol, resolvedModel string) (string, error) {
+	if account == nil || account.Platform != PlatformNewAPI || account.ChannelType <= 0 {
+		return "", nil
+	}
+	var format newapitypes.RelayFormat
+	switch protocol {
+	case protocolrouter.ProtocolChatCompletions:
+		format = newapitypes.RelayFormatOpenAI
+	case protocolrouter.ProtocolResponses:
+		format = newapitypes.RelayFormatOpenAIResponses
+	default:
+		return "", nil
+	}
+	in := newAPIBridgeChannelInputForModel(account, 0, "", resolvedModel).WithoutModelMapping()
+	endpoint, err := bridge.ResolveTextEndpoint(in, format, resolvedModel)
+	if err != nil {
+		return "", fmt.Errorf("resolve newapi %s endpoint: %w", protocol, err)
+	}
+	return endpoint, nil
 }
 
 func protocolAccountEndpoints(account *Account) (string, map[protocolrouter.Protocol]string, protocolrouter.OfficialEndpointProfile) {

--- a/backend/internal/service/openai_apikey_chat_completions_probe.go
+++ b/backend/internal/service/openai_apikey_chat_completions_probe.go
@@ -88,8 +88,18 @@ func (s *AccountTestService) probeOpenAIAPIKeyChatCompletionsSupport(
 		return protocolProbeObservation{}, false
 	}
 
-	probeURL := buildOpenAIEndpointURL(normalizedBaseURL, apipath.ChatCompletions)
 	probeModel := selectResponsesProbeModel(account)
+	probeURL := buildOpenAIEndpointURL(normalizedBaseURL, apipath.ChatCompletions)
+	if exactEndpoint, exactErr := protocolExactEndpoint(account, protocolrouter.ProtocolChatCompletions, probeModel); exactErr != nil {
+		logger.LegacyPrintf("service.openai_probe", "chat_completions_resolve_endpoint_failed: account_id=%d err=%v", accountID, exactErr)
+		return protocolProbeObservation{}, false
+	} else if exactEndpoint != "" {
+		probeURL, err = s.validateUpstreamBaseURL(exactEndpoint)
+		if err != nil {
+			logger.LegacyPrintf("service.openai_probe", "chat_completions_invalid_endpoint: account_id=%d endpoint=%q err=%v", accountID, exactEndpoint, err)
+			return protocolProbeObservation{}, false
+		}
+	}
 	probeCtx, cancel := context.WithTimeout(ctx, openaiChatCompletionsProbeTimeout)
 	defer cancel()
 

--- a/backend/internal/service/openai_apikey_chat_completions_probe_test.go
+++ b/backend/internal/service/openai_apikey_chat_completions_probe_test.go
@@ -7,10 +7,52 @@ import (
 	"strings"
 	"testing"
 
+	newapiconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
 	"github.com/stretchr/testify/require"
 )
+
+func TestProbeOpenAIAPIKeyChatCompletionsSupportUsesNewAPIAdaptorEndpoint(t *testing.T) {
+	updateCalls := make(chan map[string]any, 1)
+	account := Account{
+		ID:          60,
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeAli,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "dashscope-key",
+			"base_url": "https://dashscope.aliyuncs.com",
+			"model_mapping": map[string]any{
+				"qwen3.7-max": "qwen3.7-max",
+			},
+		},
+	}
+	repo := &snapshotUpdateAccountRepo{
+		stubOpenAIAccountRepo: stubOpenAIAccountRepo{accounts: []Account{account}},
+		updateExtraCalls:      updateCalls,
+	}
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body: io.NopCloser(strings.NewReader(
+			`{"choices":[{"message":{"role":"assistant","content":"OK"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`,
+		)),
+	}}
+	svc := &AccountTestService{
+		accountRepo:  repo,
+		httpUpstream: upstream,
+		cfg:          &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
+	}
+
+	svc.ProbeOpenAIAPIKeyChatCompletionsSupport(context.Background(), account.ID)
+
+	require.NotNil(t, upstream.lastReq)
+	require.Equal(t, "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions", upstream.lastReq.URL.String())
+	updates := <-updateCalls
+	require.Equal(t, []string{"chat_completions"}, updates[SupportedProtocolsExtraKey])
+}
 
 func TestProbeOpenAIAPIKeyChatCompletionsSupportPersistsPositiveCapability(t *testing.T) {
 	updateCalls := make(chan map[string]any, 1)

--- a/backend/internal/service/openai_apikey_responses_probe.go
+++ b/backend/internal/service/openai_apikey_responses_probe.go
@@ -172,8 +172,18 @@ func (s *AccountTestService) probeOpenAIAPIKeyResponsesSupport(
 		return protocolProbeObservation{}, false
 	}
 
-	probeURL := buildOpenAIResponsesURLForPlatform(account.Platform, normalizedBaseURL)
 	probeModel := selectResponsesProbeModel(account)
+	probeURL := buildOpenAIResponsesURLForPlatform(account.Platform, normalizedBaseURL)
+	if exactEndpoint, exactErr := protocolExactEndpoint(account, protocolrouter.ProtocolResponses, probeModel); exactErr != nil {
+		logger.LegacyPrintf("service.openai_probe", "probe_resolve_endpoint_failed: account_id=%d err=%v", accountID, exactErr)
+		return protocolProbeObservation{}, false
+	} else if exactEndpoint != "" {
+		probeURL, err = s.validateUpstreamBaseURL(exactEndpoint)
+		if err != nil {
+			logger.LegacyPrintf("service.openai_probe", "probe_invalid_endpoint: account_id=%d endpoint=%q err=%v", accountID, exactEndpoint, err)
+			return protocolProbeObservation{}, false
+		}
+	}
 
 	probeCtx, cancel := context.WithTimeout(ctx, openaiResponsesProbeTimeout)
 	defer cancel()

--- a/backend/internal/service/openai_apikey_responses_probe_test.go
+++ b/backend/internal/service/openai_apikey_responses_probe_test.go
@@ -8,11 +8,51 @@ import (
 	"testing"
 	"time"
 
+	newapiconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
 	"github.com/stretchr/testify/require"
 )
+
+func TestProbeOpenAIAPIKeyResponsesSupportUsesNewAPIAdaptorEndpoint(t *testing.T) {
+	updateCalls := make(chan map[string]any, 1)
+	account := Account{
+		ID:          72,
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeAli,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "dashscope-key",
+			"base_url": "https://dashscope.aliyuncs.com",
+			"model_mapping": map[string]any{
+				"qwen3.7-max": "qwen3.7-max",
+			},
+		},
+	}
+	repo := &snapshotUpdateAccountRepo{
+		stubOpenAIAccountRepo: stubOpenAIAccountRepo{accounts: []Account{account}},
+		updateExtraCalls:      updateCalls,
+	}
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(`{"status":"completed","output":[{"type":"function_call","name":"probe_ping"}]}`)),
+	}}
+	svc := &AccountTestService{
+		accountRepo:  repo,
+		httpUpstream: upstream,
+		cfg:          &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
+	}
+
+	svc.ProbeOpenAIAPIKeyResponsesSupport(context.Background(), account.ID)
+
+	require.NotNil(t, upstream.lastReq)
+	require.Equal(t, "https://dashscope.aliyuncs.com/api/v2/apps/protocols/compatible-mode/v1/responses", upstream.lastReq.URL.String())
+	updates := <-updateCalls
+	require.Equal(t, []string{"responses"}, updates[SupportedProtocolsExtraKey])
+}
 
 func TestProbeOpenAIAPIKeyResponsesSupportUsesCodexProbeHeaders(t *testing.T) {
 	updateCalls := make(chan map[string]any, 1)

--- a/backend/internal/service/protocol_execution.go
+++ b/backend/internal/service/protocol_execution.go
@@ -230,9 +230,16 @@ func ExecuteSelectedProtocol(
 	validateEndpoint ProtocolEndpointValidator,
 	executors ProtocolExecutors,
 ) (any, error) {
-	request, routed := ProtocolRoutingRequest(ctx)
+	request, canonical := protocolRoutingCanonicalRequest(ctx)
+	_, routed := ProtocolRoutingRequest(ctx)
 	plan, planned := ProtocolPlanFromSelection(selection)
 	if !protocolRoutingGovernsAccount(account) {
+		if executors.NonGoverned == nil {
+			return nil, ErrProtocolExecutorMissing
+		}
+		return executors.NonGoverned(ctx, protocolrouter.Plan{}, request)
+	}
+	if router == nil && canonical && !routed && !planned {
 		if executors.NonGoverned == nil {
 			return nil, ErrProtocolExecutorMissing
 		}

--- a/backend/internal/service/protocol_execution_test.go
+++ b/backend/internal/service/protocol_execution_test.go
@@ -220,6 +220,37 @@ func TestExecuteSelectedProtocolFailsClosedForGovernedAccountWithoutSelectedPlan
 	}
 }
 
+func TestExecuteSelectedProtocolUsesLegacyExecutorWhenCutoverRouterDisabled(t *testing.T) {
+	request := protocolRoutingTestRequest(t, protocolrouter.ProtocolChatCompletions)
+	ctx := WithProtocolRouting(context.Background(), nil, request)
+	account := protocolRoutingOpenAIAccount(60, "chat_completions")
+	account.Platform = PlatformNewAPI
+	selection := &AccountSelectionResult{Account: account}
+	calls := 0
+
+	value, err := ExecuteSelectedProtocol(
+		ctx,
+		nil,
+		selection,
+		account,
+		nil,
+		ProtocolExecutors{NonGoverned: func(_ context.Context, _ protocolrouter.Plan, got protocolrouter.CanonicalRequest) (any, error) {
+			calls++
+			if string(got.Body()) != string(request.Body()) {
+				t.Fatalf("legacy request body = %q, want %q", got.Body(), request.Body())
+			}
+			return "legacy", nil
+		}},
+	)
+
+	if err != nil {
+		t.Fatalf("ExecuteSelectedProtocol: %v", err)
+	}
+	if value != "legacy" || calls != 1 {
+		t.Fatalf("value=%v calls=%d, want legacy/1", value, calls)
+	}
+}
+
 func TestExecuteSelectedProtocolValidatesExactPlanEndpointBeforeExecutor(t *testing.T) {
 	router := NewProtocolRouter()
 	req := protocolRoutingTestRequest(t, protocolrouter.ProtocolMessages)

--- a/backend/internal/service/protocol_routing_context.go
+++ b/backend/internal/service/protocol_routing_context.go
@@ -71,9 +71,6 @@ func WithProtocolRouting(
 	router *protocolrouter.Router,
 	request protocolrouter.CanonicalRequest,
 ) context.Context {
-	if router == nil {
-		return ctx
-	}
 	return context.WithValue(ctx, protocolRoutingContextKey{}, protocolRoutingContextValue{
 		router:  router,
 		request: request,
@@ -89,6 +86,14 @@ func ProtocolRouteLegal(ctx context.Context, account *Account, requestedModel st
 func ProtocolRoutingRequest(ctx context.Context) (protocolrouter.CanonicalRequest, bool) {
 	routing, ok := ctx.Value(protocolRoutingContextKey{}).(protocolRoutingContextValue)
 	if !ok || routing.router == nil {
+		return protocolrouter.CanonicalRequest{}, false
+	}
+	return routing.request, true
+}
+
+func protocolRoutingCanonicalRequest(ctx context.Context) (protocolrouter.CanonicalRequest, bool) {
+	routing, ok := ctx.Value(protocolRoutingContextKey{}).(protocolRoutingContextValue)
+	if !ok {
 		return protocolrouter.CanonicalRequest{}, false
 	}
 	return routing.request, true

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -921,6 +921,23 @@
       "rationale": "End-to-end handler regression for CutoverReady=false: a governed NewAPI account still reaches the provider adaptor path and never the native OpenAI upstream."
     },
     {
+      "path": "backend/internal/handler/openai_gateway_count_tokens.go",
+      "must_contain": [
+        "NonGoverned: func(executionCtx context.Context, _ protocolrouter.Plan, request protocolrouter.CanonicalRequest)",
+        "ForwardResponsesInputTokens(executionCtx, c, account, request.Body())"
+      ],
+      "rationale": "Responses input-token requests must keep their legacy executor while CutoverReady=false. This call site is intentionally separate from generation handlers; losing its NonGoverned binding returns ErrProtocolExecutorMissing with an empty response even though the process-wide rollout gate says legacy routing remains active."
+    },
+    {
+      "path": "backend/internal/handler/openai_responses_input_tokens_legacy_protocol_fallback_test.go",
+      "must_contain": [
+        "TestResponsesInputTokensCutoverDisabledKeepsLegacyExecutor",
+        "Deliberately leave protocolRouter nil",
+        "gjson.GetBytes(recorder.Body.Bytes(), \"input_tokens\").Int()"
+      ],
+      "rationale": "Focused handler regression proving that the Responses input_tokens subresource still returns a real token count when the protocol router is withheld by the process-wide cutover gate."
+    },
+    {
       "path": "backend/internal/service/protocol_routing_migration.go",
       "must_contain": [
         "MigrateProtocolRoutingSSOT",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -575,6 +575,7 @@
     {
       "path": "backend/internal/handler/openai_chat_completions.go",
       "must_contain": [
+        "NonGoverned: func(executionCtx context.Context, _ protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {\n\t\t\t\t\t\treturn h.gatewayService.ForwardAsChatCompletionsDispatched(executionCtx, c, account, prepareBody(request), promptCacheKey, dispatchMappedModel)",
         "ChatIdentity: func(executionCtx context.Context, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest)",
         "return h.gatewayService.ForwardAsChatCompletionsDispatched(executionCtx, c, account, prepareBody(request), promptCacheKey, dispatchMappedModel)"
       ],
@@ -582,7 +583,7 @@
         "return h.gatewayService.ForwardAsChatCompletions(c.Request.Context(), c, account, forwardBody, promptCacheKey, dispatchMappedModel)",
         "if plan.TargetProtocol() == protocolrouter.ProtocolChatCompletions"
       ],
-      "rationale": "The production /v1/chat/completions handler binds the ChatIdentity adapter directly to the NewAPI bridge dispatcher with the plan-bound execution context and canonical request. The handler must not inspect TargetProtocol again: restoring that old branch creates a second route owner and lets future merges misroute DashScope/Vertex credentials."
+      "rationale": "The production /v1/chat/completions handler binds both the cutover-disabled legacy executor and the ChatIdentity adapter to the NewAPI bridge dispatcher. The legacy branch must preserve #1807 dispatch semantics while CutoverReady=false; reverting it to ForwardAsChatCompletions sends DashScope credentials through the native OpenAI path. The handler must not inspect TargetProtocol again: restoring that old branch creates a second route owner and lets future merges misroute DashScope/Vertex credentials."
     },
     {
       "path": "backend/internal/service/ratelimit_service.go",
@@ -848,6 +849,38 @@
       "rationale": "Behavior regressions for the Qwen credential-leak fix: inbound /v1/messages for a bridge-eligible newapi account is owned by the NewAPI adaptor (not an OpenAI-shaped fallback), a foreign credential with no OpenAI-resolvable base fails closed instead of reaching api.openai.com, and an OpenAI api-key account still resolves the official host. Deleting these tests would let an upstream merge restore either leak with a green build."
     },
     {
+      "path": "backend/internal/service/account_supported_protocols.go",
+      "must_contain": [
+        "func protocolExactEndpoint(account *Account, protocol protocolrouter.Protocol, resolvedModel string) (string, error)",
+        "endpoint, err := bridge.ResolveTextEndpoint(in, format, resolvedModel)"
+      ],
+      "rationale": "Single NewAPI text-endpoint resolver shared by protocol planning and capability probes. Provider paths such as DashScope ch17 differ from generic /v1 endpoints; losing this owner recreates split path tables and lets probes persist false capability facts for otherwise healthy accounts."
+    },
+    {
+      "path": "backend/internal/service/openai_apikey_chat_completions_probe.go",
+      "must_contain": [
+        "protocolExactEndpoint(account, protocolrouter.ProtocolChatCompletions, probeModel)",
+        "chat_completions_resolve_endpoint_failed"
+      ],
+      "rationale": "Chat Completions capability probes for NewAPI accounts must use the exact adaptor URL rather than appending /v1/chat/completions to base_url. Dropping this call marks DashScope ch17 unsupported after probing the wrong 404 endpoint."
+    },
+    {
+      "path": "backend/internal/service/openai_apikey_responses_probe.go",
+      "must_contain": [
+        "protocolExactEndpoint(account, protocolrouter.ProtocolResponses, probeModel)",
+        "probe_resolve_endpoint_failed"
+      ],
+      "rationale": "Responses capability probes for NewAPI accounts must use the exact adaptor URL rather than generic /v1/responses. DashScope ch17 serves Responses under /api/v2/apps/protocols/compatible-mode/v1/responses; probing the generic path produces a false negative and invalid routing facts."
+    },
+    {
+      "path": "backend/internal/service/protocol_routing_context.go",
+      "must_contain": [
+        "func protocolRoutingCanonicalRequest(ctx context.Context) (protocolrouter.CanonicalRequest, bool)",
+        "if !ok || routing.router == nil {\n\t\treturn protocolrouter.CanonicalRequest{}, false"
+      ],
+      "rationale": "Cutover-disabled requests retain the canonical body for legacy execution without making ProtocolRoutingRequest report routing enabled. Losing either half makes router=nil return an empty body or accidentally enables the scheduler hard gate before migration readiness."
+    },
+    {
       "path": "backend/internal/service/protocol_execution.go",
       "must_contain": [
         "messagesToResponsesAdapter",
@@ -857,9 +890,35 @@
         "responsesToChatAdapter",
         "responsesToMessagesAdapter",
         "RouteFacts",
-        "ExecuteSelectedProtocol"
+        "ExecuteSelectedProtocol",
+        "if router == nil && canonical && !routed && !planned {"
       ],
-      "rationale": "Protocol routing is the single execution boundary for NewAPI text channels. Each inbound→target pair has a concrete adapter and immutable route facts; removing this owner or restoring a generic callback lets an upstream merge send a Messages body to a Chat/Responses endpoint while compilation and unrelated NewAPI bridge tests remain green."
+      "rationale": "Protocol routing is the single execution boundary for NewAPI text channels. Each inbound→target pair has a concrete adapter and immutable route facts. When CutoverReady=false, router=nil must explicitly use the legacy executor; router-enabled requests without a selected plan remain fail-closed. Removing either invariant can send a Messages body to a Chat/Responses endpoint or turn a guarded rollout into blanket 502s."
+    },
+    {
+      "path": "backend/internal/service/openai_apikey_chat_completions_probe_test.go",
+      "must_contain": [
+        "TestProbeOpenAIAPIKeyChatCompletionsSupportUsesNewAPIAdaptorEndpoint",
+        "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+      ],
+      "rationale": "Regression proof that the ch17 Chat Completions probe follows the live adaptor endpoint instead of the generic 404 path."
+    },
+    {
+      "path": "backend/internal/service/openai_apikey_responses_probe_test.go",
+      "must_contain": [
+        "TestProbeOpenAIAPIKeyResponsesSupportUsesNewAPIAdaptorEndpoint",
+        "https://dashscope.aliyuncs.com/api/v2/apps/protocols/compatible-mode/v1/responses"
+      ],
+      "rationale": "Regression proof that the ch17 Responses probe follows the live adaptor endpoint instead of the generic 404 path."
+    },
+    {
+      "path": "backend/internal/handler/openai_chat_completions_legacy_protocol_fallback_test.go",
+      "must_contain": [
+        "TestOpenAIChatCompletionsCutoverDisabledKeepsNewAPILegacyDispatcher",
+        "require.Equal(t, \"/compatible-mode/v1/chat/completions\", upstreamPath)",
+        "legacy fallback must not leak the NewAPI credential into the native OpenAI path"
+      ],
+      "rationale": "End-to-end handler regression for CutoverReady=false: a governed NewAPI account still reaches the provider adaptor path and never the native OpenAI upstream."
     },
     {
       "path": "backend/internal/service/protocol_routing_migration.go",


### PR DESCRIPTION
## 摘要

- NewAPI Chat Completions / Responses capability probe 复用 adaptor endpoint SSOT，避免 DashScope ch17 被错误探测为 `/v1/*`。
- `CutoverReady=false` 时保留 canonical request 并回退 legacy executor，不再对 governed account 返回 `protocol route unavailable`。
- OpenAI Chat Completions legacy 分支恢复 `ForwardAsChatCompletionsDispatched`，避免 DashScope 凭据错投 OpenAI 原生上游。
- Responses `input_tokens` 子资源补齐 cutover-disabled legacy executor，避免返回空响应或 `ErrProtocolExecutorMissing`。
- 为 endpoint owner、probe 调用、cutover fallback、input-token rollback 和行为回归测试增加 upstream-merge sentinel。

upstream-touch-guarded

## 风险

- 影响范围限于协议能力探测及 cutover-disabled fallback；cutover-enabled 且缺失 selected plan 的路径继续 fail-closed。
- 无数据库迁移、无前端影响、无公共 API 契约变化。
- sentinel 已覆盖 override marker 识别的全部 6 个 revert-risk upstream 文件，并额外锚定 input-token rollback call site；后续 upstream merge 删除关键语义会触发 preflight。

## 验证

- `go test -tags=unit ./internal/service -count=1`：通过
- `go test -tags=unit ./internal/handler -count=1`：通过
- `python3 scripts/checks/protocol-routing-ssot.py`：通过
- `python3 scripts/sentinels/check-newapi.py`：100/100 PASS
- `python3 scripts/checks/upstream-override-marker.py --base origin/main`：verified coverage
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：PASS
- `$xj-review` 高风险完整一致性复审：R-001 已修复，无剩余 medium+ finding

## 提交

- `7eac80631 fix(gateway): restore protocol cutover fallback`
- `d0e596bb2 fix(gateway): preserve input-token rollback path`

最新提交：d0e596bb2