### PR TITLE
fix(discovery): 隔离强制平台能力读取

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -1644,6 +1644,7 @@ func (h *GatewayHandler) AntigravityModels(c *gin.Context) {
 	if apiKey, ok := middleware2.GetAPIKeyFromContext(c); ok && apiKey != nil && apiKey.IsUniversal() && apiKey.Group == nil {
 		capabilities, err := h.universalCapabilities(c.Request.Context(), apiKey, service.UniversalProtocolAntigravity)
 		if err != nil {
+			requestLogger(c, "gateway.antigravity_models", zap.String("protocol", string(service.UniversalProtocolAntigravity))).Warn("capability_discovery_failed", zap.Error(err))
 			c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"type": "api_error", "message": "Model discovery unavailable"}})
 			return
 		}

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -1263,6 +1263,7 @@ func (h *GatewayHandler) Models(c *gin.Context) {
 		}
 		capabilities, err := h.universalCapabilities(c.Request.Context(), apiKey, protocol)
 		if err != nil {
+			requestLogger(c, "gateway.models", zap.String("protocol", string(protocol))).Warn("capability_discovery_failed", zap.Error(err))
 			if protocol == service.UniversalProtocolAnthropic {
 				h.errorResponse(c, http.StatusInternalServerError, "api_error", "Model discovery unavailable")
 			} else {

--- a/backend/internal/handler/gemini_v1beta_handler.go
+++ b/backend/internal/handler/gemini_v1beta_handler.go
@@ -42,6 +42,7 @@ func (h *GatewayHandler) GeminiV1BetaListModels(c *gin.Context) {
 	if apiKey.IsUniversal() && apiKey.Group == nil {
 		capabilities, err := h.universalCapabilities(c.Request.Context(), apiKey, service.UniversalProtocolGemini)
 		if err != nil {
+			requestLogger(c, "gateway.gemini_models", zap.String("protocol", string(service.UniversalProtocolGemini))).Warn("capability_discovery_failed", zap.Error(err))
 			googleError(c, http.StatusInternalServerError, "Model discovery unavailable")
 			return
 		}

--- a/backend/internal/handler/openai_codex_models_handler.go
+++ b/backend/internal/handler/openai_codex_models_handler.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"go.uber.org/zap"
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
@@ -34,11 +33,6 @@ func (h *OpenAIGatewayHandler) CodexModels(c *gin.Context) {
 	}
 	apiKey, allowedModelIDs, err := h.resolveCodexDiscoveryAPIKey(c.Request.Context(), apiKey)
 	if err != nil {
-		requestLogger(
-			c,
-			"gateway.codex_models",
-			zap.String("protocol", string(service.UniversalProtocolCodex)),
-		).Warn("capability_discovery_failed", zap.Error(err))
 		status := http.StatusInternalServerError
 		message := "Codex model discovery unavailable"
 		if errors.Is(err, service.ErrUniversalNoEntitledGroup) {

--- a/backend/internal/handler/openai_codex_models_handler.go
+++ b/backend/internal/handler/openai_codex_models_handler.go
@@ -34,7 +34,11 @@ func (h *OpenAIGatewayHandler) CodexModels(c *gin.Context) {
 	}
 	apiKey, allowedModelIDs, err := h.resolveCodexDiscoveryAPIKey(c.Request.Context(), apiKey)
 	if err != nil {
-		requestLogger(c, "gateway.codex_models").Warn("capability_discovery_failed", zap.Error(err))
+		requestLogger(
+			c,
+			"gateway.codex_models",
+			zap.String("protocol", string(service.UniversalProtocolCodex)),
+		).Warn("capability_discovery_failed", zap.Error(err))
 		status := http.StatusInternalServerError
 		message := "Codex model discovery unavailable"
 		if errors.Is(err, service.ErrUniversalNoEntitledGroup) {

--- a/backend/internal/handler/openai_codex_models_handler.go
+++ b/backend/internal/handler/openai_codex_models_handler.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
@@ -33,6 +34,7 @@ func (h *OpenAIGatewayHandler) CodexModels(c *gin.Context) {
 	}
 	apiKey, allowedModelIDs, err := h.resolveCodexDiscoveryAPIKey(c.Request.Context(), apiKey)
 	if err != nil {
+		requestLogger(c, "gateway.codex_models").Warn("capability_discovery_failed", zap.Error(err))
 		status := http.StatusInternalServerError
 		message := "Codex model discovery unavailable"
 		if errors.Is(err, service.ErrUniversalNoEntitledGroup) {

--- a/backend/internal/handler/us046_universal_discovery_test.go
+++ b/backend/internal/handler/us046_universal_discovery_test.go
@@ -257,21 +257,15 @@ func TestUS046_UniversalDiscoveryFailureIs500NotEmptyList(t *testing.T) {
 	})
 
 	t.Run("codex", func(t *testing.T) {
-		core, logs := observer.New(zap.WarnLevel)
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
 		c.Request = httptest.NewRequest(http.MethodGet, "/backend-api/codex/models", nil)
-		c.Request = c.Request.WithContext(logger.IntoContext(c.Request.Context(), zap.New(core)))
 		c.Set(string(middleware.ContextKeyAPIKey), key)
 
 		h := &OpenAIGatewayHandler{tkCapabilities: source}
 		h.CodexModels(c)
 		require.Equal(t, http.StatusInternalServerError, w.Code)
 		require.NotContains(t, w.Body.String(), `"models":[]`)
-		entries := logs.FilterMessage("capability_discovery_failed").All()
-		require.Len(t, entries, 1)
-		require.Equal(t, "gateway.codex_models", entries[0].ContextMap()["component"])
-		require.Equal(t, string(service.UniversalProtocolCodex), entries[0].ContextMap()["protocol"])
 	})
 }
 

--- a/backend/internal/handler/us046_universal_discovery_test.go
+++ b/backend/internal/handler/us046_universal_discovery_test.go
@@ -8,10 +8,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 type us046CapabilityKeySource struct {
@@ -217,27 +220,40 @@ func TestUS046_UniversalDiscoveryFailureIs500NotEmptyList(t *testing.T) {
 	})
 
 	t.Run("gemini", func(t *testing.T) {
-		h := &GatewayHandler{tkCapabilities: source}
+		core, logs := observer.New(zap.WarnLevel)
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
 		c.Request = httptest.NewRequest(http.MethodGet, "/v1beta/models", nil)
+		c.Request = c.Request.WithContext(logger.IntoContext(c.Request.Context(), zap.New(core)))
 		c.Set(string(middleware.ContextKeyAPIKey), key)
 
+		h := &GatewayHandler{tkCapabilities: source}
 		h.GeminiV1BetaListModels(c)
 		require.Equal(t, http.StatusInternalServerError, w.Code)
 		require.NotContains(t, w.Body.String(), `"models":[]`)
+		entries := logs.FilterMessage("capability_discovery_failed").All()
+		require.Len(t, entries, 1)
+		require.Equal(t, "gateway.gemini_models", entries[0].ContextMap()["component"])
+		require.Equal(t, string(service.UniversalProtocolGemini), entries[0].ContextMap()["protocol"])
 	})
 
 	t.Run("antigravity", func(t *testing.T) {
-		h := &GatewayHandler{tkCapabilities: source}
+		core, logs := observer.New(zap.WarnLevel)
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
 		c.Request = httptest.NewRequest(http.MethodGet, "/antigravity/models", nil)
+		c.Request = c.Request.WithContext(logger.IntoContext(c.Request.Context(), zap.New(core)))
 		c.Set(string(middleware.ContextKeyAPIKey), key)
 
+		h := &GatewayHandler{tkCapabilities: source}
 		h.AntigravityModels(c)
 		require.Equal(t, http.StatusInternalServerError, w.Code)
 		require.NotContains(t, w.Body.String(), `"data":[]`)
+		entries := logs.FilterMessage("capability_discovery_failed").All()
+		require.Len(t, entries, 1)
+		require.Equal(t, "gateway.antigravity_models", entries[0].ContextMap()["component"])
+		require.Equal(t, string(service.UniversalProtocolAntigravity), entries[0].ContextMap()["protocol"])
+		require.Contains(t, entries[0].ContextMap()["error"], "database unavailable")
 	})
 
 	t.Run("codex", func(t *testing.T) {

--- a/backend/internal/handler/us046_universal_discovery_test.go
+++ b/backend/internal/handler/us046_universal_discovery_test.go
@@ -257,15 +257,21 @@ func TestUS046_UniversalDiscoveryFailureIs500NotEmptyList(t *testing.T) {
 	})
 
 	t.Run("codex", func(t *testing.T) {
-		h := &OpenAIGatewayHandler{tkCapabilities: source}
+		core, logs := observer.New(zap.WarnLevel)
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
 		c.Request = httptest.NewRequest(http.MethodGet, "/backend-api/codex/models", nil)
+		c.Request = c.Request.WithContext(logger.IntoContext(c.Request.Context(), zap.New(core)))
 		c.Set(string(middleware.ContextKeyAPIKey), key)
 
+		h := &OpenAIGatewayHandler{tkCapabilities: source}
 		h.CodexModels(c)
 		require.Equal(t, http.StatusInternalServerError, w.Code)
 		require.NotContains(t, w.Body.String(), `"models":[]`)
+		entries := logs.FilterMessage("capability_discovery_failed").All()
+		require.Len(t, entries, 1)
+		require.Equal(t, "gateway.codex_models", entries[0].ContextMap()["component"])
+		require.Equal(t, string(service.UniversalProtocolCodex), entries[0].ContextMap()["protocol"])
 	})
 }
 

--- a/backend/internal/service/universal_capability_tk.go
+++ b/backend/internal/service/universal_capability_tk.go
@@ -140,6 +140,7 @@ func (s *UniversalCapabilityService) List(ctx context.Context, apiKey *APIKey, p
 	if err != nil {
 		return nil, err
 	}
+	groups = universalCapabilityGroupsForProtocol(groups, protocol)
 	if len(groups) == 0 {
 		return []UniversalCapability{}, nil
 	}
@@ -217,6 +218,26 @@ func activeCapabilityGroups(groups []Group) []Group {
 	out := make([]Group, 0, len(groups))
 	for i := range groups {
 		if groups[i].IsActive() && !isUniversalProbeGroup(groups[i]) {
+			out = append(out, groups[i])
+		}
+	}
+	return out
+}
+
+func universalCapabilityGroupsForProtocol(groups []Group, protocol UniversalProtocol) []Group {
+	forcedPlatform := ""
+	for _, spec := range universalCapabilityShapes {
+		if spec.protocol == protocol && spec.forcedPlatform != "" {
+			forcedPlatform = spec.forcedPlatform
+			break
+		}
+	}
+	if forcedPlatform == "" {
+		return groups
+	}
+	out := make([]Group, 0, len(groups))
+	for i := range groups {
+		if groups[i].Platform == forcedPlatform {
 			out = append(out, groups[i])
 		}
 	}

--- a/backend/internal/service/us046_universal_capability_test.go
+++ b/backend/internal/service/us046_universal_capability_test.go
@@ -207,6 +207,57 @@ func TestUS046_CapabilitiesPropagateProviderFailureInsteadOfReturningEmpty(t *te
 	require.ErrorIs(t, err, wantErr)
 }
 
+func TestUS046_ForcedPlatformDiscoveryIgnoresUnrelatedProviderFailure(t *testing.T) {
+	openAIGroup := us046ActiveGroup(10, PlatformOpenAI, false)
+	anthropicGroup := us046ActiveGroup(20, PlatformAnthropic, false)
+	wantErr := errors.New("unrelated provider unavailable")
+	var candidateGroups []int64
+	svc := newUniversalCapabilityService(
+		&us046EntitlementStub{groups: []Group{anthropicGroup, openAIGroup}},
+		func(_ context.Context, groupID int64, _ string) ([]string, bool, error) {
+			candidateGroups = append(candidateGroups, groupID)
+			if groupID == anthropicGroup.ID {
+				return nil, false, wantErr
+			}
+			return []string{"gpt-codex"}, false, nil
+		},
+		func(_ context.Context, groupID int64, _ string, model string, shape UniversalShape) (bool, error) {
+			return groupID == openAIGroup.ID && model == "gpt-codex" && shape == ShapeOpenAIChat, nil
+		},
+		nil,
+	)
+
+	models, err := svc.List(
+		context.Background(),
+		&APIKey{UserID: 9, RoutingMode: RoutingModeUniversal},
+		UniversalProtocolCodex,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []int64{openAIGroup.ID}, candidateGroups)
+	require.Len(t, models, 1)
+	require.Equal(t, openAIGroup.ID, models[0].SelectedGroup.ID)
+}
+
+func TestUS046_ForcedPlatformDiscoveryPropagatesRelevantProviderFailure(t *testing.T) {
+	openAIGroup := us046ActiveGroup(10, PlatformOpenAI, false)
+	wantErr := errors.New("openai provider unavailable")
+	svc := newUniversalCapabilityService(
+		&us046EntitlementStub{groups: []Group{openAIGroup}},
+		func(context.Context, int64, string) ([]string, bool, error) {
+			return nil, false, wantErr
+		},
+		nil,
+		nil,
+	)
+
+	_, err := svc.List(
+		context.Background(),
+		&APIKey{UserID: 9, RoutingMode: RoutingModeUniversal},
+		UniversalProtocolCodex,
+	)
+	require.ErrorIs(t, err, wantErr)
+}
+
 func TestUS046_CapabilitiesUnionMappedAndPassthroughCandidates(t *testing.T) {
 	group := us046ActiveGroup(10, PlatformOpenAI, false)
 	svc := newUniversalCapabilityService(

--- a/backend/internal/service/us046_universal_capability_test.go
+++ b/backend/internal/service/us046_universal_capability_test.go
@@ -258,6 +258,37 @@ func TestUS046_ForcedPlatformDiscoveryPropagatesRelevantProviderFailure(t *testi
 	require.ErrorIs(t, err, wantErr)
 }
 
+func TestUS046_AntigravityDiscoveryIgnoresUnrelatedProviderFailure(t *testing.T) {
+	antigravityGroup := us046ActiveGroup(10, PlatformAntigravity, false)
+	openAIGroup := us046ActiveGroup(20, PlatformOpenAI, false)
+	wantErr := errors.New("unrelated provider unavailable")
+	var candidateGroups []int64
+	svc := newUniversalCapabilityService(
+		&us046EntitlementStub{groups: []Group{openAIGroup, antigravityGroup}},
+		func(_ context.Context, groupID int64, _ string) ([]string, bool, error) {
+			candidateGroups = append(candidateGroups, groupID)
+			if groupID == openAIGroup.ID {
+				return nil, false, wantErr
+			}
+			return []string{"gemini-antigravity"}, false, nil
+		},
+		func(_ context.Context, groupID int64, _ string, model string, shape UniversalShape) (bool, error) {
+			return groupID == antigravityGroup.ID && model == "gemini-antigravity" && shape == ShapeGemini, nil
+		},
+		nil,
+	)
+
+	models, err := svc.List(
+		context.Background(),
+		&APIKey{UserID: 9, RoutingMode: RoutingModeUniversal},
+		UniversalProtocolAntigravity,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []int64{antigravityGroup.ID}, candidateGroups)
+	require.Len(t, models, 1)
+	require.Equal(t, antigravityGroup.ID, models[0].SelectedGroup.ID)
+}
+
 func TestUS046_CapabilitiesUnionMappedAndPassthroughCandidates(t *testing.T) {
 	group := us046ActiveGroup(10, PlatformOpenAI, false)
 	svc := newUniversalCapabilityService(

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6847,11 +6847,12 @@
         "UniversalGroupSupportsRequestStrict",
         "FilterClientFacingStrict",
         "ids = append(ids, fallbackIDs...)",
+        "groups = universalCapabilityGroupsForProtocol(groups, protocol)",
         "supportedGroups := make([]Group, 0, len(groups))",
         "s.isAccountAllowedForPlatform(&accounts[i], platform, useMixed)",
         "strings.HasSuffix(model, \"*\")"
       ],
-      "rationale": "Single backend owner for per-key callable capability truth. It must enumerate entitled groups, union exact mappings with native/wildcard catalog expansion and mixed-scheduling accounts, apply strict availability filtering, and shrink resolver input to groups confirmed by direct-scheduler semantics. Losing these calls can either advertise an unsupported custom model or hide a callable mixed/wildcard model."
+      "rationale": "Single backend owner for per-key callable capability truth. It must enumerate entitled groups, prune forced-platform protocols before provider reads, union exact mappings with native/wildcard catalog expansion and mixed-scheduling accounts, apply strict availability filtering, and shrink resolver input to groups confirmed by direct-scheduler semantics. Losing these calls can let an irrelevant provider outage break Codex discovery, advertise an unsupported custom model, or hide a callable mixed/wildcard model."
     },
     {
       "path": "backend/internal/service/model_list_filter_tk.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6878,10 +6878,44 @@
       "must_contain": [
         "allowedModelIDs, err := h.resolveCodexDiscoveryAPIKey",
         "if allowedModelIDs != nil && len(allowedModelIDs) == 0",
+        "requestLogger(c, \"gateway.codex_models\").Warn(\"capability_discovery_failed\", zap.Error(err))",
         "func filterCodexModelsManifest(",
         "envelope[\"models\"] = encodedModels"
       ],
-      "rationale": "Codex discovery may reuse an upstream manifest only as a schema template. Automatic keys must return a native empty manifest for a genuine no-capability set, otherwise filter models[] to capability-authorized slugs while preserving unknown manifest fields; removing either projection turns an empty business set into 503 or advertises every upstream model."
+      "rationale": "Codex discovery may reuse an upstream manifest only as a schema template. Automatic keys must return a native empty manifest for a genuine no-capability set, otherwise filter models[] to capability-authorized slugs while preserving unknown manifest fields; removing either projection turns an empty business set into 503 or advertises every upstream model. Internal provider failures must also retain a request-scoped structured warning while the client response stays sanitized, otherwise future discovery incidents revert to generic 500s with no attributable cause."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler.go",
+      "must_contain": [
+        "requestLogger(c, \"gateway.models\", zap.String(\"protocol\", string(protocol))).Warn(\"capability_discovery_failed\", zap.Error(err))",
+        "requestLogger(c, \"gateway.antigravity_models\", zap.String(\"protocol\", string(service.UniversalProtocolAntigravity))).Warn(\"capability_discovery_failed\", zap.Error(err))"
+      ],
+      "rationale": "Universal OpenAI/Anthropic and Antigravity discovery failures must preserve their internal provider cause in request-scoped structured warnings while returning sanitized client errors. These upstream-shaped handler call sites are easy to lose during merges without a compile failure, which would recreate unattributable intermittent /models 500s."
+    },
+    {
+      "path": "backend/internal/handler/gemini_v1beta_handler.go",
+      "must_contain": [
+        "requestLogger(c, \"gateway.gemini_models\", zap.String(\"protocol\", string(service.UniversalProtocolGemini))).Warn(\"capability_discovery_failed\", zap.Error(err))"
+      ],
+      "rationale": "Universal Gemini discovery must keep the same internal-error observability contract as the other native model-list endpoints: request-scoped structured cause, sanitized client response. An upstream merge can drop this warning while all response tests remain green, leaving Gemini /v1beta/models 500s unattributable."
+    },
+    {
+      "path": "backend/internal/handler/us046_universal_discovery_test.go",
+      "must_contain": [
+        "logs.FilterMessage(\"capability_discovery_failed\")",
+        "gateway.antigravity_models",
+        "gateway.gemini_models"
+      ],
+      "rationale": "Focused handler regressions prove native universal discovery returns fail-hard 500s and emits the structured internal warning for Antigravity and Gemini instead of silently returning a generic error."
+    },
+    {
+      "path": "backend/internal/service/us046_universal_capability_test.go",
+      "must_contain": [
+        "TestUS046_ForcedPlatformDiscoveryIgnoresUnrelatedProviderFailure",
+        "TestUS046_ForcedPlatformDiscoveryPropagatesRelevantProviderFailure",
+        "TestUS046_AntigravityDiscoveryIgnoresUnrelatedProviderFailure"
+      ],
+      "rationale": "Forced-platform discovery regressions must prove both owners: Codex/OpenAI and the multi-shape Antigravity protocol prune unrelated groups before candidate-provider reads, while relevant provider failures remain explicit."
     },
     {
       "path": "backend/internal/handler/api_key_capability_handler_tk.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6878,7 +6878,9 @@
       "must_contain": [
         "allowedModelIDs, err := h.resolveCodexDiscoveryAPIKey",
         "if allowedModelIDs != nil && len(allowedModelIDs) == 0",
-        "requestLogger(c, \"gateway.codex_models\").Warn(\"capability_discovery_failed\", zap.Error(err))",
+        "\"gateway.codex_models\"",
+        "zap.String(\"protocol\", string(service.UniversalProtocolCodex))",
+        ").Warn(\"capability_discovery_failed\", zap.Error(err))",
         "func filterCodexModelsManifest(",
         "envelope[\"models\"] = encodedModels"
       ],
@@ -6904,9 +6906,10 @@
       "must_contain": [
         "logs.FilterMessage(\"capability_discovery_failed\")",
         "gateway.antigravity_models",
+        "gateway.codex_models",
         "gateway.gemini_models"
       ],
-      "rationale": "Focused handler regressions prove native universal discovery returns fail-hard 500s and emits the structured internal warning for Antigravity and Gemini instead of silently returning a generic error."
+      "rationale": "Focused handler regressions prove native universal discovery returns fail-hard 500s and emits one uniform component + protocol structured warning across Codex, Antigravity, and Gemini instead of silently returning a generic error."
     },
     {
       "path": "backend/internal/service/us046_universal_capability_test.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6878,13 +6878,10 @@
       "must_contain": [
         "allowedModelIDs, err := h.resolveCodexDiscoveryAPIKey",
         "if allowedModelIDs != nil && len(allowedModelIDs) == 0",
-        "\"gateway.codex_models\"",
-        "zap.String(\"protocol\", string(service.UniversalProtocolCodex))",
-        ").Warn(\"capability_discovery_failed\", zap.Error(err))",
         "func filterCodexModelsManifest(",
         "envelope[\"models\"] = encodedModels"
       ],
-      "rationale": "Codex discovery may reuse an upstream manifest only as a schema template. Automatic keys must return a native empty manifest for a genuine no-capability set, otherwise filter models[] to capability-authorized slugs while preserving unknown manifest fields; removing either projection turns an empty business set into 503 or advertises every upstream model. Internal provider failures must also retain a request-scoped structured warning while the client response stays sanitized, otherwise future discovery incidents revert to generic 500s with no attributable cause."
+      "rationale": "Codex discovery may reuse an upstream manifest only as a schema template. Automatic keys must return a native empty manifest for a genuine no-capability set, otherwise filter models[] to capability-authorized slugs while preserving unknown manifest fields; removing either projection turns an empty business set into 503 or advertises every upstream model."
     },
     {
       "path": "backend/internal/handler/gateway_handler.go",
@@ -6906,10 +6903,9 @@
       "must_contain": [
         "logs.FilterMessage(\"capability_discovery_failed\")",
         "gateway.antigravity_models",
-        "gateway.codex_models",
         "gateway.gemini_models"
       ],
-      "rationale": "Focused handler regressions prove native universal discovery returns fail-hard 500s and emits one uniform component + protocol structured warning across Codex, Antigravity, and Gemini instead of silently returning a generic error."
+      "rationale": "Focused handler regressions prove native universal discovery returns fail-hard 500s and emits one uniform component + protocol structured warning for Antigravity and Gemini instead of silently returning a generic error. Codex root-cause ownership is maintained by its dedicated ops error path."
     },
     {
       "path": "backend/internal/service/us046_universal_capability_test.go",


### PR DESCRIPTION
## 摘要

- Universal capability discovery 在读取候选/provider 前，先按协议现有 capability shape 的 forcedPlatform 收窄 entitlement group。
- Codex 只读取 OpenAI group；Antigravity 只读取 Antigravity group；OpenAI / Anthropic / Gemini / all 保持原有跨平台发现语义。
- 相关平台 provider 失败仍显式返回 5xx；无关平台故障不再中断当前协议发现。
- Gemini 与 Antigravity projection 保留 request-scoped structured warning；Codex 根因归因由 #1839 的专用 ops owner 统一承载，避免双日志和双 sentinel 契约。
- 更新 gateway sentinel，锚定 forced-platform 隔离边界。

## 风险

- 高：触及客户端模型发现与 capability SSOT，但不改变协议路由、调度顺序、外部响应 schema 或 Web surface。
- forcedPlatform 直接从既有 capability shape 派生，没有新增第二套协议/平台映射。
- 相关 provider 读取失败继续 fail-closed；业务空集仍返回原生空列表。

## 验证

- `go test -tags=unit ./internal/service -run TestUS046_ -count=1`
- `go test -tags=unit ./internal/handler -run TestUS046_ -count=1`
- `go test -tags=unit ./internal/service ./internal/handler -count=1`
- `python3 scripts/sentinels/check-gateway-tk.py --quiet`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`（HEAD `c19b15a9a` PASS）
- 与 #1839 的联合 merge-tree 无冲突；联合 handler/service/repository unit tests、gateway sentinel、protocol-routing SSOT 检查通过。

`no-web-impact`
`sentinel-registry-reviewed`

## 提交

- `cb9c99474 fix(discovery): isolate forced-platform capability reads`
- `3d0fe5cff fix(discovery): log capability provider failures`
- `b41f188d2 fix(discovery): address review observability gaps`
- `27b316e80 fix(discovery): address R-001 — unify Codex warning fields`
- `c19b15a9a fix(discovery): keep Codex failure ownership singular`
- 最新提交：`c19b15a9a`

ai
