### PR TITLE
fix(protocol): 收敛协议 SSOT 探测合法路径

### DIFF
--- a/backend/internal/service/account_supported_protocols.go
+++ b/backend/internal/service/account_supported_protocols.go
@@ -11,6 +11,7 @@ import (
 
 	newapitypes "github.com/QuantumNous/new-api/types"
 	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
+	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
 	"github.com/Wei-Shaw/sub2api/internal/relay/bridge"
 )
@@ -254,6 +255,13 @@ func protocolExactEndpoint(account *Account, protocol protocolrouter.Protocol, r
 		format = newapitypes.RelayFormatOpenAIResponses
 	default:
 		return "", nil
+	}
+	if isNewAPIVolcEngineAgentPlanAccount(account) {
+		base := strings.TrimRight(newapiintegration.VolcEngineAgentPlanBaseURL, "/")
+		if protocol == protocolrouter.ProtocolResponses {
+			return base + "/responses", nil
+		}
+		return base + "/chat/completions", nil
 	}
 	in := newAPIBridgeChannelInputForModel(account, 0, "", resolvedModel).WithoutModelMapping()
 	endpoint, err := bridge.ResolveTextEndpoint(in, format, resolvedModel)

--- a/backend/internal/service/account_supported_protocols_test.go
+++ b/backend/internal/service/account_supported_protocols_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"time"
 
+	newapiconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
+	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
 )
 
 type supportedProtocolsUpdateRecorder struct {
@@ -228,6 +230,38 @@ func TestProtocolAccountSnapshotUsesExplicitMessagesEndpointForCustomAnthropicOA
 	}
 	if got, want := plan.Endpoint(), "https://relay.example.test/v1/messages"; got != want {
 		t.Fatalf("endpoint = %q, want %q", got, want)
+	}
+}
+
+func TestProtocolAccountSnapshotUsesCanonicalAgentPlanEndpoints(t *testing.T) {
+	account := &Account{
+		ID:          88,
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeVolcEngine,
+		Credentials: map[string]any{
+			"api_key":       "secret",
+			"base_url":      newapiintegration.VolcEngineAgentPlanBaseURL,
+			"model_mapping": map[string]any{"ark-code-latest": "ark-code-latest"},
+		},
+		Extra: map[string]any{
+			SupportedProtocolsExtraKey: []any{"chat_completions", "responses"},
+		},
+	}
+
+	chatEndpoint, err := protocolExactEndpoint(account, protocolrouter.ProtocolChatCompletions, "ark-code-latest")
+	if err != nil {
+		t.Fatalf("protocolExactEndpoint chat: %v", err)
+	}
+	if got, want := chatEndpoint, newapiintegration.VolcEngineAgentPlanBaseURL+"/chat/completions"; got != want {
+		t.Fatalf("chat endpoint = %q, want %q", got, want)
+	}
+	responsesEndpoint, err := protocolExactEndpoint(account, protocolrouter.ProtocolResponses, "ark-code-latest")
+	if err != nil {
+		t.Fatalf("protocolExactEndpoint responses: %v", err)
+	}
+	if got, want := responsesEndpoint, newapiintegration.VolcEngineAgentPlanBaseURL+"/responses"; got != want {
+		t.Fatalf("responses endpoint = %q, want %q", got, want)
 	}
 }
 

--- a/backend/internal/service/openai_apikey_chat_completions_probe.go
+++ b/backend/internal/service/openai_apikey_chat_completions_probe.go
@@ -88,7 +88,7 @@ func (s *AccountTestService) probeOpenAIAPIKeyChatCompletionsSupport(
 		return protocolProbeObservation{}, false
 	}
 
-	probeModel := selectResponsesProbeModel(account)
+	probeModel := selectProtocolProbeModel(account)
 	probeURL := buildOpenAIEndpointURL(normalizedBaseURL, apipath.ChatCompletions)
 	if exactEndpoint, exactErr := protocolExactEndpoint(account, protocolrouter.ProtocolChatCompletions, probeModel); exactErr != nil {
 		logger.LegacyPrintf("service.openai_probe", "chat_completions_resolve_endpoint_failed: account_id=%d err=%v", accountID, exactErr)

--- a/backend/internal/service/openai_apikey_native_messages_probe.go
+++ b/backend/internal/service/openai_apikey_native_messages_probe.go
@@ -36,8 +36,9 @@ func openaiNativeMessagesProbePayload(modelID string) []byte {
 }
 
 // ProbeOpenAIAPIKeyNativeMessagesSupport probes whether an OpenAI APIKey account
-// upstream exposes Anthropic /v1/messages and persists the result to
-// accounts.extra.openai_native_messages_supported.
+// upstream exposes Anthropic /v1/messages, updates accounts.extra.supported_protocols
+// through the shared persistence path, and keeps openai_native_messages_supported
+// for legacy readers.
 func (s *AccountTestService) ProbeOpenAIAPIKeyNativeMessagesSupport(ctx context.Context, accountID int64) {
 	account, err := s.accountRepo.GetByID(ctx, accountID)
 	if err != nil {
@@ -99,7 +100,7 @@ func (s *AccountTestService) probeOpenAIAPIKeyNativeMessagesSupport(
 	}
 
 	probeURL := buildOpenAIEndpointURL(normalizedBaseURL, apipath.Messages)
-	probeModel := selectResponsesProbeModel(account)
+	probeModel := selectProtocolProbeModel(account)
 
 	probeCtx, cancel := context.WithTimeout(ctx, openaiNativeMessagesProbeTimeout)
 	defer cancel()

--- a/backend/internal/service/openai_apikey_responses_probe.go
+++ b/backend/internal/service/openai_apikey_responses_probe.go
@@ -7,11 +7,9 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"sort"
 	"strings"
 	"time"
 
-	newapiconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
@@ -75,87 +73,12 @@ func openaiResponsesProbePayload(modelID string) []byte {
 	return body
 }
 
-// selectResponsesProbeModel 选出用于探测的上游模型。
-//
-// 工具能力探测必须用上游真实存在的模型——用占位模型(DefaultTestModel)打第三方
-// 上游只会拿到 400 model-not-found,无从判定工具能力。优先取账号 model_mapping
-// 的上游模型(值),按字典序取首个具体(非通配符)模型以保证可复现;无映射时回退
-// DefaultTestModel(适配 OpenAI 官方 APIKey 账号)。
-func selectResponsesProbeModel(account *Account) string {
-	models := selectProtocolProbeModels(account)
-	if len(models) == 0 {
-		return openai.DefaultTestModel
-	}
-	return models[0]
-}
-
-func selectProtocolProbeModels(account *Account) []string {
-	if protocolRoutingAccountIsMediaOnly(account) {
-		return nil
-	}
-	mapping := account.GetModelMapping()
-	candidates := make([]string, 0, len(mapping))
-	for _, upstream := range mapping {
-		upstream = strings.TrimSpace(upstream)
-		if upstream == "" || strings.Contains(upstream, "*") || protocolProbeModelIsMedia(upstream) {
-			continue
-		}
-		candidates = append(candidates, upstream)
-	}
-	if len(candidates) == 0 {
-		return []string{openai.DefaultTestModel}
-	}
-	sort.Strings(candidates)
-	return prioritizeProtocolProbeModels(account, compactSortedStrings(candidates))
-}
-
-func prioritizeProtocolProbeModels(account *Account, models []string) []string {
-	if account == nil || account.Platform != PlatformNewAPI || account.ChannelType != newapiconstant.ChannelTypeAli {
-		return models
-	}
-	preferred := make([]string, 0, len(models))
-	fallback := make([]string, 0, len(models))
-	for _, model := range models {
-		if strings.HasPrefix(strings.ToLower(model), "qwen") {
-			preferred = append(preferred, model)
-		} else {
-			fallback = append(fallback, model)
-		}
-	}
-	return append(preferred, fallback...)
-}
-
-func protocolProbeModelIsMedia(model string) bool {
-	model = strings.ToLower(strings.TrimSpace(model))
-	return strings.Contains(model, "seedance") ||
-		strings.Contains(model, "seedream") ||
-		strings.HasPrefix(model, "gpt-image-") ||
-		strings.HasPrefix(model, "dall-e") ||
-		strings.HasPrefix(model, "sora") ||
-		strings.HasPrefix(model, "veo-") ||
-		strings.HasPrefix(model, "imagen-") ||
-		strings.HasPrefix(model, "grok-imagine-image") ||
-		strings.HasPrefix(model, "grok-imagine-video") ||
-		strings.HasPrefix(model, "grok-video")
-}
-
-func compactSortedStrings(values []string) []string {
-	if len(values) < 2 {
-		return values
-	}
-	out := values[:1]
-	for _, value := range values[1:] {
-		if value != out[len(out)-1] {
-			out = append(out, value)
-		}
-	}
-	return out
-}
-
 // ProbeOpenAIAPIKeyResponsesSupport 探测 OpenAI APIKey 账号上游是否支持
-// /v1/responses 端点，并将结果持久化到 accounts.extra.openai_responses_supported。
+// /v1/responses 端点，并通过统一持久化入口更新 accounts.extra.supported_protocols；
+// 同时写入 openai_responses_supported 兼容旧读取方。
 //
-// 调用时机：账号创建/更新后，且仅当 platform=openai && type=apikey 时。
+// 调用时机：统一协议能力探测选出 Responses 候选后；适用于所有受治理的自定义
+// APIKey/Upstream 账号，不再由 platform 名称推断能力。
 //
 // 探测策略（参见包文档 internal/pkg/openai_compat）：
 //   - 上游 404 / 405 → 端点不存在,写 false
@@ -166,8 +89,8 @@ func compactSortedStrings(values []string) []string {
 //
 // 该方法是幂等的：重复调用会以最新探测结果覆盖标记。
 //
-// 关于失败处理：探测本身的失败不应阻塞账号创建——账号能创建/更新成功就够了，
-// 探测结果只影响后续路由优化。所有错误都仅记录日志，不向调用方传播。
+// 关于失败处理：探测本身的失败不阻塞账号写入或启动准备；所有错误仅记录日志，
+// 未得出结论时保留既有能力事实。
 func (s *AccountTestService) ProbeOpenAIAPIKeyResponsesSupport(ctx context.Context, accountID int64) {
 	account, err := s.accountRepo.GetByID(ctx, accountID)
 	if err != nil {
@@ -227,7 +150,7 @@ func (s *AccountTestService) probeOpenAIAPIKeyResponsesSupport(
 		return protocolProbeObservation{}, false
 	}
 
-	probeModel := selectResponsesProbeModel(account)
+	probeModel := selectProtocolProbeModel(account)
 	probeURL := buildOpenAIResponsesURLForPlatform(account.Platform, normalizedBaseURL)
 	if exactEndpoint, exactErr := protocolExactEndpoint(account, protocolrouter.ProtocolResponses, probeModel); exactErr != nil {
 		logger.LegacyPrintf("service.openai_probe", "probe_resolve_endpoint_failed: account_id=%d err=%v", accountID, exactErr)

--- a/backend/internal/service/openai_apikey_responses_probe.go
+++ b/backend/internal/service/openai_apikey_responses_probe.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	newapiconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
@@ -81,20 +82,74 @@ func openaiResponsesProbePayload(modelID string) []byte {
 // 的上游模型(值),按字典序取首个具体(非通配符)模型以保证可复现;无映射时回退
 // DefaultTestModel(适配 OpenAI 官方 APIKey 账号)。
 func selectResponsesProbeModel(account *Account) string {
+	models := selectProtocolProbeModels(account)
+	if len(models) == 0 {
+		return openai.DefaultTestModel
+	}
+	return models[0]
+}
+
+func selectProtocolProbeModels(account *Account) []string {
+	if protocolRoutingAccountIsMediaOnly(account) {
+		return nil
+	}
 	mapping := account.GetModelMapping()
 	candidates := make([]string, 0, len(mapping))
 	for _, upstream := range mapping {
 		upstream = strings.TrimSpace(upstream)
-		if upstream == "" || strings.Contains(upstream, "*") {
+		if upstream == "" || strings.Contains(upstream, "*") || protocolProbeModelIsMedia(upstream) {
 			continue
 		}
 		candidates = append(candidates, upstream)
 	}
 	if len(candidates) == 0 {
-		return openai.DefaultTestModel
+		return []string{openai.DefaultTestModel}
 	}
 	sort.Strings(candidates)
-	return candidates[0]
+	return prioritizeProtocolProbeModels(account, compactSortedStrings(candidates))
+}
+
+func prioritizeProtocolProbeModels(account *Account, models []string) []string {
+	if account == nil || account.Platform != PlatformNewAPI || account.ChannelType != newapiconstant.ChannelTypeAli {
+		return models
+	}
+	preferred := make([]string, 0, len(models))
+	fallback := make([]string, 0, len(models))
+	for _, model := range models {
+		if strings.HasPrefix(strings.ToLower(model), "qwen") {
+			preferred = append(preferred, model)
+		} else {
+			fallback = append(fallback, model)
+		}
+	}
+	return append(preferred, fallback...)
+}
+
+func protocolProbeModelIsMedia(model string) bool {
+	model = strings.ToLower(strings.TrimSpace(model))
+	return strings.Contains(model, "seedance") ||
+		strings.Contains(model, "seedream") ||
+		strings.HasPrefix(model, "gpt-image-") ||
+		strings.HasPrefix(model, "dall-e") ||
+		strings.HasPrefix(model, "sora") ||
+		strings.HasPrefix(model, "veo-") ||
+		strings.HasPrefix(model, "imagen-") ||
+		strings.HasPrefix(model, "grok-imagine-image") ||
+		strings.HasPrefix(model, "grok-imagine-video") ||
+		strings.HasPrefix(model, "grok-video")
+}
+
+func compactSortedStrings(values []string) []string {
+	if len(values) < 2 {
+		return values
+	}
+	out := values[:1]
+	for _, value := range values[1:] {
+		if value != out[len(out)-1] {
+			out = append(out, value)
+		}
+	}
+	return out
 }
 
 // ProbeOpenAIAPIKeyResponsesSupport 探测 OpenAI APIKey 账号上游是否支持

--- a/backend/internal/service/openai_apikey_responses_probe_test.go
+++ b/backend/internal/service/openai_apikey_responses_probe_test.go
@@ -10,7 +10,6 @@ import (
 
 	newapiconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/Wei-Shaw/sub2api/internal/config"
-	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
 	"github.com/stretchr/testify/require"
@@ -226,9 +225,9 @@ func TestResponsesProbeBodyHasFunctionCall(t *testing.T) {
 	require.False(t, responsesProbeBodyHasFunctionCall([]byte(`garbage`)))
 }
 
-func TestSelectResponsesProbeModel(t *testing.T) {
+func TestSelectProtocolProbeModelUsesDeterministicTextFallback(t *testing.T) {
 	// No model_mapping -> fall back to DefaultTestModel (OpenAI official APIKey).
-	require.Equal(t, openai.DefaultTestModel, selectResponsesProbeModel(&Account{}))
+	require.Equal(t, openai.DefaultTestModel, selectProtocolProbeModel(&Account{}))
 
 	// model_mapping values are upstream models; pick first by sort for reproducibility.
 	acct := &Account{Credentials: map[string]any{
@@ -237,7 +236,7 @@ func TestSelectResponsesProbeModel(t *testing.T) {
 			"client-a": "alpha-model",
 		},
 	}}
-	require.Equal(t, "alpha-model", selectResponsesProbeModel(acct))
+	require.Equal(t, "alpha-model", selectProtocolProbeModel(acct))
 
 	// Wildcard / blank upstream values are skipped.
 	acctWild := &Account{Credentials: map[string]any{
@@ -247,16 +246,16 @@ func TestSelectResponsesProbeModel(t *testing.T) {
 			"c": "real-model",
 		},
 	}}
-	require.Equal(t, "real-model", selectResponsesProbeModel(acctWild))
+	require.Equal(t, "real-model", selectProtocolProbeModel(acctWild))
 
 	// Only wildcard mappings -> DefaultTestModel.
 	acctAllWild := &Account{Credentials: map[string]any{
 		"model_mapping": map[string]any{"a": "gpt-*"},
 	}}
-	require.Equal(t, openai.DefaultTestModel, selectResponsesProbeModel(acctAllWild))
+	require.Equal(t, openai.DefaultTestModel, selectProtocolProbeModel(acctAllWild))
 }
 
-func TestSelectProtocolProbeModelsExcludesMediaAndKeepsDeterministicTextFallbacks(t *testing.T) {
+func TestSelectProtocolProbeModelExcludesMediaAndUsesDeterministicTextFallback(t *testing.T) {
 	account := &Account{
 		Platform:    PlatformNewAPI,
 		Type:        AccountTypeAPIKey,
@@ -271,10 +270,10 @@ func TestSelectProtocolProbeModelsExcludesMediaAndKeepsDeterministicTextFallback
 		},
 	}
 
-	require.Equal(t, []string{"glm-4.5", "qwen-plus"}, selectProtocolProbeModels(account))
+	require.Equal(t, "glm-4.5", selectProtocolProbeModel(account))
 }
 
-func TestSelectProtocolProbeModelsPrefersAliNativeQwenFamily(t *testing.T) {
+func TestSelectProtocolProbeModelPrefersAliNativeQwenFamily(t *testing.T) {
 	account := &Account{
 		Platform:    PlatformNewAPI,
 		Type:        AccountTypeAPIKey,
@@ -287,21 +286,5 @@ func TestSelectProtocolProbeModelsPrefersAliNativeQwenFamily(t *testing.T) {
 		},
 	}
 
-	require.Equal(t, []string{"qwen-plus", "glm-4.5"}, selectProtocolProbeModels(account))
-}
-
-func TestSelectProtocolProbeModelsReturnsNoneForXRTokenVideoOnlyAccount(t *testing.T) {
-	account := &Account{
-		Platform:    PlatformNewAPI,
-		Type:        AccountTypeAPIKey,
-		ChannelType: newapiconstant.ChannelTypeDoubaoVideo,
-		Credentials: map[string]any{
-			"base_url": newapiintegration.XRTokenBaseURL,
-			"model_mapping": map[string]any{
-				"video": "doubao-seedance-2-0-260128",
-			},
-		},
-	}
-
-	require.Empty(t, selectProtocolProbeModels(account))
+	require.Equal(t, "qwen-plus", selectProtocolProbeModel(account))
 }

--- a/backend/internal/service/openai_apikey_responses_probe_test.go
+++ b/backend/internal/service/openai_apikey_responses_probe_test.go
@@ -10,6 +10,7 @@ import (
 
 	newapiconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
 	"github.com/stretchr/testify/require"
@@ -50,6 +51,46 @@ func TestProbeOpenAIAPIKeyResponsesSupportUsesNewAPIAdaptorEndpoint(t *testing.T
 
 	require.NotNil(t, upstream.lastReq)
 	require.Equal(t, "https://dashscope.aliyuncs.com/api/v2/apps/protocols/compatible-mode/v1/responses", upstream.lastReq.URL.String())
+	updates := <-updateCalls
+	require.Equal(t, []string{"responses"}, updates[SupportedProtocolsExtraKey])
+}
+
+func TestProbeOpenAIAPIKeyResponsesSupportPrefersChannelNativeTextModel(t *testing.T) {
+	updateCalls := make(chan map[string]any, 1)
+	account := Account{
+		ID:          78,
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeAli,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "dashscope-key",
+			"base_url": "https://dashscope.aliyuncs.com",
+			"model_mapping": map[string]any{
+				"glm-4.5":   "glm-4.5",
+				"qwen-plus": "qwen-plus",
+			},
+		},
+	}
+	repo := &snapshotUpdateAccountRepo{
+		stubOpenAIAccountRepo: stubOpenAIAccountRepo{accounts: []Account{account}},
+		updateExtraCalls:      updateCalls,
+	}
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(`{"status":"completed","output":[{"type":"function_call","name":"probe_ping"}]}`)),
+	}}
+	svc := &AccountTestService{
+		accountRepo:  repo,
+		httpUpstream: upstream,
+		cfg:          &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
+	}
+
+	svc.ProbeOpenAIAPIKeyResponsesSupport(context.Background(), account.ID)
+
+	require.Len(t, upstream.bodies, 1)
+	require.Contains(t, string(upstream.bodies[0]), `"model":"qwen-plus"`)
 	updates := <-updateCalls
 	require.Equal(t, []string{"responses"}, updates[SupportedProtocolsExtraKey])
 }
@@ -213,4 +254,54 @@ func TestSelectResponsesProbeModel(t *testing.T) {
 		"model_mapping": map[string]any{"a": "gpt-*"},
 	}}
 	require.Equal(t, openai.DefaultTestModel, selectResponsesProbeModel(acctAllWild))
+}
+
+func TestSelectProtocolProbeModelsExcludesMediaAndKeepsDeterministicTextFallbacks(t *testing.T) {
+	account := &Account{
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeVolcEngine,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				"video": "doubao-seedance-2-0-260128",
+				"later": "qwen-plus",
+				"first": "glm-4.5",
+				"image": "doubao-seedream-4-0-250828",
+			},
+		},
+	}
+
+	require.Equal(t, []string{"glm-4.5", "qwen-plus"}, selectProtocolProbeModels(account))
+}
+
+func TestSelectProtocolProbeModelsPrefersAliNativeQwenFamily(t *testing.T) {
+	account := &Account{
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeAli,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				"glm":  "glm-4.5",
+				"qwen": "qwen-plus",
+			},
+		},
+	}
+
+	require.Equal(t, []string{"qwen-plus", "glm-4.5"}, selectProtocolProbeModels(account))
+}
+
+func TestSelectProtocolProbeModelsReturnsNoneForXRTokenVideoOnlyAccount(t *testing.T) {
+	account := &Account{
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeDoubaoVideo,
+		Credentials: map[string]any{
+			"base_url": newapiintegration.XRTokenBaseURL,
+			"model_mapping": map[string]any{
+				"video": "doubao-seedance-2-0-260128",
+			},
+		},
+	}
+
+	require.Empty(t, selectProtocolProbeModels(account))
 }

--- a/backend/internal/service/protocol_probe_model_tk.go
+++ b/backend/internal/service/protocol_probe_model_tk.go
@@ -1,0 +1,77 @@
+package service
+
+import (
+	"sort"
+	"strings"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
+)
+
+// selectProtocolProbeModel selects one deterministic representative text model
+// shared by Chat Completions, Responses, and Messages capability probes.
+func selectProtocolProbeModel(account *Account) string {
+	if account == nil || protocolRoutingAccountIsMediaOnly(account) {
+		return openai.DefaultTestModel
+	}
+	mapping := account.GetModelMapping()
+	candidates := make([]string, 0, len(mapping))
+	for _, upstream := range mapping {
+		upstream = strings.TrimSpace(upstream)
+		if upstream == "" || strings.Contains(upstream, "*") || protocolProbeModelIsMedia(upstream) {
+			continue
+		}
+		candidates = append(candidates, upstream)
+	}
+	if len(candidates) == 0 {
+		return openai.DefaultTestModel
+	}
+	sort.Strings(candidates)
+	if account.Platform == PlatformNewAPI && account.ChannelType == newapiconstant.ChannelTypeAli {
+		for _, model := range candidates {
+			if strings.HasPrefix(strings.ToLower(model), "qwen") {
+				return model
+			}
+		}
+	}
+	return candidates[0]
+}
+
+func protocolRoutingAccountIsMediaOnly(account *Account) bool {
+	if account == nil {
+		return false
+	}
+	if isNewAPIXRTokenAccount(account) {
+		return true
+	}
+	mapping := account.GetModelMapping()
+	if len(mapping) == 0 {
+		return false
+	}
+	declared := 0
+	for _, model := range mapping {
+		model = strings.TrimSpace(model)
+		if model == "" {
+			continue
+		}
+		declared++
+		if !protocolProbeModelIsMedia(model) {
+			return false
+		}
+	}
+	return declared > 0
+}
+
+func protocolProbeModelIsMedia(model string) bool {
+	model = strings.ToLower(strings.TrimSpace(model))
+	return isOpenAIImageGenerationModel(model) ||
+		isGrokVideoGenerationModel(model) ||
+		antigravity.IsImageModel(model) ||
+		strings.Contains(model, "seedance") ||
+		strings.Contains(model, "seedream") ||
+		strings.HasPrefix(model, "dall-e") ||
+		strings.HasPrefix(model, "sora") ||
+		strings.HasPrefix(model, "veo-") ||
+		strings.HasPrefix(model, "imagen-")
+}

--- a/backend/internal/service/protocol_routing_context.go
+++ b/backend/internal/service/protocol_routing_context.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
@@ -152,31 +151,6 @@ func protocolRoutingGovernsAccount(account *Account) bool {
 	default:
 		return false
 	}
-}
-
-func protocolRoutingAccountIsMediaOnly(account *Account) bool {
-	if account == nil {
-		return false
-	}
-	if isNewAPIXRTokenAccount(account) {
-		return true
-	}
-	mapping := account.GetModelMapping()
-	if len(mapping) == 0 {
-		return false
-	}
-	declared := 0
-	for _, model := range mapping {
-		model = strings.TrimSpace(model)
-		if model == "" {
-			continue
-		}
-		declared++
-		if !protocolProbeModelIsMedia(model) {
-			return false
-		}
-	}
-	return declared > 0
 }
 
 func attachProtocolPlan(

--- a/backend/internal/service/protocol_routing_context.go
+++ b/backend/internal/service/protocol_routing_context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
@@ -136,6 +137,9 @@ func protocolRoutingGovernsAccount(account *Account) bool {
 	if account == nil || account.IsBedrock() || account.Type == AccountTypeServiceAccount {
 		return false
 	}
+	if protocolRoutingAccountIsMediaOnly(account) {
+		return false
+	}
 	switch account.Platform {
 	case PlatformAnthropic,
 		PlatformOpenAI,
@@ -148,6 +152,31 @@ func protocolRoutingGovernsAccount(account *Account) bool {
 	default:
 		return false
 	}
+}
+
+func protocolRoutingAccountIsMediaOnly(account *Account) bool {
+	if account == nil {
+		return false
+	}
+	if isNewAPIXRTokenAccount(account) {
+		return true
+	}
+	mapping := account.GetModelMapping()
+	if len(mapping) == 0 {
+		return false
+	}
+	declared := 0
+	for _, model := range mapping {
+		model = strings.TrimSpace(model)
+		if model == "" {
+			continue
+		}
+		declared++
+		if !protocolProbeModelIsMedia(model) {
+			return false
+		}
+	}
+	return declared > 0
 }
 
 func attachProtocolPlan(

--- a/backend/internal/service/protocol_routing_migration.go
+++ b/backend/internal/service/protocol_routing_migration.go
@@ -34,7 +34,8 @@ type ProtocolRoutingRemediation struct {
 type ProtocolRoutingMigrationReport struct {
 	ActiveGoverned int
 	SeededOfficial int
-	ProbedAccounts int
+	ProbeAttempts  int
+	ProbeResolved  int
 	CutoverReady   bool
 	Remediation    []ProtocolRoutingRemediation
 }
@@ -125,14 +126,28 @@ func prepareProtocolRoutingSSOT(
 	probeProtocolRoutingAccounts(ctx, prober, accountIDs)
 
 	final, err := MigrateProtocolRoutingSSOT(ctx, repo, router)
+	final.ProbeAttempts = len(accountIDs)
+	final.ProbeResolved = protocolRoutingResolvedProbeCount(accountIDs, final.Remediation)
 	if err != nil {
 		final.SeededOfficial += initial.SeededOfficial
-		final.ProbedAccounts = len(accountIDs)
 		return ProtocolRoutingSSOTReady{Report: final}, err
 	}
 	final.SeededOfficial += initial.SeededOfficial
-	final.ProbedAccounts = len(accountIDs)
 	return newProtocolRoutingSSOTReady(final, router), nil
+}
+
+func protocolRoutingResolvedProbeCount(accountIDs []int64, remediation []ProtocolRoutingRemediation) int {
+	unresolved := make(map[int64]struct{}, len(remediation))
+	for _, item := range remediation {
+		unresolved[item.AccountID] = struct{}{}
+	}
+	resolved := 0
+	for _, accountID := range accountIDs {
+		if _, remains := unresolved[accountID]; !remains {
+			resolved++
+		}
+	}
+	return resolved
 }
 
 func probeProtocolRoutingAccounts(ctx context.Context, prober protocolRoutingCapabilityProber, accountIDs []int64) {
@@ -181,7 +196,7 @@ func protocolRoutingMigrationModels(account *Account) []string {
 	models := make([]string, 0, len(mapping))
 	for requested := range mapping {
 		requested = strings.TrimSpace(requested)
-		if requested == "" || strings.Contains(requested, "*") {
+		if requested == "" {
 			continue
 		}
 		models = append(models, requested)

--- a/backend/internal/service/protocol_routing_migration_test.go
+++ b/backend/internal/service/protocol_routing_migration_test.go
@@ -6,7 +6,9 @@ import (
 	"sync"
 	"testing"
 
+	newapiconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
+	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
 )
 
 type protocolRoutingMigrationProber struct {
@@ -91,6 +93,48 @@ func TestMigrateProtocolRoutingSSOTSeedsOnlyOfficialProfilesAndReportsCustomAcco
 	}
 }
 
+func TestMigrateProtocolRoutingSSOTExcludesVideoOnlyAccounts(t *testing.T) {
+	repo := &protocolRoutingMigrationRepo{accounts: []Account{{
+		ID:          96,
+		Name:        "xrtoken",
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeDoubaoVideo,
+		Credentials: map[string]any{
+			"api_key":  "secret",
+			"base_url": newapiintegration.XRTokenBaseURL,
+			"model_mapping": map[string]any{
+				"doubao-seedance-2-0-260128": "doubao-seedance-2-0-260128",
+			},
+		},
+	}}}
+
+	report, err := MigrateProtocolRoutingSSOT(context.Background(), repo, NewProtocolRouter())
+	if err != nil {
+		t.Fatalf("MigrateProtocolRoutingSSOT: %v", err)
+	}
+	if report.ActiveGoverned != 0 || !report.CutoverReady || len(report.Remediation) != 0 {
+		t.Fatalf("video-only account entered text protocol governance: %+v", report)
+	}
+}
+
+func TestProtocolRoutingMediaOnlyClassificationKeepsTextWildcardAccounts(t *testing.T) {
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				"gpt-*":       "gpt-*",
+				"gpt-image-1": "gpt-image-1",
+			},
+		},
+	}
+
+	if protocolRoutingAccountIsMediaOnly(account) {
+		t.Fatal("text wildcard plus image model was misclassified as media-only")
+	}
+}
+
 func TestProtocolRoutingMigrationReportRejectsCanonicalAccountWithoutLegalRoute(t *testing.T) {
 	repo := &protocolRoutingMigrationRepo{accounts: []Account{{
 		ID:       9,
@@ -111,6 +155,32 @@ func TestProtocolRoutingMigrationReportRejectsCanonicalAccountWithoutLegalRoute(
 	}
 	if report.CutoverReady || len(report.Remediation) != 1 || report.Remediation[0].Reason != ProtocolRoutingRemediationNoLegalRoute {
 		t.Fatalf("report = %+v", report)
+	}
+}
+
+func TestProtocolRoutingMigrationUsesWildcardServedModelsForLegalRoute(t *testing.T) {
+	repo := &protocolRoutingMigrationRepo{accounts: []Account{{
+		ID:       95,
+		Name:     "cloudwise",
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":  "secret",
+			"base_url": "https://api.cloudwise.ai/api",
+			"model_mapping": map[string]any{
+				"claude-*": "claude-*",
+				"kimi-*":   "kimi-*",
+			},
+		},
+		Extra: map[string]any{SupportedProtocolsExtraKey: []any{string(protocolrouter.ProtocolMessages)}},
+	}}}
+
+	report, err := MigrateProtocolRoutingSSOT(context.Background(), repo, NewProtocolRouter())
+	if err != nil {
+		t.Fatalf("MigrateProtocolRoutingSSOT: %v", err)
+	}
+	if !report.CutoverReady || len(report.Remediation) != 0 {
+		t.Fatalf("wildcard served-model rules were replaced by an unrelated default: %+v", report)
 	}
 }
 
@@ -140,6 +210,9 @@ func TestPrepareProtocolRoutingSSOTProbesRemediationBeforeEnablingRouter(t *test
 	if !ready.Report.CutoverReady || ready.EnabledRouter() != router {
 		t.Fatalf("ready = %+v router=%p, want cutover-ready router %p", ready.Report, ready.EnabledRouter(), router)
 	}
+	if ready.Report.ProbeAttempts != 1 || ready.Report.ProbeResolved != 1 {
+		t.Fatalf("probe outcome = attempts:%d resolved:%d, want 1/1", ready.Report.ProbeAttempts, ready.Report.ProbeResolved)
+	}
 	if !reflect.DeepEqual(prober.calls, []int64{12}) {
 		t.Fatalf("probe calls = %v, want [12]", prober.calls)
 	}
@@ -167,6 +240,9 @@ func TestPrepareProtocolRoutingSSOTKeepsLegacyRoutingWhenRemediationRemains(t *t
 	}
 	if ready.Report.CutoverReady || ready.EnabledRouter() != nil {
 		t.Fatalf("ready = %+v router=%p, want remediation with legacy routing", ready.Report, ready.EnabledRouter())
+	}
+	if ready.Report.ProbeAttempts != 1 || ready.Report.ProbeResolved != 0 {
+		t.Fatalf("probe outcome = attempts:%d resolved:%d, want 1/0", ready.Report.ProbeAttempts, ready.Report.ProbeResolved)
 	}
 	if !reflect.DeepEqual(prober.calls, []int64{13}) {
 		t.Fatalf("probe calls = %v, want [13]", prober.calls)

--- a/backend/internal/service/protocol_routing_migration_test.go
+++ b/backend/internal/service/protocol_routing_migration_test.go
@@ -135,6 +135,26 @@ func TestProtocolRoutingMediaOnlyClassificationKeepsTextWildcardAccounts(t *test
 	}
 }
 
+func TestProtocolRoutingMediaOnlyClassificationExcludesKnownImageAliases(t *testing.T) {
+	for _, model := range []string{
+		"grok-imagine",
+		"grok-imagine-edit",
+		"gemini-3.1-flash-image-preview",
+	} {
+		account := &Account{
+			Platform: PlatformNewAPI,
+			Type:     AccountTypeAPIKey,
+			Credentials: map[string]any{
+				"model_mapping": map[string]any{model: model},
+			},
+		}
+
+		if !protocolRoutingAccountIsMediaOnly(account) {
+			t.Fatalf("model %q was not classified as media-only", model)
+		}
+	}
+}
+
 func TestProtocolRoutingMigrationReportRejectsCanonicalAccountWithoutLegalRoute(t *testing.T) {
 	repo := &protocolRoutingMigrationRepo{accounts: []Account{{
 		ID:       9,

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -62,10 +62,11 @@ func ProvideProtocolRoutingSSOTReady(accountRepo AccountRepository, accountTestS
 	}
 	logger.LegacyPrintf(
 		"service.protocol_routing",
-		"protocol SSOT migration/report: active_governed=%d seeded_official=%d probed_accounts=%d cutover_ready=%t remediation=%d",
+		"protocol SSOT migration/report: active_governed=%d seeded_official=%d probe_attempts=%d probe_resolved=%d cutover_ready=%t remediation=%d",
 		report.ActiveGoverned,
 		report.SeededOfficial,
-		report.ProbedAccounts,
+		report.ProbeAttempts,
+		report.ProbeResolved,
 		report.CutoverReady,
 		len(report.Remediation),
 	)

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -916,22 +916,42 @@
     {
       "path": "backend/internal/service/openai_apikey_chat_completions_probe.go",
       "must_contain": [
+        "selectProtocolProbeModel(account)",
         "protocolExactEndpoint(account, protocolrouter.ProtocolChatCompletions, probeModel)",
         "chat_completions_resolve_endpoint_failed"
       ],
-      "rationale": "Chat Completions capability probes for NewAPI accounts must use the exact adaptor URL rather than appending /v1/chat/completions to base_url. Dropping this call marks DashScope ch17 unsupported after probing the wrong 404 endpoint."
+      "rationale": "Chat Completions capability probes must use the shared representative model and exact NewAPI adaptor URL rather than appending /v1/chat/completions to base_url. Dropping either call can probe a media/foreign model or mark DashScope ch17 unsupported after hitting the wrong 404 endpoint."
+    },
+    {
+      "path": "backend/internal/service/protocol_probe_model_tk.go",
+      "must_contain": [
+        "func selectProtocolProbeModel(account *Account) string",
+        "func protocolRoutingAccountIsMediaOnly(account *Account) bool",
+        "newapiconstant.ChannelTypeAli",
+        "isOpenAIImageGenerationModel(model)",
+        "isGrokVideoGenerationModel(model)",
+        "antigravity.IsImageModel(model)",
+        "return openai.DefaultTestModel"
+      ],
+      "rationale": "Single representative text-model owner shared by all protocol capability probes and text-governance classification. It deterministically prefers qwen-* for Ali channels, excludes canonical image/video families, and prevents media-only accounts from blocking SSOT cutover readiness."
     },
     {
       "path": "backend/internal/service/openai_apikey_responses_probe.go",
       "must_contain": [
-        "selectProtocolProbeModels(account)",
-        "protocolRoutingAccountIsMediaOnly(account)",
-        "newapiconstant.ChannelTypeAli",
-        "protocolProbeModelIsMedia",
+        "selectProtocolProbeModel(account)",
         "protocolExactEndpoint(account, protocolrouter.ProtocolResponses, probeModel)",
         "probe_resolve_endpoint_failed"
       ],
-      "rationale": "Responses capability probes for NewAPI accounts must use the exact adaptor URL and a representative native text model rather than a media model or arbitrary lexicographic first mapping. DashScope ch17 serves Responses under /api/v2/apps/protocols/compatible-mode/v1/responses and should prefer qwen-*; losing either rule produces false capability facts."
+      "rationale": "Responses capability probes for NewAPI accounts must use the shared representative model and exact adaptor URL. DashScope ch17 serves Responses under /api/v2/apps/protocols/compatible-mode/v1/responses; losing either owner produces false capability facts."
+    },
+    {
+      "path": "backend/internal/service/openai_apikey_native_messages_probe.go",
+      "must_contain": [
+        "selectProtocolProbeModel(account)",
+        "ProtocolMessages",
+        "openai_native_messages_supported"
+      ],
+      "rationale": "Native Messages capability probes share the same representative text-model owner and persist canonical protocol evidence while retaining the legacy compatibility field. Losing that call recreates per-protocol model selection drift."
     },
     {
       "path": "backend/internal/service/protocol_routing_context.go",
@@ -970,12 +990,12 @@
       "must_contain": [
         "TestProbeOpenAIAPIKeyResponsesSupportUsesNewAPIAdaptorEndpoint",
         "TestProbeOpenAIAPIKeyResponsesSupportPrefersChannelNativeTextModel",
-        "TestSelectProtocolProbeModelsExcludesMediaAndKeepsDeterministicTextFallbacks",
-        "TestSelectProtocolProbeModelsPrefersAliNativeQwenFamily",
-        "TestSelectProtocolProbeModelsReturnsNoneForXRTokenVideoOnlyAccount",
+        "TestSelectProtocolProbeModelUsesDeterministicTextFallback",
+        "TestSelectProtocolProbeModelExcludesMediaAndUsesDeterministicTextFallback",
+        "TestSelectProtocolProbeModelPrefersAliNativeQwenFamily",
         "https://dashscope.aliyuncs.com/api/v2/apps/protocols/compatible-mode/v1/responses"
       ],
-      "rationale": "Regression proof that the ch17 Responses probe follows the live adaptor endpoint, prefers qwen-* for Ali channels, and never treats XRToken/video mappings as text capability evidence."
+      "rationale": "Regression proof that the ch17 Responses probe follows the live adaptor endpoint, prefers qwen-* for Ali channels, filters media mappings, and chooses one deterministic representative model."
     },
     {
       "path": "backend/internal/handler/openai_chat_completions_legacy_protocol_fallback_test.go",
@@ -1021,6 +1041,7 @@
       "must_contain": [
         "TestMigrateProtocolRoutingSSOTExcludesVideoOnlyAccounts",
         "TestProtocolRoutingMediaOnlyClassificationKeepsTextWildcardAccounts",
+        "TestProtocolRoutingMediaOnlyClassificationExcludesKnownImageAliases",
         "TestProtocolRoutingMigrationUsesWildcardServedModelsForLegalRoute",
         "ProbeAttempts != 1 || ready.Report.ProbeResolved != 1",
         "ProbeAttempts != 1 || ready.Report.ProbeResolved != 0"

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -898,9 +898,20 @@
       "path": "backend/internal/service/account_supported_protocols.go",
       "must_contain": [
         "func protocolExactEndpoint(account *Account, protocol protocolrouter.Protocol, resolvedModel string) (string, error)",
+        "isNewAPIVolcEngineAgentPlanAccount(account)",
+        "newapiintegration.VolcEngineAgentPlanBaseURL",
         "endpoint, err := bridge.ResolveTextEndpoint(in, format, resolvedModel)"
       ],
-      "rationale": "Single NewAPI text-endpoint resolver shared by protocol planning and capability probes. Provider paths such as DashScope ch17 differ from generic /v1 endpoints; losing this owner recreates split path tables and lets probes persist false capability facts for otherwise healthy accounts."
+      "rationale": "Single NewAPI text-endpoint resolver shared by protocol planning and capability probes. Provider paths such as DashScope ch17 and VolcEngine Agent Plan differ from generic /v1 endpoints; losing this owner recreates split path tables and lets probes persist false capability facts for otherwise healthy accounts."
+    },
+    {
+      "path": "backend/internal/service/account_supported_protocols_test.go",
+      "must_contain": [
+        "TestProtocolAccountSnapshotUsesCanonicalAgentPlanEndpoints",
+        "VolcEngineAgentPlanBaseURL+\"/chat/completions\"",
+        "VolcEngineAgentPlanBaseURL+\"/responses\""
+      ],
+      "rationale": "Regression proof that Agent Plan account 88 resolves both governed text protocols under the canonical /api/plan/v3 base instead of probing or executing the generic VolcEngine paths that returned 404 during rollout preparation."
     },
     {
       "path": "backend/internal/service/openai_apikey_chat_completions_probe.go",
@@ -913,18 +924,23 @@
     {
       "path": "backend/internal/service/openai_apikey_responses_probe.go",
       "must_contain": [
+        "selectProtocolProbeModels(account)",
+        "protocolRoutingAccountIsMediaOnly(account)",
+        "newapiconstant.ChannelTypeAli",
+        "protocolProbeModelIsMedia",
         "protocolExactEndpoint(account, protocolrouter.ProtocolResponses, probeModel)",
         "probe_resolve_endpoint_failed"
       ],
-      "rationale": "Responses capability probes for NewAPI accounts must use the exact adaptor URL rather than generic /v1/responses. DashScope ch17 serves Responses under /api/v2/apps/protocols/compatible-mode/v1/responses; probing the generic path produces a false negative and invalid routing facts."
+      "rationale": "Responses capability probes for NewAPI accounts must use the exact adaptor URL and a representative native text model rather than a media model or arbitrary lexicographic first mapping. DashScope ch17 serves Responses under /api/v2/apps/protocols/compatible-mode/v1/responses and should prefer qwen-*; losing either rule produces false capability facts."
     },
     {
       "path": "backend/internal/service/protocol_routing_context.go",
       "must_contain": [
+        "protocolRoutingAccountIsMediaOnly(account)",
         "func protocolRoutingCanonicalRequest(ctx context.Context) (protocolrouter.CanonicalRequest, bool)",
         "if !ok || routing.router == nil {\n\t\treturn protocolrouter.CanonicalRequest{}, false"
       ],
-      "rationale": "Cutover-disabled requests retain the canonical body for legacy execution without making ProtocolRoutingRequest report routing enabled. Losing either half makes router=nil return an empty body or accidentally enables the scheduler hard gate before migration readiness."
+      "rationale": "Text protocol governance excludes media-only accounts before scheduling. Cutover-disabled text requests retain the canonical body for legacy execution without making ProtocolRoutingRequest report routing enabled. Losing either boundary can pull video-only accounts into remediation or enable the scheduler hard gate before migration readiness."
     },
     {
       "path": "backend/internal/service/protocol_execution.go",
@@ -953,9 +969,13 @@
       "path": "backend/internal/service/openai_apikey_responses_probe_test.go",
       "must_contain": [
         "TestProbeOpenAIAPIKeyResponsesSupportUsesNewAPIAdaptorEndpoint",
+        "TestProbeOpenAIAPIKeyResponsesSupportPrefersChannelNativeTextModel",
+        "TestSelectProtocolProbeModelsExcludesMediaAndKeepsDeterministicTextFallbacks",
+        "TestSelectProtocolProbeModelsPrefersAliNativeQwenFamily",
+        "TestSelectProtocolProbeModelsReturnsNoneForXRTokenVideoOnlyAccount",
         "https://dashscope.aliyuncs.com/api/v2/apps/protocols/compatible-mode/v1/responses"
       ],
-      "rationale": "Regression proof that the ch17 Responses probe follows the live adaptor endpoint instead of the generic 404 path."
+      "rationale": "Regression proof that the ch17 Responses probe follows the live adaptor endpoint, prefers qwen-* for Ali channels, and never treats XRToken/video mappings as text capability evidence."
     },
     {
       "path": "backend/internal/handler/openai_chat_completions_legacy_protocol_fallback_test.go",
@@ -989,9 +1009,32 @@
         "MigrateProtocolRoutingSSOT",
         "ProtocolRoutingRemediationProbeRequired",
         "ProtocolRoutingRemediationNoLegalRoute",
+        "ProbeAttempts",
+        "ProbeResolved",
+        "protocolRoutingMigrationModels",
         "CutoverReady"
       ],
-      "rationale": "NewAPI accounts are custom endpoints and must never inherit official protocol capabilities. The additive migration reports them for per-account probes and blocks cutover readiness when no legal route exists instead of inferring from channel_type/api_protocol."
+      "rationale": "NewAPI accounts are custom endpoints and must never inherit official protocol capabilities. The additive migration reports them for per-account probes, preserves wildcard served-model rules when checking legal paths, distinguishes probe attempts from resolved accounts, and blocks cutover readiness when remediation remains."
+    },
+    {
+      "path": "backend/internal/service/protocol_routing_migration_test.go",
+      "must_contain": [
+        "TestMigrateProtocolRoutingSSOTExcludesVideoOnlyAccounts",
+        "TestProtocolRoutingMediaOnlyClassificationKeepsTextWildcardAccounts",
+        "TestProtocolRoutingMigrationUsesWildcardServedModelsForLegalRoute",
+        "ProbeAttempts != 1 || ready.Report.ProbeResolved != 1",
+        "ProbeAttempts != 1 || ready.Report.ProbeResolved != 0"
+      ],
+      "rationale": "Regression proof for the rollout-remediation fixes: XRToken video-only accounts stay outside text governance, mixed wildcard accounts stay governed, CloudWise wildcard mappings remain legal, and startup reporting no longer calls every attempted probe resolved."
+    },
+    {
+      "path": "backend/internal/service/wire.go",
+      "must_contain": [
+        "probe_attempts=%d probe_resolved=%d",
+        "report.ProbeAttempts",
+        "report.ProbeResolved"
+      ],
+      "rationale": "Startup reporting must distinguish attempted capability probes from accounts whose remediation was actually cleared. Calling attempts probed_accounts made the release report look converged while the router remained disabled."
     }
   ]
 }


### PR DESCRIPTION
### 摘要

- 为 VolcEngine Agent Plan 账号统一 Chat Completions 与 Responses 的规范端点，避免启动探测命中错误路径。
- 将 Chat Completions、Responses、Messages 的代表模型选择收敛到一个共享 owner：Ali 账号优先确定性的 qwen 模型，其他账号选择确定性的具体文本模型。
- 文本协议治理排除纯媒体账号，并复用现有 OpenAI、Grok、Gemini 媒体模型分类 owner，覆盖 `grok-imagine`、`grok-imagine-edit` 和 Gemini image aliases。
- 合法路径检查保留 wildcard 服务规则；启动报告区分 `probe_attempts` 与 `probe_resolved`。
- 将共享模型选择、三协议调用点、媒体排除、规范端点和回归测试登记到 NewAPI sentinel，防止 upstream merge 静默回归。

### 风险

- 影响启动期协议能力探测、迁移报告和文本账号治理范围，不修改数据库 schema，不影响 Web。
- 未收敛账号仍保留 remediation 并阻止路由硬切换；没有放宽 fail-closed 门禁。
- 与 `docs/approved/protocol-routing-ssot.md` 一致：媒体操作不进入文本治理，探测结论仍按账号独立写入 `accounts.extra.supported_protocols`，每个协议探测只使用一个代表模型。

### 验证

- `go test ./... -count=1`（backend，对齐最新 `origin/main` 后）
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- NewAPI sentinel registry：PASS
- `$xj-review #1827`：`high / full_conformance`，最终 0 个 medium+ finding

### 提交

- `424c31c1e` fix(protocol): converge SSOT probes on valid account paths (no-web-impact)
- `b809d1d2b` fix(protocol): address review findings for probe convergence (no-web-impact)
- `c4a68c372` Merge remote-tracking branch 'origin/main' into fix/protocol-ssot-probe-convergence
- 最新提交：`c4a68c372`
