### PR TITLE
fix(protocol): 修复协议 SSOT 探测鉴权与 Grok OAuth 覆盖

### DIFF
--- a/backend/internal/service/openai_apikey_chat_completions_probe.go
+++ b/backend/internal/service/openai_apikey_chat_completions_probe.go
@@ -69,10 +69,7 @@ func (s *AccountTestService) probeOpenAIAPIKeyChatCompletionsSupport(
 	_ string,
 ) (protocolProbeObservation, bool) {
 	accountID := account.ID
-	apiKey := account.GetOpenAIProtocolAPIKey()
-	if apiKey == "" {
-		apiKey = account.GetCredential("api_key")
-	}
+	apiKey := protocolProbeAuthToken(account)
 	if apiKey == "" {
 		logger.LegacyPrintf("service.openai_probe", "chat_completions_skip_no_apikey: account_id=%d", accountID)
 		return protocolProbeObservation{}, false
@@ -108,11 +105,10 @@ func (s *AccountTestService) probeOpenAIAPIKeyChatCompletionsSupport(
 		logger.LegacyPrintf("service.openai_probe", "chat_completions_build_request_failed: account_id=%d err=%v", accountID, err)
 		return protocolProbeObservation{}, false
 	}
-	req = req.WithContext(WithHTTPUpstreamProfile(req.Context(), HTTPUpstreamProfileOpenAI))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Accept", "application/json")
-	account.ApplyHeaderOverrides(req.Header)
+	req = applyProtocolProbeRequestIdentity(req, account, protocolrouter.ProtocolChatCompletions)
 
 	proxyURL := ""
 	if account.ProxyID != nil && account.Proxy != nil {

--- a/backend/internal/service/openai_apikey_native_messages_probe.go
+++ b/backend/internal/service/openai_apikey_native_messages_probe.go
@@ -75,15 +75,7 @@ func (s *AccountTestService) probeOpenAIAPIKeyNativeMessagesSupport(
 	_ string,
 ) (protocolProbeObservation, bool) {
 	accountID := account.ID
-	authToken := ""
-	if account.Platform == PlatformAnthropic && account.IsAnthropicOAuthOrSetupToken() {
-		authToken = account.GetCredential("access_token")
-	} else {
-		authToken = account.GetOpenAIProtocolAPIKey()
-		if authToken == "" {
-			authToken = account.GetCredential("api_key")
-		}
-	}
+	authToken := protocolProbeAuthToken(account)
 	if authToken == "" {
 		logger.LegacyPrintf("service.openai_probe", "native_messages_skip_no_auth: account_id=%d", accountID)
 		return protocolProbeObservation{}, false
@@ -110,7 +102,6 @@ func (s *AccountTestService) probeOpenAIAPIKeyNativeMessagesSupport(
 		logger.LegacyPrintf("service.openai_probe", "native_messages_build_request_failed: account_id=%d err=%v", accountID, err)
 		return protocolProbeObservation{}, false
 	}
-	req = req.WithContext(WithHTTPUpstreamProfile(req.Context(), HTTPUpstreamProfileOpenAI))
 	req.Header.Set("Content-Type", "application/json")
 	if account.Platform == PlatformAnthropic {
 		req.Header.Set("anthropic-version", "2023-06-01")
@@ -124,7 +115,7 @@ func (s *AccountTestService) probeOpenAIAPIKeyNativeMessagesSupport(
 		req.Header.Set("Authorization", "Bearer "+authToken)
 	}
 	req.Header.Set("Accept", "application/json")
-	account.ApplyHeaderOverrides(req.Header)
+	req = applyProtocolProbeRequestIdentity(req, account, protocolrouter.ProtocolMessages)
 
 	proxyURL := ""
 	if account.ProxyID != nil && account.Proxy != nil {

--- a/backend/internal/service/openai_apikey_responses_probe.go
+++ b/backend/internal/service/openai_apikey_responses_probe.go
@@ -131,10 +131,7 @@ func (s *AccountTestService) probeOpenAIAPIKeyResponsesSupport(
 		return protocolProbeObservation{}, false
 	}
 
-	apiKey := account.GetOpenAIApiKey()
-	if apiKey == "" {
-		apiKey = account.GetOpenAIProtocolAPIKey()
-	}
+	apiKey := protocolProbeAuthToken(account)
 	if apiKey == "" {
 		logger.LegacyPrintf("service.openai_probe", "probe_skip_no_apikey: account_id=%d", accountID)
 		return protocolProbeObservation{}, false
@@ -171,14 +168,10 @@ func (s *AccountTestService) probeOpenAIAPIKeyResponsesSupport(
 		logger.LegacyPrintf("service.openai_probe", "probe_build_request_failed: account_id=%d err=%v", accountID, err)
 		return protocolProbeObservation{}, false
 	}
-	req = req.WithContext(WithHTTPUpstreamProfile(req.Context(), HTTPUpstreamProfileOpenAI))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Accept", "application/json")
-	applyOpenAICodexProbeHeaders(req.Header)
-
-	// 账号级请求头覆写：能力探测与真实转发保持一致的最终头
-	account.ApplyHeaderOverrides(req.Header)
+	req = applyProtocolProbeRequestIdentity(req, account, protocolrouter.ProtocolResponses)
 
 	proxyURL := ""
 	if account.ProxyID != nil && account.Proxy != nil {

--- a/backend/internal/service/openai_apikey_responses_probe_test.go
+++ b/backend/internal/service/openai_apikey_responses_probe_test.go
@@ -130,6 +130,42 @@ func TestProbeOpenAIAPIKeyResponsesSupportUsesCodexProbeHeaders(t *testing.T) {
 	require.Equal(t, true, updates[openai_compat.ExtraKeyResponsesSupported])
 }
 
+func TestProbeOpenAIAPIKeyResponsesSupportUsesGenericAPIKeyForAnthropicMirror(t *testing.T) {
+	updateCalls := make(chan map[string]any, 1)
+	account := Account{
+		ID:          197,
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "mirror-api-key",
+			"base_url": "https://mirror.example.test/v1",
+		},
+	}
+	repo := &snapshotUpdateAccountRepo{
+		stubOpenAIAccountRepo: stubOpenAIAccountRepo{accounts: []Account{account}},
+		updateExtraCalls:      updateCalls,
+	}
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(`{"status":"completed","output":[{"type":"function_call","name":"probe_ping"}]}`)),
+	}}
+	svc := &AccountTestService{
+		accountRepo:  repo,
+		httpUpstream: upstream,
+		cfg:          &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
+	}
+
+	svc.ProbeOpenAIAPIKeyResponsesSupport(context.Background(), account.ID)
+
+	require.NotNil(t, upstream.lastReq, "Anthropic API-key mirrors must execute a real Responses probe")
+	require.Equal(t, "Bearer mirror-api-key", upstream.lastReq.Header.Get("Authorization"))
+	require.True(t, HTTPUpstreamRedirectsDisabled(upstream.lastReq.Context()))
+	updates := <-updateCalls
+	require.Equal(t, []string{"responses"}, updates[SupportedProtocolsExtraKey])
+}
+
 func TestProbeOpenAIAPIKeyResponsesSupportCNProviders(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/backend/internal/service/protocol_capability_probe.go
+++ b/backend/internal/service/protocol_capability_probe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -235,18 +236,62 @@ func protocolProbeBaseURL(account *Account, protocol protocolrouter.Protocol) st
 	return baseURL
 }
 
+// protocolProbeAuthToken is the single credential-binding owner for protocol
+// capability probes. It returns the bearer/API-key material used by the
+// protocol-specific request builder without inferring endpoint capability.
+func protocolProbeAuthToken(account *Account) string {
+	if account == nil {
+		return ""
+	}
+	if account.IsGrokOAuth() {
+		return account.GetGrokAccessToken()
+	}
+	if account.Platform == PlatformAnthropic && account.IsAnthropicOAuthOrSetupToken() {
+		return account.GetCredential("access_token")
+	}
+	if token := account.GetOpenAIProtocolAPIKey(); token != "" {
+		return token
+	}
+	return account.GetCredential("api_key")
+}
+
+func applyProtocolProbeRequestIdentity(
+	req *http.Request,
+	account *Account,
+	protocol protocolrouter.Protocol,
+) *http.Request {
+	if req == nil {
+		return nil
+	}
+	profile := HTTPUpstreamProfileOpenAI
+	if account != nil && account.IsGrok() {
+		profile = HTTPUpstreamProfileGrok
+	} else if protocol == protocolrouter.ProtocolResponses {
+		applyOpenAICodexProbeHeaders(req.Header)
+	}
+	reqCtx := WithHTTPUpstreamProfile(req.Context(), profile)
+	req = req.WithContext(WithHTTPUpstreamRedirectsDisabled(reqCtx))
+	if account != nil && account.IsGrokOAuth() {
+		applyGrokCLIHeaders(req.Header)
+	}
+	if account != nil {
+		account.ApplyHeaderOverrides(req.Header)
+	}
+	return req
+}
+
 func ProtocolProbeCandidates(account *Account) []protocolrouter.Protocol {
 	if !protocolRoutingGovernsAccount(account) || len(officialSupportedProtocols(account)) > 0 {
 		return nil
 	}
-	switch account.Type {
-	case AccountTypeAPIKey, AccountTypeUpstream:
+	switch {
+	case account.Type == AccountTypeAPIKey, account.Type == AccountTypeUpstream:
+	case account.IsGrokOAuth():
+	case account.Platform == PlatformAnthropic &&
+		account.IsAnthropicOAuthOrSetupToken() &&
+		account.IsCustomBaseURLEnabled():
 	default:
-		if account.Platform != PlatformAnthropic ||
-			!account.IsAnthropicOAuthOrSetupToken() ||
-			!account.IsCustomBaseURLEnabled() {
-			return nil
-		}
+		return nil
 	}
 	candidates := make([]protocolrouter.Protocol, 0, len(protocolrouter.AllProtocols()))
 	for _, protocol := range protocolrouter.AllProtocols() {

--- a/backend/internal/service/protocol_capability_probe_test.go
+++ b/backend/internal/service/protocol_capability_probe_test.go
@@ -76,6 +76,11 @@ type protocolProbeSetUpstream struct {
 	mu             sync.Mutex
 	paths          []string
 	authorizations []string
+	profiles       []HTTPUpstreamProfile
+	redirectsOff   []bool
+	grokVersions   []string
+	originators    []string
+	codexWindows   []string
 }
 
 type protocolProbeBarrierUpstream struct {
@@ -157,6 +162,11 @@ func (u *protocolProbeSetUpstream) DoWithTLS(
 	u.mu.Lock()
 	u.paths = append(u.paths, req.URL.Path)
 	u.authorizations = append(u.authorizations, getHeaderRaw(req.Header, "authorization"))
+	u.profiles = append(u.profiles, HTTPUpstreamProfileFromContext(req.Context()))
+	u.redirectsOff = append(u.redirectsOff, HTTPUpstreamRedirectsDisabled(req.Context()))
+	u.grokVersions = append(u.grokVersions, req.Header.Get("X-Grok-Client-Version"))
+	u.originators = append(u.originators, req.Header.Get("Originator"))
+	u.codexWindows = append(u.codexWindows, req.Header.Get("X-Codex-Window-ID"))
 	u.mu.Unlock()
 
 	body := `{"output":[{"type":"function_call","name":"probe_ping"}]}`
@@ -266,6 +276,13 @@ func TestProtocolProbeCandidatesCoverGovernedCustomAccountsOnly(t *testing.T) {
 			want: []protocolrouter.Protocol{protocolrouter.ProtocolMessages},
 		},
 		{
+			name: "grok oauth probes its explicit text endpoints",
+			account: &Account{Platform: PlatformGrok, Type: AccountTypeOAuth, Credentials: map[string]any{
+				"access_token": "oauth-secret", "base_url": "https://grok.example.test/v1",
+			}},
+			want: protocolrouter.AllProtocols(),
+		},
+		{
 			name: "ungoverned gemini is excluded",
 			account: &Account{Platform: PlatformGemini, Type: AccountTypeAPIKey, Credentials: map[string]any{
 				"api_key": "secret", "base_url": "https://gemini.example.test",
@@ -279,6 +296,77 @@ func TestProtocolProbeCandidatesCoverGovernedCustomAccountsOnly(t *testing.T) {
 				t.Fatalf("ProtocolProbeCandidates = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestProbeAccountProtocolCapabilitiesSupportsGrokOAuth(t *testing.T) {
+	account := &Account{
+		ID:          198,
+		Name:        "grok-oauth",
+		Platform:    PlatformGrok,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token": "grok-oauth-secret",
+			"base_url":     "https://grok.example.test/v1",
+		},
+		UpdatedAt: time.Date(2026, 8, 25, 6, 0, 0, 0, time.UTC),
+	}
+	repo := &protocolProbeCASRepo{account: cloneProtocolProbeAccount(account)}
+	upstream := &protocolProbeSetUpstream{}
+	svc := &AccountTestService{
+		accountRepo:  repo,
+		httpUpstream: upstream,
+		cfg: &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{
+			Enabled: false,
+		}}},
+	}
+
+	svc.ProbeAccountProtocolCapabilities(context.Background(), account.ID)
+
+	got, err := repo.GetByID(context.Background(), account.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if want := protocolrouter.AllProtocols(); !reflect.DeepEqual(got.SupportedProtocols(), want) {
+		t.Fatalf("supported protocols = %v, want %v", got.SupportedProtocols(), want)
+	}
+	upstream.mu.Lock()
+	defer upstream.mu.Unlock()
+	wantPaths := []string{"/v1/chat/completions", "/v1/messages", "/v1/responses"}
+	gotPaths := append([]string(nil), upstream.paths...)
+	slices.Sort(gotPaths)
+	if !reflect.DeepEqual(gotPaths, wantPaths) {
+		t.Fatalf("probe paths = %v, want %v", gotPaths, wantPaths)
+	}
+	for _, authorization := range upstream.authorizations {
+		if authorization != "Bearer grok-oauth-secret" {
+			t.Fatalf("probe authorization = %q, want bearer Grok access token", authorization)
+		}
+	}
+	for _, profile := range upstream.profiles {
+		if profile != HTTPUpstreamProfileGrok {
+			t.Fatalf("probe HTTP profile = %q, want %q", profile, HTTPUpstreamProfileGrok)
+		}
+	}
+	for _, redirectsOff := range upstream.redirectsOff {
+		if !redirectsOff {
+			t.Fatal("credential-bearing Grok OAuth probe allowed HTTP redirects")
+		}
+	}
+	for _, version := range upstream.grokVersions {
+		if strings.TrimSpace(version) == "" {
+			t.Fatal("Grok OAuth probe omitted the pinned CLI identity headers")
+		}
+	}
+	for i := range upstream.originators {
+		if upstream.originators[i] != "" || upstream.codexWindows[i] != "" {
+			t.Fatalf(
+				"Grok OAuth probe leaked Codex identity headers: originator=%q window=%q",
+				upstream.originators[i],
+				upstream.codexWindows[i],
+			)
+		}
 	}
 }
 

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -914,6 +914,30 @@
       "rationale": "Regression proof that Agent Plan account 88 resolves both governed text protocols under the canonical /api/plan/v3 base instead of probing or executing the generic VolcEngine paths that returned 404 during rollout preparation."
     },
     {
+      "path": "backend/internal/service/protocol_capability_probe.go",
+      "must_contain": [
+        "func protocolProbeAuthToken(account *Account) string",
+        "func applyProtocolProbeRequestIdentity(",
+        "case account.IsGrokOAuth():",
+        "HTTPUpstreamProfileGrok",
+        "applyGrokCLIHeaders(req.Header)",
+        "WithHTTPUpstreamRedirectsDisabled(reqCtx)"
+      ],
+      "rationale": "Protocol capability probes must share one credential and outbound-identity owner. Anthropic API-key mirrors use the generic api_key binding, while Grok OAuth uses its access token plus Grok HTTP/CLI identity; every credential-bearing probe disables redirects so validated endpoint boundaries cannot be bypassed. Removing these anchors recreates probe_skip_no_apikey, leaves governed Grok OAuth accounts permanently outside the candidate set, or risks forwarding probe credentials beyond the validated endpoint."
+    },
+    {
+      "path": "backend/internal/service/protocol_capability_probe_test.go",
+      "must_contain": [
+        "grok oauth probes its explicit text endpoints",
+        "TestProbeAccountProtocolCapabilitiesSupportsGrokOAuth",
+        "Bearer grok-oauth-secret",
+        "HTTPUpstreamProfileGrok",
+        "credential-bearing Grok OAuth probe allowed HTTP redirects",
+        "Grok OAuth probe leaked Codex identity headers"
+      ],
+      "rationale": "Behavior proof for the governed/probe parity boundary: Grok OAuth must probe all explicit text endpoints with its bearer access token and Grok identity, without following redirects or leaking Codex probe headers. This prevents a green unit suite from masking a startup remediation loop on us3/us4 or a credential-boundary regression."
+    },
+    {
       "path": "backend/internal/service/openai_apikey_chat_completions_probe.go",
       "must_contain": [
         "selectProtocolProbeModel(account)",
@@ -989,6 +1013,8 @@
       "path": "backend/internal/service/openai_apikey_responses_probe_test.go",
       "must_contain": [
         "TestProbeOpenAIAPIKeyResponsesSupportUsesNewAPIAdaptorEndpoint",
+        "TestProbeOpenAIAPIKeyResponsesSupportUsesGenericAPIKeyForAnthropicMirror",
+        "HTTPUpstreamRedirectsDisabled(upstream.lastReq.Context())",
         "TestProbeOpenAIAPIKeyResponsesSupportPrefersChannelNativeTextModel",
         "TestSelectProtocolProbeModelUsesDeterministicTextFallback",
         "TestSelectProtocolProbeModelExcludesMediaAndUsesDeterministicTextFallback",


### PR DESCRIPTION
## 摘要

- 为三种文本协议探测建立统一的账号凭据绑定与上游请求身份 owner。
- Anthropic API-key mirror 的 Responses 探测读取通用 `credentials.api_key`，避免 `probe_skip_no_apikey`。
- 将受协议路由治理的 Grok OAuth 账号纳入探测候选，使用 OAuth access token、Grok HTTP profile 与 pinned CLI headers，并避免泄漏 Codex identity headers。
- 所有携带凭据的协议探测均禁止 HTTP redirect；同步增加聚焦回归测试与 NewAPI sentinel 锚点。

## 风险

- 高风险点：该变更影响 `supported_protocols` 的真实探测输入，进而影响协议路由硬门禁的账号可用性判断。
- 保持 `docs/approved/protocol-routing-ssot.md` 既有语义：不从 legacy flags 推断协议能力，不复制同 base URL 账号的结果，429/503 仍保持 inconclusive/model-specific，不伪造 positive。
- 无数据库 schema、Web/API 契约或前端改动；本 PR 不执行生产写入、外部探测或部署。
- `no-web-impact`
- `high-risk-anchor: docs/approved/protocol-routing-ssot.md`

## 验证

- TDD RED：Anthropic mirror 与 Grok OAuth 的 redirect 断言在修复前均按预期失败。
- `go test ./internal/service -run 'TestProbeOpenAIAPIKeyResponsesSupportUsesGenericAPIKeyForAnthropicMirror|TestProbeAccountProtocolCapabilitiesSupportsGrokOAuth' -count=1`
- `go test ./... -count=1`
- `python3 scripts/checks/test_protocol_routing_ssot.py`
- `python3 scripts/sentinels/check-newapi.py --quiet`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- `$xj-review`：`risk_level=high`、`review_mode=full_conformance`，零 medium+ finding。

## 提交

- `4400abc0e fix(protocol): bind capability probes to account auth`
- 最新提交：`4400abc0e`
