### PR TITLE
perf(ci): neutral 变更跳过 Go preflight 初始化

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -42,6 +42,7 @@ jobs:
       deploy: ${{ steps.classify.outputs.deploy }}
       ops: ${{ steps.classify.outputs.ops }}
       contracts: ${{ steps.classify.outputs.contracts }}
+      preflight_go: ${{ steps.classify.outputs.preflight_go }}
       service_unit_cold: ${{ steps.classify.outputs.service_unit_cold }}
       all: ${{ steps.classify.outputs.all }}
     steps:
@@ -111,23 +112,28 @@ jobs:
             scripts.test_ci_gate_handoffs \
             scripts.ci.test_changed_surfaces \
             scripts.test_backend_ci_routing
-      # Preflight runs `go test` for QA evidence dataset validation; backend/go.mod
-      # replaces new-api with ../../new-api — same sibling checkout as test/lint jobs.
+      # Go-backed preflight contracts use backend/go.mod and its ../../new-api
+      # replacement. Neutral changes skip this whole bootstrap path.
       - uses: ./.github/actions/cache-and-checkout-new-api
+        if: needs.changes.outputs.preflight_go == 'true'
       - name: Fetch base ref for diff gates
         # fetch-depth alone does not guarantee origin/main on PR checkouts; preflight
         # deleted-file / merge-base gates need origin/main...HEAD.
         run: git fetch --no-tags origin "${GITHUB_BASE_REF:-main}:refs/remotes/origin/${GITHUB_BASE_REF:-main}" --depth=64
       - uses: actions/setup-go@v6
+        if: needs.changes.outputs.preflight_go == 'true'
         with:
           go-version-file: backend/go.mod
           check-latest: false
           cache: false
       - name: Unit runner contract tests
+        if: needs.changes.outputs.preflight_go == 'true'
         run: python3 -m unittest scripts.ci.test_unit_test_runner
       - name: Integration package discovery contract tests
+        if: needs.changes.outputs.preflight_go == 'true'
         run: python3 -m unittest scripts.ci.test_integration_packages
       - uses: ./.github/actions/go-rolling-cache
+        if: needs.changes.outputs.preflight_go == 'true'
         with:
           prefix: preflight
       - name: Run preflight
@@ -142,6 +148,7 @@ jobs:
           PREFLIGHT_SKIP_SLOW_OPS_CONTRACTS: ${{ needs.changes.outputs.all != 'true' && needs.changes.outputs.ops != 'true' && '1' || '0' }}
           PREFLIGHT_SKIP_MAIN_ANCESTRY: "1"
           PREFLIGHT_SKIP_AGENT_CONTRACT: ${{ needs.changes.outputs.all != 'true' && needs.changes.outputs.contracts != 'true' && '1' || '0' }}
+          PREFLIGHT_SKIP_GO_CONTRACTS: ${{ needs.changes.outputs.preflight_go != 'true' && '1' || '0' }}
         run: |
           if [ -x scripts/preflight.sh ]; then
             ./scripts/preflight.sh

--- a/scripts/ci/changed-surfaces.py
+++ b/scripts/ci/changed-surfaces.py
@@ -16,6 +16,7 @@ KEYS = (
     "deploy",
     "ops",
     "contracts",
+    "preflight_go",
     "service_unit_cold",
     "all",
 )
@@ -47,6 +48,15 @@ CONTRACT_FILES = {
     "ops/migration/usage_logs_daily_partition.py",
 }
 
+PREFLIGHT_GO_FILES = {
+    # Checked-in projections and their Go-backed drift gate must keep the
+    # preflight toolchain path even though they live outside backend/.
+    "ops/observability/generated/model-family-rules.json",
+    "ops/pricing/model-surface-bundle.json",
+    "scripts/preflight.sh",
+    "scripts/sentinels/check-model-family-rules.sh",
+}
+
 NEUTRAL_TOP_LEVEL = {
     ".gitignore",
     ".gitattributes",
@@ -69,6 +79,9 @@ def classify(paths: Iterable[str]) -> dict[str, bool]:
         path = raw_path.replace("\\", "/")
         if not path:
             continue
+
+        if path in PREFLIGHT_GO_FILES:
+            result["preflight_go"] = True
 
         if path in SERVICE_UNIT_COLD_FILES or (
             path.startswith("backend/") and path.endswith(".go")
@@ -141,6 +154,9 @@ def classify(paths: Iterable[str]) -> dict[str, bool]:
             continue
 
         result["all"] = True
+
+    if result["backend"] or result["ops"] or result["all"]:
+        result["preflight_go"] = True
 
     return result
 

--- a/scripts/ci/test_changed_surfaces.py
+++ b/scripts/ci/test_changed_surfaces.py
@@ -28,6 +28,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": False,
+                "preflight_go": True,
                 "service_unit_cold": True,
                 "all": False,
             },
@@ -42,6 +43,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": False,
+                "preflight_go": False,
                 "service_unit_cold": False,
                 "all": False,
             },
@@ -56,6 +58,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": True,
                 "ops": False,
                 "contracts": False,
+                "preflight_go": False,
                 "service_unit_cold": False,
                 "all": False,
             },
@@ -70,6 +73,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": True,
+                "preflight_go": True,
                 "service_unit_cold": True,
                 "all": False,
             },
@@ -84,6 +88,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": True,
                 "contracts": False,
+                "preflight_go": True,
                 "service_unit_cold": True,
                 "all": False,
             },
@@ -98,6 +103,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": False,
+                "preflight_go": False,
                 "service_unit_cold": False,
                 "all": False,
             },
@@ -112,6 +118,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": False,
+                "preflight_go": False,
                 "service_unit_cold": False,
                 "all": False,
             },
@@ -131,6 +138,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": False,
+                "preflight_go": True,
                 "service_unit_cold": True,
                 "all": False,
             },
@@ -145,6 +153,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": False,
+                "preflight_go": True,
                 "service_unit_cold": True,
                 "all": False,
             },
@@ -160,6 +169,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": False,
+                "preflight_go": True,
                 "service_unit_cold": False,
                 "all": True,
             },
@@ -175,6 +185,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": False,
+                "preflight_go": True,
                 "service_unit_cold": False,
                 "all": True,
             },
@@ -190,6 +201,7 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": False,
+                "preflight_go": True,
                 "service_unit_cold": False,
                 "all": True,
             },
@@ -204,10 +216,21 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "deploy": False,
                 "ops": False,
                 "contracts": False,
+                "preflight_go": True,
                 "service_unit_cold": False,
                 "all": False,
             },
         )
+
+    def test_go_derived_preflight_contract_changes_enable_go_bootstrap(self) -> None:
+        for path in (
+            "ops/pricing/model-surface-bundle.json",
+            "ops/observability/generated/model-family-rules.json",
+            "scripts/sentinels/check-model-family-rules.sh",
+            "scripts/preflight.sh",
+        ):
+            with self.subTest(path=path):
+                self.assertTrue(changed_surfaces.classify([path])["preflight_go"])
 
     def test_unit_runner_and_ci_entrypoints_force_service_cold_path(self) -> None:
         for path in (

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -134,6 +134,10 @@ _preflight_skip_slow_ops=0
 case "${PREFLIGHT_SKIP_SLOW_OPS_CONTRACTS:-}" in
     1|true|yes|TRUE|YES) _preflight_skip_slow_ops=1 ;;
 esac
+_preflight_skip_go_contracts=0
+case "${PREFLIGHT_SKIP_GO_CONTRACTS:-}" in
+    1|true|yes|TRUE|YES) _preflight_skip_go_contracts=1 ;;
+esac
 _preflight_skip_main_ancestry=0
 case "${PREFLIGHT_SKIP_MAIN_ANCESTRY:-}" in
     1|true|yes|TRUE|YES) _preflight_skip_main_ancestry=1 ;;
@@ -229,7 +233,7 @@ export PREFLIGHT_BASE="${template_base:-origin/main}"
 _qa_bundle_gate_run() {
     cd backend && go test -tags=unit -v ./internal/observability/qa/bundle ./internal/observability/qa
 }
-if [ "$_preflight_skip_slow_ops" -ne 1 ] && command -v python3 >/dev/null 2>&1 && command -v go >/dev/null 2>&1; then
+if [ "$_preflight_skip_go_contracts" -ne 1 ] && [ "$_preflight_skip_slow_ops" -ne 1 ] && command -v python3 >/dev/null 2>&1 && command -v go >/dev/null 2>&1; then
     _bg_spawn qa_bundle _qa_bundle_gate_run
 fi
 if command -v python3 >/dev/null 2>&1; then
@@ -802,7 +806,9 @@ fi
 # model list.
 echo ""
 echo "=== sub2api: generated model-surface bundle drift ==="
-if ! command -v go >/dev/null 2>&1; then
+if [ "$_preflight_skip_go_contracts" -eq 1 ]; then
+    echo "  skip: unchanged Go preflight surface"
+elif ! command -v go >/dev/null 2>&1; then
     echo "  FAIL: go not on PATH (required for model-surface bundle drift check)"
     errors=$((errors + 1))
 elif ! (cd backend && go run ./cmd/account-model-mapping bundle --check ../ops/pricing/model-surface-bundle.json); then
@@ -818,7 +824,9 @@ fi
 # classification owner so alert grouping cannot drift into a second rule set.
 echo ""
 echo "=== sub2api: model-family alert artifact drift ==="
-if ! command -v go >/dev/null 2>&1; then
+if [ "$_preflight_skip_go_contracts" -eq 1 ]; then
+    echo "  skip: unchanged Go preflight surface"
+elif ! command -v go >/dev/null 2>&1; then
     echo "  FAIL: go not on PATH (required for model-family artifact drift check)"
     errors=$((errors + 1))
 elif ! bash ./scripts/sentinels/check-model-family-rules.sh; then
@@ -1379,7 +1387,9 @@ fi
 # authorization test in verbose output so a rename/deletion cannot pass vacuously.
 echo ""
 echo "=== sub2api: QA Bundle service/worker contract ==="
-if [ "$_preflight_skip_slow_ops" -eq 1 ]; then
+if [ "$_preflight_skip_go_contracts" -eq 1 ]; then
+    echo "  skip: unchanged Go preflight surface"
+elif [ "$_preflight_skip_slow_ops" -eq 1 ]; then
     echo "  skip: unchanged CI surface; required preflight gate not needed"
 elif ! command -v go >/dev/null 2>&1; then
     echo "  FAIL: go not on PATH (required to run QA Bundle contract tests)"
@@ -3080,7 +3090,9 @@ echo "=== sub2api: Wire DI staleness ==="
 _wire_gen="backend/cmd/server/wire_gen.go"
 _backend_go_version="$(awk '/^go / { print $2; exit }' backend/go.mod 2>/dev/null)"
 _backend_go_toolchain="go${_backend_go_version}"
-if [ ! -f "$_wire_gen" ]; then
+if [ "$_preflight_skip_go_contracts" -eq 1 ]; then
+    echo "  skip: unchanged Go preflight surface"
+elif [ ! -f "$_wire_gen" ]; then
     echo "  FAIL: $_wire_gen does not exist — run 'go generate ./cmd/server' in backend/"
     errors=$((errors + 1))
 elif ! command -v git >/dev/null 2>&1; then
@@ -3122,7 +3134,9 @@ if has_merge_base_with_head "${PREFLIGHT_BASE:-origin/main}" && \
    git diff --name-only "${PREFLIGHT_BASE:-origin/main}...HEAD" 2>/dev/null | grep -q '^backend/ent/schema/'; then
     _ent_schema_changed=1
 fi
-if ! command -v go >/dev/null 2>&1; then
+if [ "$_preflight_skip_go_contracts" -eq 1 ]; then
+    echo "  skip: unchanged Go preflight surface"
+elif ! command -v go >/dev/null 2>&1; then
     echo "  skip: go not on PATH"
 elif [ "$_preflight_fast" = "1" ] && [ "$_ent_schema_changed" = "0" ]; then
     echo "  skip: Ent generation staleness (preflight-fast; no backend/ent/schema changes)"
@@ -3163,7 +3177,9 @@ fi
 echo ""
 echo "=== sub2api: go.mod replace path validation ==="
 _replace_path=$(grep 'QuantumNous/new-api =>' backend/go.mod 2>/dev/null | awk '{print $NF}')
-if [ -z "$_replace_path" ]; then
+if [ "$_preflight_skip_go_contracts" -eq 1 ]; then
+    echo "  skip: unchanged Go preflight surface"
+elif [ -z "$_replace_path" ]; then
     echo "  skip: no QuantumNous/new-api replace directive found in backend/go.mod"
 else
     _resolved_path="backend/$_replace_path"

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -28,6 +28,7 @@ class BackendCIRoutingTest(unittest.TestCase):
                 "deploy",
                 "ops",
                 "contracts",
+                "preflight_go",
                 "service_unit_cold",
                 "all",
             },
@@ -62,6 +63,35 @@ class BackendCIRoutingTest(unittest.TestCase):
         env = run_preflight["env"]
         self.assertIn("needs.changes.outputs.ops", env["PREFLIGHT_SKIP_SLOW_OPS_CONTRACTS"])
         self.assertIn("needs.changes.outputs.contracts", env["PREFLIGHT_SKIP_AGENT_CONTRACT"])
+
+    def test_preflight_go_bootstrap_uses_the_preflight_go_surface(self) -> None:
+        steps = self.jobs["preflight"]["steps"]
+        go_steps = [
+            next(
+                step
+                for step in steps
+                if step.get("uses") == "./.github/actions/cache-and-checkout-new-api"
+            ),
+            next(step for step in steps if step.get("uses") == "actions/setup-go@v6"),
+            next(step for step in steps if step.get("name") == "Unit runner contract tests"),
+            next(
+                step
+                for step in steps
+                if step.get("name") == "Integration package discovery contract tests"
+            ),
+            next(
+                step
+                for step in steps
+                if step.get("uses") == "./.github/actions/go-rolling-cache"
+            ),
+        ]
+
+        for step in go_steps:
+            with self.subTest(step=step.get("name", step.get("uses"))):
+                self.assertEqual(
+                    step.get("if"),
+                    "needs.changes.outputs.preflight_go == 'true'",
+                )
 
     def test_preflight_job_runs_ci_orchestration_contracts(self) -> None:
         matching_steps = [

--- a/scripts/test_preflight_ci_handoffs.py
+++ b/scripts/test_preflight_ci_handoffs.py
@@ -29,6 +29,17 @@ class PreflightCIHandoffTest(unittest.TestCase):
         self.assertIn("needs.changes.outputs.ops", skip_expression)
         self.assertIn("needs.changes.outputs.all", skip_expression)
 
+    def test_required_preflight_skips_go_contracts_when_go_surface_is_unchanged(self) -> None:
+        workflow = load_workflow(BACKEND_CI)
+        preflight = workflow["jobs"]["preflight"]
+        run_preflight = next(
+            step for step in preflight["steps"] if step.get("name") == "Run preflight"
+        )
+        self.assertEqual(
+            run_preflight["env"]["PREFLIGHT_SKIP_GO_CONTRACTS"],
+            "${{ needs.changes.outputs.preflight_go != 'true' && '1' || '0' }}",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 摘要

- 为 changed-surface classifier 增加 fail-closed 的 `preflight_go` 决策。
- docs、issue-cache 等 neutral 变更跳过 new-api checkout、setup-go、Go contract tests 和 rolling Go cache。
- backend、ops、CI/preflight、Go 派生 artifact 及未知路径仍运行完整 Go preflight。
- required `preflight` job 保持不变，不新增 job、matrix 或 runner。

## 风险

- 常规风险：分类遗漏可能跳过 Go 派生契约；未知路径和 `all` 路径 fail-closed，Go owner/artifact/check 均有显式正向覆盖。
- 不改变生产代码和 Web 行为；`no-web-impact`。
- 不增加 GitHub Actions runner 数量或 credits 并行倍数。

## 验证

- TDD RED：新增分类与 workflow 路由测试在实现前按预期失败。
- `python3 -m unittest ...CI orchestration contracts...`：39/39 PASS。
- CI-like neutral 模拟：`PREFLIGHT_SKIP_GO_CONTRACTS=1` 且任何 `go` 调用强制失败时，完整 preflight PASS。
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：完整严格 Go 路径 PASS。
- `xj-review` mechanical pipeline：0 FAIL、0 warn candidate、0 finding。

## 提交

- `9743a899c perf(ci): skip Go preflight bootstrap for neutral changes`

最新提交：9743a899c
