### PR TITLE
chore(ci): 加速 service unit 冷路径

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -42,6 +42,7 @@ jobs:
       deploy: ${{ steps.classify.outputs.deploy }}
       ops: ${{ steps.classify.outputs.ops }}
       contracts: ${{ steps.classify.outputs.contracts }}
+      service_unit_cold: ${{ steps.classify.outputs.service_unit_cold }}
       all: ${{ steps.classify.outputs.all }}
     steps:
       - uses: actions/checkout@v6
@@ -109,6 +110,7 @@ jobs:
             scripts.test_preflight_ci_handoffs \
             scripts.test_ci_gate_handoffs \
             scripts.ci.test_changed_surfaces \
+            scripts.ci.test_unit_test_runner \
             scripts.test_backend_ci_routing
       # Preflight runs `go test` for QA evidence dataset validation; backend/go.mod
       # replaces new-api with ../../new-api — same sibling checkout as test/lint jobs.
@@ -220,6 +222,8 @@ jobs:
           go version | grep -Fq "go${expected}"
       - name: Unit tests
         working-directory: backend
+        env:
+          UNIT_TEST_SERVICE_SHARD: ${{ github.event_name != 'push' && needs.changes.outputs.service_unit_cold == 'true' && '1' || '0' }}
         run: make test-unit
       - name: Anthropic prompt surface fixture gateway
         run: python3 ops/anthropic/probe_prompt_surfaces.py --check-fixture-gateway

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -110,7 +110,6 @@ jobs:
             scripts.test_preflight_ci_handoffs \
             scripts.test_ci_gate_handoffs \
             scripts.ci.test_changed_surfaces \
-            scripts.ci.test_unit_test_runner \
             scripts.test_backend_ci_routing
       # Preflight runs `go test` for QA evidence dataset validation; backend/go.mod
       # replaces new-api with ../../new-api — same sibling checkout as test/lint jobs.
@@ -124,6 +123,8 @@ jobs:
           go-version-file: backend/go.mod
           check-latest: false
           cache: false
+      - name: Unit runner contract tests
+        run: python3 -m unittest scripts.ci.test_unit_test_runner
       - name: Integration package discovery contract tests
         run: python3 -m unittest scripts.ci.test_integration_packages
       - uses: ./.github/actions/go-rolling-cache

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -28,6 +28,7 @@ GOLANGCI_LINT_VERSION ?= v2.9.0
 GOLANGCI_LINT_CONCURRENCY ?= 4
 GOLANGCI_LINT_FAST_ARGS ?= --concurrency=$(GOLANGCI_LINT_CONCURRENCY)
 GOLANGCI_LINT_SECURITY_ARGS ?= --concurrency=$(GOLANGCI_LINT_CONCURRENCY)
+UNIT_TEST_SERVICE_SHARD ?= 0
 
 .PHONY: verify-toolchain
 verify-toolchain:
@@ -57,7 +58,11 @@ generate:
 test: test-unit lint
 
 test-unit:
+ifeq ($(UNIT_TEST_SERVICE_SHARD),1)
+	python3 ../scripts/ci/unit_test_runner.py --root .
+else
 	go test -tags=unit ./...
+endif
 
 test-integration:
 	@packages="$$(python3 ../scripts/ci/integration-packages.py --root .)" || exit $$?; \

--- a/backend/internal/service/channel_monitor_quota_mode_test.go
+++ b/backend/internal/service/channel_monitor_quota_mode_test.go
@@ -270,7 +270,8 @@ func TestValidateCreateParams_CheckModeMatrix(t *testing.T) {
 			name: "probe requires api key",
 			params: ChannelMonitorCreateParams{
 				Provider: MonitorProviderOpenAI, CheckMode: MonitorCheckModeProbe,
-				Endpoint: "https://api.openai.com", IntervalSeconds: 60, PrimaryModel: "gpt-5",
+				// Use a public IP literal so this validation-order case never depends on external DNS.
+				Endpoint: "https://1.1.1.1", IntervalSeconds: 60, PrimaryModel: "gpt-5",
 			},
 			wantErr: ErrChannelMonitorMissingAPIKey,
 		},
@@ -330,7 +331,8 @@ func TestValidateCreateParams_CheckModeMatrix(t *testing.T) {
 			name: "quota_probe requires primary model",
 			params: ChannelMonitorCreateParams{
 				Provider: MonitorProviderKimi, CheckMode: MonitorCheckModeQuotaProbe,
-				Endpoint: "https://api.kimi.com", APIKey: "sk",
+				// Use a public IP literal so this validation-order case never depends on external DNS.
+				Endpoint: "https://1.1.1.1", APIKey: "sk",
 				IntervalSeconds: 60, AccountID: &accountID,
 			},
 			wantErr: ErrChannelMonitorMissingPrimaryModel,

--- a/scripts/ci/changed-surfaces.py
+++ b/scripts/ci/changed-surfaces.py
@@ -10,7 +10,26 @@ import sys
 from typing import Iterable
 
 
-KEYS = ("backend", "frontend", "deploy", "ops", "contracts", "all")
+KEYS = (
+    "backend",
+    "frontend",
+    "deploy",
+    "ops",
+    "contracts",
+    "service_unit_cold",
+    "all",
+)
+
+SERVICE_UNIT_COLD_FILES = {
+    ".github/workflows/backend-ci.yml",
+    ".new-api-ref",
+    "backend/Makefile",
+    "backend/go.mod",
+    "backend/go.sum",
+    "scripts/ci/list_go_tests.go",
+    "scripts/ci/test_unit_test_runner.py",
+    "scripts/ci/unit_test_runner.py",
+}
 
 CONTRACT_FILES = {
     "backend/internal/domain/constants.go",
@@ -50,6 +69,11 @@ def classify(paths: Iterable[str]) -> dict[str, bool]:
         path = raw_path.replace("\\", "/")
         if not path:
             continue
+
+        if path in SERVICE_UNIT_COLD_FILES or (
+            path.startswith("backend/") and path.endswith(".go")
+        ):
+            result["service_unit_cold"] = True
 
         if path == ".github/workflows/backend-ci.yml" or _starts(
             path,

--- a/scripts/ci/list_go_tests.go
+++ b/scripts/ci/list_go_tests.go
@@ -1,0 +1,145 @@
+// Command list_go_tests reports the test entries registered by cmd/go.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/doc"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+type discovery struct {
+	Entries     []string `json:"entries"`
+	HasTestMain bool     `json:"has_test_main"`
+}
+
+func main() {
+	filenames := os.Args[1:]
+	if len(filenames) > 0 && filenames[0] == "--" {
+		filenames = filenames[1:]
+	}
+	if len(filenames) == 0 {
+		fatalf("no Go test files provided")
+	}
+
+	entries := make(map[string]struct{})
+	hasTestMain := false
+	fileset := token.NewFileSet()
+	for _, filename := range filenames {
+		file, err := parser.ParseFile(
+			fileset,
+			filename,
+			nil,
+			parser.ParseComments|parser.SkipObjectResolution,
+		)
+		if err != nil {
+			fatalf("parse %s: %v", filename, err)
+		}
+
+		for _, declaration := range file.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Recv != nil {
+				continue
+			}
+			name := function.Name.Name
+			switch {
+			case name == "TestMain":
+				if isTestFunc(function, "T") {
+					entries[name] = struct{}{}
+					continue
+				}
+				if err := checkTestFunc(function, "M"); err != nil {
+					fatalf("%s: %v", fileset.Position(function.Pos()), err)
+				}
+				hasTestMain = true
+			case isTest(name, "Test"):
+				if err := checkTestFunc(function, "T"); err != nil {
+					fatalf("%s: %v", fileset.Position(function.Pos()), err)
+				}
+				entries[name] = struct{}{}
+			case isTest(name, "Fuzz"):
+				if err := checkTestFunc(function, "F"); err != nil {
+					fatalf("%s: %v", fileset.Position(function.Pos()), err)
+				}
+				entries[name] = struct{}{}
+			}
+		}
+
+		for _, example := range doc.Examples(file) {
+			if example.Output == "" && !example.EmptyOutput {
+				continue
+			}
+			entries["Example"+example.Name] = struct{}{}
+		}
+	}
+
+	names := make([]string, 0, len(entries))
+	for name := range entries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if err := json.NewEncoder(os.Stdout).Encode(discovery{
+		Entries:     names,
+		HasTestMain: hasTestMain,
+	}); err != nil {
+		fatalf("encode discovery: %v", err)
+	}
+}
+
+func isTestFunc(function *ast.FuncDecl, argument string) bool {
+	if function.Type.Results != nil && len(function.Type.Results.List) > 0 ||
+		function.Type.Params.List == nil ||
+		len(function.Type.Params.List) != 1 ||
+		len(function.Type.Params.List[0].Names) > 1 {
+		return false
+	}
+	pointer, ok := function.Type.Params.List[0].Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	if identifier, ok := pointer.X.(*ast.Ident); ok {
+		return identifier.Name == argument
+	}
+	if selector, ok := pointer.X.(*ast.SelectorExpr); ok {
+		return selector.Sel.Name == argument
+	}
+	return false
+}
+
+func isTest(name, prefix string) bool {
+	if !strings.HasPrefix(name, prefix) {
+		return false
+	}
+	if len(name) == len(prefix) {
+		return true
+	}
+	runeValue, _ := utf8.DecodeRuneInString(name[len(prefix):])
+	return !unicode.IsLower(runeValue)
+}
+
+func checkTestFunc(function *ast.FuncDecl, argument string) error {
+	if !isTestFunc(function, argument) {
+		return fmt.Errorf(
+			"wrong signature for %s, must be func(%s *testing.%s)",
+			function.Name.Name,
+			strings.ToLower(argument),
+			argument,
+		)
+	}
+	if function.Type.TypeParams != nil && function.Type.TypeParams.NumFields() > 0 {
+		return fmt.Errorf("test function %s cannot have type parameters", function.Name.Name)
+	}
+	return nil
+}
+
+func fatalf(format string, arguments ...any) {
+	fmt.Fprintf(os.Stderr, "list-go-tests: "+format+"\n", arguments...)
+	os.Exit(1)
+}

--- a/scripts/ci/test_changed_surfaces.py
+++ b/scripts/ci/test_changed_surfaces.py
@@ -4,7 +4,10 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
+import subprocess
+import sys
 import unittest
 
 
@@ -25,6 +28,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": False,
+                "service_unit_cold": True,
                 "all": False,
             },
         )
@@ -38,6 +42,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": False,
+                "service_unit_cold": False,
                 "all": False,
             },
         )
@@ -51,6 +56,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": True,
                 "ops": False,
                 "contracts": False,
+                "service_unit_cold": False,
                 "all": False,
             },
         )
@@ -64,6 +70,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": True,
+                "service_unit_cold": True,
                 "all": False,
             },
         )
@@ -77,6 +84,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": True,
                 "contracts": False,
+                "service_unit_cold": True,
                 "all": False,
             },
         )
@@ -90,6 +98,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": False,
+                "service_unit_cold": False,
                 "all": False,
             },
         )
@@ -103,6 +112,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": False,
+                "service_unit_cold": False,
                 "all": False,
             },
         )
@@ -121,6 +131,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": False,
+                "service_unit_cold": True,
                 "all": False,
             },
         )
@@ -134,6 +145,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": False,
+                "service_unit_cold": True,
                 "all": False,
             },
         )
@@ -148,6 +160,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": False,
+                "service_unit_cold": False,
                 "all": True,
             },
         )
@@ -162,6 +175,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": False,
+                "service_unit_cold": False,
                 "all": True,
             },
         )
@@ -176,9 +190,52 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": False,
+                "service_unit_cold": False,
                 "all": True,
             },
         )
+
+    def test_backend_non_go_change_keeps_service_cache_path(self) -> None:
+        self.assertEqual(
+            changed_surfaces.classify(["backend/migrations/001.sql"]),
+            {
+                "backend": True,
+                "frontend": False,
+                "deploy": False,
+                "ops": False,
+                "contracts": False,
+                "service_unit_cold": False,
+                "all": False,
+            },
+        )
+
+    def test_unit_runner_and_ci_entrypoints_force_service_cold_path(self) -> None:
+        for path in (
+            ".new-api-ref",
+            "backend/go.mod",
+            "backend/go.sum",
+            "scripts/ci/list_go_tests.go",
+            "scripts/ci/unit_test_runner.py",
+            "scripts/ci/test_unit_test_runner.py",
+            "backend/Makefile",
+            ".github/workflows/backend-ci.yml",
+        ):
+            with self.subTest(path=path):
+                self.assertTrue(changed_surfaces.classify([path])["service_unit_cold"])
+
+    def test_all_mode_marks_service_cold_path(self) -> None:
+        completed = subprocess.run(
+            [sys.executable, str(MODULE_PATH), "--all"],
+            input="",
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        result = json.loads(completed.stdout)
+        self.assertEqual(set(result), set(changed_surfaces.KEYS))
+        self.assertTrue(all(result.values()))
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_unit_test_runner.py
+++ b/scripts/ci/test_unit_test_runner.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Behavior tests for the compile-once Go unit test runner."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parent / "unit_test_runner.py"
+DISCOVERY_HELPER = Path(__file__).resolve().parent / "list_go_tests.go"
+
+
+class UnitTestRunnerTest(unittest.TestCase):
+    def test_compiles_service_once_and_runs_all_entries_in_stable_binary_shards(self) -> None:
+        test_names = [f"TestCase{i:02d}_{'x' * 24}" for i in range(22)] + [
+            "ExampleService",
+            "FuzzServiceInput",
+            "TestCommentSeparated",
+        ]
+        with self._fake_go(test_names) as fixture:
+            first = self._run(fixture, "--min-shards", "2", "--max-regex-bytes", "180")
+            first_events = self._events(fixture.events)
+
+            fixture.events.write_text("", encoding="utf-8")
+            second = self._run(fixture, "--min-shards", "2", "--max-regex-bytes", "180")
+            second_events = self._events(fixture.events)
+
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.assertEqual(self._binary_patterns(first_events), self._binary_patterns(second_events))
+
+        go_calls = self._go_calls(first_events)
+        self.assertEqual(
+            [call for call in go_calls if call and call[0] == "list"],
+            [["list", "-json", "-tags=unit", "./..."]],
+        )
+        self.assertEqual(
+            [call for call in go_calls if "./internal/other" in call],
+            [["test", "-tags=unit", "./internal/other"]],
+        )
+        compile_calls = [call for call in go_calls if "-c" in call]
+        self.assertEqual(len(compile_calls), 1, go_calls)
+        self.assertIn("./internal/service", compile_calls[0])
+        self.assertFalse(
+            [
+                call
+                for call in go_calls
+                if "./internal/service" in call and "-c" not in call
+            ],
+            go_calls,
+        )
+
+        binary_events = self._binary_events(first_events)
+        self.assertGreater(len(binary_events), 2)
+        matched: list[str] = []
+        for event in binary_events:
+            args = event["args"]
+            pattern = args[args.index("-test.run") + 1]
+            self.assertNotIn("TestMain", pattern)
+            self.assertNotIn("TestPhantom", pattern)
+            self.assertLessEqual(len(pattern.encode("utf-8")), 180)
+            self.assertIn("-test.timeout=10m", args)
+            self.assertIn("-test.paniconexit0", args)
+            self.assertEqual(
+                Path(event["cwd"]).resolve(),
+                (fixture.root / "internal" / "service").resolve(),
+            )
+            matched.extend(name for name in test_names if re.fullmatch(pattern, name))
+        self.assertCountEqual(matched, test_names)
+        self.assertEqual(len(matched), len(set(matched)))
+
+    def test_test_main_falls_back_to_one_native_go_test(self) -> None:
+        with self._fake_go(["TestOne"], has_test_main=True) as fixture:
+            result = self._run(fixture)
+            events = self._events(fixture.events)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        go_calls = self._go_calls(events)
+        self.assertIn(["test", "-tags=unit", "./..."], go_calls)
+        self.assertFalse([call for call in go_calls if "-c" in call])
+        self.assertFalse(self._binary_events(events))
+
+    def test_go_ast_discovery_matches_testing_registration_rules(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            test_file = Path(temporary) / "fixture_test.go"
+            test_file.write_text(
+                textwrap.dedent(
+                    '''\
+                    package fixture
+
+                    import "testing"
+
+                    type fixture struct{}
+                    var phantom = `
+                    func TestPhantom(t *testing.T) {}
+                    `
+
+                    func /* comment */ TestCommentSeparated(t *testing.T) {}
+                    func FuzzInput(f *testing.F) {}
+                    func (fixture) TestMethod(t *testing.T) {}
+                    func ExampleRegistered() {
+                        // Output: ok
+                    }
+                    func ExampleWithoutOutput() {}
+                    func TestMain(m *testing.M) {}
+                    '''
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                ["go", "run", str(DISCOVERY_HELPER), "--", str(test_file)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            json.loads(result.stdout),
+            {
+                "entries": [
+                    "ExampleRegistered",
+                    "FuzzInput",
+                    "TestCommentSeparated",
+                ],
+                "has_test_main": True,
+            },
+        )
+
+    def test_compile_failure_stops_before_any_service_shard(self) -> None:
+        with self._fake_go(["TestOne", "TestTwo"], fail_compile=True) as fixture:
+            result = self._run(fixture, "--min-shards", "2")
+            events = self._events(fixture.events)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("intentional compile failure", result.stderr)
+        self.assertEqual(len([call for call in self._go_calls(events) if "-c" in call]), 1)
+        self.assertFalse(self._binary_events(events))
+
+    def test_failed_shard_fails_the_run_and_expands_only_its_log(self) -> None:
+        with self._fake_go(
+            ["TestPass", "TestFail"],
+            fail_test="TestFail",
+        ) as fixture:
+            result = self._run(fixture, "--min-shards", "2")
+
+        combined = result.stdout + result.stderr
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("intentional TestFail failure", combined)
+        self.assertNotIn("successful shard noise", combined)
+        self.assertIn("unit-test-runner: FAIL", combined)
+
+    def test_fails_closed_when_service_test_discovery_is_empty(self) -> None:
+        with self._fake_go([]) as fixture:
+            result = self._run(fixture)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("no service unit tests discovered", result.stderr)
+
+    def test_reports_each_shard_duration_instead_of_the_slowest_duration(self) -> None:
+        with self._fake_go(
+            ["TestFast2", "TestSlow"],
+            slow_test="TestFast2",
+        ) as fixture:
+            result = self._run(fixture, "--min-shards", "2")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        durations = [
+            float(match)
+            for match in re.findall(r"service-shard-\d+ \(([0-9.]+)s\)", result.stdout)
+        ]
+        self.assertEqual(len(durations), 2, result.stdout)
+        self.assertLess(min(durations), 0.5)
+        self.assertGreaterEqual(max(durations), 0.7)
+
+    def _run(self, fixture: "FakeGoFixture", *args: str) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["PATH"] = f"{fixture.bin_dir}{os.pathsep}{env['PATH']}"
+        env["FAKE_GO_EVENTS"] = str(fixture.events)
+        env["FAKE_GO_ROOT"] = str(fixture.root)
+        env["FAKE_GO_TESTS"] = json.dumps(fixture.test_names)
+        if fixture.has_test_main:
+            env["FAKE_GO_HAS_TEST_MAIN"] = "1"
+        if fixture.fail_compile:
+            env["FAKE_GO_FAIL_COMPILE"] = "1"
+        if fixture.fail_test:
+            env["FAKE_GO_FAIL_TEST"] = fixture.fail_test
+        if fixture.slow_test:
+            env["FAKE_GO_SLOW_TEST"] = fixture.slow_test
+        return subprocess.run(
+            ["python3", str(SCRIPT), "--root", str(fixture.root), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    @staticmethod
+    def _events(path: Path) -> list[dict[str, object]]:
+        return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+    @staticmethod
+    def _go_calls(events: list[dict[str, object]]) -> list[list[str]]:
+        return [event["args"] for event in events if event["kind"] == "go"]
+
+    @staticmethod
+    def _binary_events(events: list[dict[str, object]]) -> list[dict[str, object]]:
+        return [event for event in events if event["kind"] == "binary"]
+
+    @classmethod
+    def _binary_patterns(cls, events: list[dict[str, object]]) -> list[str]:
+        patterns = []
+        for event in cls._binary_events(events):
+            args = event["args"]
+            patterns.append(args[args.index("-test.run") + 1])
+        return sorted(patterns)
+
+    def _fake_go(
+        self,
+        test_names: list[str],
+        *,
+        has_test_main: bool = False,
+        fail_compile: bool = False,
+        fail_test: str | None = None,
+        slow_test: str | None = None,
+    ) -> "FakeGoFixtureContext":
+        return FakeGoFixtureContext(
+            test_names,
+            has_test_main,
+            fail_compile,
+            fail_test,
+            slow_test,
+        )
+
+
+class FakeGoFixture:
+    def __init__(
+        self,
+        temporary: tempfile.TemporaryDirectory[str],
+        test_names: list[str],
+        has_test_main: bool,
+        fail_compile: bool,
+        fail_test: str | None,
+        slow_test: str | None,
+    ) -> None:
+        self._temporary = temporary
+        self.root = Path(temporary.name)
+        self.bin_dir = self.root / "bin"
+        self.bin_dir.mkdir()
+        self.events = self.root / "events.jsonl"
+        self.events.write_text("", encoding="utf-8")
+        self.test_names = test_names
+        self.has_test_main = has_test_main
+        self.fail_compile = fail_compile
+        self.fail_test = fail_test
+        self.slow_test = slow_test
+        service_dir = self.root / "internal" / "service"
+        service_dir.mkdir(parents=True)
+        declarations = []
+        for name in test_names:
+            if name == "TestCommentSeparated":
+                declarations.append(
+                    "func /* comment */ TestCommentSeparated(t *testing.T) {}"
+                )
+            else:
+                declarations.append(f"func {name}(t *testing.T) {{}}")
+        (service_dir / "service_test.go").write_text(
+            "package service\n\n"
+            'import "testing"\n\n'
+            "var phantom = `\n"
+            "func TestPhantom(t *testing.T) {}\n"
+            "`\n\n"
+            + "\n".join(declarations)
+            + "\n",
+            encoding="utf-8",
+        )
+
+
+class FakeGoFixtureContext:
+    def __init__(
+        self,
+        test_names: list[str],
+        has_test_main: bool,
+        fail_compile: bool,
+        fail_test: str | None,
+        slow_test: str | None,
+    ) -> None:
+        self.test_names = test_names
+        self.has_test_main = has_test_main
+        self.fail_compile = fail_compile
+        self.fail_test = fail_test
+        self.slow_test = slow_test
+        self.temporary: tempfile.TemporaryDirectory[str] | None = None
+
+    def __enter__(self) -> FakeGoFixture:
+        self.temporary = tempfile.TemporaryDirectory()
+        fixture = FakeGoFixture(
+            self.temporary,
+            self.test_names,
+            self.has_test_main,
+            self.fail_compile,
+            self.fail_test,
+            self.slow_test,
+        )
+        fake_binary_source = textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import json
+            import os
+            from pathlib import Path
+            import sys
+            import time
+
+            args = sys.argv[1:]
+            with Path(os.environ["FAKE_GO_EVENTS"]).open("a", encoding="utf-8") as output:
+                output.write(json.dumps({"kind": "binary", "args": args, "cwd": os.getcwd()}) + "\\n")
+            pattern = args[args.index("-test.run") + 1]
+            fail_test = os.environ.get("FAKE_GO_FAIL_TEST", "")
+            slow_test = os.environ.get("FAKE_GO_SLOW_TEST", "")
+            if slow_test and slow_test in pattern:
+                time.sleep(0.75)
+            if fail_test and fail_test in pattern:
+                print(f"intentional {fail_test} failure")
+                raise SystemExit(1)
+            print("successful shard noise")
+            print("PASS")
+            """
+        )
+        fake_go_source = textwrap.dedent(
+            """\
+                #!/usr/bin/env python3
+                import json
+                import os
+                from pathlib import Path
+                import sys
+
+                args = sys.argv[1:]
+                events = Path(os.environ["FAKE_GO_EVENTS"])
+                with events.open("a", encoding="utf-8") as output:
+                    output.write(json.dumps({"kind": "go", "args": args}) + "\\n")
+
+                if args and args[0] == "run":
+                    print(json.dumps({
+                        "entries": json.loads(os.environ["FAKE_GO_TESTS"]),
+                        "has_test_main": os.environ.get("FAKE_GO_HAS_TEST_MAIN") == "1",
+                    }))
+                    raise SystemExit(0)
+
+                if args == ["list", "-json", "-tags=unit", "./..."]:
+                    root = Path(os.environ["FAKE_GO_ROOT"])
+                    print(json.dumps({
+                        "Dir": str(root / "internal" / "service"),
+                        "ImportPath": "example.com/fixture/internal/service",
+                        "TestGoFiles": ["service_test.go"],
+                    }))
+                    print(json.dumps({
+                        "Dir": str(root / "internal" / "other"),
+                        "ImportPath": "example.com/fixture/internal/other",
+                    }))
+                    raise SystemExit(0)
+
+                if "-c" in args:
+                    if os.environ.get("FAKE_GO_FAIL_COMPILE") == "1":
+                        print("intentional compile failure", file=sys.stderr)
+                        raise SystemExit(1)
+                    binary = Path(args[args.index("-o") + 1])
+                    binary.write_text(__BINARY_SOURCE__, encoding="utf-8")
+                    binary.chmod(0o755)
+                    raise SystemExit(0)
+
+                print("ok  fake/package  0.001s")
+                """
+        ).replace("__BINARY_SOURCE__", repr(fake_binary_source))
+        fake_go = fixture.bin_dir / "go"
+        fake_go.write_text(fake_go_source, encoding="utf-8")
+        fake_go.chmod(0o755)
+        return fixture
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        assert self.temporary is not None
+        self.temporary.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_unit_test_runner.py
+++ b/scripts/ci/test_unit_test_runner.py
@@ -3,18 +3,26 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 from pathlib import Path
 import re
 import subprocess
+import sys
 import tempfile
 import textwrap
 import unittest
+from unittest import mock
 
 
 SCRIPT = Path(__file__).resolve().parent / "unit_test_runner.py"
 DISCOVERY_HELPER = Path(__file__).resolve().parent / "list_go_tests.go"
+RUNNER_SPEC = importlib.util.spec_from_file_location("ci_unit_test_runner", SCRIPT)
+assert RUNNER_SPEC and RUNNER_SPEC.loader
+unit_test_runner = importlib.util.module_from_spec(RUNNER_SPEC)
+sys.modules[RUNNER_SPEC.name] = unit_test_runner
+RUNNER_SPEC.loader.exec_module(unit_test_runner)
 
 
 class UnitTestRunnerTest(unittest.TestCase):
@@ -57,7 +65,18 @@ class UnitTestRunnerTest(unittest.TestCase):
             go_calls,
         )
 
-        binary_events = self._binary_events(first_events)
+        registry_events = [
+            event
+            for event in self._binary_events(first_events)
+            if "-test.list" in event["args"]
+        ]
+        self.assertEqual(len(registry_events), 1)
+        self.assertEqual(
+            Path(registry_events[0]["cwd"]).resolve(),
+            (fixture.root / "internal" / "service").resolve(),
+        )
+
+        binary_events = self._binary_run_events(first_events)
         self.assertGreater(len(binary_events), 2)
         matched: list[str] = []
         for event in binary_events:
@@ -86,6 +105,29 @@ class UnitTestRunnerTest(unittest.TestCase):
         self.assertIn(["test", "-tags=unit", "./..."], go_calls)
         self.assertFalse([call for call in go_calls if "-c" in call])
         self.assertFalse(self._binary_events(events))
+
+    def test_fails_closed_when_ast_discovery_differs_from_binary_registry(self) -> None:
+        with self._fake_go(
+            ["TestVisible"],
+            binary_test_names=["TestVisible", "TestHidden"],
+        ) as fixture:
+            result = self._run(fixture)
+            events = self._events(fixture.events)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("service test registry mismatch", result.stderr)
+        self.assertIn("missing from AST discovery: TestHidden", result.stderr)
+        self.assertFalse(self._binary_run_events(events))
+
+    def test_fails_closed_when_binary_registry_omits_discovered_test(self) -> None:
+        with self._fake_go(["TestMissing"], binary_test_names=[]) as fixture:
+            result = self._run(fixture)
+            events = self._events(fixture.events)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("service test registry mismatch", result.stderr)
+        self.assertIn("missing from binary registry: TestMissing", result.stderr)
+        self.assertFalse(self._binary_run_events(events))
 
     def test_go_ast_discovery_matches_testing_registration_rules(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -144,6 +186,38 @@ class UnitTestRunnerTest(unittest.TestCase):
         self.assertEqual(len([call for call in self._go_calls(events) if "-c" in call]), 1)
         self.assertFalse(self._binary_events(events))
 
+    def test_partial_start_failure_terminates_started_processes(self) -> None:
+        class FakeProcess:
+            def __init__(self) -> None:
+                self.terminated = False
+                self.waited = False
+
+            def poll(self) -> int | None:
+                return -15 if self.terminated else None
+
+            def terminate(self) -> None:
+                self.terminated = True
+
+            def wait(self, timeout: float | None = None) -> int:
+                self.waited = True
+                return -15
+
+        process = FakeProcess()
+        commands = [
+            unit_test_runner.Command("started", ("first",), Path.cwd()),
+            unit_test_runner.Command("spawn-fails", ("second",), Path.cwd()),
+        ]
+        with mock.patch.object(
+            unit_test_runner.subprocess,
+            "Popen",
+            side_effect=[process, OSError("intentional spawn failure")],
+        ):
+            with self.assertRaisesRegex(OSError, "intentional spawn failure"):
+                unit_test_runner.run_commands(commands)
+
+        self.assertTrue(process.terminated)
+        self.assertTrue(process.waited)
+
     def test_failed_shard_fails_the_run_and_expands_only_its_log(self) -> None:
         with self._fake_go(
             ["TestPass", "TestFail"],
@@ -186,6 +260,7 @@ class UnitTestRunnerTest(unittest.TestCase):
         env["FAKE_GO_EVENTS"] = str(fixture.events)
         env["FAKE_GO_ROOT"] = str(fixture.root)
         env["FAKE_GO_TESTS"] = json.dumps(fixture.test_names)
+        env["FAKE_GO_BINARY_TESTS"] = json.dumps(fixture.binary_test_names)
         if fixture.has_test_main:
             env["FAKE_GO_HAS_TEST_MAIN"] = "1"
         if fixture.fail_compile:
@@ -215,9 +290,17 @@ class UnitTestRunnerTest(unittest.TestCase):
         return [event for event in events if event["kind"] == "binary"]
 
     @classmethod
+    def _binary_run_events(cls, events: list[dict[str, object]]) -> list[dict[str, object]]:
+        return [
+            event
+            for event in cls._binary_events(events)
+            if "-test.run" in event["args"]
+        ]
+
+    @classmethod
     def _binary_patterns(cls, events: list[dict[str, object]]) -> list[str]:
         patterns = []
-        for event in cls._binary_events(events):
+        for event in cls._binary_run_events(events):
             args = event["args"]
             patterns.append(args[args.index("-test.run") + 1])
         return sorted(patterns)
@@ -227,6 +310,7 @@ class UnitTestRunnerTest(unittest.TestCase):
         test_names: list[str],
         *,
         has_test_main: bool = False,
+        binary_test_names: list[str] | None = None,
         fail_compile: bool = False,
         fail_test: str | None = None,
         slow_test: str | None = None,
@@ -234,6 +318,7 @@ class UnitTestRunnerTest(unittest.TestCase):
         return FakeGoFixtureContext(
             test_names,
             has_test_main,
+            binary_test_names,
             fail_compile,
             fail_test,
             slow_test,
@@ -246,6 +331,7 @@ class FakeGoFixture:
         temporary: tempfile.TemporaryDirectory[str],
         test_names: list[str],
         has_test_main: bool,
+        binary_test_names: list[str] | None,
         fail_compile: bool,
         fail_test: str | None,
         slow_test: str | None,
@@ -257,6 +343,7 @@ class FakeGoFixture:
         self.events = self.root / "events.jsonl"
         self.events.write_text("", encoding="utf-8")
         self.test_names = test_names
+        self.binary_test_names = test_names if binary_test_names is None else binary_test_names
         self.has_test_main = has_test_main
         self.fail_compile = fail_compile
         self.fail_test = fail_test
@@ -288,12 +375,14 @@ class FakeGoFixtureContext:
         self,
         test_names: list[str],
         has_test_main: bool,
+        binary_test_names: list[str] | None,
         fail_compile: bool,
         fail_test: str | None,
         slow_test: str | None,
     ) -> None:
         self.test_names = test_names
         self.has_test_main = has_test_main
+        self.binary_test_names = binary_test_names
         self.fail_compile = fail_compile
         self.fail_test = fail_test
         self.slow_test = slow_test
@@ -305,6 +394,7 @@ class FakeGoFixtureContext:
             self.temporary,
             self.test_names,
             self.has_test_main,
+            self.binary_test_names,
             self.fail_compile,
             self.fail_test,
             self.slow_test,
@@ -321,6 +411,10 @@ class FakeGoFixtureContext:
             args = sys.argv[1:]
             with Path(os.environ["FAKE_GO_EVENTS"]).open("a", encoding="utf-8") as output:
                 output.write(json.dumps({"kind": "binary", "args": args, "cwd": os.getcwd()}) + "\\n")
+            if "-test.list" in args:
+                for name in json.loads(os.environ["FAKE_GO_BINARY_TESTS"]):
+                    print(name)
+                raise SystemExit(0)
             pattern = args[args.index("-test.run") + 1]
             fail_test = os.environ.get("FAKE_GO_FAIL_TEST", "")
             slow_test = os.environ.get("FAKE_GO_SLOW_TEST", "")

--- a/scripts/ci/unit_test_runner.py
+++ b/scripts/ci/unit_test_runner.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Run Go unit tests while sharding the large internal/service package."""
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+import time
+
+
+DEFAULT_SERVICE_PACKAGE = "./internal/service"
+DEFAULT_MIN_SHARDS = 8
+TEST_DISCOVERY_HELPER = Path(__file__).resolve().with_name("list_go_tests.go")
+# Linux limits a single argv entry to 128 KiB. Keep 32 KiB of headroom while
+# avoiding unnecessary shard/link fan-out at the current service test scale.
+DEFAULT_MAX_REGEX_BYTES = 96 * 1024
+
+
+class RunnerError(RuntimeError):
+    """Raised when discovery cannot produce a safe test plan."""
+
+
+@dataclass(frozen=True)
+class Command:
+    label: str
+    argv: tuple[str, ...]
+    cwd: Path
+
+
+def _run_checked(argv: list[str], root: Path) -> str:
+    result = subprocess.run(
+        argv,
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "command failed"
+        raise RunnerError(f"{' '.join(argv)}: {detail}")
+    return result.stdout
+
+
+def _decode_go_list(output: str) -> list[dict[str, object]]:
+    packages: list[dict[str, object]] = []
+    decoder = json.JSONDecoder()
+    offset = 0
+    while offset < len(output):
+        while offset < len(output) and output[offset].isspace():
+            offset += 1
+        if offset >= len(output):
+            break
+        package, offset = decoder.raw_decode(output, offset)
+        packages.append(package)
+    return packages
+
+
+def _test_entries(root: Path, test_files: list[Path]) -> tuple[list[str], bool]:
+    output = _run_checked(
+        [
+            "go",
+            "run",
+            str(TEST_DISCOVERY_HELPER),
+            "--",
+            *(str(test_file) for test_file in test_files),
+        ],
+        root,
+    )
+    try:
+        discovery = json.loads(output)
+        entries = discovery["entries"]
+        has_test_main = discovery["has_test_main"]
+    except (KeyError, TypeError, json.JSONDecodeError) as exc:
+        raise RunnerError("invalid Go test discovery output") from exc
+    if (
+        not isinstance(entries, list)
+        or not all(isinstance(entry, str) for entry in entries)
+        or not isinstance(has_test_main, bool)
+    ):
+        raise RunnerError("invalid Go test discovery output")
+    return sorted(set(entries)), has_test_main
+
+
+def discover_test_plan(
+    root: Path,
+    service_package: str,
+) -> tuple[list[str], list[str], bool]:
+    output = _run_checked(["go", "list", "-json", "-tags=unit", "./..."], root)
+    service_dir = (root / service_package.removeprefix("./")).resolve()
+    packages: list[str] = []
+    service_test_files: list[Path] | None = None
+    for package in _decode_go_list(output):
+        package_dir = Path(str(package["Dir"])).resolve()
+        try:
+            relative = package_dir.relative_to(root)
+        except ValueError as exc:
+            raise RunnerError(f"package outside backend root: {package_dir}") from exc
+        if package_dir == service_dir:
+            filenames = [
+                *package.get("TestGoFiles", []),
+                *package.get("XTestGoFiles", []),
+            ]
+            service_test_files = [package_dir / str(name) for name in filenames]
+            continue
+        packages.append(f"./{relative.as_posix()}")
+    if service_test_files is None:
+        raise RunnerError(f"service package not found: {service_package}")
+    tests, has_test_main = _test_entries(root, service_test_files)
+    if not tests and not has_test_main:
+        raise RunnerError("no service unit tests discovered")
+    return sorted(set(packages)), tests, has_test_main
+
+
+def _test_pattern(test_names: list[str]) -> str:
+    return "^(" + "|".join(re.escape(name) for name in sorted(test_names)) + ")$"
+
+
+def shard_service_tests(
+    test_names: list[str],
+    min_shards: int,
+    max_regex_bytes: int,
+) -> list[str]:
+    if min_shards < 1:
+        raise RunnerError("min shards must be positive")
+    if max_regex_bytes < 1:
+        raise RunnerError("max regex bytes must be positive")
+
+    shard_count = min(min_shards, len(test_names))
+    while True:
+        shards: list[list[str]] = [[] for _ in range(shard_count)]
+        for test_name in test_names:
+            digest = hashlib.sha256(test_name.encode("utf-8")).digest()
+            shard_index = int.from_bytes(digest[:8], "big") % shard_count
+            shards[shard_index].append(test_name)
+        patterns = [_test_pattern(shard) for shard in shards if shard]
+        if all(len(pattern.encode("utf-8")) <= max_regex_bytes for pattern in patterns):
+            return patterns
+        if shard_count == len(test_names):
+            raise RunnerError(
+                f"a single test name exceeds max regex bytes ({max_regex_bytes})"
+            )
+        shard_count = min(len(test_names), shard_count * 2)
+
+
+def build_test_plan(
+    root: Path,
+    service_package: str,
+    min_shards: int,
+    max_regex_bytes: int,
+) -> tuple[list[str], list[str], bool]:
+    other_packages, service_tests, has_test_main = discover_test_plan(
+        root,
+        service_package,
+    )
+    if has_test_main:
+        return other_packages, [], True
+    patterns = shard_service_tests(
+        service_tests,
+        min_shards,
+        max_regex_bytes,
+    )
+    return other_packages, patterns, False
+
+
+def build_commands(
+    root: Path,
+    service_package: str,
+    service_binary: Path,
+    other_packages: list[str],
+    patterns: list[str],
+) -> list[Command]:
+    commands: list[Command] = []
+    if other_packages:
+        commands.append(
+            Command(
+                "other-packages",
+                tuple(["go", "test", "-tags=unit", *other_packages]),
+                root,
+            )
+        )
+    service_dir = root / service_package.removeprefix("./")
+    width = len(str(len(patterns) - 1))
+    for index, pattern in enumerate(patterns):
+        commands.append(
+            Command(
+                f"service-shard-{index:0{width}d}",
+                (
+                    str(service_binary),
+                    "-test.run",
+                    pattern,
+                    "-test.timeout=10m",
+                    "-test.paniconexit0",
+                ),
+                service_dir,
+            )
+        )
+    return commands
+
+
+def _last_summary(output: str) -> str:
+    lines = [line for line in output.splitlines() if line.strip()]
+    return lines[-1] if lines else "no output"
+
+
+def run_commands(commands: list[Command]) -> int:
+    with tempfile.TemporaryDirectory(prefix="sub2api-unit-") as temporary:
+        log_dir = Path(temporary)
+        running: list[tuple[Command, subprocess.Popen[bytes], Path, float]] = []
+        handles = []
+        try:
+            for index, command in enumerate(commands):
+                log_path = log_dir / f"{index:02d}-{command.label}.log"
+                handle = log_path.open("wb")
+                handles.append(handle)
+                process = subprocess.Popen(
+                    command.argv,
+                    cwd=command.cwd,
+                    stdout=handle,
+                    stderr=subprocess.STDOUT,
+                )
+                running.append((command, process, log_path, time.monotonic()))
+
+            def wait_for_process(
+                item: tuple[Command, subprocess.Popen[bytes], Path, float],
+            ) -> tuple[Command, int, Path, float]:
+                command, process, log_path, started_at = item
+                returncode = process.wait()
+                elapsed = time.monotonic() - started_at
+                return command, returncode, log_path, elapsed
+
+            with ThreadPoolExecutor(max_workers=len(running)) as executor:
+                results = list(executor.map(wait_for_process, running))
+            failed = any(returncode != 0 for _, returncode, _, _ in results)
+        except KeyboardInterrupt:
+            for _, process, _, _ in running:
+                process.terminate()
+            for _, process, _, _ in running:
+                process.wait()
+            raise
+        finally:
+            for handle in handles:
+                handle.close()
+
+        for command, returncode, log_path, elapsed in results:
+            output = log_path.read_text(encoding="utf-8", errors="replace")
+            if returncode == 0:
+                print(
+                    f"unit-test-runner: PASS {command.label} "
+                    f"({elapsed:.1f}s): {_last_summary(output)}"
+                )
+                continue
+            print(
+                f"unit-test-runner: FAIL {command.label} ({elapsed:.1f}s)",
+                file=sys.stderr,
+            )
+            print(output.rstrip(), file=sys.stderr)
+        return 1 if failed else 0
+
+
+def run_unit_tests(
+    root: Path,
+    service_package: str,
+    min_shards: int,
+    max_regex_bytes: int,
+) -> int:
+    other_packages, patterns, has_test_main = build_test_plan(
+        root,
+        service_package,
+        min_shards,
+        max_regex_bytes,
+    )
+    if has_test_main:
+        print("unit-test-runner: TestMain detected; using native go test")
+        return subprocess.run(
+            ["go", "test", "-tags=unit", "./..."],
+            cwd=root,
+            check=False,
+        ).returncode
+    with tempfile.TemporaryDirectory(prefix="sub2api-service-test-") as temporary:
+        service_binary = Path(temporary) / "service.test"
+        _run_checked(
+            [
+                "go",
+                "test",
+                "-c",
+                "-tags=unit",
+                "-o",
+                str(service_binary),
+                service_package,
+            ],
+            root,
+        )
+        commands = build_commands(
+            root,
+            service_package,
+            service_binary,
+            other_packages,
+            patterns,
+        )
+        return run_commands(commands)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--service-package", default=DEFAULT_SERVICE_PACKAGE)
+    parser.add_argument("--min-shards", type=int, default=DEFAULT_MIN_SHARDS)
+    parser.add_argument(
+        "--max-regex-bytes",
+        type=int,
+        default=DEFAULT_MAX_REGEX_BYTES,
+    )
+    args = parser.parse_args(argv)
+    root = args.root.resolve()
+    try:
+        return run_unit_tests(
+            root,
+            args.service_package,
+            args.min_shards,
+            args.max_regex_bytes,
+        )
+    except (OSError, RunnerError) as exc:
+        print(f"unit-test-runner: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/unit_test_runner.py
+++ b/scripts/ci/unit_test_runner.py
@@ -155,19 +155,46 @@ def build_test_plan(
     service_package: str,
     min_shards: int,
     max_regex_bytes: int,
-) -> tuple[list[str], list[str], bool]:
+) -> tuple[list[str], list[str], list[str], bool]:
     other_packages, service_tests, has_test_main = discover_test_plan(
         root,
         service_package,
     )
     if has_test_main:
-        return other_packages, [], True
+        return other_packages, service_tests, [], True
     patterns = shard_service_tests(
         service_tests,
         min_shards,
         max_regex_bytes,
     )
-    return other_packages, patterns, False
+    return other_packages, service_tests, patterns, False
+
+
+def verify_binary_registry(
+    service_binary: Path,
+    service_dir: Path,
+    discovered_tests: list[str],
+) -> None:
+    output = _run_checked(
+        [str(service_binary), "-test.list", "^(Test|Fuzz|Example)"],
+        service_dir,
+    )
+    registered_tests = sorted(
+        {line.strip() for line in output.splitlines() if line.strip()}
+    )
+    discovered = set(discovered_tests)
+    registered = set(registered_tests)
+    if discovered == registered:
+        return
+
+    details = []
+    missing = sorted(registered - discovered)
+    unexpected = sorted(discovered - registered)
+    if missing:
+        details.append("missing from AST discovery: " + ", ".join(missing))
+    if unexpected:
+        details.append("missing from binary registry: " + ", ".join(unexpected))
+    raise RunnerError("service test registry mismatch; " + "; ".join(details))
 
 
 def build_commands(
@@ -210,6 +237,24 @@ def _last_summary(output: str) -> str:
     return lines[-1] if lines else "no output"
 
 
+def _terminate_processes(
+    running: list[tuple[Command, subprocess.Popen[bytes], Path, float]],
+) -> None:
+    for _, process, _, _ in running:
+        if process.poll() is not None:
+            continue
+        try:
+            process.terminate()
+        except ProcessLookupError:
+            continue
+    for _, process, _, _ in running:
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+
+
 def run_commands(commands: list[Command]) -> int:
     with tempfile.TemporaryDirectory(prefix="sub2api-unit-") as temporary:
         log_dir = Path(temporary)
@@ -239,11 +284,8 @@ def run_commands(commands: list[Command]) -> int:
             with ThreadPoolExecutor(max_workers=len(running)) as executor:
                 results = list(executor.map(wait_for_process, running))
             failed = any(returncode != 0 for _, returncode, _, _ in results)
-        except KeyboardInterrupt:
-            for _, process, _, _ in running:
-                process.terminate()
-            for _, process, _, _ in running:
-                process.wait()
+        except BaseException:
+            _terminate_processes(running)
             raise
         finally:
             for handle in handles:
@@ -271,7 +313,7 @@ def run_unit_tests(
     min_shards: int,
     max_regex_bytes: int,
 ) -> int:
-    other_packages, patterns, has_test_main = build_test_plan(
+    other_packages, service_tests, patterns, has_test_main = build_test_plan(
         root,
         service_package,
         min_shards,
@@ -298,6 +340,8 @@ def run_unit_tests(
             ],
             root,
         )
+        service_dir = root / service_package.removeprefix("./")
+        verify_binary_registry(service_binary, service_dir, service_tests)
         commands = build_commands(
             root,
             service_package,

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import subprocess
 import unittest
 
 import yaml
@@ -19,7 +20,18 @@ class BackendCIRoutingTest(unittest.TestCase):
 
     def test_changes_job_exports_all_surface_decisions(self) -> None:
         outputs = self.jobs["changes"]["outputs"]
-        self.assertEqual(set(outputs), {"backend", "frontend", "deploy", "ops", "contracts", "all"})
+        self.assertEqual(
+            set(outputs),
+            {
+                "backend",
+                "frontend",
+                "deploy",
+                "ops",
+                "contracts",
+                "service_unit_cold",
+                "all",
+            },
+        )
 
     def test_expensive_jobs_depend_on_the_matching_surface(self) -> None:
         expected = {
@@ -67,6 +79,7 @@ class BackendCIRoutingTest(unittest.TestCase):
             "scripts.test_preflight_ci_handoffs",
             "scripts.test_ci_gate_handoffs",
             "scripts.ci.test_changed_surfaces",
+            "scripts.ci.test_unit_test_runner",
             "scripts.test_backend_ci_routing",
         }
         for module in expected_modules:
@@ -99,6 +112,61 @@ class BackendCIRoutingTest(unittest.TestCase):
         target = makefile.split("test-integration:\n", 1)[1].split("\n\n", 1)[0]
         self.assertIn("integration-packages.py", target)
         self.assertNotIn("go test -tags=integration ./...", target)
+
+    def test_unit_job_passes_the_service_cold_path_decision(self) -> None:
+        unit_step = next(
+            step
+            for step in self.jobs["test-unit"]["steps"]
+            if step.get("name") == "Unit tests"
+        )
+
+        self.assertIn(
+            "needs.changes.outputs.service_unit_cold",
+            unit_step["env"]["UNIT_TEST_SERVICE_SHARD"],
+        )
+
+    def test_unit_main_writer_uses_native_path_to_seed_result_cache(self) -> None:
+        unit_step = next(
+            step
+            for step in self.jobs["test-unit"]["steps"]
+            if step.get("name") == "Unit tests"
+        )
+
+        self.assertIn(
+            "github.event_name != 'push'",
+            unit_step["env"]["UNIT_TEST_SERVICE_SHARD"],
+        )
+
+    def test_unit_target_uses_go_cache_by_default(self) -> None:
+        result = subprocess.run(
+            ["make", "-n", "-C", str(BACKEND_MAKEFILE.parent), "test-unit"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("go test -tags=unit ./...", result.stdout)
+        self.assertNotIn("unit_test_runner.py", result.stdout)
+
+    def test_unit_target_uses_compile_once_shards_on_cold_path(self) -> None:
+        result = subprocess.run(
+            [
+                "make",
+                "-n",
+                "-C",
+                str(BACKEND_MAKEFILE.parent),
+                "UNIT_TEST_SERVICE_SHARD=1",
+                "test-unit",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("unit_test_runner.py", result.stdout)
+        self.assertNotIn("go test -tags=unit ./...", result.stdout)
 
 
 if __name__ == "__main__":

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -79,12 +79,34 @@ class BackendCIRoutingTest(unittest.TestCase):
             "scripts.test_preflight_ci_handoffs",
             "scripts.test_ci_gate_handoffs",
             "scripts.ci.test_changed_surfaces",
-            "scripts.ci.test_unit_test_runner",
             "scripts.test_backend_ci_routing",
         }
         for module in expected_modules:
             with self.subTest(module=module):
                 self.assertIn(module, command)
+
+    def test_go_dependent_unit_runner_contract_runs_after_pinned_setup(self) -> None:
+        steps = self.jobs["preflight"]["steps"]
+        orchestration = next(
+            step for step in steps if step.get("name") == "CI orchestration contract tests"
+        )
+        self.assertNotIn("scripts.ci.test_unit_test_runner", orchestration.get("run", ""))
+
+        setup_index = next(
+            index for index, step in enumerate(steps) if step.get("uses") == "actions/setup-go@v6"
+        )
+        contract_steps = [
+            (index, step)
+            for index, step in enumerate(steps)
+            if step.get("name") == "Unit runner contract tests"
+        ]
+        self.assertEqual(len(contract_steps), 1)
+        contract_index, contract_step = contract_steps[0]
+        self.assertGreater(contract_index, setup_index)
+        self.assertIn(
+            "scripts.ci.test_unit_test_runner",
+            contract_step.get("run", ""),
+        )
 
     def test_go_dependent_integration_contract_runs_after_pinned_setup(self) -> None:
         steps = self.jobs["preflight"]["steps"]


### PR DESCRIPTION
## 摘要

- 保留原生 Go result cache 热路径；仅在 PR / 手动 CI 且 service 测试可能失效时启用冷分片。
- service 测试只编译一次 test binary，再在同一 runner 内并行执行 8 个 shard；未增加 job、matrix 或 runner。
- 使用 Go AST 按 `cmd/go` 规则发现 Test / Fuzz / Example，并与真实 test binary 注册表 fail-closed 对账；发现 `TestMain` 时回退原生执行。
- main push 保持原生 `go test`，继续为 rolling cache 写入 test-result cache。
- 部分子进程启动失败时会终止并回收已启动进程；validation-order 单测不再依赖外部 DNS。

## 风险

- 不改变生产代码和 Web 行为；`no-web-impact`。
- 不增加 GitHub Actions runner 数量或 credits 并行倍数。
- 冷路径直接执行 test binary，显式保持 package cwd、10 分钟 timeout、`paniconexit0`，并对 AST 发现结果与 binary registry 做双向一致性校验。
- main 更新已通过普通 merge 纳入；未 rebase、未 force-push。

## 验证

- `python3 -m unittest ...CI orchestration contracts...`：46/46 PASS
- `UNIT_TEST_SERVICE_SHARD=1 make test-unit`：other packages 与 8 个 service shard 全部 PASS，墙钟 35.03s
- `make test-integration`：6 个 integration package PASS
- `make lint`：0 issues
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：PASS
- `xj-review` mechanical pipeline：0 FAIL、0 warn candidate、0 finding

## 提交

- `8a04bf2b9 Merge remote-tracking branch 'origin/main' into chore/ci-unit-service-shards`
- `e07325821 Merge remote-tracking branch 'origin/main' into chore/ci-unit-service-shards`
- `b65ad0010 fix(ci): address R-001..R-003 — harden service shards`
- `19e65ec39 chore(ci): compile service unit tests once per cold run`

最新提交：8a04bf2b9
