### PR TITLE
fix(gateway): 冷却 CloudWise 424 跨请求故障

### DIFF
--- a/backend/internal/service/openai_account_runtime_block_fastpath.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath.go
@@ -132,7 +132,8 @@ func (s *OpenAIGatewayService) handleOpenAIAccountUpstreamError(ctx context.Cont
 		len(matchTempUnschedulableRules(account, statusCode, responseBody)) > 0
 	cloudwiseModelBalanceMatched := len(canonicalModel) > 0 &&
 		tkIsCloudwiseModelBalance402(account, statusCode, responseBody, canonicalModel[0])
-	if shouldDisable && !modelTempMatched && !cloudwiseModelBalanceMatched {
+	cloudwiseProvider424Matched := tkIsCloudwiseProvider424Response(account, statusCode, responseBody)
+	if shouldDisable && !modelTempMatched && !cloudwiseModelBalanceMatched && !cloudwiseProvider424Matched {
 		s.BlockAccountScheduling(account, time.Time{}, "upstream_disable")
 	}
 	// Pool-mode retryable upstream errors are already bounded by the request-local

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -401,6 +401,9 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 	if cloudwiseModelBalance402 && s.tkTryCloudwiseModelBalanceCooldown(ctx, account, statusCode, responseBody, firstRequestedModel(requestedModel)) {
 		return true
 	}
+	if s.tkTryCloudwiseProvider424Cooldown(ctx, account, statusCode, responseBody, firstRequestedModel(requestedModel)) {
+		return true
+	}
 
 	// 池模式默认不标记本地账号状态；但管理员显式配置的临时不可调度规则优先。
 	// 401 保留现有认证错误语义，不在这里改变池模式的认证处理。

--- a/backend/internal/service/ratelimit_service_tk_cloudwise_424.go
+++ b/backend/internal/service/ratelimit_service_tk_cloudwise_424.go
@@ -1,0 +1,110 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	tkCloudwiseProvider424Reason          = "cloudwise_provider_error_424"
+	tkCloudwiseProvider424ModelCooldown   = 15 * time.Minute
+	tkCloudwiseProvider424AccountCooldown = 30 * time.Minute
+)
+
+func tkIsCloudwiseProvider424Response(account *Account, statusCode int, responseBody []byte) bool {
+	if account == nil || statusCode != http.StatusFailedDependency || !isCloudwiseRelayAccount(account) {
+		return false
+	}
+	return strings.Contains(strings.ToLower(string(responseBody)), "provider error")
+}
+
+func tkHasOtherCloudwiseProvider424ModelCooldown(account *Account, currentScope string, now time.Time) bool {
+	if account == nil {
+		return false
+	}
+	for scope, cooldown := range account.ActiveModelRateLimits(now) {
+		if scope != currentScope && cooldown.Reason == tkCloudwiseProvider424Reason {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *RateLimitService) tkApplyCloudwiseProvider424AccountCooldown(
+	ctx context.Context,
+	account *Account,
+	responseBody []byte,
+	reason string,
+) {
+	rule := TempUnschedulableRule{DurationMinutes: int(tkCloudwiseProvider424AccountCooldown / time.Minute)}
+	if !s.triggerTempUnschedulable(
+		ctx,
+		account,
+		rule,
+		-1,
+		http.StatusFailedDependency,
+		tkCloudwiseProvider424Reason,
+		responseBody,
+	) {
+		slog.Warn("cloudwise_provider_424_account_cooldown_failed",
+			"account_id", account.ID,
+			"reason", reason)
+		return
+	}
+	slog.Warn("cloudwise_provider_424_account_cooled",
+		"account_id", account.ID,
+		"cooldown", tkCloudwiseProvider424AccountCooldown,
+		"reason", reason)
+}
+
+func (s *RateLimitService) tkTryCloudwiseProvider424Cooldown(
+	ctx context.Context,
+	account *Account,
+	statusCode int,
+	responseBody []byte,
+	requestedModel string,
+) bool {
+	if s == nil || s.accountRepo == nil || !tkIsCloudwiseProvider424Response(account, statusCode, responseBody) {
+		return false
+	}
+
+	scopeKey := strings.TrimSpace(account.GetMappedModel(requestedModel))
+	if scopeKey == "" {
+		s.tkApplyCloudwiseProvider424AccountCooldown(ctx, account, responseBody, "missing_model_scope")
+		return true
+	}
+
+	now := time.Now()
+	resetAt := now.Add(tkCloudwiseProvider424ModelCooldown)
+	if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, scopeKey, resetAt, tkCloudwiseProvider424Reason); err != nil {
+		slog.Warn("cloudwise_provider_424_model_cooldown_failed",
+			"account_id", account.ID,
+			"model", scopeKey,
+			"error", err)
+		s.tkApplyCloudwiseProvider424AccountCooldown(ctx, account, responseBody, "model_cooldown_write_failed")
+		return true
+	}
+
+	slog.Warn("cloudwise_provider_424_model_cooled",
+		"account_id", account.ID,
+		"model", scopeKey,
+		"reset_at", resetAt,
+		"cooldown", tkCloudwiseProvider424ModelCooldown)
+
+	latest := account
+	if refreshed, err := s.accountRepo.GetByID(ctx, account.ID); err != nil {
+		slog.Warn("cloudwise_provider_424_account_refresh_failed",
+			"account_id", account.ID,
+			"model", scopeKey,
+			"error", err)
+	} else if refreshed != nil {
+		latest = refreshed
+	}
+	if tkHasOtherCloudwiseProvider424ModelCooldown(latest, scopeKey, now) {
+		s.tkApplyCloudwiseProvider424AccountCooldown(ctx, account, responseBody, "distinct_model_424")
+	}
+	return true
+}

--- a/backend/internal/service/ratelimit_service_tk_cloudwise_424_test.go
+++ b/backend/internal/service/ratelimit_service_tk_cloudwise_424_test.go
@@ -1,0 +1,237 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+const cloudwiseProvider424Body = `{"error":{"message":"Provider error (request id: aitk-test)","type":"server_error"}}`
+
+func cloudwise424TestAccount(platform string) *Account {
+	return &Account{
+		ID:          94,
+		Name:        "cloudwise",
+		Platform:    platform,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Credentials: map[string]any{
+			"base_url": "https://api.cloudwise.ai/api",
+		},
+	}
+}
+
+func cloudwise424ActiveModelCooldown(resetAt time.Time) map[string]any {
+	return map[string]any{
+		"rate_limited_at":     time.Now().UTC().Format(time.RFC3339),
+		"rate_limit_reset_at": resetAt.UTC().Format(time.RFC3339),
+		"reason":              "cloudwise_provider_error_424",
+	}
+}
+
+func TestRateLimitService_CloudwiseProvider424_CoolsMappedModelForFifteenMinutes(t *testing.T) {
+	account := cloudwise424TestAccount(PlatformAnthropic)
+	account.Credentials["model_mapping"] = map[string]any{
+		"claude-opus-latest": "claude-opus-4-8",
+	}
+	repo := &rateLimitAccountRepoStub{accountOnGet: account}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+
+	startedAt := time.Now()
+	shouldFailover := svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusFailedDependency,
+		http.Header{},
+		[]byte(cloudwiseProvider424Body),
+		"claude-opus-latest",
+	)
+
+	require.True(t, shouldFailover)
+	require.Zero(t, repo.setErrorCalls)
+	require.Zero(t, repo.tempCalls)
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	call := repo.modelRateLimitCalls[0]
+	require.Equal(t, "claude-opus-4-8", call.scope)
+	require.Equal(t, "cloudwise_provider_error_424", call.reason)
+	require.WithinDuration(t, startedAt.Add(15*time.Minute), call.resetAt, time.Second)
+}
+
+func TestRateLimitService_CloudwiseProvider424_SecondDistinctModelEscalatesAccountForThirtyMinutes(t *testing.T) {
+	now := time.Now()
+	account := cloudwise424TestAccount(PlatformAnthropic)
+	account.Extra = map[string]any{
+		modelRateLimitsKey: map[string]any{
+			"claude-opus-4-8": cloudwise424ActiveModelCooldown(now.Add(10 * time.Minute)),
+		},
+	}
+	repo := &rateLimitAccountRepoStub{accountOnGet: account}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+
+	startedAt := time.Now()
+	shouldFailover := svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusFailedDependency,
+		http.Header{},
+		[]byte(cloudwiseProvider424Body),
+		"claude-sonnet-4-6",
+	)
+
+	require.True(t, shouldFailover)
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	require.Equal(t, "claude-sonnet-4-6", repo.modelRateLimitCalls[0].scope)
+	require.Equal(t, 1, repo.tempCalls)
+
+	var state TempUnschedState
+	require.NoError(t, json.Unmarshal([]byte(repo.lastTempReason), &state))
+	require.Equal(t, http.StatusFailedDependency, state.StatusCode)
+	require.Equal(t, "cloudwise_provider_error_424", state.MatchedKeyword)
+	require.WithinDuration(t, startedAt.Add(30*time.Minute), time.Unix(state.UntilUnix, 0), time.Second)
+}
+
+func TestRateLimitService_CloudwiseProvider424_RepeatedSameModelDoesNotEscalateAccount(t *testing.T) {
+	account := cloudwise424TestAccount(PlatformAnthropic)
+	account.Extra = map[string]any{
+		modelRateLimitsKey: map[string]any{
+			"claude-opus-4-8": cloudwise424ActiveModelCooldown(time.Now().Add(10 * time.Minute)),
+		},
+	}
+	repo := &rateLimitAccountRepoStub{accountOnGet: account}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+
+	shouldFailover := svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusFailedDependency,
+		http.Header{},
+		[]byte(cloudwiseProvider424Body),
+		"claude-opus-4-8",
+	)
+
+	require.True(t, shouldFailover)
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	require.Zero(t, repo.tempCalls)
+}
+
+func TestRateLimitService_CloudwiseProvider424_WithoutModelUsesShortAccountCooldown(t *testing.T) {
+	account := cloudwise424TestAccount(PlatformAnthropic)
+	repo := &rateLimitAccountRepoStub{}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+
+	startedAt := time.Now()
+	shouldFailover := svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusFailedDependency,
+		http.Header{},
+		[]byte(cloudwiseProvider424Body),
+	)
+
+	require.True(t, shouldFailover)
+	require.Empty(t, repo.modelRateLimitCalls)
+	require.Equal(t, 1, repo.tempCalls)
+
+	var state TempUnschedState
+	require.NoError(t, json.Unmarshal([]byte(repo.lastTempReason), &state))
+	require.WithinDuration(t, startedAt.Add(30*time.Minute), time.Unix(state.UntilUnix, 0), time.Second)
+}
+
+func TestRateLimitService_CloudwiseProvider424_ModelCooldownWriteFailureUsesShortAccountCooldown(t *testing.T) {
+	account := cloudwise424TestAccount(PlatformAnthropic)
+	repo := &rateLimitAccountRepoStub{modelRateLimitErr: context.DeadlineExceeded}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+
+	startedAt := time.Now()
+	shouldFailover := svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusFailedDependency,
+		http.Header{},
+		[]byte(cloudwiseProvider424Body),
+		"claude-opus-4-8",
+	)
+
+	require.True(t, shouldFailover)
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	require.Equal(t, 1, repo.tempCalls)
+
+	var state TempUnschedState
+	require.NoError(t, json.Unmarshal([]byte(repo.lastTempReason), &state))
+	require.WithinDuration(t, startedAt.Add(30*time.Minute), time.Unix(state.UntilUnix, 0), time.Second)
+}
+
+func TestRateLimitService_NonCloudwiseOrNonProvider424_DoesNotCool(t *testing.T) {
+	tests := []struct {
+		name    string
+		account *Account
+		body    string
+	}{
+		{
+			name: "official anthropic provider error",
+			account: &Account{
+				ID:       1,
+				Platform: PlatformAnthropic,
+				Type:     AccountTypeAPIKey,
+				Credentials: map[string]any{
+					"base_url": "https://api.anthropic.com",
+				},
+			},
+			body: cloudwiseProvider424Body,
+		},
+		{
+			name:    "cloudwise unrelated failed dependency",
+			account: cloudwise424TestAccount(PlatformAnthropic),
+			body:    `{"error":{"message":"request dependency missing","type":"invalid_request_error"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &rateLimitAccountRepoStub{}
+			svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+
+			shouldDisable := svc.HandleUpstreamError(
+				context.Background(),
+				tt.account,
+				http.StatusFailedDependency,
+				http.Header{},
+				[]byte(tt.body),
+				"claude-opus-4-8",
+			)
+
+			require.False(t, shouldDisable)
+			require.Empty(t, repo.modelRateLimitCalls)
+			require.Zero(t, repo.tempCalls)
+		})
+	}
+}
+
+func TestOpenAIGateway_CloudwiseProvider424_ModelCooldownDoesNotRuntimeBlockWholeAccount(t *testing.T) {
+	account := cloudwise424TestAccount(PlatformOpenAI)
+	repo := &rateLimitAccountRepoStub{accountOnGet: account}
+	rateLimits := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	gateway := &OpenAIGatewayService{rateLimitService: rateLimits}
+	rateLimits.SetAccountRuntimeBlocker(gateway)
+
+	shouldFailover := gateway.handleOpenAIAccountUpstreamError(
+		context.Background(),
+		account,
+		http.StatusFailedDependency,
+		http.Header{},
+		[]byte(cloudwiseProvider424Body),
+		"claude-opus-4-8",
+	)
+
+	require.True(t, shouldFailover)
+	require.False(t, gateway.isOpenAIAccountRuntimeBlocked(account))
+	require.Len(t, repo.modelRateLimitCalls, 1)
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3652,17 +3652,43 @@
       "rationale": "Regression coverage for CloudWise 402 isolation: exact model receives the 5h cooldown, sibling models stay schedulable, OpenAI-compatible runtime blocking remains model-scoped, pool/custom early exits cannot bypass either the model cooldown or its fail-closed account fallback, and absent model context keeps the conservative account-level fallback."
     },
     {
+      "path": "backend/internal/service/ratelimit_service_tk_cloudwise_424.go",
+      "must_contain": [
+        "tkCloudwiseProvider424Reason          = \"cloudwise_provider_error_424\"",
+        "tkCloudwiseProvider424ModelCooldown   = 15 * time.Minute",
+        "tkCloudwiseProvider424AccountCooldown = 30 * time.Minute",
+        "func tkIsCloudwiseProvider424Response(",
+        "func (s *RateLimitService) tkTryCloudwiseProvider424Cooldown(",
+        "SetModelRateLimit(ctx, account.ID, scopeKey, resetAt, tkCloudwiseProvider424Reason)",
+        "s.triggerTempUnschedulable("
+      ],
+      "rationale": "CloudWise 424 circuit-breaker owner. The observed Failed Dependency envelope is a provider-health signal, not a five-hour balance window: the mapped model is cooled for 15 minutes while the existing request failover selects another account. A second distinct active model cooldown escalates through the shared temp_unschedulable owner for 30 minutes, and missing model context or a failed model-cooldown write uses the same bounded account fallback. Losing this companion restores cross-request reselection of a known-bad CloudWise route."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_cloudwise_424_test.go",
+      "must_contain": [
+        "TestRateLimitService_CloudwiseProvider424_CoolsMappedModelForFifteenMinutes",
+        "TestRateLimitService_CloudwiseProvider424_SecondDistinctModelEscalatesAccountForThirtyMinutes",
+        "TestRateLimitService_CloudwiseProvider424_RepeatedSameModelDoesNotEscalateAccount",
+        "TestRateLimitService_CloudwiseProvider424_ModelCooldownWriteFailureUsesShortAccountCooldown",
+        "TestRateLimitService_NonCloudwiseOrNonProvider424_DoesNotCool",
+        "TestOpenAIGateway_CloudwiseProvider424_ModelCooldownDoesNotRuntimeBlockWholeAccount"
+      ],
+      "rationale": "Behavior guards for the CloudWise 424 breaker: exact mapped-model isolation, distinct-model account escalation, same-model non-escalation, fail-closed bounded fallback, narrow provider-error matching, and preservation of sibling-model OpenAI runtime scheduling."
+    },
+    {
       "path": "backend/internal/service/ratelimit_service.go",
       "must_contain": [
         "cloudwiseModelBalance402 := tkIsCloudwiseModelBalance402Response(",
         "s.tkTryCloudwiseModelBalanceCooldown(ctx, account, statusCode, responseBody, firstRequestedModel(requestedModel))",
+        "s.tkTryCloudwiseProvider424Cooldown(ctx, account, statusCode, responseBody, firstRequestedModel(requestedModel))",
         "account.Platform != PlatformAnthropic && !cloudwiseModelBalance402",
         "if !cloudwiseModelBalance402 && !planGatedModel",
         "if len(requestedModel) > 0 && s.tkTryAnthropicModelScopedCooldown(ctx, account, requestedModel[0], result) {",
         "if len(requestedModel) > 0 && s.tkTryOpenAICodexModelScopedCooldown(ctx, account, requestedModel[0], resetTime) {",
         "rateLimitSet := s.handle429(ctx, account, headers, responseBody, requestedModel...)"
       ],
-      "rationale": "G4 injection point in the upstream-shaped error dispatch. CloudWise model-balance 402 must try the exact-model cooldown before pool/custom early exits, while a failed write or missing model bypasses those exits and reaches the conservative account-level 402 fallback. The Anthropic per-window (5h/7d) branch must try the (account x model class) cooldown BEFORE the account-level SetRateLimited fallback, and the dispatch must thread requestedModel into handle429. The OpenAI/Codex body path (usage_limit_reached) must likewise try tkTryOpenAICodexModelScopedCooldown BEFORE the whole-account SetRateLimited so a spark per-model sub-limit 429 (account-wide window healthy) is narrowed to the model. An upstream merge that rewrites these paths or drops the requestedModel passthrough would silently restore whole-account amplification or fail-open CloudWise scheduling; this sentinel anchors the calls, fallbacks, and threading."
+      "rationale": "G4 injection point in the upstream-shaped error dispatch. CloudWise model-balance 402 must try the exact-model cooldown before pool/custom early exits, while a failed write or missing model bypasses those exits and reaches the conservative account-level 402 fallback. CloudWise Provider error 424 must likewise enter its bounded model/account breaker before those configurable exits. The Anthropic per-window (5h/7d) branch must try the (account x model class) cooldown BEFORE the account-level SetRateLimited fallback, and the dispatch must thread requestedModel into handle429. The OpenAI/Codex body path (usage_limit_reached) must likewise try tkTryOpenAICodexModelScopedCooldown BEFORE the whole-account SetRateLimited so a spark per-model sub-limit 429 (account-wide window healthy) is narrowed to the model. An upstream merge that rewrites these paths or drops the requestedModel passthrough would silently restore whole-account amplification or fail-open CloudWise scheduling; this sentinel anchors the calls, fallbacks, and threading."
     },
     {
       "path": "backend/internal/service/model_rate_limit.go",
@@ -6951,9 +6977,10 @@
       "must_contain": [
         "HandleOpenAIImageCapabilityLoss400(stateCtx, account, statusCode, responseBody)",
         "cloudwiseModelBalanceMatched := len(canonicalModel) > 0 &&",
-        "!modelTempMatched && !cloudwiseModelBalanceMatched"
+        "cloudwiseProvider424Matched := tkIsCloudwiseProvider424Response(account, statusCode, responseBody)",
+        "!modelTempMatched && !cloudwiseModelBalanceMatched && !cloudwiseProvider424Matched"
       ],
-      "rationale": "Gateway error fastpath must cool openai:image_generation on capability-loss 400 without blocking the whole account. The same boundary must recognize a successfully persisted CloudWise model-balance 402 and skip the whole-account in-memory runtime block while still returning shouldDisable=true so the current request fails over. Losing that guard makes the durable model scope ineffective until process restart because healthy sibling models remain hidden behind an account-wide runtime block."
+      "rationale": "Gateway error fastpath must cool openai:image_generation on capability-loss 400 without blocking the whole account. The same boundary must recognize CloudWise model-balance 402 and Provider error 424 breaker handling, skipping the generic permanent in-memory block while still returning shouldDisable=true so the current request fails over. A 424 account escalation already writes the bounded shared temp_unschedulable runtime block; losing this guard would overwrite model isolation or the finite account cooldown with an unbounded whole-account block."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_account_capability_400.go",


### PR DESCRIPTION
## 摘要

- 对 CloudWise 返回的 `HTTP 424 + Provider error` 接入跨请求熔断，同时保留当前请求内的统一 failover。
- 首次故障按映射后的精确模型冷却 15 分钟；同账号出现第二个不同模型的活跃 424 冷却时，复用统一 `temp_unschedulable` 机制将账号冷却 30 分钟。
- 缺少模型上下文或模型冷却写入失败时，回退到账号级 30 分钟冷却；OpenAI 入口不会误写永久 runtime block。
- 更新 gateway sentinel，防止后续上游合并丢失熔断 owner、注入点和回归测试。

## 风险

- 仅匹配 CloudWise 的 `Provider error` 424；其他供应商和其他 424 不触发该冷却。
- 账号级升级最长 30 分钟并自动恢复；可能短时减少该账号容量，但避免持续把真实用户请求重新调度到已知故障路由。
- Web impact: none。

## 验证

- `go test -tags unit ./internal/service -count=1`
- `go test ./internal/service -count=1`
- `python3 scripts/sentinels/check-gateway-tk.py`（PASS，750/750）
- `git diff --check`
- `./scripts/preflight.sh`（当前 HEAD `178f162c8`，PASS）

## 提交

- `178f162c8 fix(gateway): cool CloudWise 424 failures across requests`

最新提交：`178f162c8`