### PR TITLE
fix(scheduling): name which gate rejected an openai-compat account

### DIFF
--- a/backend/internal/service/gateway_scheduling.go
+++ b/backend/internal/service/gateway_scheduling.go
@@ -2087,6 +2087,12 @@ type selectionFailureStats struct {
 	SampleMappingIDs        []int64
 	SampleRateLimitIDs      []string
 	SampleRuntimeBlockedIDs []int64
+	// SampleUnschedulableReasons carries "<account_id>(<reason>)" samples for the
+	// unschedulable bucket. Without it that bucket is a bare count, and the
+	// scheduling gate has many independent branches that all land in it — which is
+	// exactly what made the 2026-08-25 edge us6 outage take a full day to
+	// attribute (see openai_gateway_scheduling_tk_eligibility_reason.go).
+	SampleUnschedulableReasons []string
 }
 
 type selectionFailureDiagnosis struct {
@@ -2234,6 +2240,24 @@ func appendSelectionFailureSampleID(samples []int64, id int64) []int64 {
 		return samples
 	}
 	return append(samples, id)
+}
+
+// appendSelectionFailureReasonSample records "<account_id>(<reason>)" for the
+// unschedulable bucket so the log line names the gate that rejected each
+// candidate instead of only counting them.
+// An empty reason records "unspecified" rather than dropping the sample: a
+// silently dropped sample makes the sample list disagree with the bucket count,
+// which is the same class of "the number is there but says nothing" defect this
+// whole reason plumbing exists to remove.
+func appendSelectionFailureReasonSample(samples []string, accountID int64, reason string) []string {
+	const limit = 5
+	if len(samples) >= limit {
+		return samples
+	}
+	if reason = strings.TrimSpace(reason); reason == "" {
+		reason = "unspecified"
+	}
+	return append(samples, fmt.Sprintf("%d(%s)", accountID, reason))
 }
 
 func appendSelectionFailureRateSample(samples []string, accountID int64, remaining time.Duration) []string {

--- a/backend/internal/service/openai_account_scheduler_tk_selection_diag.go
+++ b/backend/internal/service/openai_account_scheduler_tk_selection_diag.go
@@ -51,6 +51,10 @@ func (s *OpenAIGatewayService) collectOpenAICompatSelectionFailureStatsForReques
 			stats.SampleRateLimitIDs = appendSelectionFailureRateSample(stats.SampleRateLimitIDs, acc.ID, remaining)
 		case "unschedulable":
 			stats.Unschedulable++
+			// Carry the naming reason, not just the count: this bucket absorbs every
+			// scheduling gate, so a bare count cannot be acted on (2026-08-25).
+			stats.SampleUnschedulableReasons = appendSelectionFailureReasonSample(
+				stats.SampleUnschedulableReasons, acc.ID, diagnosis.Detail)
 		case openAIProfitFilterReasonThreshold:
 			stats.ProfitThreshold++
 		case openAIProfitFilterReasonInvalidAccountRate:
@@ -88,7 +92,10 @@ func (s *OpenAIGatewayService) diagnoseOpenAICompatSelectionFailure(
 			Detail:   "model_or_channel",
 		}
 	}
-	if !openAICompatAccountMeetsSchedulingPrerequisites(ctx, acc, platform, requestedModel, requireCompact, requiredCapability) {
+	// Ask WHICH gate rejected the account, not merely whether one did: the reason
+	// string is what turns a bare "unschedulable=1" into an actionable line. See
+	// openai_gateway_scheduling_tk_eligibility_reason.go for the 2026-08-25 incident.
+	if reason := openAICompatEligibilityReason(ctx, acc, platform, requestedModel, requireCompact, requiredCapability); reason != "" {
 		if requestedModel != "" && !acc.IsSchedulableForModelWithContext(ctx, requestedModel) {
 			remaining := acc.GetRateLimitRemainingTimeWithContext(ctx, requestedModel)
 			if remaining > 0 {
@@ -98,7 +105,7 @@ func (s *OpenAIGatewayService) diagnoseOpenAICompatSelectionFailure(
 				}
 			}
 		}
-		return openAICompatSelectionFailureDiagnosis{Category: "unschedulable", Detail: "eligibility"}
+		return openAICompatSelectionFailureDiagnosis{Category: "unschedulable", Detail: reason}
 	}
 	if vetoed, reason := openAIProfitControlVetoReason(ctx, acc); vetoed {
 		return openAICompatSelectionFailureDiagnosis{Category: reason}
@@ -140,6 +147,8 @@ func (s *OpenAIGatewayService) logOpenAICompatSelectionFailure(
 		"sample_runtime_blocked", stats.SampleRuntimeBlockedIDs,
 		"sample_model_unsupported", stats.SampleMappingIDs,
 		"sample_model_rate_limited", stats.SampleRateLimitIDs,
+		// The field that makes an unschedulable=N line actionable: which gate said no.
+		"sample_unschedulable", stats.SampleUnschedulableReasons,
 	)
 	_ = ctx
 }

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -323,10 +323,6 @@ func normalizeOpenAICompatiblePlatform(platform string) string {
 	return NormalizeOpenAICompatiblePlatform(platform)
 }
 
-func openAICompatAccountMeetsSchedulingPrerequisites(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) bool {
-	return isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx, account, platform, requestedModel, requireCompact, requiredCapability)
-}
-
 // noAvailableOpenAISelectionError builds the standard "no account available" error
 // while preserving the legacy /responses/compact error when applicable.
 // details carries an optional machine-parseable exclusion summary (e.g.
@@ -410,50 +406,15 @@ func isOpenAICompatibleAccountEligibleForRequest(ctx context.Context, account *A
 // isOpenAICompatibleAccountEligibleForRequestBeforeProfit applies every
 // ordinary scheduling gate. Legacy selection uses it before classifying the
 // profit veto so earlier failures retain their actual reason.
+// TK: the gate order and every rejection condition now live in
+// openAICompatEligibilityReason (openai_gateway_scheduling_tk_eligibility_reason.go),
+// which returns the NAME of the branch that rejected the account instead of a
+// bare false. This wrapper keeps the boolean call sites unchanged while making
+// exactly one copy of the gate authoritative — a mirrored bool version would be
+// free to drift from the reason version, and a drifted diagnostic is worse than
+// none (2026-08-25: five hours of "unschedulable=1" that named no predicate).
 func isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) bool {
-	platform = NormalizeOpenAICompatiblePlatform(platform)
-	if account == nil || !account.IsOpenAICompatPoolMember(platform) || !account.IsOpenAICompatible() || !account.IsSchedulableForModelWithContext(ctx, requestedModel) {
-		return false
-	}
-	if account.IsOpenAI() {
-		if paused, reason := shouldAutoPauseOpenAIAccountByQuota(ctx, account); paused {
-			// Debug level: this fires per-candidate on the scheduling hot path, so Info
-			// would amplify into log spam once several accounts cross the threshold.
-			slog.Debug("account_auto_paused_by_quota",
-				"account_id", account.ID,
-				"window", reason.window,
-				"threshold", reason.threshold,
-				"utilization", reason.utilization,
-			)
-			return false
-		}
-	}
-	if account.IsGrok() {
-		if paused, reason := shouldAutoPauseGrokAccountByQuota(account); paused {
-			slog.Debug("grok_account_auto_paused_by_quota",
-				"account_id", account.ID,
-				"window", reason.window,
-				"threshold", reason.threshold,
-				"utilization", reason.utilization,
-			)
-			return false
-		}
-	}
-	if requestedModel != "" && !account.IsModelSupported(requestedModel) {
-		return false
-	}
-	if !protocolRoutingOwnsOpenAITextCapability(ctx, requiredCapability) &&
-		!account.SupportsOpenAIEndpointCapability(requiredCapability) {
-		if account.IsGrok() && requiredCapability == OpenAIEndpointCapabilityGrokMediaGeneration {
-			_, reason := account.GrokMediaGenerationEligibility()
-			slog.Debug("grok_media_account_ineligible", "account_id", account.ID, "reason", reason)
-		}
-		return false
-	}
-	if requireCompact && openAICompactSupportTier(account) == 0 {
-		return false
-	}
-	return ProtocolRouteLegal(ctx, account, requestedModel)
+	return openAICompatEligibilityReason(ctx, account, platform, requestedModel, requireCompact, requiredCapability) == ""
 }
 
 type openAIQuotaAutoPauseDecision struct {

--- a/backend/internal/service/openai_gateway_scheduling_tk_eligibility_reason.go
+++ b/backend/internal/service/openai_gateway_scheduling_tk_eligibility_reason.go
@@ -1,0 +1,129 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// TK: name the reason an OpenAI-compat account failed the scheduling gate.
+//
+// WHY (2026-08-25 incident): the edge us6 openai pool served
+// "no available accounts ... total=1 eligible=0 unschedulable=1" for five hours.
+// Every diagnostic field said the same thing — `unschedulable=1` — because the
+// eligibility predicate has SEVEN independent `return false` branches that all
+// collapsed into one bucket, and the one field that could have distinguished
+// them (`openAICompatSelectionFailureDiagnosis.Detail`, hard-coded to the
+// useless string "eligibility") was never emitted to any log at any level.
+//
+// Ruling that out cost a full day of probing: five separate hypotheses (5h
+// quota window, lapsed subscription, DB schedulable flags, redis cooldown,
+// model support) each had to be disproved by hand against prod and the upstream
+// API, because the log could not say which predicate had actually fired. The
+// real cause — ProtocolRouteLegal finding no legal route after protocol-routing
+// governance took over the account — is the LAST of the seven branches, and the
+// only one that was completely invisible.
+//
+// So: one reason string per branch, the route error text included verbatim, and
+// the bool predicate becomes a thin wrapper so there is exactly one copy of the
+// gate order. A future reader gets the answer from the log line instead of a
+// day of bisection.
+const (
+	openAICompatIneligibleAccountNil        = "account_nil"
+	openAICompatIneligibleNotPoolMember     = "not_pool_member"
+	openAICompatIneligibleNotCompatible     = "not_openai_compatible"
+	openAICompatIneligibleAccountCooling    = "account_cooling_or_disabled"
+	openAICompatIneligibleQuotaAutoPause    = "quota_auto_pause"
+	openAICompatIneligibleModelUnsupported  = "model_unsupported_by_account"
+	openAICompatIneligibleCapabilityMissing = "endpoint_capability_missing"
+	openAICompatIneligibleCompactMissing    = "compact_unsupported"
+	openAICompatIneligibleNoLegalRoute      = "no_legal_protocol_route"
+)
+
+// openAICompatEligibilityReason returns "" when the account passes every
+// ordinary scheduling gate, else a stable reason code naming the branch that
+// rejected it. Gate ORDER and semantics must stay identical to the bool
+// predicate below, which delegates here — they are the same code path, so they
+// cannot drift.
+func openAICompatEligibilityReason(
+	ctx context.Context,
+	account *Account,
+	platform string,
+	requestedModel string,
+	requireCompact bool,
+	requiredCapability OpenAIEndpointCapability,
+) string {
+	platform = NormalizeOpenAICompatiblePlatform(platform)
+	if account == nil {
+		return openAICompatIneligibleAccountNil
+	}
+	if !account.IsOpenAICompatPoolMember(platform) {
+		return fmt.Sprintf("%s(account_platform=%s requested=%s)",
+			openAICompatIneligibleNotPoolMember, account.Platform, platform)
+	}
+	if !account.IsOpenAICompatible() {
+		return openAICompatIneligibleNotCompatible
+	}
+	if !account.IsSchedulableForModelWithContext(ctx, requestedModel) {
+		// Distinguishing "whole account not schedulable" from "this model is
+		// cooling" is what the caller needs; it re-checks the model cooldown to
+		// classify model_rate_limited, so only name the account-level case here.
+		return openAICompatIneligibleAccountCooling
+	}
+	if account.IsOpenAI() {
+		if paused, reason := shouldAutoPauseOpenAIAccountByQuota(ctx, account); paused {
+			return fmt.Sprintf("%s(window=%s threshold=%.2f utilization=%.2f)",
+				openAICompatIneligibleQuotaAutoPause, reason.window, reason.threshold, reason.utilization)
+		}
+	}
+	if account.IsGrok() {
+		if paused, reason := shouldAutoPauseGrokAccountByQuota(account); paused {
+			return fmt.Sprintf("%s(window=%s threshold=%.2f utilization=%.2f)",
+				openAICompatIneligibleQuotaAutoPause, reason.window, reason.threshold, reason.utilization)
+		}
+	}
+	if requestedModel != "" && !account.IsModelSupported(requestedModel) {
+		return openAICompatIneligibleModelUnsupported
+	}
+	if !protocolRoutingOwnsOpenAITextCapability(ctx, requiredCapability) &&
+		!account.SupportsOpenAIEndpointCapability(requiredCapability) {
+		detail := string(requiredCapability)
+		if account.IsGrok() && requiredCapability == OpenAIEndpointCapabilityGrokMediaGeneration {
+			if _, grokReason := account.GrokMediaGenerationEligibility(); grokReason != "" {
+				detail = grokReason
+			}
+		}
+		return fmt.Sprintf("%s(%s)", openAICompatIneligibleCapabilityMissing, detail)
+	}
+	if requireCompact && openAICompactSupportTier(account) == 0 {
+		return openAICompatIneligibleCompactMissing
+	}
+	if reason := tkProtocolRouteIllegalReason(ctx, account, requestedModel); reason != "" {
+		return reason
+	}
+	return ""
+}
+
+// tkProtocolRouteIllegalReason names why protocol routing refused this
+// (account, model) pair, or "" when the route is legal / the account is not
+// governed. The upstream error text is carried verbatim: for the 2026-08-25
+// incident it is the difference between "unschedulable" and "the account only
+// declares supported_protocols=[responses], and this inbound shape has no
+// preserving route to it".
+func tkProtocolRouteIllegalReason(ctx context.Context, account *Account, requestedModel string) string {
+	_, governed, err := protocolPlanForAccount(ctx, account, requestedModel)
+	if !governed || err == nil {
+		return ""
+	}
+	detail := strings.TrimSpace(err.Error())
+	if errors.Is(err, ErrProtocolRouteUnavailable) {
+		// Strip the wrapper prefix so the reason reads as one clause; the code
+		// itself already says the route was unavailable.
+		detail = strings.TrimSpace(strings.TrimPrefix(detail, ErrProtocolRouteUnavailable.Error()+":"))
+	}
+	if detail == "" {
+		return openAICompatIneligibleNoLegalRoute
+	}
+	return fmt.Sprintf("%s(%s)", openAICompatIneligibleNoLegalRoute, detail)
+}

--- a/backend/internal/service/openai_gateway_scheduling_tk_eligibility_reason_test.go
+++ b/backend/internal/service/openai_gateway_scheduling_tk_eligibility_reason_test.go
@@ -1,0 +1,161 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The reason string and the bool predicate must agree for every input: the bool
+// delegates to the reason function, so a disagreement would mean the diagnostic
+// log names a gate that did not actually reject the account (or stays silent
+// about one that did). 2026-08-25: the absence of any such reason is what made
+// the edge us6 outage take a day to attribute — every branch reported the same
+// bare "unschedulable".
+func TestEligibilityReasonAgreesWithPredicate(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name    string
+		account *Account
+		model   string
+	}{
+		{
+			name:    "nil account",
+			account: nil,
+		},
+		{
+			name: "healthy openai oauth",
+			account: &Account{
+				ID: 1, Platform: PlatformOpenAI, Type: AccountTypeOAuth,
+				Status: StatusActive, Schedulable: true,
+			},
+			model: "gpt-5.6-sol",
+		},
+		{
+			name: "not schedulable",
+			account: &Account{
+				ID: 2, Platform: PlatformOpenAI, Type: AccountTypeOAuth,
+				Status: StatusActive, Schedulable: false,
+			},
+			model: "gpt-5.6-sol",
+		},
+		{
+			name: "disabled account",
+			account: &Account{
+				ID: 3, Platform: PlatformOpenAI, Type: AccountTypeOAuth,
+				Status: StatusDisabled, Schedulable: true,
+			},
+			model: "gpt-5.6-sol",
+		},
+		{
+			name: "foreign platform for an openai pool",
+			account: &Account{
+				ID: 4, Platform: PlatformAnthropic, Type: AccountTypeOAuth,
+				Status: StatusActive, Schedulable: true,
+			},
+			model: "gpt-5.6-sol",
+		},
+		{
+			name: "oauth account asked for a foreign model",
+			account: &Account{
+				ID: 5, Platform: PlatformOpenAI, Type: AccountTypeOAuth,
+				Status: StatusActive, Schedulable: true,
+			},
+			model: "qwen3-8b",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reason := openAICompatEligibilityReason(ctx, tc.account, PlatformOpenAI, tc.model, false, "")
+			eligible := isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx, tc.account, PlatformOpenAI, tc.model, false, "")
+			require.Equal(t, reason == "", eligible,
+				"reason=%q must be empty exactly when the predicate passes (got eligible=%v)", reason, eligible)
+		})
+	}
+}
+
+// Each rejecting branch must name ITSELF, not a shared placeholder. A bare
+// "unschedulable" cannot be acted on; "not_pool_member(account_platform=...)"
+// can.
+func TestEligibilityReasonNamesTheFailingGate(t *testing.T) {
+	ctx := context.Background()
+
+	nilReason := openAICompatEligibilityReason(ctx, nil, PlatformOpenAI, "gpt-5.6-sol", false, "")
+	require.Equal(t, openAICompatIneligibleAccountNil, nilReason)
+
+	foreignPlatform := &Account{
+		ID: 10, Platform: PlatformAnthropic, Type: AccountTypeOAuth,
+		Status: StatusActive, Schedulable: true,
+	}
+	reason := openAICompatEligibilityReason(ctx, foreignPlatform, PlatformOpenAI, "gpt-5.6-sol", false, "")
+	require.True(t, strings.HasPrefix(reason, openAICompatIneligibleNotPoolMember),
+		"want a not_pool_member reason, got %q", reason)
+	require.Contains(t, reason, PlatformAnthropic,
+		"the reason must name the offending platform so the reader need not look it up")
+
+	notSchedulable := &Account{
+		ID: 11, Platform: PlatformOpenAI, Type: AccountTypeOAuth,
+		Status: StatusActive, Schedulable: false,
+	}
+	require.Equal(t, openAICompatIneligibleAccountCooling,
+		openAICompatEligibilityReason(ctx, notSchedulable, PlatformOpenAI, "gpt-5.6-sol", false, ""))
+
+	foreignModel := &Account{
+		ID: 12, Platform: PlatformOpenAI, Type: AccountTypeOAuth,
+		Status: StatusActive, Schedulable: true,
+	}
+	require.Equal(t, openAICompatIneligibleModelUnsupported,
+		openAICompatEligibilityReason(ctx, foreignModel, PlatformOpenAI, "qwen3-8b", false, ""),
+		"an openai oauth account cannot serve a foreign vendor model")
+
+	// Every reason code must be a non-empty, whitespace-free token so log
+	// consumers can group on it.
+	for _, code := range []string{
+		openAICompatIneligibleAccountNil,
+		openAICompatIneligibleNotPoolMember,
+		openAICompatIneligibleNotCompatible,
+		openAICompatIneligibleAccountCooling,
+		openAICompatIneligibleQuotaAutoPause,
+		openAICompatIneligibleModelUnsupported,
+		openAICompatIneligibleCapabilityMissing,
+		openAICompatIneligibleCompactMissing,
+		openAICompatIneligibleNoLegalRoute,
+	} {
+		require.NotEmpty(t, code)
+		require.NotContains(t, code, " ", "reason code %q must be a single token", code)
+	}
+}
+
+// An ungoverned account must not be reported as route-illegal: protocol routing
+// only governs requests that carry a routing context, and a false positive here
+// would blame the router for every ordinary rejection.
+func TestProtocolRouteIllegalReasonEmptyWhenUngoverned(t *testing.T) {
+	acc := &Account{
+		ID: 20, Platform: PlatformOpenAI, Type: AccountTypeOAuth,
+		Status: StatusActive, Schedulable: true,
+	}
+	require.Empty(t, tkProtocolRouteIllegalReason(context.Background(), acc, "gpt-5.6-sol"),
+		"no routing context in ctx => not governed => no route reason")
+}
+
+// The unschedulable bucket must carry per-account reason samples, capped like
+// the sibling sample helpers so a large pool cannot flood one log line.
+func TestAppendSelectionFailureReasonSampleIsCapped(t *testing.T) {
+	var samples []string
+	for i := int64(1); i <= 10; i++ {
+		samples = appendSelectionFailureReasonSample(samples, i, "no_legal_protocol_route")
+	}
+	require.Len(t, samples, 5, "reason samples must be capped at 5 like the other buckets")
+	require.Equal(t, "1(no_legal_protocol_route)", samples[0],
+		"a sample must pair the account id with its reason")
+
+	// An empty reason still records the account, so the count never disagrees
+	// with the bucket total.
+	require.Equal(t, "7(unspecified)", appendSelectionFailureReasonSample(nil, 7, "")[0])
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3507,9 +3507,12 @@
       "must_contain": [
         "func (s *OpenAIGatewayService) collectOpenAICompatSelectionFailureStatsForRequest(",
         "openai_account_selection_failed",
-        "runtime_blocked"
+        "runtime_blocked",
+        "stats.SampleUnschedulableReasons = appendSelectionFailureReasonSample(",
+        "\"sample_unschedulable\", stats.SampleUnschedulableReasons,",
+        "openAICompatEligibilityReason(ctx, acc, platform, requestedModel, requireCompact, requiredCapability)"
       ],
-      "rationale": "Prod 2026-07-28 GPT-pro3/4 incident observability: when OpenAI-compat selection empties the pool, log openai_account_selection_failed with per-account rejection axes including runtime_blocked (in-memory block vs DB schedulable drift). collectOpenAICompatSelectionFailureStatsForRequest mirrors scheduler eligibility ordering so ops can distinguish client-fault unsupported model from whole-account runtime block without restart."
+      "rationale": "Prod 2026-07-28 GPT-pro3/4 incident observability: when OpenAI-compat selection empties the pool, log openai_account_selection_failed with per-account rejection axes including runtime_blocked (in-memory block vs DB schedulable drift). collectOpenAICompatSelectionFailureStatsForRequest mirrors scheduler eligibility ordering so ops can distinguish client-fault unsupported model from whole-account runtime block without restart. Extended 2026-08-25: the unschedulable bucket must also carry per-account REASON samples (sample_unschedulable, fed by openAICompatEligibilityReason). Without them that bucket is a bare count over many independent gate branches, which is what made the edge us6 outage take a full day to attribute — every hypothesis had to be disproved by hand because the log could not say which gate fired."
     },
     {
       "path": "backend/internal/service/openai_account_scheduler_tk_selection_diag_test.go",
@@ -7224,6 +7227,26 @@
         "TestFirstSeenTitleFollowsReason"
       ],
       "rationale": "Focused regressions pinning that a served_at_fallback digest entry never prints '未计费', that reason is part of the aggregation key, and that title/header severity follow the buffer's actual content instead of a hardcoded P0 leak framing."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_scheduling_tk_eligibility_reason.go",
+      "must_contain": [
+        "func openAICompatEligibilityReason(",
+        "func tkProtocolRouteIllegalReason(",
+        "openAICompatIneligibleNoLegalRoute      = \"no_legal_protocol_route\"",
+        "openAICompatIneligibleQuotaAutoPause    = \"quota_auto_pause\""
+      ],
+      "rationale": "Names WHICH scheduling gate rejected an openai-compat account. The bool predicate isOpenAICompatibleAccountEligibleForRequestBeforeProfit delegates here, so this file owns the single copy of the gate order; dropping it collapses nine distinct rejection causes back into one bare 'unschedulable' count. That collapse is what made the 2026-08-25 edge us6 outage (five hours of 'total=1 eligible=0 unschedulable=1' on a healthy account, upstream quota/subscription/DB/redis all verified fine) cost a full day to attribute to ProtocolRouteLegal finding no legal route. tkProtocolRouteIllegalReason carries the router's error text verbatim, which is the only signal distinguishing 'account is broken' from 'this inbound shape has no preserving route to the protocols this account declares'."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_scheduling_tk_eligibility_reason_test.go",
+      "must_contain": [
+        "TestEligibilityReasonAgreesWithPredicate",
+        "TestEligibilityReasonNamesTheFailingGate",
+        "TestProtocolRouteIllegalReasonEmptyWhenUngoverned",
+        "TestAppendSelectionFailureReasonSampleIsCapped"
+      ],
+      "rationale": "Focused regressions for the ineligibility-reason plumbing: reason=='' must agree with the bool predicate for every input (otherwise the diagnostic log names a gate that did not fire, or stays silent about one that did), each gate must report its own reason code, an ungoverned account must yield no route reason, and the reason samples stay capped like the sibling buckets so one log line cannot be flooded by a large pool."
     }
   ]
 }


### PR DESCRIPTION
## Problem

The openai-compat scheduling gate has seven independent `return false` branches. All seven were reported to ops as one counter:

```
openai_account_selection_failed
  total=1 eligible=0 excluded=0 unschedulable=1
  runtime_blocked=0 model_unsupported=0 model_rate_limited=0
```

`unschedulable=1` was the entire diagnostic. The field that could have distinguished the branches — `openAICompatSelectionFailureDiagnosis.Detail` — was hard-coded to `"eligibility"` and never emitted to any log at any level, so raising the log level did not help either.

## What that cost

2026-08-25, edge us6: this counter was the whole surface for a five-hour openai outage. Attributing it took a day of probing, disproving five hypotheses one at a time against prod and the upstream API:

| hypothesis | how it was ruled out |
|---|---|
| codex 5h window | upstream `/wham/usage` 200: `secondary_window=null`, `allowed=true` |
| lapsed subscription | `plan_type=pro`; account served 41351 requests after the stored expiry |
| DB not schedulable | all five `IsSchedulable()` predicates recomputed in SQL — all true |
| redis cooldown | six key patterns, zero keys (no scheduler snapshot at all) |
| model unsupported | upstream `codex/models` 200, requested slug present |

The real cause was branch seven: `ProtocolRouteLegal` finding no legal route after protocol-routing governance took the account over at a container restart. It was the only branch with no diagnostic whatsoever.

## Change

- `openAICompatEligibilityReason` returns one reason code per branch, carrying the protocol-route error text verbatim.
- `isOpenAICompatibleAccountEligibleForRequestBeforeProfit` becomes a thin wrapper over it — gate order exists in one place, so the bool and the reason cannot drift. A test asserts that parity across inputs.
- The unschedulable bucket gains a capped sample list. The same outage would now have printed, in its first log line:

```
unschedulable=1
sample_unschedulable=[9(no_legal_protocol_route(no legal route: ...))]
```

- Deleted `openAICompatAccountMeetsSchedulingPrerequisites` — its only caller now asks for the reason, leaving it unused (caught by golangci-lint, not by me).

**No scheduling decision changes.** Same gates, same order, same verdicts; diagnostics only.

## Verification

```
go build ./...                     ok
go vet ./internal/service/...      ok
gofmt -l                           clean
golangci-lint run ./...            0 issues
go test -tags=unit ./internal/service/    ok (full package, 107s)
scripts/preflight.sh               PASS (both segments)
```

Mutation-tested the new tests — each of the five assertions fails when its production line is reverted:

```
pinned: route-illegal branch          pinned: not_pool_member branch
pinned: account_cooling branch        pinned: bool/reason parity
pinned: reason-sample cap
```

Review focus:
1. Gate order in `openAICompatEligibilityReason` vs the original predicate — they must stay byte-identical in sequence, which is why the bool now delegates rather than mirrors.
2. Whether the verbatim route error text is safe to log (it names protocols and models, no credentials).

ai
