### PR TITLE
fix(dev): pin preflight to declared Go toolchain

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -98,6 +98,15 @@ set -u
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
+# Match every local Go gate and generator to the exact toolchain installed by
+# CI from backend/go.mod. GOTOOLCHAIN=auto never downgrades a newer ambient Go.
+_go_mod_version="$(awk '$1 == "go" { print $2; exit }' backend/go.mod)"
+if [ -z "$_go_mod_version" ]; then
+    echo "FAIL: cannot read Go version from backend/go.mod" >&2
+    exit 1
+fi
+export GOTOOLCHAIN="go$_go_mod_version"
+
 # ---- TK: clear worktree git-config debt before any submodule traversal -------
 # When this script runs inside a git worktree that contains nested submodules
 # (e.g. `dev-rules/`), `git submodule status` and similar walkers will silently


### PR DESCRIPTION
## Summary

- derive the exact Go toolchain from `backend/go.mod` at preflight startup
- export it for every Go gate and generator invoked by preflight or its child scripts
- fail early when the Go directive cannot be read

## Why

`GOTOOLCHAIN=auto` does not downgrade a newer ambient Go. A developer with Go 1.27 could therefore regenerate Ent or run local gates with a different toolchain than GitHub, even though CI and the backend Makefile already honor `backend/go.mod`. This closes that remaining local entry-point gap without adding another version file or launcher.

## Verification

- `./scripts/preflight.sh`
- `make test`
- ambient Go 1.27 proxy check proved every preflight `go` invocation inherited the exact `go1.26.6` pin
- generated Ent/Wire files remained unchanged

ai