### PR TITLE
perf(ci): overlap bottlenecks and roll lint cache

### DIFF
--- a/.github/actions/go-rolling-cache/action.yml
+++ b/.github/actions/go-rolling-cache/action.yml
@@ -6,7 +6,7 @@
 # save race poisoned the others, so the test-result cache effectively never
 # restored and every run cold-compiled + re-ran all packages.
 #
-# Two caches, deliberately split:
+# Three caches, deliberately split:
 #   - module cache: identical across all jobs, only changes with go.sum, so one
 #     shared immutable entry is correct and avoids triplicating ~1GB of
 #     GOMODCACHE against the 10GB/repo budget.
@@ -14,6 +14,10 @@
 #     forward every run; restore-keys seeds from the previous run (incremental,
 #     not cold). Go's cache is content-addressed, so a stale entry is unused,
 #     never wrong.
+#   - golangci analysis cache: optional, lint-only, and rolling for the same
+#     reason. golangci-lint-action's interval key is immutable after the first
+#     save, so changed-package analysis cannot be written back until the interval
+#     changes. Main owns the rolling writer; PRs restore but never save.
 #
 # Set `cache: false` on the calling job's actions/setup-go step and call this
 # AFTER it (mirrors warm-release-cache in backend-ci.yml).
@@ -24,6 +28,10 @@ inputs:
   prefix:
     description: Per-job cache namespace (e.g. unit / integration / lint) — keeps build objects from colliding across build tags.
     required: true
+  golangci_cache:
+    description: Also roll ~/.cache/golangci-lint (enable only for the lint job).
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -63,3 +71,23 @@ runs:
         restore-keys: |
           ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.sum') }}-
           ${{ runner.os }}-gobuild-${{ inputs.prefix }}-
+
+    - name: Restore golangci-lint analysis cache (non-main writer)
+      if: inputs.golangci_cache == 'true' && (github.event_name != 'push' || github.ref != 'refs/heads/main')
+      uses: actions/cache/restore@v6
+      with:
+        path: ~/.cache/golangci-lint
+        key: ${{ runner.os }}-golangci-${{ hashFiles('backend/go.sum', 'backend/.golangci.yml') }}-${{ github.run_id }}
+        restore-keys: |
+          ${{ runner.os }}-golangci-${{ hashFiles('backend/go.sum', 'backend/.golangci.yml') }}-
+          ${{ runner.os }}-golangci-
+
+    - name: golangci-lint analysis cache (rolling main writer)
+      if: inputs.golangci_cache == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/golangci-lint
+        key: ${{ runner.os }}-golangci-${{ hashFiles('backend/go.sum', 'backend/.golangci.yml') }}-${{ github.run_id }}
+        restore-keys: |
+          ${{ runner.os }}-golangci-${{ hashFiles('backend/go.sum', 'backend/.golangci.yml') }}-
+          ${{ runner.os }}-golangci-

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -109,6 +109,7 @@ jobs:
             scripts.checks.test_release_cache_key_parity \
             scripts.checks.test_go_rolling_cache_policy \
             scripts.test_preflight_ci_handoffs \
+            scripts.test_preflight_background_output \
             scripts.test_ci_gate_handoffs \
             scripts.ci.test_changed_surfaces \
             scripts.test_backend_ci_routing

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -296,8 +296,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/cache-and-checkout-new-api
       # cache:false + ./.github/actions/go-rolling-cache — see test-unit above.
-      # golangci-lint-action manages its own analysis cache (~/.cache/golangci-lint)
-      # on top of the GOCACHE this rolls; the two are independent.
+      # The composite also rolls ~/.cache/golangci-lint from main. The action's
+      # built-in interval cache is immutable after its first save, so it cannot
+      # persist changed-package analysis again until the interval key changes.
       - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod
@@ -306,6 +307,7 @@ jobs:
       - uses: ./.github/actions/go-rolling-cache
         with:
           prefix: lint
+          golangci_cache: "true"
       - name: Verify Go version
         run: |
           expected=$(awk '/^go /{print $2; exit}' backend/go.mod)
@@ -319,6 +321,7 @@ jobs:
           args: --concurrency=4 --timeout=30m
           working-directory: backend
           only-new-issues: false
+          skip-cache: "true"
 
   backend-security:
     needs: changes

--- a/scripts/checks/test_go_rolling_cache_policy.py
+++ b/scripts/checks/test_go_rolling_cache_policy.py
@@ -18,16 +18,36 @@ class GoRollingCachePolicyTest(unittest.TestCase):
     def test_only_main_push_steps_can_save_caches(self) -> None:
         steps = yaml.safe_load(ACTION.read_text(encoding="utf-8"))["runs"]["steps"]
         saving = [step for step in steps if step.get("uses") == "actions/cache@v6"]
-        self.assertEqual(len(saving), 2)
-        self.assertTrue(all(step.get("if") == MAIN_WRITER_IF for step in saving))
+        self.assertEqual(len(saving), 3)
+        self.assertTrue(all(MAIN_WRITER_IF in step.get("if", "") for step in saving))
 
-    def test_non_main_events_restore_but_never_save_both_cache_layers(self) -> None:
+    def test_non_main_events_restore_but_never_save_all_cache_layers(self) -> None:
         steps = yaml.safe_load(ACTION.read_text(encoding="utf-8"))["runs"]["steps"]
         restore_only = [step for step in steps if step.get("uses") == "actions/cache/restore@v6"]
-        self.assertEqual(len(restore_only), 2)
-        self.assertTrue(all(step.get("if") == NON_MAIN_IF for step in restore_only))
+        self.assertEqual(len(restore_only), 3)
+        self.assertTrue(all(NON_MAIN_IF in step.get("if", "") for step in restore_only))
         restored_paths = {step["with"]["path"] for step in restore_only}
-        self.assertEqual(restored_paths, {"~/go/pkg/mod", "~/.cache/go-build"})
+        self.assertEqual(
+            restored_paths,
+            {"~/go/pkg/mod", "~/.cache/go-build", "~/.cache/golangci-lint"},
+        )
+
+    def test_golangci_cache_is_opt_in_and_rolls_from_main(self) -> None:
+        action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
+        self.assertEqual(action["inputs"]["golangci_cache"]["default"], "false")
+        steps = action["runs"]["steps"]
+        golangci_steps = [
+            step
+            for step in steps
+            if step.get("with", {}).get("path") == "~/.cache/golangci-lint"
+        ]
+        self.assertEqual(len(golangci_steps), 2)
+        for step in golangci_steps:
+            with self.subTest(step=step["name"]):
+                self.assertIn("inputs.golangci_cache == 'true'", step["if"])
+                self.assertIn("github.run_id", step["with"]["key"])
+                self.assertIn("backend/go.sum", step["with"]["key"])
+                self.assertIn("backend/.golangci.yml", step["with"]["key"])
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_unit_test_runner.py
+++ b/scripts/ci/test_unit_test_runner.py
@@ -254,6 +254,37 @@ class UnitTestRunnerTest(unittest.TestCase):
         self.assertLess(min(durations), 0.5)
         self.assertGreaterEqual(max(durations), 0.7)
 
+    def test_runs_other_packages_while_service_binary_compiles(self) -> None:
+        with self._fake_go(
+            ["TestOne", "TestTwo"],
+            compile_delay=0.75,
+        ) as fixture:
+            result = self._run(fixture, "--min-shards", "2")
+            events = self._events(fixture.events)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        compile_finished = next(
+            event["at"]
+            for event in events
+            if event["kind"] == "go-finished" and "-c" in event["args"]
+        )
+        other_started = next(
+            event["at"]
+            for event in events
+            if event["kind"] == "go"
+            and "./internal/other" in event["args"]
+        )
+        self.assertLess(other_started, compile_finished, events)
+
+    def test_reports_discovery_compile_and_registry_stage_durations(self) -> None:
+        with self._fake_go(["TestOne"]) as fixture:
+            result = self._run(fixture)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertRegex(result.stdout, r"STAGE discovery \([0-9.]+s\)")
+        self.assertRegex(result.stdout, r"STAGE service-compile \([0-9.]+s\)")
+        self.assertRegex(result.stdout, r"STAGE registry-check \([0-9.]+s\)")
+
     def _run(self, fixture: "FakeGoFixture", *args: str) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env["PATH"] = f"{fixture.bin_dir}{os.pathsep}{env['PATH']}"
@@ -269,6 +300,8 @@ class UnitTestRunnerTest(unittest.TestCase):
             env["FAKE_GO_FAIL_TEST"] = fixture.fail_test
         if fixture.slow_test:
             env["FAKE_GO_SLOW_TEST"] = fixture.slow_test
+        if fixture.compile_delay:
+            env["FAKE_GO_COMPILE_DELAY"] = str(fixture.compile_delay)
         return subprocess.run(
             ["python3", str(SCRIPT), "--root", str(fixture.root), *args],
             check=False,
@@ -314,6 +347,7 @@ class UnitTestRunnerTest(unittest.TestCase):
         fail_compile: bool = False,
         fail_test: str | None = None,
         slow_test: str | None = None,
+        compile_delay: float = 0.0,
     ) -> "FakeGoFixtureContext":
         return FakeGoFixtureContext(
             test_names,
@@ -322,6 +356,7 @@ class UnitTestRunnerTest(unittest.TestCase):
             fail_compile,
             fail_test,
             slow_test,
+            compile_delay,
         )
 
 
@@ -335,6 +370,7 @@ class FakeGoFixture:
         fail_compile: bool,
         fail_test: str | None,
         slow_test: str | None,
+        compile_delay: float,
     ) -> None:
         self._temporary = temporary
         self.root = Path(temporary.name)
@@ -348,6 +384,7 @@ class FakeGoFixture:
         self.fail_compile = fail_compile
         self.fail_test = fail_test
         self.slow_test = slow_test
+        self.compile_delay = compile_delay
         service_dir = self.root / "internal" / "service"
         service_dir.mkdir(parents=True)
         declarations = []
@@ -379,6 +416,7 @@ class FakeGoFixtureContext:
         fail_compile: bool,
         fail_test: str | None,
         slow_test: str | None,
+        compile_delay: float,
     ) -> None:
         self.test_names = test_names
         self.has_test_main = has_test_main
@@ -386,6 +424,7 @@ class FakeGoFixtureContext:
         self.fail_compile = fail_compile
         self.fail_test = fail_test
         self.slow_test = slow_test
+        self.compile_delay = compile_delay
         self.temporary: tempfile.TemporaryDirectory[str] | None = None
 
     def __enter__(self) -> FakeGoFixture:
@@ -398,6 +437,7 @@ class FakeGoFixtureContext:
             self.fail_compile,
             self.fail_test,
             self.slow_test,
+            self.compile_delay,
         )
         fake_binary_source = textwrap.dedent(
             """\
@@ -434,11 +474,12 @@ class FakeGoFixtureContext:
                 import os
                 from pathlib import Path
                 import sys
+                import time
 
                 args = sys.argv[1:]
                 events = Path(os.environ["FAKE_GO_EVENTS"])
                 with events.open("a", encoding="utf-8") as output:
-                    output.write(json.dumps({"kind": "go", "args": args}) + "\\n")
+                    output.write(json.dumps({"kind": "go", "args": args, "at": time.monotonic()}) + "\\n")
 
                 if args and args[0] == "run":
                     print(json.dumps({
@@ -461,6 +502,9 @@ class FakeGoFixtureContext:
                     raise SystemExit(0)
 
                 if "-c" in args:
+                    time.sleep(float(os.environ.get("FAKE_GO_COMPILE_DELAY", "0")))
+                    with events.open("a", encoding="utf-8") as output:
+                        output.write(json.dumps({"kind": "go-finished", "args": args, "at": time.monotonic()}) + "\\n")
                     if os.environ.get("FAKE_GO_FAIL_COMPILE") == "1":
                         print("intentional compile failure", file=sys.stderr)
                         raise SystemExit(1)

--- a/scripts/ci/unit_test_runner.py
+++ b/scripts/ci/unit_test_runner.py
@@ -35,6 +35,9 @@ class Command:
     cwd: Path
 
 
+RunningCommand = tuple[Command, subprocess.Popen[bytes], Path, float]
+
+
 def _run_checked(argv: list[str], root: Path) -> str:
     result = subprocess.run(
         argv,
@@ -238,7 +241,7 @@ def _last_summary(output: str) -> str:
 
 
 def _terminate_processes(
-    running: list[tuple[Command, subprocess.Popen[bytes], Path, float]],
+    running: list[RunningCommand],
 ) -> None:
     for _, process, _, _ in running:
         if process.poll() is not None:
@@ -255,10 +258,13 @@ def _terminate_processes(
             process.wait()
 
 
-def run_commands(commands: list[Command]) -> int:
+def run_commands(
+    commands: list[Command],
+    initial_running: list[RunningCommand] | None = None,
+) -> int:
     with tempfile.TemporaryDirectory(prefix="sub2api-unit-") as temporary:
         log_dir = Path(temporary)
-        running: list[tuple[Command, subprocess.Popen[bytes], Path, float]] = []
+        running = list(initial_running or [])
         handles = []
         try:
             for index, command in enumerate(commands):
@@ -313,11 +319,17 @@ def run_unit_tests(
     min_shards: int,
     max_regex_bytes: int,
 ) -> int:
+    discovery_started_at = time.monotonic()
     other_packages, service_tests, patterns, has_test_main = build_test_plan(
         root,
         service_package,
         min_shards,
         max_regex_bytes,
+    )
+    print(
+        f"unit-test-runner: STAGE discovery "
+        f"({time.monotonic() - discovery_started_at:.1f}s)",
+        flush=True,
     )
     if has_test_main:
         print("unit-test-runner: TestMain detected; using native go test")
@@ -328,20 +340,6 @@ def run_unit_tests(
         ).returncode
     with tempfile.TemporaryDirectory(prefix="sub2api-service-test-") as temporary:
         service_binary = Path(temporary) / "service.test"
-        _run_checked(
-            [
-                "go",
-                "test",
-                "-c",
-                "-tags=unit",
-                "-o",
-                str(service_binary),
-                service_package,
-            ],
-            root,
-        )
-        service_dir = root / service_package.removeprefix("./")
-        verify_binary_registry(service_binary, service_dir, service_tests)
         commands = build_commands(
             root,
             service_package,
@@ -349,7 +347,59 @@ def run_unit_tests(
             other_packages,
             patterns,
         )
-        return run_commands(commands)
+        other_commands = [command for command in commands if command.label == "other-packages"]
+        service_commands = [command for command in commands if command.label != "other-packages"]
+        with tempfile.TemporaryDirectory(prefix="sub2api-unit-overlap-") as overlap_temp:
+            initial_running: list[RunningCommand] = []
+            other_handle = None
+            try:
+                if other_commands:
+                    other_command = other_commands[0]
+                    other_log = Path(overlap_temp) / "other-packages.log"
+                    other_handle = other_log.open("wb")
+                    other_process = subprocess.Popen(
+                        other_command.argv,
+                        cwd=other_command.cwd,
+                        stdout=other_handle,
+                        stderr=subprocess.STDOUT,
+                    )
+                    initial_running.append(
+                        (other_command, other_process, other_log, time.monotonic())
+                    )
+
+                compile_started_at = time.monotonic()
+                _run_checked(
+                    [
+                        "go",
+                        "test",
+                        "-c",
+                        "-tags=unit",
+                        "-o",
+                        str(service_binary),
+                        service_package,
+                    ],
+                    root,
+                )
+                print(
+                    f"unit-test-runner: STAGE service-compile "
+                    f"({time.monotonic() - compile_started_at:.1f}s)",
+                    flush=True,
+                )
+                service_dir = root / service_package.removeprefix("./")
+                registry_started_at = time.monotonic()
+                verify_binary_registry(service_binary, service_dir, service_tests)
+                print(
+                    f"unit-test-runner: STAGE registry-check "
+                    f"({time.monotonic() - registry_started_at:.1f}s)",
+                    flush=True,
+                )
+                return run_commands(service_commands, initial_running)
+            except BaseException:
+                _terminate_processes(initial_running)
+                raise
+            finally:
+                if other_handle is not None:
+                    other_handle.close()
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -2232,7 +2232,7 @@ if ! command -v python3 >/dev/null 2>&1; then
 else
     _bg_rc=1
     if _bg_spawned anthropic_unittest; then
-        _bg_join anthropic_unittest
+        _bg_join anthropic_unittest replay-on-failure
     fi
     if [ "$_bg_rc" -ne 0 ]; then
         echo "  FAIL: ops/anthropic unittest failed (re-run: python3 -m unittest discover -s ops/anthropic -p 'test_*.py' -t ops/anthropic -v)"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -178,6 +178,31 @@ _bg_join() {  # _bg_join <key> [replay-on-failure] → sets _bg_rc; output in $_
 }
 _bg_spawned() { [ -f "$_preflight_bg_dir/$1.pid" ]; }
 
+_archive_rehearsal_gate_run() {
+    local script
+    for script in \
+        ./ops/archive/test_data_layer_archive_rehearsal.py \
+        ./ops/archive/test_data_layer_archive_prod_canary.py \
+        ./ops/archive/test_data_layer_archive_prod_export.py \
+        ./ops/archive/test_data_layer_archive_promote_batch.py \
+        ./ops/archive/test_data_layer_archive_cleanup_hold.py; do
+        if ! python3 "$script"; then
+            printf 'failed command: python3 %s\n' "${script#./}"
+            return 1
+        fi
+    done
+    if ! python3 ./scripts/checks/data-layer-archive-ssot.py --quiet; then
+        echo "failed command: python3 scripts/checks/data-layer-archive-ssot.py"
+        return 1
+    fi
+}
+
+_archive_rehearsal_spawn_if_needed() {
+    if [ "$_preflight_skip_slow_ops" -ne 1 ] && command -v python3 >/dev/null 2>&1; then
+        _bg_spawn archive_rehearsal _archive_rehearsal_gate_run
+    fi
+}
+
 # ---- Sections 1-8: delegate to dev-rules template ----------------------------
 if [ ! -x ./dev-rules/templates/preflight.sh ]; then
     echo "FAIL: dev-rules submodule not initialized."
@@ -1365,6 +1390,11 @@ else
     echo "  ok: edge_phase1_baseline.py present (Phase 1 soak probe wired)"
 fi
 
+# Start the Docker-backed archive rehearsal here instead of at preflight startup:
+# the following QA baseline and lightweight contracts provide enough overlap,
+# while avoiding extra Docker pressure during the initial Caddy/template fanout.
+_archive_rehearsal_spawn_if_needed
+
 # ---- sub2api: QA Phase 1 closeout + Phase 2 baseline ops -------------------
 echo ""
 echo "=== sub2api: QA Phase 1 closeout + Phase 2 baseline ==="
@@ -1686,32 +1716,17 @@ if [ "$_preflight_skip_slow_ops" -eq 1 ]; then
 elif ! command -v python3 >/dev/null 2>&1; then
     echo "  FAIL: python3 not on PATH (required for archive rehearsal tests)"
     errors=$((errors + 1))
-elif ! python3 ./ops/archive/test_data_layer_archive_rehearsal.py >/dev/null 2>&1; then
-    echo "  FAIL: nonprod archive/restore rehearsal contracts"
-    echo "        — run: python3 ops/archive/test_data_layer_archive_rehearsal.py"
-    errors=$((errors + 1))
-elif ! python3 ./ops/archive/test_data_layer_archive_prod_canary.py >/dev/null 2>&1; then
-    echo "  FAIL: production export-only archive canary contracts"
-    echo "        — run: python3 ops/archive/test_data_layer_archive_prod_canary.py"
-    errors=$((errors + 1))
-elif ! python3 ./ops/archive/test_data_layer_archive_prod_export.py >/dev/null 2>&1; then
-    echo "  FAIL: production legacy cold batch export contracts"
-    echo "        — run: python3 ops/archive/test_data_layer_archive_prod_export.py"
-    errors=$((errors + 1))
-elif ! python3 ./ops/archive/test_data_layer_archive_promote_batch.py >/dev/null 2>&1; then
-    echo "  FAIL: production archive promote contracts"
-    echo "        — run: python3 ops/archive/test_data_layer_archive_promote_batch.py"
-    errors=$((errors + 1))
-elif ! python3 ./ops/archive/test_data_layer_archive_cleanup_hold.py >/dev/null 2>&1; then
-    echo "  FAIL: production archive cleanup hold contracts"
-    echo "        — run: python3 ops/archive/test_data_layer_archive_cleanup_hold.py"
-    errors=$((errors + 1))
-elif ! python3 ./scripts/checks/data-layer-archive-ssot.py --quiet; then
-    echo "  FAIL: data-layer archive pipeline_status ↔ rehearsal constants drift"
-    echo "        — run: python3 scripts/checks/data-layer-archive-ssot.py"
+elif ! _bg_spawned archive_rehearsal; then
+    echo "  FAIL: archive rehearsal background job was not spawned (internal preflight bug)"
     errors=$((errors + 1))
 else
-    echo "  ok: nonprod rehearsal + cleanup hold + export canary + legacy export + archive promote"
+    _bg_join archive_rehearsal replay-on-failure
+    if [ "$_bg_rc" -ne 0 ]; then
+        echo "  FAIL: nonprod archive/restore rehearsal contracts"
+        errors=$((errors + 1))
+    else
+        echo "  ok: nonprod rehearsal + cleanup hold + export canary + legacy export + archive promote"
+    fi
 fi
 
 # ---- sub2api: runtime resource config verdict selftest ---------------------

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -138,6 +138,17 @@ class BackendCIRoutingTest(unittest.TestCase):
             contract_step.get("run", ""),
         )
 
+    def test_preflight_background_output_contract_runs_in_orchestration_gate(self) -> None:
+        orchestration = next(
+            step
+            for step in self.jobs["preflight"]["steps"]
+            if step.get("name") == "CI orchestration contract tests"
+        )
+        self.assertIn(
+            "scripts.test_preflight_background_output",
+            orchestration.get("run", ""),
+        )
+
     def test_go_dependent_integration_contract_runs_after_pinned_setup(self) -> None:
         steps = self.jobs["preflight"]["steps"]
         orchestration = next(

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -200,6 +200,23 @@ class BackendCIRoutingTest(unittest.TestCase):
             unit_step["env"]["UNIT_TEST_SERVICE_SHARD"],
         )
 
+    def test_lint_uses_rolling_analysis_cache_instead_of_action_cache(self) -> None:
+        steps = self.jobs["golangci-lint"]["steps"]
+        rolling_cache = next(
+            step
+            for step in steps
+            if step.get("uses") == "./.github/actions/go-rolling-cache"
+        )
+        self.assertEqual(rolling_cache["with"]["prefix"], "lint")
+        self.assertEqual(rolling_cache["with"]["golangci_cache"], "true")
+
+        lint_action = next(
+            step
+            for step in steps
+            if step.get("uses") == "golangci/golangci-lint-action@v9"
+        )
+        self.assertEqual(lint_action["with"]["skip-cache"], "true")
+
     def test_unit_target_uses_go_cache_by_default(self) -> None:
         result = subprocess.run(
             ["make", "-n", "-C", str(BACKEND_MAKEFILE.parent), "test-unit"],

--- a/scripts/test_preflight_background_output.py
+++ b/scripts/test_preflight_background_output.py
@@ -40,6 +40,35 @@ printf 'joined-rc=%s\\n' "$_bg_rc"
         )
 
 
+def _anthropic_gate() -> str:
+    text = PREFLIGHT.read_text(encoding="utf-8")
+    start = text.index('echo "=== sub2api: ops/anthropic orchestrators unittest ==="')
+    end = text.index("# Servable-model allowlist generator", start)
+    return text[start:end]
+
+
+def _run_anthropic_failure_gate() -> subprocess.CompletedProcess[str]:
+    script = f"""
+set -u
+errors=0
+_bg_spawned() {{ return 0; }}
+_bg_join() {{
+    if [ "${{2:-silent}}" = "replay-on-failure" ]; then
+        printf 'captured anthropic traceback\n'
+    fi
+    _bg_rc=1
+}}
+{_anthropic_gate()}
+printf 'errors=%s\n' "$errors"
+"""
+    return subprocess.run(
+        ["bash", "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
 class PreflightBackgroundOutputTest(unittest.TestCase):
     def test_failure_replays_captured_output(self) -> None:
         result = _run_spawned_join(1, "replay-on-failure")
@@ -58,6 +87,13 @@ class PreflightBackgroundOutputTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertNotIn("captured job detail", result.stdout)
         self.assertIn("joined-rc=1", result.stdout)
+
+    def test_anthropic_gate_replays_failure_detail(self) -> None:
+        result = _run_anthropic_failure_gate()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("captured anthropic traceback", result.stdout)
+        self.assertIn("FAIL: ops/anthropic unittest failed", result.stdout)
+        self.assertIn("errors=1", result.stdout)
 
 
 if __name__ == "__main__":

--- a/scripts/test_preflight_background_output.py
+++ b/scripts/test_preflight_background_output.py
@@ -21,6 +21,13 @@ def _shell_function(name: str) -> str:
     raise AssertionError(f"unterminated shell function: {name}")
 
 
+def _optional_shell_function(name: str) -> str:
+    try:
+        return _shell_function(name)
+    except (StopIteration, ValueError, AssertionError):
+        return ""
+
+
 def _run_spawned_join(return_code: int, output_mode: str) -> subprocess.CompletedProcess[str]:
     with tempfile.TemporaryDirectory() as tmp:
         script = f"""
@@ -69,6 +76,54 @@ printf 'errors=%s\n' "$errors"
     )
 
 
+def _archive_gate() -> str:
+    text = PREFLIGHT.read_text(encoding="utf-8")
+    start = text.index('echo "=== sub2api: nonprod archive/restore rehearsal ==="')
+    end = text.index("# ---- sub2api: runtime resource config verdict selftest", start)
+    return text[start:end]
+
+
+def _run_archive_spawn(skip_slow_ops: int) -> subprocess.CompletedProcess[str]:
+    script = f"""
+set -u
+_preflight_skip_slow_ops={skip_slow_ops}
+_bg_spawn() {{ printf 'spawned=%s:%s\n' "$1" "$2"; }}
+{_optional_shell_function("_archive_rehearsal_spawn_if_needed")}
+_archive_rehearsal_spawn_if_needed
+"""
+    return subprocess.run(
+        ["bash", "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _run_archive_failure_gate() -> subprocess.CompletedProcess[str]:
+    script = f"""
+set -u
+errors=0
+_preflight_skip_slow_ops=0
+python3() {{ return 0; }}
+_bg_spawned() {{ return 0; }}
+_bg_join() {{
+    if [ "${{2:-silent}}" = "replay-on-failure" ]; then
+        printf 'captured archive traceback\n'
+        printf 'failed command: python3 ops/archive/test_data_layer_archive_rehearsal.py\n'
+    fi
+    _bg_rc=1
+}}
+{_archive_gate()}
+printf 'errors=%s\n' "$errors"
+"""
+    return subprocess.run(
+        ["bash", "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
 class PreflightBackgroundOutputTest(unittest.TestCase):
     def test_failure_replays_captured_output(self) -> None:
         result = _run_spawned_join(1, "replay-on-failure")
@@ -93,6 +148,30 @@ class PreflightBackgroundOutputTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("captured anthropic traceback", result.stdout)
         self.assertIn("FAIL: ops/anthropic unittest failed", result.stdout)
+        self.assertIn("errors=1", result.stdout)
+
+    def test_archive_gate_spawns_one_composite_background_job(self) -> None:
+        result = _run_archive_spawn(skip_slow_ops=0)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            "spawned=archive_rehearsal:_archive_rehearsal_gate_run",
+            result.stdout,
+        )
+
+    def test_archive_gate_does_not_spawn_when_slow_ops_are_skipped(self) -> None:
+        result = _run_archive_spawn(skip_slow_ops=1)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("spawned=", result.stdout)
+
+    def test_archive_gate_replays_background_failure_detail(self) -> None:
+        result = _run_archive_failure_gate()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("captured archive traceback", result.stdout)
+        self.assertIn(
+            "failed command: python3 ops/archive/test_data_layer_archive_rehearsal.py",
+            result.stdout,
+        )
+        self.assertIn("FAIL: nonprod archive/restore rehearsal contracts", result.stdout)
         self.assertIn("errors=1", result.stdout)
 
 


### PR DESCRIPTION
## 摘要

- 在冷 service unit 路径中，提前启动非 service 包测试，使其与 `service.test` 编译和 registry 校验重叠，并输出 discovery、compile、registry 阶段耗时。
- 在 QA baseline 开始前启动 composite archive rehearsal，内部仍串行执行 PostgreSQL/archive 测试，在原 archive 段位 join 并保留阻塞语义。
- 为 lint job 增加 main-only writer / PR restore-only 的 rolling golangci analysis cache，并关闭 action 内置固定周期 cache。
- 后台 Anthropic 和 archive 检查失败时回放完整诊断；所有 cache ownership 与 workflow wiring 均有机械契约测试。

## 风险

- 常规风险。所有执行重叠发生在原 runner 内；archive 内部不并发启动两个 PostgreSQL 容器，失败仍累计到 preflight errors。
- GOMODCACHE 继续共享，GOCACHE 继续按 job 滚动；新增的 `~/.cache/golangci-lint` 仅 lint opt-in，main push 保存、PR 只恢复。
- 不增加 GitHub Actions job 或 runner；warm steady state 预计降低 lint runner wall time 和 credits。
- 无 Web 影响。

## 验证

- 当前 HEAD CI run `32934419947`：全部检查通过；workflow wall 3m30s，`preflight` job 2m31s，Run preflight step 72s。
- 当前 lint 首轮冷启动：job 3m16s；rolling golangci cache restore 为预期 miss（0.394s），GOCACHE restore 31.1s，lint analysis 143.8s；action 内置 cache restore/save 均明确 skipped。
- 新 cache namespace 只能由 merge 后的 main push 首次写入，因此本轮只证明 wiring/fail-closed 正确；真实 warm-cache 收益需由后续 PR 测量。
- 上一 HEAD CI run `32931859353`：全部检查通过；PR 整体 2m36s，`preflight` job 2m13s，Run preflight step约 72.8s。
- lint 基线：job 约 2m23s，GOCACHE restore 29.6s，lint analysis 94.0s；action 日志显示固定 primary key 命中后不保存更新。
- 本地 cache 隔离：双热 1.82s；Go cache 热而 golangci cache 空 50.66s；Go cache 空而 golangci cache 热 69.94s，并重新生成约 2GB GOCACHE。
- `python3 -m unittest` required orchestration suite：49 tests passed。
- `GOTOOLCHAIN=go1.26.6 make -C backend lint`：0 issues。
- 两次 `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：PASS。

## 提交

- `9e4601440 chore(ci): overlap unit compile with package tests`
- `86ac90d88 perf(ci): overlap archive rehearsal with QA baseline`
- `d609c18ec perf(ci): roll golangci analysis cache from main`

最新提交：`d609c18ec`
