### PR TITLE
test(ci): close service retry review gaps

### DIFF
--- a/backend/internal/service/antigravity_single_account_retry_test.go
+++ b/backend/internal/service/antigravity_single_account_retry_test.go
@@ -186,7 +186,7 @@ func TestHandleSmartRetry_503_LongDelay_NoSingleAccountRetry_StillSwitches(t *te
 
 	availableURLs := []string{"https://ag-1.test"}
 
-	svc := &AntigravityGatewayService{retryWait: immediateAntigravityRetryWait}
+	svc := &AntigravityGatewayService{}
 	result := svc.handleSmartRetry(params, resp, respBody, "https://ag-1.test", 0, availableURLs)
 
 	require.NotNil(t, result)
@@ -245,7 +245,7 @@ func TestHandleSmartRetry_429_LongDelay_SingleAccountRetry_StillSwitches(t *test
 
 	availableURLs := []string{"https://ag-1.test"}
 
-	svc := &AntigravityGatewayService{retryWait: immediateAntigravityRetryWait}
+	svc := &AntigravityGatewayService{}
 	result := svc.handleSmartRetry(params, resp, respBody, "https://ag-1.test", 0, availableURLs)
 
 	require.NotNil(t, result)
@@ -546,55 +546,59 @@ func TestHandleSingleAccountRetryInPlace_AllRetriesFail(t *testing.T) {
 
 // TestHandleSingleAccountRetryInPlace_WaitDurationClamped 等待时间被限制在 [min, max] 范围
 func TestHandleSingleAccountRetryInPlace_WaitDurationClamped(t *testing.T) {
-	// 用短延迟的成功响应，只验证不 panic
-	successResp := &http.Response{
-		StatusCode: http.StatusOK,
-		Header:     http.Header{},
-		Body:       io.NopCloser(strings.NewReader(`{"result":"ok"}`)),
-	}
-	upstream := &mockSmartRetryUpstream{
-		responses: []*http.Response{successResp},
-		errors:    []error{nil},
+	tests := []struct {
+		name          string
+		waitDuration  time.Duration
+		expectedDelay time.Duration
+	}{
+		{name: "minimum", waitDuration: 0, expectedDelay: antigravitySmartRetryMinWait},
+		{name: "maximum", waitDuration: antigravitySingleAccountSmartRetryMaxWait + time.Second, expectedDelay: antigravitySingleAccountSmartRetryMaxWait},
 	}
 
-	account := &Account{
-		ID:          12,
-		Name:        "acc-clamp",
-		Type:        AccountTypeOAuth,
-		Platform:    PlatformAntigravity,
-		Concurrency: 1,
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstream := &mockSmartRetryUpstream{
+				responses: []*http.Response{{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{},
+					Body:       io.NopCloser(strings.NewReader(`{"result":"ok"}`)),
+				}},
+				errors: []error{nil},
+			}
+			account := &Account{
+				ID:          12,
+				Name:        "acc-clamp",
+				Type:        AccountTypeOAuth,
+				Platform:    PlatformAntigravity,
+				Concurrency: 1,
+			}
+			params := antigravityRetryLoopParams{
+				ctx:          ctxWithSingleAccountRetry(),
+				prefix:       "[test]",
+				account:      account,
+				accessToken:  "token",
+				action:       "generateContent",
+				body:         []byte(`{"input":"test"}`),
+				httpUpstream: upstream,
+			}
 
-	resp := &http.Response{
-		StatusCode: http.StatusServiceUnavailable,
-		Header:     http.Header{},
-	}
+			var retryWaits []time.Duration
+			svc := &AntigravityGatewayService{
+				retryWait: func(_ context.Context, delay time.Duration) bool {
+					retryWaits = append(retryWaits, delay)
+					return true
+				},
+			}
+			resp := &http.Response{StatusCode: http.StatusServiceUnavailable, Header: http.Header{}}
 
-	params := antigravityRetryLoopParams{
-		ctx:          ctxWithSingleAccountRetry(),
-		prefix:       "[test]",
-		account:      account,
-		accessToken:  "token",
-		action:       "generateContent",
-		body:         []byte(`{"input":"test"}`),
-		httpUpstream: upstream,
+			result := svc.handleSingleAccountRetryInPlace(params, resp, nil, "https://ag-1.test", tt.waitDuration, "gemini-3-pro")
+			require.NotNil(t, result)
+			require.Equal(t, smartRetryActionBreakWithResp, result.action)
+			require.NotNil(t, result.resp)
+			require.Equal(t, http.StatusOK, result.resp.StatusCode)
+			require.Equal(t, []time.Duration{tt.expectedDelay}, retryWaits)
+		})
 	}
-
-	var retryWaits []time.Duration
-	svc := &AntigravityGatewayService{
-		retryWait: func(_ context.Context, delay time.Duration) bool {
-			retryWaits = append(retryWaits, delay)
-			return true
-		},
-	}
-
-	// waitDuration=0 会被 clamp 到 antigravitySmartRetryMinWait=1s。
-	result := svc.handleSingleAccountRetryInPlace(params, resp, nil, "https://ag-1.test", 0, "gemini-3-pro")
-	require.NotNil(t, result)
-	require.Equal(t, smartRetryActionBreakWithResp, result.action)
-	require.NotNil(t, result.resp)
-	require.Equal(t, http.StatusOK, result.resp.StatusCode)
-	require.Equal(t, []time.Duration{antigravitySmartRetryMinWait}, retryWaits)
 }
 
 // TestHandleSingleAccountRetryInPlace_ContextCanceled context 取消时立即返回
@@ -713,7 +717,7 @@ func TestAntigravityRetryLoop_PreCheck_SingleAccountRetry_SkipsRateLimit(t *test
 		},
 	}
 
-	svc := &AntigravityGatewayService{retryWait: immediateAntigravityRetryWait}
+	svc := &AntigravityGatewayService{}
 	result, err := svc.antigravityRetryLoop(antigravityRetryLoopParams{
 		ctx:            ctxWithSingleAccountRetry(),
 		prefix:         "[test]",
@@ -757,7 +761,7 @@ func TestAntigravityRetryLoop_PreCheck_NoSingleAccountRetry_SwitchesOnRateLimit(
 		},
 	}
 
-	svc := &AntigravityGatewayService{retryWait: immediateAntigravityRetryWait}
+	svc := &AntigravityGatewayService{}
 	result, err := svc.antigravityRetryLoop(antigravityRetryLoopParams{
 		ctx:            context.Background(), // 无单账号标记
 		prefix:         "[test]",

--- a/backend/internal/service/antigravity_single_account_retry_test.go
+++ b/backend/internal/service/antigravity_single_account_retry_test.go
@@ -186,7 +186,7 @@ func TestHandleSmartRetry_503_LongDelay_NoSingleAccountRetry_StillSwitches(t *te
 
 	availableURLs := []string{"https://ag-1.test"}
 
-	svc := &AntigravityGatewayService{}
+	svc := &AntigravityGatewayService{retryWait: failOnAntigravityRetryWait(t)}
 	result := svc.handleSmartRetry(params, resp, respBody, "https://ag-1.test", 0, availableURLs)
 
 	require.NotNil(t, result)
@@ -245,7 +245,7 @@ func TestHandleSmartRetry_429_LongDelay_SingleAccountRetry_StillSwitches(t *test
 
 	availableURLs := []string{"https://ag-1.test"}
 
-	svc := &AntigravityGatewayService{}
+	svc := &AntigravityGatewayService{retryWait: failOnAntigravityRetryWait(t)}
 	result := svc.handleSmartRetry(params, resp, respBody, "https://ag-1.test", 0, availableURLs)
 
 	require.NotNil(t, result)
@@ -717,7 +717,7 @@ func TestAntigravityRetryLoop_PreCheck_SingleAccountRetry_SkipsRateLimit(t *test
 		},
 	}
 
-	svc := &AntigravityGatewayService{}
+	svc := &AntigravityGatewayService{retryWait: failOnAntigravityRetryWait(t)}
 	result, err := svc.antigravityRetryLoop(antigravityRetryLoopParams{
 		ctx:            ctxWithSingleAccountRetry(),
 		prefix:         "[test]",
@@ -761,7 +761,7 @@ func TestAntigravityRetryLoop_PreCheck_NoSingleAccountRetry_SwitchesOnRateLimit(
 		},
 	}
 
-	svc := &AntigravityGatewayService{}
+	svc := &AntigravityGatewayService{retryWait: failOnAntigravityRetryWait(t)}
 	result, err := svc.antigravityRetryLoop(antigravityRetryLoopParams{
 		ctx:            context.Background(), // 无单账号标记
 		prefix:         "[test]",

--- a/backend/internal/service/antigravity_smart_retry_test.go
+++ b/backend/internal/service/antigravity_smart_retry_test.go
@@ -128,7 +128,7 @@ func TestHandleSmartRetry_URLLevelRateLimit(t *testing.T) {
 
 	availableURLs := []string{"https://ag-1.test", "https://ag-2.test"}
 
-	svc := &AntigravityGatewayService{retryWait: immediateAntigravityRetryWait}
+	svc := &AntigravityGatewayService{}
 	result := svc.handleSmartRetry(params, resp, respBody, "https://ag-1.test", 0, availableURLs)
 
 	require.NotNil(t, result)
@@ -180,7 +180,7 @@ func TestHandleSmartRetry_LongDelay_ReturnsSwitchError(t *testing.T) {
 
 	availableURLs := []string{"https://ag-1.test"}
 
-	svc := &AntigravityGatewayService{retryWait: immediateAntigravityRetryWait}
+	svc := &AntigravityGatewayService{}
 	result := svc.handleSmartRetry(params, resp, respBody, "https://ag-1.test", 0, availableURLs)
 
 	require.NotNil(t, result)
@@ -509,7 +509,7 @@ func TestHandleSmartRetry_NonAntigravityAccount_ContinuesDefaultLogic(t *testing
 
 	availableURLs := []string{"https://ag-1.test"}
 
-	svc := &AntigravityGatewayService{retryWait: immediateAntigravityRetryWait}
+	svc := &AntigravityGatewayService{}
 	result := svc.handleSmartRetry(params, resp, respBody, "https://ag-1.test", 0, availableURLs)
 
 	require.NotNil(t, result)
@@ -558,7 +558,7 @@ func TestHandleSmartRetry_NonModelRateLimit_ContinuesDefaultLogic(t *testing.T) 
 
 	availableURLs := []string{"https://ag-1.test"}
 
-	svc := &AntigravityGatewayService{retryWait: immediateAntigravityRetryWait}
+	svc := &AntigravityGatewayService{}
 	result := svc.handleSmartRetry(params, resp, respBody, "https://ag-1.test", 0, availableURLs)
 
 	require.NotNil(t, result)
@@ -609,7 +609,7 @@ func TestHandleSmartRetry_ExactlyAtThreshold_ReturnsSwitchError(t *testing.T) {
 
 	availableURLs := []string{"https://ag-1.test"}
 
-	svc := &AntigravityGatewayService{retryWait: immediateAntigravityRetryWait}
+	svc := &AntigravityGatewayService{}
 	result := svc.handleSmartRetry(params, resp, respBody, "https://ag-1.test", 0, availableURLs)
 
 	require.NotNil(t, result)
@@ -652,7 +652,7 @@ func TestAntigravityRetryLoop_HandleSmartRetry_SwitchError_Propagates(t *testing
 		Concurrency: 1,
 	}
 
-	svc := &AntigravityGatewayService{retryWait: immediateAntigravityRetryWait}
+	svc := &AntigravityGatewayService{}
 	result, err := svc.antigravityRetryLoop(antigravityRetryLoopParams{
 		ctx:             context.Background(),
 		prefix:          "[test]",
@@ -784,7 +784,7 @@ func TestHandleSmartRetry_NoRetryDelay_UsesDefaultRateLimit(t *testing.T) {
 
 	availableURLs := []string{"https://ag-1.test"}
 
-	svc := &AntigravityGatewayService{retryWait: immediateAntigravityRetryWait}
+	svc := &AntigravityGatewayService{}
 	result := svc.handleSmartRetry(params, resp, respBody, "https://ag-1.test", 0, availableURLs)
 
 	require.NotNil(t, result)
@@ -1164,7 +1164,7 @@ func TestHandleSmartRetry_LongDelay_StickySession_ClearsSession(t *testing.T) {
 
 	availableURLs := []string{"https://ag-1.test"}
 
-	svc := &AntigravityGatewayService{cache: cache, retryWait: immediateAntigravityRetryWait}
+	svc := &AntigravityGatewayService{cache: cache}
 	result := svc.handleSmartRetry(params, resp, respBody, "https://ag-1.test", 0, availableURLs)
 
 	require.NotNil(t, result)

--- a/backend/internal/service/antigravity_smart_retry_test.go
+++ b/backend/internal/service/antigravity_smart_retry_test.go
@@ -31,6 +31,14 @@ func immediateAntigravityRetryWait(_ context.Context, _ time.Duration) bool {
 	return true
 }
 
+func failOnAntigravityRetryWait(t *testing.T) func(context.Context, time.Duration) bool {
+	t.Helper()
+	return func(_ context.Context, delay time.Duration) bool {
+		t.Fatalf("unexpected Antigravity retry wait: %v", delay)
+		return false
+	}
+}
+
 func (c *stubSmartRetryCache) DeleteSessionAccountID(_ context.Context, groupID int64, sessionHash string) error {
 	c.deleteCalls = append(c.deleteCalls, deleteSessionCall{groupID: groupID, sessionHash: sessionHash})
 	return nil
@@ -128,7 +136,7 @@ func TestHandleSmartRetry_URLLevelRateLimit(t *testing.T) {
 
 	availableURLs := []string{"https://ag-1.test", "https://ag-2.test"}
 
-	svc := &AntigravityGatewayService{}
+	svc := &AntigravityGatewayService{retryWait: failOnAntigravityRetryWait(t)}
 	result := svc.handleSmartRetry(params, resp, respBody, "https://ag-1.test", 0, availableURLs)
 
 	require.NotNil(t, result)
@@ -180,7 +188,7 @@ func TestHandleSmartRetry_LongDelay_ReturnsSwitchError(t *testing.T) {
 
 	availableURLs := []string{"https://ag-1.test"}
 
-	svc := &AntigravityGatewayService{}
+	svc := &AntigravityGatewayService{retryWait: failOnAntigravityRetryWait(t)}
 	result := svc.handleSmartRetry(params, resp, respBody, "https://ag-1.test", 0, availableURLs)
 
 	require.NotNil(t, result)
@@ -509,7 +517,7 @@ func TestHandleSmartRetry_NonAntigravityAccount_ContinuesDefaultLogic(t *testing
 
 	availableURLs := []string{"https://ag-1.test"}
 
-	svc := &AntigravityGatewayService{}
+	svc := &AntigravityGatewayService{retryWait: failOnAntigravityRetryWait(t)}
 	result := svc.handleSmartRetry(params, resp, respBody, "https://ag-1.test", 0, availableURLs)
 
 	require.NotNil(t, result)
@@ -558,7 +566,7 @@ func TestHandleSmartRetry_NonModelRateLimit_ContinuesDefaultLogic(t *testing.T) 
 
 	availableURLs := []string{"https://ag-1.test"}
 
-	svc := &AntigravityGatewayService{}
+	svc := &AntigravityGatewayService{retryWait: failOnAntigravityRetryWait(t)}
 	result := svc.handleSmartRetry(params, resp, respBody, "https://ag-1.test", 0, availableURLs)
 
 	require.NotNil(t, result)
@@ -609,7 +617,7 @@ func TestHandleSmartRetry_ExactlyAtThreshold_ReturnsSwitchError(t *testing.T) {
 
 	availableURLs := []string{"https://ag-1.test"}
 
-	svc := &AntigravityGatewayService{}
+	svc := &AntigravityGatewayService{retryWait: failOnAntigravityRetryWait(t)}
 	result := svc.handleSmartRetry(params, resp, respBody, "https://ag-1.test", 0, availableURLs)
 
 	require.NotNil(t, result)
@@ -652,7 +660,7 @@ func TestAntigravityRetryLoop_HandleSmartRetry_SwitchError_Propagates(t *testing
 		Concurrency: 1,
 	}
 
-	svc := &AntigravityGatewayService{}
+	svc := &AntigravityGatewayService{retryWait: failOnAntigravityRetryWait(t)}
 	result, err := svc.antigravityRetryLoop(antigravityRetryLoopParams{
 		ctx:             context.Background(),
 		prefix:          "[test]",
@@ -784,7 +792,7 @@ func TestHandleSmartRetry_NoRetryDelay_UsesDefaultRateLimit(t *testing.T) {
 
 	availableURLs := []string{"https://ag-1.test"}
 
-	svc := &AntigravityGatewayService{}
+	svc := &AntigravityGatewayService{retryWait: failOnAntigravityRetryWait(t)}
 	result := svc.handleSmartRetry(params, resp, respBody, "https://ag-1.test", 0, availableURLs)
 
 	require.NotNil(t, result)
@@ -1164,7 +1172,7 @@ func TestHandleSmartRetry_LongDelay_StickySession_ClearsSession(t *testing.T) {
 
 	availableURLs := []string{"https://ag-1.test"}
 
-	svc := &AntigravityGatewayService{cache: cache}
+	svc := &AntigravityGatewayService{cache: cache, retryWait: failOnAntigravityRetryWait(t)}
 	result := svc.handleSmartRetry(params, resp, respBody, "https://ag-1.test", 0, availableURLs)
 
 	require.NotNil(t, result)

--- a/backend/internal/service/openai_gateway_tk_oauth401_refresh_test.go
+++ b/backend/internal/service/openai_gateway_tk_oauth401_refresh_test.go
@@ -496,8 +496,12 @@ func TestOpenAIGatewayService_PassthroughWS_OAuth401RefreshesOnce(t *testing.T) 
 	require.Equal(t, []string{"Bearer stale-token", "Bearer fresh-token"}, dialer.auths)
 	require.Zero(t, rateRepo.setErrorCalls)
 	select {
-	case <-serverErr:
+	case err := <-serverErr:
+		if err != nil {
+			require.ErrorIs(t, err, errOpenAIWSConnClosed)
+		}
 	case <-time.After(3 * time.Second):
+		t.Fatal("passthrough WS server did not stop after both connections closed")
 	}
 }
 


### PR DESCRIPTION
## 摘要

- 收紧 OAuth 401 WebSocket passthrough teardown 断言：只允许正常结束或已知的 `errOpenAIWSConnClosed`，其他错误与超时均失败。
- 将单账号 retry wait clamp 测试改为表驱动，同时覆盖最小值与最大值。
- 对所有声明“不进入等待路径”的 Antigravity 用例注入 fail-fast waiter；未来若误入 wait 分支会立即失败，不再真实睡眠后继续通过。
- `sentinel-registry-reviewed`：仅修改测试断言，未新增或改变 load-bearing TK 行为及注入点，无需更新 sentinel registry。

## 风险

- 低风险，仅修改测试，不改变生产行为或公共契约。

## 验证

- `go test -race -tags=unit ./internal/service -count=1 -run '^(TestHandleSmartRetry.*|TestHandleSingleAccountRetryInPlace.*|TestRetryLoop_ErrorPolicy_NoPolicy_OriginalBehavior|TestOpenAIGatewayService_Forward_PreservePreviousResponseIDWhenWSEnabled|TestOpenAIGatewayService_Forward_WSv2FallbackCoolingSkipWS|TestOpenAIGatewayService_PassthroughWS_OAuth401RefreshesOnce)$'`
- `make test-unit`
- `DOCKER_HOST=unix:///Users/feng/.colima/default/docker.sock TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock make test-integration`
- `make lint`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`

以上均通过。

## 提交

- `353a9f78e test(ci): close R-001..R-003 review gaps`
- `a8b6d7940 test(ci): fail fast on unexpected retry waits`

最新提交：`a8b6d7940`