### PR TITLE
fix(gemini): route Universal native requests to Vertex

### DIFF
--- a/backend/internal/handler/gemini_v1beta_handler.go
+++ b/backend/internal/handler/gemini_v1beta_handler.go
@@ -375,6 +375,10 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 	cleanedForUnknownBinding := false
 
 	fs := NewFailoverState(h.maxAccountSwitchesGemini, hasBoundSession)
+	if apiKey.IsUniversal() && apiKey.Group != nil && apiKey.Group.Platform == service.PlatformNewAPI {
+		ctx := service.WithNativeGeminiVertexAccountRequirement(c.Request.Context())
+		c.Request = c.Request.WithContext(ctx)
+	}
 
 	// 单账号分组提前设置 SingleAccountRetry 标记，让 Service 层首次 503 就不设模型限流标记。
 	// 避免单账号分组收到 503 (MODEL_CAPACITY_EXHAUSTED) 时设 29s 限流，导致后续请求连续快速失败。

--- a/backend/internal/handler/gemini_v1beta_handler.go
+++ b/backend/internal/handler/gemini_v1beta_handler.go
@@ -51,7 +51,7 @@ func (h *GatewayHandler) GeminiV1BetaListModels(c *gin.Context) {
 	// 检查平台：优先使用强制平台（/antigravity 路由），否则要求 gemini/antigravity 分组
 	forcePlatform, hasForcePlatform := middleware.GetForcePlatformFromContext(c)
 	if !hasForcePlatform && !geminiV1BetaGroupPlatformAllowed(apiKey) {
-		googleError(c, http.StatusBadRequest, "API key group platform is not gemini or antigravity")
+		googleError(c, http.StatusBadRequest, "API key group cannot serve native Gemini requests")
 		return
 	}
 
@@ -100,7 +100,7 @@ func (h *GatewayHandler) GeminiV1BetaGetModel(c *gin.Context) {
 	// 检查平台：优先使用强制平台（/antigravity 路由），否则要求 gemini/antigravity 分组
 	forcePlatform, hasForcePlatform := middleware.GetForcePlatformFromContext(c)
 	if !hasForcePlatform && !geminiV1BetaGroupPlatformAllowed(apiKey) {
-		googleError(c, http.StatusBadRequest, "API key group platform is not gemini or antigravity")
+		googleError(c, http.StatusBadRequest, "API key group cannot serve native Gemini requests")
 		return
 	}
 
@@ -177,7 +177,7 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 	// 检查平台：优先使用强制平台（/antigravity 路由，中间件已设置 request.Context），否则要求 gemini/antigravity 分组
 	if !middleware.HasForcePlatform(c) {
 		if !geminiV1BetaGroupPlatformAllowed(apiKey) {
-			googleError(c, http.StatusBadRequest, "API key group platform is not gemini or antigravity")
+			googleError(c, http.StatusBadRequest, "API key group cannot serve native Gemini requests")
 			return
 		}
 	}
@@ -413,6 +413,17 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 			}
 		}
 		account := selection.Account
+		if apiKey.IsUniversal() && apiKey.Group != nil && apiKey.Group.Platform == service.PlatformNewAPI && !account.IsNewAPIVertexServiceAccount() {
+			if selection.ReleaseFunc != nil {
+				selection.ReleaseFunc()
+			}
+			reqLog.Error("gemini.universal_vertex_account_rejected",
+				zap.Int64("account_id", account.ID),
+				zap.Int("channel_type", account.ChannelType),
+			)
+			googleError(c, http.StatusServiceUnavailable, "No available Gemini accounts")
+			return
+		}
 		setOpsSelectedAccountFrom(c, account)
 
 		// 检测账号切换：如果粘性会话绑定的账号与当前选择的账号不同，清除 thoughtSignature
@@ -637,6 +648,11 @@ func geminiV1BetaGroupPlatformAllowed(apiKey *service.APIKey) bool {
 	switch apiKey.Group.Platform {
 	case service.PlatformGemini, service.PlatformAntigravity:
 		return true
+	case service.PlatformNewAPI:
+		// Direct newapi keys remain outside the native Gemini surface. Universal
+		// routing has already proved exact Vertex account/model serviceability
+		// before replacing the key's backing group.
+		return apiKey.IsUniversal()
 	default:
 		return false
 	}

--- a/backend/internal/handler/gemini_v1beta_handler_test.go
+++ b/backend/internal/handler/gemini_v1beta_handler_test.go
@@ -109,6 +109,19 @@ func TestGeminiV1BetaGroupPlatformAllowed(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "universal vertex group",
+			apiKey: &service.APIKey{
+				RoutingMode: service.RoutingModeUniversal,
+				Group:       &service.Group{Platform: service.PlatformNewAPI},
+			},
+			expected: true,
+		},
+		{
+			name:     "direct newapi group",
+			apiKey:   &service.APIKey{Group: &service.Group{Platform: service.PlatformNewAPI}},
+			expected: false,
+		},
+		{
 			name:     "openai group",
 			apiKey:   &service.APIKey{Group: &service.Group{Platform: service.PlatformOpenAI}},
 			expected: false,

--- a/backend/internal/service/gateway_multiplatform_test.go
+++ b/backend/internal/service/gateway_multiplatform_test.go
@@ -5,6 +5,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -2248,6 +2249,99 @@ func TestGatewayService_SelectAccountWithLoadAwareness(t *testing.T) {
 		require.NotNil(t, result)
 		require.NotNil(t, result.Account)
 		require.Equal(t, int64(1), result.Account.ID, "应选择优先级最高的账号")
+	})
+
+	t.Run("native Gemini Vertex requirement filters mixed newapi group", func(t *testing.T) {
+		groupID := int64(41)
+		model := "gemini-3.7-flash"
+		accounts := []Account{
+			{
+				ID:          1,
+				Platform:    PlatformNewAPI,
+				Type:        AccountTypeAPIKey,
+				ChannelType: 1,
+				Priority:    1,
+				Status:      StatusActive,
+				Schedulable: true,
+				Concurrency: 5,
+				Credentials: map[string]any{"model_mapping": map[string]any{model: model}},
+			},
+			{
+				ID:          2,
+				Platform:    PlatformNewAPI,
+				Type:        AccountTypeServiceAccount,
+				ChannelType: 41,
+				Priority:    2,
+				Status:      StatusActive,
+				Schedulable: true,
+				Concurrency: 5,
+				Credentials: map[string]any{"model_mapping": map[string]any{model: model}},
+			},
+		}
+		repo := &mockAccountRepoForPlatform{accounts: accounts, accountsByID: map[int64]*Account{}}
+		for i := range repo.accounts {
+			repo.accountsByID[repo.accounts[i].ID] = &repo.accounts[i]
+		}
+		groupRepo := &mockGroupRepoForGateway{groups: map[int64]*Group{
+			groupID: {ID: groupID, Platform: PlatformNewAPI, Status: StatusActive, Hydrated: true},
+		}}
+
+		for _, loadBatchEnabled := range []bool{false, true} {
+			t.Run(fmt.Sprintf("load_batch=%t", loadBatchEnabled), func(t *testing.T) {
+				cfg := testConfig()
+				cfg.Gateway.Scheduling.LoadBatchEnabled = loadBatchEnabled
+				svc := &GatewayService{
+					accountRepo: repo,
+					groupRepo:   groupRepo,
+					cache:       &mockGatewayCacheForPlatform{},
+					cfg:         cfg,
+				}
+				if loadBatchEnabled {
+					svc.concurrencyService = NewConcurrencyService(&mockConcurrencyCache{})
+				}
+				ctx := WithNativeGeminiVertexAccountRequirement(context.Background())
+				result, err := svc.SelectAccountWithLoadAwareness(ctx, &groupID, "", model, nil, "", 0)
+				require.NoError(t, err)
+				require.Equal(t, int64(2), result.Account.ID)
+			})
+		}
+	})
+
+	t.Run("native Gemini Vertex requirement rejects all non-Vertex candidates", func(t *testing.T) {
+		groupID := int64(42)
+		model := "gemini-3.7-flash"
+		repo := &mockAccountRepoForPlatform{
+			accounts: []Account{{
+				ID:          3,
+				Platform:    PlatformNewAPI,
+				Type:        AccountTypeAPIKey,
+				ChannelType: 1,
+				Priority:    1,
+				Status:      StatusActive,
+				Schedulable: true,
+				Concurrency: 5,
+				Credentials: map[string]any{"model_mapping": map[string]any{model: model}},
+			}},
+			accountsByID: map[int64]*Account{},
+		}
+		repo.accountsByID[3] = &repo.accounts[0]
+		groupRepo := &mockGroupRepoForGateway{groups: map[int64]*Group{
+			groupID: {ID: groupID, Platform: PlatformNewAPI, Status: StatusActive, Hydrated: true},
+		}}
+		cfg := testConfig()
+		cfg.Gateway.Scheduling.LoadBatchEnabled = true
+		svc := &GatewayService{
+			accountRepo:        repo,
+			groupRepo:          groupRepo,
+			cache:              &mockGatewayCacheForPlatform{},
+			cfg:                cfg,
+			concurrencyService: NewConcurrencyService(&mockConcurrencyCache{}),
+		}
+
+		ctx := WithNativeGeminiVertexAccountRequirement(context.Background())
+		result, err := svc.SelectAccountWithLoadAwareness(ctx, &groupID, "", model, nil, "", 0)
+		require.ErrorIs(t, err, ErrNoAvailableAccounts)
+		require.Nil(t, result)
 	})
 
 	t.Run("模型路由-无ConcurrencyService也生效", func(t *testing.T) {

--- a/backend/internal/service/gateway_scheduling.go
+++ b/backend/internal/service/gateway_scheduling.go
@@ -991,6 +991,7 @@ func (s *GatewayService) listSchedulableAccounts(ctx context.Context, groupID *i
 	if s.schedulerSnapshot != nil {
 		accounts, useMixed, err := s.schedulerSnapshot.ListSchedulableAccounts(ctx, groupID, platform, hasForcePlatform)
 		if err == nil {
+			accounts = filterAccountsForNativeGeminiVertexRequirement(ctx, accounts)
 			accounts = s.filterAccountsBySchedulingThreshold(ctx, accounts)
 			if platform == PlatformGrok || strings.EqualFold(platform, PlatformGrok) {
 				accounts = s.filterGrokFreeQuotaAccountsForGateway(ctx, accounts)
@@ -1040,6 +1041,7 @@ func (s *GatewayService) listSchedulableAccounts(ctx context.Context, groupID *i
 			}
 			filtered = append(filtered, acc)
 		}
+		filtered = filterAccountsForNativeGeminiVertexRequirement(ctx, filtered)
 		slog.Debug("account_scheduling_list_mixed",
 			"group_id", derefGroupID(groupID),
 			"platform", platform,
@@ -1091,6 +1093,7 @@ func (s *GatewayService) listSchedulableAccounts(ctx context.Context, groupID *i
 				"tls_fingerprint", acc.IsTLSFingerprintEnabled())
 		}
 	}
+	accounts = filterAccountsForNativeGeminiVertexRequirement(ctx, accounts)
 	accounts = s.filterAccountsBySchedulingThreshold(ctx, accounts)
 	if platform == PlatformGrok || strings.EqualFold(platform, PlatformGrok) {
 		accounts = s.filterGrokFreeQuotaAccountsForGateway(ctx, accounts)
@@ -1171,7 +1174,7 @@ func (s *GatewayService) getSchedulableAccount(ctx context.Context, accountID in
 	if err != nil || account == nil {
 		return account, err
 	}
-	if s.isAccountBlockedBySchedulingThreshold(ctx, account) {
+	if !accountSupportsNativeGeminiVertexRequirement(ctx, account) || s.isAccountBlockedBySchedulingThreshold(ctx, account) {
 		return nil, nil
 	}
 	// Sticky / non-list selection must honor free soft-gate (same as listSchedulableAccounts).

--- a/backend/internal/service/gateway_scheduling_tk_request_capability.go
+++ b/backend/internal/service/gateway_scheduling_tk_request_capability.go
@@ -1,0 +1,37 @@
+package service
+
+import "context"
+
+type nativeGeminiVertexAccountRequirementContextKey struct{}
+
+func WithNativeGeminiVertexAccountRequirement(ctx context.Context) context.Context {
+	return context.WithValue(ctx, nativeGeminiVertexAccountRequirementContextKey{}, true)
+}
+
+func nativeGeminiVertexAccountRequired(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	required, _ := ctx.Value(nativeGeminiVertexAccountRequirementContextKey{}).(bool)
+	return required
+}
+
+func accountSupportsNativeGeminiVertexRequirement(ctx context.Context, account *Account) bool {
+	if account == nil {
+		return false
+	}
+	return !nativeGeminiVertexAccountRequired(ctx) || account.IsNewAPIVertexServiceAccount()
+}
+
+func filterAccountsForNativeGeminiVertexRequirement(ctx context.Context, accounts []Account) []Account {
+	if !nativeGeminiVertexAccountRequired(ctx) {
+		return accounts
+	}
+	filtered := make([]Account, 0, len(accounts))
+	for i := range accounts {
+		if accountSupportsNativeGeminiVertexRequirement(ctx, &accounts[i]) {
+			filtered = append(filtered, accounts[i])
+		}
+	}
+	return filtered
+}

--- a/backend/internal/service/gemini_token_provider.go
+++ b/backend/internal/service/gemini_token_provider.go
@@ -53,8 +53,10 @@ func (p *GeminiTokenProvider) GetAccessToken(ctx context.Context, account *Accou
 	if account == nil {
 		return "", errors.New("account is nil")
 	}
-	if account.Platform != PlatformGemini || (account.Type != AccountTypeOAuth && account.Type != AccountTypeServiceAccount) {
-		return "", errors.New("not a gemini oauth or service account")
+	isGeminiAccount := account.Platform == PlatformGemini &&
+		(account.Type == AccountTypeOAuth || account.Type == AccountTypeServiceAccount)
+	if !isGeminiAccount && !account.IsNewAPIVertexServiceAccount() {
+		return "", errors.New("not a gemini oauth or Vertex service account")
 	}
 	if account.Type == AccountTypeServiceAccount {
 		return p.getServiceAccountAccessToken(ctx, account)

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -288,9 +288,17 @@ type groupAwareStubOpenAIAccountRepo struct {
 }
 
 func (r groupAwareStubOpenAIAccountRepo) ListSchedulableByGroupIDAndPlatform(ctx context.Context, groupID int64, platform string) ([]Account, error) {
+	return r.ListSchedulableByGroupIDAndPlatforms(ctx, groupID, []string{platform})
+}
+
+func (r groupAwareStubOpenAIAccountRepo) ListSchedulableByGroupIDAndPlatforms(_ context.Context, groupID int64, platforms []string) ([]Account, error) {
+	allowed := make(map[string]struct{}, len(platforms))
+	for _, platform := range platforms {
+		allowed[platform] = struct{}{}
+	}
 	var result []Account
 	for _, acc := range r.accounts {
-		if acc.Platform == platform && openAIStickyAccountMatchesGroup(&acc, &groupID) {
+		if _, ok := allowed[acc.Platform]; ok && openAIStickyAccountMatchesGroup(&acc, &groupID) {
 			result = append(result, acc)
 		}
 	}

--- a/backend/internal/service/universal_routing_tk_endpoint_map.go
+++ b/backend/internal/service/universal_routing_tk_endpoint_map.go
@@ -158,7 +158,10 @@ func universalCandidatePlatforms(shape UniversalShape, forcedPlatform string, ha
 		}
 		return out
 	case ShapeGemini:
-		return []string{PlatformGemini, PlatformAntigravity}
+		// Native Gemini requests can also be served by Vertex service accounts
+		// represented as newapi ch41. Account-level shape/model checks below keep
+		// unrelated newapi vendors out of this candidate pool.
+		return []string{PlatformGemini, PlatformAntigravity, PlatformNewAPI}
 	default:
 		return nil
 	}

--- a/backend/internal/service/universal_routing_tk_serving.go
+++ b/backend/internal/service/universal_routing_tk_serving.go
@@ -63,8 +63,19 @@ func (s *GatewayService) UniversalGroupSupportsRequest(ctx context.Context, grou
 	if err != nil {
 		return false, false
 	}
-	accounts = append(accounts, s.listErrorAccountsForUniversalEntitlement(ctx, groupID, platform)...)
-	return s.universalAccountsSupportRequest(ctx, accounts, useMixed, platform, model, shape), true
+	// Native Gemini has multiple wire-compatible Google backends. Its resolver
+	// therefore needs current scheduler reachability so an error-only native pool
+	// cannot mask a healthy Vertex group through the Gemini platform hint. Other
+	// shapes retain error-account entitlement to prevent semantic cross-vendor
+	// misrouting (for example Qianfan-owned DeepSeek models).
+	return s.universalAccountsSupportRequest(
+		ctx,
+		s.accountsForUniversalRequestEntitlement(ctx, groupID, platform, shape, accounts),
+		useMixed,
+		platform,
+		model,
+		shape,
+	), true
 }
 
 // UniversalGroupSupportsRequestStrict is the discovery counterpart of the
@@ -78,6 +89,7 @@ func (s *GatewayService) UniversalGroupSupportsRequestStrict(ctx context.Context
 	if err != nil {
 		return false, err
 	}
+	accounts = s.accountsForUniversalRequestEntitlement(ctx, &groupID, platform, shape, accounts)
 	return s.universalAccountsSupportRequest(ctx, accounts, useMixed, platform, model, shape), nil
 }
 
@@ -116,11 +128,7 @@ func withUniversalCapabilityAccountCache(ctx context.Context) context.Context {
 func (s *GatewayService) universalCapabilityAccounts(ctx context.Context, groupID int64, platform string) ([]Account, bool, error) {
 	cache, _ := ctx.Value(universalCapabilityAccountCacheContextKey{}).(*universalCapabilityAccountCache)
 	if cache == nil {
-		accounts, useMixed, err := s.listSchedulableAccounts(ctx, &groupID, platform, false)
-		if err != nil {
-			return accounts, useMixed, err
-		}
-		return append(accounts, s.listErrorAccountsForUniversalEntitlement(ctx, &groupID, platform)...), useMixed, nil
+		return s.listSchedulableAccounts(ctx, &groupID, platform, false)
 	}
 
 	key := universalCapabilityAccountCacheKey{groupID: groupID, platform: platform}
@@ -130,15 +138,25 @@ func (s *GatewayService) universalCapabilityAccounts(ctx context.Context, groupI
 		return cached.accounts, cached.useMixed, cached.err
 	}
 	accounts, useMixed, err := s.listSchedulableAccounts(ctx, &groupID, platform, false)
-	if err == nil {
-		accounts = append(accounts, s.listErrorAccountsForUniversalEntitlement(ctx, &groupID, platform)...)
-	}
 	cache.entries[key] = universalCapabilityAccountCacheEntry{
 		accounts: accounts,
 		useMixed: useMixed,
 		err:      err,
 	}
 	return accounts, useMixed, err
+}
+
+func (s *GatewayService) accountsForUniversalRequestEntitlement(
+	ctx context.Context,
+	groupID *int64,
+	platform string,
+	shape UniversalShape,
+	accounts []Account,
+) []Account {
+	if shape == ShapeGemini {
+		return accounts
+	}
+	return append(accounts, s.listErrorAccountsForUniversalEntitlement(ctx, groupID, platform)...)
 }
 
 func (s *GatewayService) listErrorAccountsForUniversalEntitlement(ctx context.Context, groupID *int64, platform string) []Account {
@@ -155,6 +173,9 @@ func (s *GatewayService) listErrorAccountsForUniversalEntitlement(ctx context.Co
 func (s *GatewayService) universalAccountsSupportRequest(ctx context.Context, accounts []Account, useMixed bool, platform, model string, shape UniversalShape) bool {
 	for i := range accounts {
 		acc := &accounts[i]
+		if shape == ShapeGemini && !s.isAccountSchedulableForModelSelection(ctx, acc, model) {
+			continue
+		}
 		if IsOpenAICompatPlatform(platform) {
 			if !acc.IsOpenAICompatPoolMember(platform) {
 				continue
@@ -230,6 +251,8 @@ func universalOpenAICompatMappingHonorsPlatformHint(account *Account, model stri
 
 func universalOpenAICompatAccountSupportsShape(account *Account, shape UniversalShape) bool {
 	switch shape {
+	case ShapeGemini:
+		return account.IsNewAPIVertexServiceAccount()
 	case ShapeOpenAIEmbeddings:
 		return accountSupportsOpenAIRequestCapabilities(account, OpenAIEndpointCapabilityEmbeddings, "", false)
 	case ShapeOpenAIImages, ShapeOpenAIImagesEdit:

--- a/backend/internal/service/universal_routing_tk_serving_test.go
+++ b/backend/internal/service/universal_routing_tk_serving_test.go
@@ -5,6 +5,7 @@ package service
 import (
 	"context"
 	"testing"
+	"time"
 )
 
 // servedProvider 构造一个按 group id 返回显式服务集的 provider stub。
@@ -412,6 +413,152 @@ func TestResolve_ImagenPicksVertexNewapiGroup(t *testing.T) {
 	g, err := r.Resolve(ctx, universalKey(1), ShapeOpenAIImages, "imagen-4.0-fast-generate-001", "")
 	if err != nil || g == nil || g.ID != 16 {
 		t.Fatalf("imagen 应落 vertex newapi 组 gid=16, got=%v err=%v", g, err)
+	}
+}
+
+func TestResolve_GeminiNativePicksVertexNewapiGroup(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		grp(16, PlatformNewAPI, 10, false),
+	}
+	modelMapping := map[string]any{"gemini-3.7-flash": "gemini-3.7-flash"}
+	svc := &GatewayService{
+		accountRepo: groupAwareStubOpenAIAccountRepo{stubOpenAIAccountRepo{accounts: []Account{
+			{
+				ID:          47,
+				GroupIDs:    []int64{16},
+				Platform:    PlatformNewAPI,
+				Type:        AccountTypeServiceAccount,
+				Status:      StatusActive,
+				Schedulable: true,
+				ChannelType: 41,
+				Credentials: map[string]any{"model_mapping": modelMapping},
+			},
+		}}},
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetModelSupportProvider(svc.UniversalGroupSupportsRequest)
+
+	g, err := r.Resolve(ctx, universalKey(1), ShapeGemini, "gemini-3.7-flash", "")
+	if err != nil || g == nil || g.ID != 16 {
+		t.Fatalf("gemini-native universal must pick vertex gid=16, got=%v err=%v", g, err)
+	}
+}
+
+func TestResolve_GeminiNativeRejectsNonVertexNewapiGroup(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		grp(19, PlatformNewAPI, 10, false),
+	}
+	modelMapping := map[string]any{"gemini-3.7-flash": "gemini-3.7-flash"}
+	svc := &GatewayService{
+		accountRepo: groupAwareStubOpenAIAccountRepo{stubOpenAIAccountRepo{accounts: []Account{
+			{
+				ID:          90,
+				GroupIDs:    []int64{19},
+				Platform:    PlatformNewAPI,
+				Type:        AccountTypeAPIKey,
+				Status:      StatusActive,
+				Schedulable: true,
+				ChannelType: 46,
+				Credentials: map[string]any{"model_mapping": modelMapping},
+			},
+		}}},
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetModelSupportProvider(svc.UniversalGroupSupportsRequest)
+
+	g, err := r.Resolve(ctx, universalKey(1), ShapeGemini, "gemini-3.7-flash", "")
+	if g != nil || err != ErrUniversalNoEntitledGroup {
+		t.Fatalf("gemini-native universal must reject non-Vertex newapi group, got=%v err=%v", g, err)
+	}
+}
+
+func TestResolve_GeminiNativeSkipsModelCooledGeminiAccountForSchedulableVertex(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		grp(8, PlatformGemini, 5, false),
+		grp(16, PlatformNewAPI, 10, false),
+	}
+	modelMapping := map[string]any{"gemini-3.7-flash": "gemini-3.7-flash"}
+	resetAt := time.Now().Add(time.Hour).Format(time.RFC3339)
+	svc := &GatewayService{
+		accountRepo: groupAwareStubOpenAIAccountRepo{stubOpenAIAccountRepo{accounts: []Account{
+			{
+				ID:          44,
+				GroupIDs:    []int64{8},
+				Platform:    PlatformGemini,
+				Type:        AccountTypeOAuth,
+				Status:      StatusActive,
+				Schedulable: true,
+				Credentials: map[string]any{"model_mapping": modelMapping},
+				Extra: map[string]any{
+					"model_rate_limits": map[string]any{
+						"gemini-3.7-flash": map[string]any{"rate_limit_reset_at": resetAt},
+					},
+				},
+			},
+			{
+				ID:          47,
+				GroupIDs:    []int64{16},
+				Platform:    PlatformNewAPI,
+				Type:        AccountTypeServiceAccount,
+				Status:      StatusActive,
+				Schedulable: true,
+				ChannelType: 41,
+				Credentials: map[string]any{"model_mapping": modelMapping},
+			},
+		}}},
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetModelSupportProvider(svc.UniversalGroupSupportsRequest)
+
+	g, err := r.Resolve(ctx, universalKey(1), ShapeGemini, "gemini-3.7-flash", "")
+	if err != nil || g == nil || g.ID != 16 {
+		t.Fatalf("gemini-native universal must skip model-cooled native account for Vertex gid=16, got=%v err=%v", g, err)
+	}
+}
+
+func TestResolve_GeminiNativeSkipsErrorGeminiAccountForSchedulableVertex(t *testing.T) {
+	ctx := context.Background()
+	span := []Group{
+		grp(8, PlatformGemini, 5, false),
+		grp(16, PlatformNewAPI, 10, false),
+	}
+	modelMapping := map[string]any{"gemini-3.7-flash": "gemini-3.7-flash"}
+	svc := &GatewayService{
+		accountRepo: entitlementAwareStubAccountRepo{
+			groupAwareStubOpenAIAccountRepo: groupAwareStubOpenAIAccountRepo{
+				stubOpenAIAccountRepo{accounts: []Account{
+					{
+						ID:          44,
+						GroupIDs:    []int64{8},
+						Platform:    PlatformGemini,
+						Type:        AccountTypeOAuth,
+						Status:      StatusError,
+						Schedulable: false,
+						Credentials: map[string]any{"model_mapping": modelMapping},
+					},
+					{
+						ID:          47,
+						GroupIDs:    []int64{16},
+						Platform:    PlatformNewAPI,
+						Type:        AccountTypeServiceAccount,
+						Status:      StatusActive,
+						Schedulable: true,
+						ChannelType: 41,
+						Credentials: map[string]any{"model_mapping": modelMapping},
+					},
+				}},
+			},
+		},
+	}
+	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
+	r.SetModelSupportProvider(svc.UniversalGroupSupportsRequest)
+
+	g, err := r.Resolve(ctx, universalKey(1), ShapeGemini, "gemini-3.7-flash", "")
+	if err != nil || g == nil || g.ID != 16 {
+		t.Fatalf("gemini-native universal must use currently schedulable Vertex gid=16, got=%v err=%v", g, err)
 	}
 }
 
@@ -1024,20 +1171,32 @@ func TestUniversalOpenAICompatAccountSupportsModel_AinzyMappingDoesNotStealNewAP
 // only) and ListAllWithFilters(status=error) so overdue Qianfan rows stay visible
 // to universal entitlement without being dispatchable.
 type entitlementAwareStubAccountRepo struct {
-	stubOpenAIAccountRepo
+	groupAwareStubOpenAIAccountRepo
 }
 
 func (r entitlementAwareStubAccountRepo) ListSchedulableByGroupIDAndPlatform(_ context.Context, groupID int64, platform string) ([]Account, error) {
+	return r.listSchedulableByGroupIDAndPlatforms(groupID, []string{platform}), nil
+}
+
+func (r entitlementAwareStubAccountRepo) ListSchedulableByGroupIDAndPlatforms(_ context.Context, groupID int64, platforms []string) ([]Account, error) {
+	return r.listSchedulableByGroupIDAndPlatforms(groupID, platforms), nil
+}
+
+func (r entitlementAwareStubAccountRepo) listSchedulableByGroupIDAndPlatforms(groupID int64, platforms []string) []Account {
+	allowed := make(map[string]struct{}, len(platforms))
+	for _, platform := range platforms {
+		allowed[platform] = struct{}{}
+	}
 	var result []Account
 	for _, acc := range r.accounts {
-		if acc.Platform != platform || !acc.IsSchedulable() {
+		if _, ok := allowed[acc.Platform]; !ok || !acc.IsSchedulable() {
 			continue
 		}
 		if openAIStickyAccountMatchesGroup(&acc, &groupID) {
 			result = append(result, acc)
 		}
 	}
-	return result, nil
+	return result
 }
 
 func (r entitlementAwareStubAccountRepo) ListAllWithFilters(_ context.Context, platform, _, status string, _ string, groupID int64, _ string, _ int) ([]Account, error) {
@@ -1061,7 +1220,7 @@ func TestResolve_User16DeepseekV32StaysOnQianfanWhenTokenseaAlsoMapsIt(t *testin
 	ctx := context.Background()
 	span := append(user16Span(), dispatchGrp(19, PlatformNewAPI, 0, true))
 	svc := &GatewayService{
-		accountRepo: entitlementAwareStubAccountRepo{stubOpenAIAccountRepo{accounts: []Account{
+		accountRepo: entitlementAwareStubAccountRepo{groupAwareStubOpenAIAccountRepo{stubOpenAIAccountRepo{accounts: []Account{
 			{
 				ID:          92,
 				GroupIDs:    []int64{2},
@@ -1092,7 +1251,7 @@ func TestResolve_User16DeepseekV32StaysOnQianfanWhenTokenseaAlsoMapsIt(t *testin
 					},
 				},
 			},
-		}}},
+		}}}},
 	}
 	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
 	r.SetModelSupportProvider(svc.UniversalGroupSupportsRequest)
@@ -1110,7 +1269,7 @@ func TestResolve_User38QianfanDatedFlashDoesNot403WhenOnlyErrorAccountHasMapping
 		dispatchGrp(19, PlatformNewAPI, 0, true),
 	}
 	svc := &GatewayService{
-		accountRepo: entitlementAwareStubAccountRepo{stubOpenAIAccountRepo{accounts: []Account{
+		accountRepo: entitlementAwareStubAccountRepo{groupAwareStubOpenAIAccountRepo{stubOpenAIAccountRepo{accounts: []Account{
 			{
 				ID:          92,
 				GroupIDs:    []int64{2},
@@ -1137,7 +1296,7 @@ func TestResolve_User38QianfanDatedFlashDoesNot403WhenOnlyErrorAccountHasMapping
 					},
 				},
 			},
-		}}},
+		}}}},
 	}
 	r := NewUniversalRoutingResolver(&stubSpanLister{groups: span})
 	r.SetModelSupportProvider(svc.UniversalGroupSupportsRequest)

--- a/backend/internal/service/vertex_service_account.go
+++ b/backend/internal/service/vertex_service_account.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	newapiconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyurl"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyutil"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/servertiming"
@@ -57,6 +58,17 @@ type vertexTokenResponse struct {
 
 func (a *Account) IsVertexServiceAccount() bool {
 	return a != nil && a.Type == AccountTypeServiceAccount
+}
+
+// IsNewAPIVertexServiceAccount identifies the exact persisted account shape
+// that may serve native Gemini requests through Vertex. Keeping channel and
+// platform checks here prevents unrelated newapi service accounts from gaining
+// Google credential or endpoint behavior.
+func (a *Account) IsNewAPIVertexServiceAccount() bool {
+	return a != nil &&
+		a.Platform == PlatformNewAPI &&
+		a.ChannelType == newapiconstant.ChannelTypeVertexAi &&
+		a.IsVertexServiceAccount()
 }
 
 func (a *Account) VertexProjectID() string {

--- a/backend/internal/service/vertex_service_account_test.go
+++ b/backend/internal/service/vertex_service_account_test.go
@@ -30,6 +30,75 @@ func TestBuildVertexGeminiURLUsesGlobalEndpointHost(t *testing.T) {
 	require.Equal(t, "https://aiplatform.googleapis.com/v1/projects/my-project/locations/global/publishers/google/models/gemini-3-flash-preview:streamGenerateContent?alt=sse", got)
 }
 
+func TestIsNewAPIVertexServiceAccount(t *testing.T) {
+	tests := []struct {
+		name    string
+		account *Account
+		want    bool
+	}{
+		{
+			name: "newapi vertex service account",
+			account: &Account{
+				Platform:    PlatformNewAPI,
+				Type:        AccountTypeServiceAccount,
+				ChannelType: 41,
+			},
+			want: true,
+		},
+		{
+			name: "direct gemini service account",
+			account: &Account{
+				Platform:    PlatformGemini,
+				Type:        AccountTypeServiceAccount,
+				ChannelType: 41,
+			},
+		},
+		{
+			name: "other newapi service account",
+			account: &Account{
+				Platform:    PlatformNewAPI,
+				Type:        AccountTypeServiceAccount,
+				ChannelType: 46,
+			},
+		},
+		{
+			name: "vertex api key",
+			account: &Account{
+				Platform:    PlatformNewAPI,
+				Type:        AccountTypeAPIKey,
+				ChannelType: 41,
+			},
+		},
+		{name: "nil", account: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.account.IsNewAPIVertexServiceAccount())
+		})
+	}
+}
+
+func TestGeminiTokenProviderRejectsUnrelatedNewAPIServiceAccountBeforeTokenExchange(t *testing.T) {
+	provider := &GeminiTokenProvider{}
+	_, err := provider.GetAccessToken(context.Background(), &Account{
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeServiceAccount,
+		ChannelType: 46,
+	})
+	require.EqualError(t, err, "not a gemini oauth or Vertex service account")
+}
+
+func TestGeminiTokenProviderAcceptsNewAPIVertexServiceAccount(t *testing.T) {
+	provider := &GeminiTokenProvider{}
+	_, err := provider.GetAccessToken(context.Background(), &Account{
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeServiceAccount,
+		ChannelType: 41,
+	})
+	require.EqualError(t, err, "service account credentials not configured")
+}
+
 func TestVertexLocationUsesGlobalForGlobalOnlyGeminiModels(t *testing.T) {
 	account := &Account{Credentials: map[string]any{"location": "us-central1"}}
 

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6385,9 +6385,10 @@
         "copyFailoverRetryAfter(c, failoverErr.ResponseHeaders)",
         "googleError(c, failoverErr.ClientStatusCode, message)",
         "return apiKey.IsUniversal()",
+        "service.WithNativeGeminiVertexAccountRequirement(c.Request.Context())",
         "!account.IsNewAPIVertexServiceAccount()"
       ],
-      "rationale": "Native Gemini terminal failover must emit the Google 429 envelope and safe Retry-After for classified relay capacity. Universal keys may additionally enter through a resolver-proven newapi Vertex group, while direct newapi keys remain rejected and the selected account is revalidated as exact ch41 service-account shape before credentials or network I/O."
+      "rationale": "Native Gemini terminal failover must emit the Google 429 envelope and safe Retry-After for classified relay capacity. Universal keys may additionally enter through a resolver-proven newapi Vertex group, while direct newapi keys remain rejected. The handler carries the exact ch41 service-account requirement into every scheduler path and still revalidates the selected account before credentials or network I/O."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_antigravity_relay_capacity_test.go",
@@ -6877,6 +6878,32 @@
         "func NormalizePlatformUsage("
       ],
       "rationale": "Single backend owner for the public usage-platform taxonomy. Dashboard and admin user-usage outputs must merge internal Gemini and Antigravity routing sources into Google while routing, quota enforcement, and ops retain their raw keys; removing this owner can silently expose source channels again without breaking database or API schemas."
+    },
+    {
+      "path": "backend/internal/service/gateway_scheduling_tk_request_capability.go",
+      "must_contain": [
+        "func WithNativeGeminiVertexAccountRequirement(ctx context.Context) context.Context",
+        "return !nativeGeminiVertexAccountRequired(ctx) || account.IsNewAPIVertexServiceAccount()",
+        "func filterAccountsForNativeGeminiVertexRequirement(ctx context.Context, accounts []Account) []Account"
+      ],
+      "rationale": "Request-scoped scheduler capability owner for native Gemini Universal routing through newapi. Group-level serviceability requires an exact Vertex ch41 service account, so every legacy, sticky, model-routing, and load-aware selection path must filter the same way before choosing or binding an account."
+    },
+    {
+      "path": "backend/internal/service/gateway_scheduling.go",
+      "must_contain": [
+        "accounts = filterAccountsForNativeGeminiVertexRequirement(ctx, accounts)",
+        "filtered = filterAccountsForNativeGeminiVertexRequirement(ctx, filtered)",
+        "!accountSupportsNativeGeminiVertexRequirement(ctx, account)"
+      ],
+      "rationale": "Load-bearing scheduler wiring for request-scoped account capabilities. Filtering list/snapshot candidates plus direct sticky-account lookups keeps native Gemini Universal group admission and actual account selection on the same exact Vertex predicate across both legacy and load-aware paths."
+    },
+    {
+      "path": "backend/internal/service/gateway_multiplatform_test.go",
+      "must_contain": [
+        "native Gemini Vertex requirement filters mixed newapi group",
+        "native Gemini Vertex requirement rejects all non-Vertex candidates"
+      ],
+      "rationale": "Focused regressions prove a higher-priority unrelated newapi account cannot steal a native Gemini Universal request from a lower-priority Vertex ch41 service account, and an all-invalid pool terminates as no available accounts without handler retry loops."
     },
     {
       "path": "backend/internal/service/vertex_service_account.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -5525,9 +5525,10 @@
         "engine.CapabilityForEndpoint(bridgeEndpoint)",
         "func universalModelPlatformHint(",
         "ShapeOpenAIEmbeddings",
-        "gemini-embedding"
+        "gemini-embedding",
+        "return []string{PlatformGemini, PlatformAntigravity, PlatformNewAPI}"
       ],
-      "rationale": "Universal Key endpoint-shape -> candidate-platforms map. Candidate sets are DERIVED from engine single-source (OpenAICompatPlatforms / engine.CapabilityForEndpoint) so a sixth compat platform flows through automatically and the preflight newapi compat-pool drift guard stays satisfied. count_tokens must stay anthropic/antigravity-only; the model->platform hint biases grok/openai/newapi within the openai-compat shape. gemini-embedding-* on /v1/embeddings must hint newapi (Google-Vertex ch41 bridge), matching imagen/veo on image/video shapes. An upstream refactor hardcoding platform slices here would silently break grok routing and trip the drift guard."
+      "rationale": "Universal Key endpoint-shape -> candidate-platforms map. Candidate sets are DERIVED from engine single-source (OpenAICompatPlatforms / engine.CapabilityForEndpoint) so a sixth compat platform flows through automatically and the preflight newapi compat-pool drift guard stays satisfied. Native Gemini must include newapi so account-level serviceability can admit only Vertex ch41 service accounts; gemini-embedding-* on /v1/embeddings likewise hints newapi. An upstream refactor that drops Vertex or hardcodes other compat slices would silently break Google fallback or vendor routing."
     },
     {
       "path": "backend/internal/server/middleware/universal_routing_tk.go",
@@ -6382,9 +6383,11 @@
       "must_contain": [
         "failoverErr.ClientStatusCode > 0",
         "copyFailoverRetryAfter(c, failoverErr.ResponseHeaders)",
-        "googleError(c, failoverErr.ClientStatusCode, message)"
+        "googleError(c, failoverErr.ClientStatusCode, message)",
+        "return apiKey.IsUniversal()",
+        "!account.IsNewAPIVertexServiceAccount()"
       ],
-      "rationale": "Native Gemini terminal failover must emit the Google 429 envelope and safe Retry-After for classified relay capacity before generic provider-status mapping."
+      "rationale": "Native Gemini terminal failover must emit the Google 429 envelope and safe Retry-After for classified relay capacity. Universal keys may additionally enter through a resolver-proven newapi Vertex group, while direct newapi keys remain rejected and the selected account is revalidated as exact ch41 service-account shape before credentials or network I/O."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_antigravity_relay_capacity_test.go",
@@ -6879,9 +6882,11 @@
       "path": "backend/internal/service/vertex_service_account.go",
       "must_contain": [
         "func vertexModelUsesGlobalLocation(model string) bool",
-        "\"gemini-3.5-flash-lite\", \"gemini-3.6-flash\", \"gemini-3.7-flash\""
+        "\"gemini-3.5-flash-lite\", \"gemini-3.6-flash\", \"gemini-3.7-flash\"",
+        "func (a *Account) IsNewAPIVertexServiceAccount() bool",
+        "a.ChannelType == newapiconstant.ChannelTypeVertexAi"
       ],
-      "rationale": "Gemini 3.5 Flash Lite / 3.6 Flash / 3.7 Flash are publisher-global-only on Vertex. vertexModelUsesGlobalLocation must keep these ids on the global endpoint; an upstream merge that drops the case or the 3.7 id sends traffic to the account default us-central1 and the publisher model 404s. Live extras can write vertex_model_locations, but the compiled owner is what survives the next release and empty extras."
+      "rationale": "Vertex native Gemini ownership has two load-bearing facts: global-only Gemini ids must use the publisher-global endpoint, and only newapi ch41 service-account rows may acquire Vertex tokens or claim native Gemini routing. Dropping either silently turns a valid Vertex route into a 404 or broadens Google credential behavior to unrelated newapi vendors."
     },
     {
       "path": "backend/internal/service/openai_gateway_forward.go",


### PR DESCRIPTION
## Summary

- allow Native Gemini Universal Key routing to consider newapi Vertex ch41 service-account groups
- derive current Gemini serviceability from the existing scheduler, model mapping, status, and model-cooldown owners
- keep direct newapi keys and unrelated newapi channel types outside the Native Gemini surface
- preserve error-account semantic entitlement for non-Gemini routing
- add gateway sentinels and focused regressions for Vertex admission and Gemini-to-Vertex failover

## SSOT boundary

This is the narrow runtime P0 that complements the broader pricing/serving/display design work in #1821. It does not add a model-state table, registry, or protocol graph. Native Gemini runtime routing and Universal capability discovery share the existing scheduler-backed account/model predicate; catalog and pricing owners remain unchanged.

## Verification

- `./scripts/preflight.sh`
- `make test`
- Go unit packages, golangci-lint, frontend lint/typecheck, and 180 frontend tests all pass
- no new upstream conflict files reported

## Review markers

- no-web-impact
- upstream-touch-guarded
- sentinel-registry-reviewed

ai