### PR TITLE
fix(gateway): preserve discovery and stream failure semantics

### DIFF
--- a/backend/internal/handler/client_closed_request_tk.go
+++ b/backend/internal/handler/client_closed_request_tk.go
@@ -26,6 +26,24 @@ func writeClientClosedRequest(c *gin.Context, write gatewayErrorResponseFunc) {
 	write(c, statusClientClosedRequest, "api_error", "context canceled")
 }
 
+// markClientClosedForwardRequest records a Forward-time caller cancellation
+// without writing a body to a connection that no longer has a receiver.
+func markClientClosedForwardRequest(c *gin.Context) {
+	if c == nil || c.Writer == nil {
+		return
+	}
+	service.MarkOpsClientClosedRequest(c)
+	// Stop compact keepalive before touching the writer. A committed keepalive
+	// has already fixed the HTTP status at 200, so only the ops classification
+	// can still be corrected.
+	if service.StopOpenAICompactSSEKeepaliveCommitted(c) {
+		return
+	}
+	if !c.Writer.Written() {
+		c.Status(statusClientClosedRequest)
+	}
+}
+
 func writeReadRequestBodyError(c *gin.Context, err error, write gatewayErrorResponseFunc) {
 	if maxErr, ok := extractMaxBytesError(err); ok {
 		write(c, http.StatusRequestEntityTooLarge, "invalid_request_error", buildBodyTooLargeMessage(maxErr.Limit))

--- a/backend/internal/handler/failover_loop.go
+++ b/backend/internal/handler/failover_loop.go
@@ -376,16 +376,7 @@ func failoverClientGone(c *gin.Context) bool {
 	if c == nil || c.Request == nil || c.Request.Context().Err() == nil {
 		return false
 	}
-	// 先停 compact 心跳（接管 ResponseWriter，建立 happens-before），与
-	// handleStreamingAwareError/errorResponse 等终结路径对齐，避免心跳
-	// goroutine 与下面的状态标记并发触碰同一 writer。心跳已提交 200 时
-	// 状态码已固化，不再标 499。
-	if service.StopOpenAICompactSSEKeepaliveCommitted(c) {
-		return true
-	}
-	if !c.Writer.Written() {
-		c.Status(statusClientClosedRequest)
-	}
+	markClientClosedForwardRequest(c)
 	return true
 }
 

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -585,7 +585,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 				upstreamErrorAlreadyCommunicated := gatewayForwardErrorAlreadyCommunicated(c, writerSizeBeforeForward, err)
 				wroteFallback := false
 				if !upstreamErrorAlreadyCommunicated {
-					wroteFallback = h.ensureForwardErrorResponse(c, streamStarted)
+					wroteFallback = h.ensureForwardErrorResponseForError(c, err, streamStarted)
 				}
 				forwardFailedFields := []zap.Field{
 					zap.Int64("account_id", account.ID),
@@ -1171,7 +1171,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 				upstreamErrorAlreadyCommunicated := gatewayForwardErrorAlreadyCommunicated(c, writerSizeBeforeForward, err)
 				wroteFallback := false
 				if !upstreamErrorAlreadyCommunicated {
-					wroteFallback = h.ensureForwardErrorResponse(c, streamStarted)
+					wroteFallback = h.ensureForwardErrorResponseForError(c, err, streamStarted)
 				}
 				forwardFailedFields := []zap.Field{
 					zap.Int64("account_id", account.ID),
@@ -2151,6 +2151,10 @@ func (h *GatewayHandler) handleStreamingAwareError(c *gin.Context, status int, e
 // 让 handleStreamingAwareError 通过 SSE 发协议合规的终止事件，
 // 否则下游收到的就是 silent EOF。
 func (h *GatewayHandler) ensureForwardErrorResponse(c *gin.Context, streamStarted bool) bool {
+	return h.ensureForwardErrorResponseForError(c, nil, streamStarted)
+}
+
+func (h *GatewayHandler) ensureForwardErrorResponseForError(c *gin.Context, err error, streamStarted bool) bool {
 	if c == nil || c.Writer == nil {
 		return false
 	}
@@ -2158,9 +2162,8 @@ func (h *GatewayHandler) ensureForwardErrorResponse(c *gin.Context, streamStarte
 	// generic 502 here only corrupts access/ops semantics; there is no client left
 	// to receive it. Keep the established 499 classification used by failover and
 	// concurrency cancellation paths.
-	if isClientClosedRequest(c, nil) {
-		service.MarkOpsClientClosedRequest(c)
-		failoverClientGone(c)
+	if isClientClosedRequest(c, err) {
+		markClientClosedForwardRequest(c)
 		return false
 	}
 	if service.IsResponseCommitted(c) {

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -377,7 +377,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 			upstreamErrorAlreadyCommunicated := gatewayForwardErrorAlreadyCommunicated(c, writerSizeBeforeForward, err)
 			wroteFallback := false
 			if !upstreamErrorAlreadyCommunicated {
-				wroteFallback = h.ensureForwardErrorResponse(c, streamStarted)
+				wroteFallback = h.ensureForwardErrorResponseForError(c, err, streamStarted)
 			}
 			reqLog.Error("gateway.cc.forward_failed",
 				zap.Int64("account_id", account.ID),

--- a/backend/internal/handler/gateway_handler_error_fallback_test.go
+++ b/backend/internal/handler/gateway_handler_error_fallback_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
@@ -52,6 +54,57 @@ func TestGatewayEnsureForwardErrorResponse_ClientCanceledWrites499WithoutBody(t 
 	require.Equal(t, statusClientClosedRequest, c.Writer.Status())
 	require.Empty(t, w.Body.String())
 	require.True(t, service.HasOpsClientClosedRequest(c))
+}
+
+func TestGatewayEnsureForwardErrorResponse_WrappedForwardCancellationWrites499(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, EndpointMessages, nil)
+	forwardErr := fmt.Errorf("kiro upstream call failed: %w", context.Canceled)
+
+	h := &GatewayHandler{}
+	wrote := h.ensureForwardErrorResponseForError(c, forwardErr, false)
+
+	require.False(t, wrote)
+	require.Equal(t, statusClientClosedRequest, c.Writer.Status())
+	require.Empty(t, w.Body.String())
+	require.True(t, service.HasOpsClientClosedRequest(c))
+}
+
+func TestGatewayWrappedForwardCancellationDoesNotRecordAvailabilityFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, EndpointMessages, nil)
+	forwardErr := fmt.Errorf("kiro upstream call failed: %w", context.Canceled)
+	repo := &countingAvailabilityRepo{}
+	availability := service.NewPricingAvailabilityService(repo, time.Now)
+	gateway := &service.GatewayService{}
+	gateway.SetPricingAvailabilityService(availability)
+
+	h := &GatewayHandler{}
+	wrote := h.ensureForwardErrorResponseForError(c, forwardErr, false)
+	TkRecordFailureFromErr(gateway, c.Request.Context(), service.PlatformAnthropic, "claude-opus-5", 18, forwardErr)
+
+	require.False(t, wrote)
+	require.Equal(t, statusClientClosedRequest, c.Writer.Status())
+	require.Empty(t, w.Body.String())
+	require.True(t, service.HasOpsClientClosedRequest(c))
+	require.Zero(t, repo.upsertCalls, "caller cancellation must not mutate model availability")
+}
+
+type countingAvailabilityRepo struct {
+	upsertCalls int
+}
+
+func (r *countingAvailabilityRepo) Upsert(_ context.Context, _, _ string, _ func(service.AvailabilityState) service.AvailabilityState) error {
+	r.upsertCalls++
+	return nil
+}
+
+func (r *countingAvailabilityRepo) Get(context.Context, string, string) (service.AvailabilityState, error) {
+	return service.AvailabilityState{}, nil
 }
 
 // Writer 已写后 ensureForwardErrorResponse 必须把错误以 SSE 形式追加，

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -406,7 +406,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 			upstreamErrorAlreadyCommunicated := gatewayForwardErrorAlreadyCommunicated(c, writerSizeBeforeForward, err)
 			wroteFallback := false
 			if !upstreamErrorAlreadyCommunicated {
-				wroteFallback = h.ensureForwardErrorResponse(c, streamStarted)
+				wroteFallback = h.ensureForwardErrorResponseForError(c, err, streamStarted)
 			}
 			reqLog.Error("gateway.responses.forward_failed",
 				zap.Int64("account_id", account.ID),

--- a/backend/internal/handler/gateway_handler_tk_forward_error.go
+++ b/backend/internal/handler/gateway_handler_tk_forward_error.go
@@ -59,6 +59,12 @@ func TkRecordFailureFromErr(
 	if svc == nil || err == nil {
 		return
 	}
+	if errors.Is(err, context.Canceled) {
+		// Caller-owned cancellation is not evidence about model health. Recording
+		// it as the default upstream_5xx failure can make a fresh availability
+		// cell unreachable and hide a callable model from strict discovery.
+		return
+	}
 	statusCode := 0
 	body := err.Error()
 	network := false

--- a/backend/internal/handler/openai_codex_models_handler.go
+++ b/backend/internal/handler/openai_codex_models_handler.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
@@ -31,6 +32,7 @@ func (h *OpenAIGatewayHandler) CodexModels(c *gin.Context) {
 		h.errorResponse(c, http.StatusUnauthorized, "invalid_request_error", "Invalid API key")
 		return
 	}
+	discoveryAPIKeyID := apiKey.ID
 	apiKey, allowedModelIDs, err := h.resolveCodexDiscoveryAPIKey(c.Request.Context(), apiKey)
 	if err != nil {
 		status := http.StatusInternalServerError
@@ -39,6 +41,11 @@ func (h *OpenAIGatewayHandler) CodexModels(c *gin.Context) {
 			status = http.StatusServiceUnavailable
 			message = "No available OpenAI group for Codex"
 		}
+		service.SetOpsUpstreamError(c, 0, message, err.Error())
+		requestLogger(c, "handler.openai_gateway.codex_models",
+			zap.Int64("api_key_id", discoveryAPIKeyID),
+			zap.String("stage", "capability_resolution"),
+		).Error("codex.model_discovery_failed", zap.Error(err))
 		h.errorResponse(c, status, "upstream_error", message)
 		return
 	}

--- a/backend/internal/handler/us046_universal_discovery_test.go
+++ b/backend/internal/handler/us046_universal_discovery_test.go
@@ -250,6 +250,10 @@ func TestUS046_UniversalDiscoveryFailureIs500NotEmptyList(t *testing.T) {
 		h.CodexModels(c)
 		require.Equal(t, http.StatusInternalServerError, w.Code)
 		require.NotContains(t, w.Body.String(), `"models":[]`)
+		require.NotContains(t, w.Body.String(), "database unavailable", "internal discovery errors must stay server-side")
+		detail, ok := c.Get(service.OpsUpstreamErrorDetailKey)
+		require.True(t, ok, "ops context must retain the discovery root cause")
+		require.Equal(t, "database unavailable", detail)
 	})
 }
 

--- a/backend/internal/repository/model_availability_repo_tk.go
+++ b/backend/internal/repository/model_availability_repo_tk.go
@@ -62,6 +62,28 @@ func (r *modelAvailabilityRepository) Get(ctx context.Context, platform, modelID
 	return entRowToState(row), nil
 }
 
+func (r *modelAvailabilityRepository) GetBatch(ctx context.Context, platform string, modelIDs []string) (map[string]service.AvailabilityState, error) {
+	if r == nil || r.client == nil {
+		return nil, errors.New("model availability repo: nil client")
+	}
+	if len(modelIDs) == 0 {
+		return map[string]service.AvailabilityState{}, nil
+	}
+	rows, err := r.client.ModelAvailability.Query().
+		Where(modelavailability.PlatformEQ(modelavailability.Platform(platform))).
+		Where(modelavailability.ModelIDIn(modelIDs...)).
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]service.AvailabilityState, len(rows))
+	for _, row := range rows {
+		state := entRowToState(row)
+		out[state.ModelID] = state
+	}
+	return out, nil
+}
+
 func (r *modelAvailabilityRepository) Upsert(ctx context.Context, platform, modelID string, fn func(service.AvailabilityState) service.AvailabilityState) error {
 	if r == nil || r.client == nil {
 		return errors.New("model availability repo: nil client")

--- a/backend/internal/repository/model_availability_repo_tk_test.go
+++ b/backend/internal/repository/model_availability_repo_tk_test.go
@@ -1,0 +1,59 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"testing"
+
+	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/ent/enttest"
+	"github.com/Wei-Shaw/sub2api/ent/modelavailability"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+
+	"entgo.io/ent/dialect"
+	entsql "entgo.io/ent/dialect/sql"
+)
+
+func newModelAvailabilityRepoSQLite(t *testing.T) (*modelAvailabilityRepository, *dbent.Client) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", fmt.Sprintf("file:%s?mode=memory&cache=shared&_fk=1", t.Name()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	drv := entsql.OpenDB(dialect.SQLite, db)
+	client := enttest.NewClient(t, enttest.WithOptions(dbent.Driver(drv)))
+	t.Cleanup(func() { _ = client.Close() })
+
+	return &modelAvailabilityRepository{client: client, muCells: make(map[string]*sync.Mutex)}, client
+}
+
+func TestModelAvailabilityRepositoryGetBatchFiltersPlatformAndMissingModels(t *testing.T) {
+	repo, client := newModelAvailabilityRepoSQLite(t)
+	ctx := context.Background()
+
+	_, err := client.ModelAvailability.Create().
+		SetPlatform(modelavailability.PlatformOpenai).
+		SetModelID("model-a").
+		SetStatus(modelavailability.StatusOk).
+		Save(ctx)
+	require.NoError(t, err)
+	_, err = client.ModelAvailability.Create().
+		SetPlatform(modelavailability.PlatformAnthropic).
+		SetModelID("model-a").
+		SetStatus(modelavailability.StatusUnreachable).
+		Save(ctx)
+	require.NoError(t, err)
+
+	got, err := repo.GetBatch(ctx, service.PlatformOpenAI, []string{"model-a", "model-missing"})
+
+	require.NoError(t, err)
+	require.Equal(t, map[string]service.AvailabilityState{
+		"model-a": {Platform: service.PlatformOpenAI, ModelID: "model-a", Status: service.AvailabilityStatusOK},
+	}, got)
+}

--- a/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
+++ b/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
@@ -1237,6 +1237,120 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_MissingTerminalEventReturnsEr
 	require.NotNil(t, result)
 }
 
+func TestGatewayService_AnthropicAPIKeyPassthrough_StreamErrorPreservesUpstreamFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	svc := &GatewayService{
+		cfg: &config.Config{
+			Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize},
+		},
+		rateLimitService: &RateLimitService{},
+	}
+	rawError := `{"type":"error","error":{"type":"upstream_error","message":"MODEL_TEMPORARILY_UNAVAILABLE: unexpectedly high load"}}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			"event: error",
+			"data: " + rawError,
+			"",
+		}, "\n"))),
+	}
+
+	result, err := svc.handleStreamingResponseAnthropicAPIKeyPassthrough(
+		context.Background(), resp, c, &Account{ID: 18}, time.Now(), "claude-opus-5",
+	)
+
+	require.Error(t, err)
+	var streamErr *sseStreamErrorEventError
+	require.ErrorAs(t, err, &streamErr)
+	require.Equal(t, rawError, streamErr.RawData)
+	require.NotContains(t, err.Error(), "missing terminal event")
+	require.NotNil(t, result)
+	require.Contains(t, rec.Body.String(), "event: error\n")
+	require.Contains(t, rec.Body.String(), "data: "+rawError+"\n\n")
+	require.True(t, IsResponseCommitted(c), "forwarded terminal error must suppress a second generic SSE error")
+}
+
+func TestGatewayService_AnthropicAPIKeyPassthrough_EventOnlyStreamErrorIsTerminal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	svc := &GatewayService{
+		cfg: &config.Config{
+			Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize},
+		},
+		rateLimitService: &RateLimitService{},
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader("event: error\n\n")),
+	}
+
+	result, err := svc.handleStreamingResponseAnthropicAPIKeyPassthrough(
+		context.Background(), resp, c, &Account{ID: 18}, time.Now(), "claude-opus-5",
+	)
+
+	require.Error(t, err)
+	var streamErr *sseStreamErrorEventError
+	require.ErrorAs(t, err, &streamErr)
+	require.Empty(t, streamErr.RawData)
+	require.NotContains(t, err.Error(), "missing terminal event")
+	require.NotNil(t, result)
+	require.Equal(t, "event: error\n\n", rec.Body.String())
+	require.True(t, IsResponseCommitted(c))
+}
+
+func TestGatewayService_AnthropicAPIKeyPassthrough_ForwardRecordsStreamErrorEvidence(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	rawError := `{"type":"error","error":{"type":"upstream_error","message":"MODEL_TEMPORARILY_UNAVAILABLE: unexpectedly high load"}}`
+	upstream := &anthropicHTTPUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream"},
+			"x-request-id": []string{"kiro-high-load"},
+		},
+		Body: io.NopCloser(strings.NewReader("event: error\ndata: " + rawError + "\n\n")),
+	}}
+	svc := &GatewayService{
+		cfg:              &config.Config{},
+		httpUpstream:     upstream,
+		rateLimitService: &RateLimitService{},
+	}
+	account := newAnthropicAPIKeyAccountForTest()
+	account.ID = 18
+	account.Name = "kiro-us4"
+	body := []byte(`{"model":"claude-opus-5","stream":true,"messages":[{"role":"user","content":"hello"}]}`)
+
+	_, err := svc.forwardAnthropicAPIKeyPassthrough(
+		context.Background(), c, account, body, "claude-opus-5", "claude-opus-5", true, time.Now(),
+	)
+
+	require.Error(t, err)
+	var streamErr *sseStreamErrorEventError
+	require.ErrorAs(t, err, &streamErr)
+	rawEvents, ok := c.Get(OpsUpstreamErrorsKey)
+	require.True(t, ok, "typed stream failure must be persisted in ops context")
+	events, ok := rawEvents.([]*OpsUpstreamErrorEvent)
+	require.True(t, ok)
+	require.Len(t, events, 1)
+	require.Equal(t, http.StatusBadGateway, events[0].UpstreamStatusCode)
+	require.Equal(t, "stream_error", events[0].Kind)
+	require.Contains(t, events[0].Message, "MODEL_TEMPORARILY_UNAVAILABLE")
+	require.Equal(t, 1, strings.Count(rec.Body.String(), "event: error"), "terminal upstream error must not be duplicated")
+}
+
 func TestGatewayService_AnthropicAPIKeyPassthrough_ForwardDirect_NonStreamingSuccess(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()

--- a/backend/internal/service/gateway_anthropic_passthrough.go
+++ b/backend/internal/service/gateway_anthropic_passthrough.go
@@ -415,6 +415,14 @@ func (s *GatewayService) forwardAnthropicPassthroughWithInput(
 	if input.RequestStream {
 		streamResult, err := s.handleStreamingResponseAnthropicAPIKeyPassthrough(ctx, resp, c, account, input.StartTime, input.RequestModel)
 		if err != nil {
+			var sseErr *sseStreamErrorEventError
+			if errors.As(err, &sseErr) {
+				// The error frame has already been forwarded as the terminal client
+				// outcome. Reuse the canonical recorder for ops evidence, but keep
+				// the non-failover error shape so the handler does not append a
+				// second generic SSE error after semantic output was committed.
+				_ = s.sseStreamErrorFailover(c, account, resp, sseErr, http.StatusBadGateway)
+			}
 			// 流中断时保留已观测到的 usage 与错误一起返回，避免上游已计量的请求
 			// 完全漏记漏计费（issue #5148）。
 			if partial := partialStreamUsageResult(c, resp, streamResult, input.OriginalModel, input.RequestModel, input.StartTime, err); partial != nil {
@@ -668,14 +676,23 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 		keepaliveTimer.Reset(keepaliveInterval)
 	}
 	inPartialEvent := false
+	pendingEventName := ""
+	var pendingStreamError *sseStreamErrorEventError
 
 	for {
 		select {
 		case ev, ok := <-events:
 			if !ok {
+				if pendingStreamError != nil && inPartialEvent && !clientDisconnected {
+					_, _ = io.WriteString(w, "\n")
+				}
 				if !clientDisconnected {
 					// 兜底补刷，确保最后一个未以空行结尾的事件也能及时送达客户端。
 					flusher.Flush()
+				}
+				if pendingStreamError != nil {
+					MarkResponseCommitted(c)
+					return &streamingResult{usage: usage, firstTokenMs: firstTokenMs, clientDisconnect: clientDisconnected}, pendingStreamError
 				}
 				if !sawTerminalEvent {
 					if clientDisconnected && streamInterval > 0 {
@@ -706,6 +723,7 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 			}
 
 			line := ev.line
+			trimmedLine := strings.TrimSpace(line)
 			if blocks, ok := parseKiroInternalThinkingSSECommentLine(line); ok {
 				applyKiroInternalThinkingBlocks(c, blocks)
 				continue
@@ -713,6 +731,9 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 			if data, ok := extractAnthropicSSEDataLine(line); ok {
 				trimmed := strings.TrimSpace(data)
 				observer.ObserveAnthropic([]byte(trimmed))
+				if strings.EqualFold(pendingEventName, "error") || gjson.Get(trimmed, "type").String() == "error" {
+					pendingStreamError = &sseStreamErrorEventError{RawData: trimmed}
+				}
 				if anthropicStreamEventIsTerminal("", trimmed) {
 					sawTerminalEvent = true
 				}
@@ -722,9 +743,14 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 				}
 				parseSSEUsagePassthrough(data, usage)
 			} else {
-				trimmed := strings.TrimSpace(line)
-				if strings.HasPrefix(trimmed, "event:") && anthropicStreamEventIsTerminal(strings.TrimSpace(strings.TrimPrefix(trimmed, "event:")), "") {
-					sawTerminalEvent = true
+				if strings.HasPrefix(trimmedLine, "event:") {
+					pendingEventName = strings.TrimSpace(strings.TrimPrefix(trimmedLine, "event:"))
+					if strings.EqualFold(pendingEventName, "error") {
+						pendingStreamError = &sseStreamErrorEventError{}
+					}
+					if anthropicStreamEventIsTerminal(pendingEventName, "") {
+						sawTerminalEvent = true
+					}
 				}
 			}
 
@@ -742,6 +768,11 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 					lastDataAt = time.Now()
 					resetKeepaliveTimer()
 					inPartialEvent = false
+					if pendingStreamError != nil {
+						MarkResponseCommitted(c)
+						return &streamingResult{usage: usage, firstTokenMs: firstTokenMs, clientDisconnect: false}, pendingStreamError
+					}
+					pendingEventName = ""
 				} else {
 					inPartialEvent = true
 				}

--- a/backend/internal/service/model_list_filter_tk.go
+++ b/backend/internal/service/model_list_filter_tk.go
@@ -67,19 +67,24 @@ func (f *ModelListFilter) FilterClientFacingStrict(ctx context.Context, platform
 	if f == nil || f.pricing == nil || len(candidates) == 0 {
 		return candidates, nil
 	}
-	out := make([]string, 0, len(candidates))
+	priced := make([]string, 0, len(candidates))
 	for _, id := range candidates {
 		if !f.pricing.IsModelPriced(id, platform) {
 			continue
 		}
-		if f.availability != nil {
-			state, err := f.availability.GetAvailability(ctx, platform, id)
-			if err != nil {
-				return nil, fmt.Errorf("read model availability for %s/%s: %w", platform, id, err)
-			}
-			if state.Status == AvailabilityStatusUnreachable {
-				continue
-			}
+		priced = append(priced, id)
+	}
+	if f.availability == nil || len(priced) == 0 {
+		return priced, nil
+	}
+	states, err := f.availability.GetAvailabilityBatch(ctx, platform, priced)
+	if err != nil {
+		return nil, fmt.Errorf("read model availability for %s: %w", platform, err)
+	}
+	out := make([]string, 0, len(priced))
+	for _, id := range priced {
+		if states[id].Status == AvailabilityStatusUnreachable {
+			continue
 		}
 		out = append(out, id)
 	}

--- a/backend/internal/service/model_list_filter_tk_batch_test.go
+++ b/backend/internal/service/model_list_filter_tk_batch_test.go
@@ -1,0 +1,120 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type batchAvailabilityRepoStub struct {
+	states      map[string]AvailabilityState
+	getCalls    int
+	batchCalls  int
+	batchInputs [][]string
+}
+
+func (s *batchAvailabilityRepoStub) Upsert(context.Context, string, string, func(AvailabilityState) AvailabilityState) error {
+	return nil
+}
+
+func (s *batchAvailabilityRepoStub) Get(_ context.Context, platform, modelID string) (AvailabilityState, error) {
+	s.getCalls++
+	return s.states[platform+"/"+modelID], nil
+}
+
+func (s *batchAvailabilityRepoStub) GetBatch(_ context.Context, platform string, modelIDs []string) (map[string]AvailabilityState, error) {
+	s.batchCalls++
+	s.batchInputs = append(s.batchInputs, append([]string(nil), modelIDs...))
+	out := make(map[string]AvailabilityState, len(modelIDs))
+	for _, modelID := range modelIDs {
+		if state, ok := s.states[platform+"/"+modelID]; ok {
+			out[modelID] = state
+		}
+	}
+	return out, nil
+}
+
+func TestModelListFilterStrict_BatchesPricedAvailabilityReads(t *testing.T) {
+	pricing := NewPricingCatalogService(nil)
+	pricing.SetSourceForTesting(func() ([]byte, time.Time, bool) {
+		return []byte(`{
+			"model-a":{"input_cost_per_token":0.000001,"output_cost_per_token":0.000002,"litellm_provider":"openai"},
+			"model-b":{"input_cost_per_token":0.000001,"output_cost_per_token":0.000002,"litellm_provider":"openai"}
+		}`), time.Unix(1, 0), true
+	})
+	repo := &batchAvailabilityRepoStub{states: map[string]AvailabilityState{
+		"openai/model-b": {Platform: "openai", ModelID: "model-b", Status: AvailabilityStatusUnreachable},
+	}}
+	filter := NewModelListFilter(pricing, NewPricingAvailabilityService(repo, time.Now))
+
+	got, err := filter.FilterClientFacingStrict(
+		context.Background(),
+		PlatformOpenAI,
+		[]string{"model-a", "unpriced-model", "model-b"},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"model-a"}, got)
+	require.Zero(t, repo.getCalls, "strict discovery must not issue one availability query per model")
+	require.Equal(t, 1, repo.batchCalls)
+	require.Equal(t, [][]string{{"model-a", "model-b"}}, repo.batchInputs)
+}
+
+func TestModelListFilterStrict_ReusesAvailabilityReadsWithinDiscoveryRequest(t *testing.T) {
+	pricing := NewPricingCatalogService(nil)
+	pricing.SetSourceForTesting(func() ([]byte, time.Time, bool) {
+		return []byte(`{
+			"model-a":{"input_cost_per_token":0.000001,"output_cost_per_token":0.000002,"litellm_provider":"openai"},
+			"model-b":{"input_cost_per_token":0.000001,"output_cost_per_token":0.000002,"litellm_provider":"openai"},
+			"model-c":{"input_cost_per_token":0.000001,"output_cost_per_token":0.000002,"litellm_provider":"openai"}
+		}`), time.Unix(1, 0), true
+	})
+	repo := &batchAvailabilityRepoStub{states: map[string]AvailabilityState{}}
+	filter := NewModelListFilter(pricing, NewPricingAvailabilityService(repo, time.Now))
+	ctx := withModelAvailabilityRequestCache(context.Background())
+
+	first, err := filter.FilterClientFacingStrict(ctx, PlatformOpenAI, []string{"model-a", "model-b"})
+	require.NoError(t, err)
+	second, err := filter.FilterClientFacingStrict(ctx, PlatformOpenAI, []string{"model-b", "model-c"})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"model-a", "model-b"}, first)
+	require.Equal(t, []string{"model-b", "model-c"}, second)
+	require.Zero(t, repo.getCalls)
+	require.Equal(t, 2, repo.batchCalls)
+	require.Equal(t, [][]string{{"model-a", "model-b"}, {"model-c"}}, repo.batchInputs)
+}
+
+func TestUniversalCapabilityList_ReusesBatchedAvailabilityForCatalogFallbackGroups(t *testing.T) {
+	groups := []Group{
+		us046ActiveGroup(10, PlatformOpenAI, true),
+		us046ActiveGroup(20, PlatformOpenAI, true),
+	}
+	repo := &batchAvailabilityRepoStub{states: map[string]AvailabilityState{}}
+	filter := NewModelListFilter(nil, NewPricingAvailabilityService(repo, time.Now))
+	svc := newUniversalCapabilityService(
+		&us046EntitlementStub{groups: groups},
+		func(context.Context, int64, string) ([]string, bool, error) {
+			return nil, true, nil
+		},
+		func(_ context.Context, _ int64, _ string, _ string, shape UniversalShape) (bool, error) {
+			return shape == ShapeOpenAIChat, nil
+		},
+		func(ctx context.Context, platform string) ([]string, error) {
+			return filter.ServableClientFacingIDsStrict(ctx, platform)
+		},
+	)
+
+	got, err := svc.List(
+		context.Background(),
+		&APIKey{UserID: 9, RoutingMode: RoutingModeUniversal},
+		UniversalProtocolCodex,
+	)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+	require.Zero(t, repo.getCalls, "catalog fallback must not issue one availability read per model")
+	require.Equal(t, 1, repo.batchCalls, "same-platform fallback groups must share one request-local batch")
+}

--- a/backend/internal/service/pricing_availability_service_tk.go
+++ b/backend/internal/service/pricing_availability_service_tk.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
@@ -112,6 +113,34 @@ type ModelAvailabilityRepository interface {
 	Get(ctx context.Context, platform, modelID string) (AvailabilityState, error)
 }
 
+// modelAvailabilityBatchRepository is an optional read optimization implemented
+// by the production repository. Keeping it separate preserves compatibility
+// with focused test repositories while discovery can avoid one query per model.
+type modelAvailabilityBatchRepository interface {
+	GetBatch(ctx context.Context, platform string, modelIDs []string) (map[string]AvailabilityState, error)
+}
+
+type modelAvailabilityRequestCacheContextKey struct{}
+
+type modelAvailabilityRequestCache struct {
+	mu     sync.Mutex
+	loaded map[string]struct{}
+	states map[string]AvailabilityState
+}
+
+func withModelAvailabilityRequestCache(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Value(modelAvailabilityRequestCacheContextKey{}).(*modelAvailabilityRequestCache); ok {
+		return ctx
+	}
+	return context.WithValue(ctx, modelAvailabilityRequestCacheContextKey{}, &modelAvailabilityRequestCache{
+		loaded: make(map[string]struct{}),
+		states: make(map[string]AvailabilityState),
+	})
+}
+
 // AvailabilityState is the in-memory shape of a model_availability row.
 // Mirrors the ent ModelAvailability fields. Pointers are used for nullable
 // timestamps; a fresh state has Status="" (untested has not been written yet).
@@ -210,6 +239,91 @@ func (s *PricingAvailabilityService) GetAvailability(ctx context.Context, platfo
 		return AvailabilityState{}, ErrAvailabilityRepoNil
 	}
 	return s.repo.Get(ctx, strings.TrimSpace(platform), strings.TrimSpace(modelID))
+}
+
+// GetAvailabilityBatch returns the current states for the requested model IDs.
+// Missing rows are omitted and therefore retain the same zero-value/untested
+// semantics as GetAvailability.
+func (s *PricingAvailabilityService) GetAvailabilityBatch(ctx context.Context, platform string, modelIDs []string) (map[string]AvailabilityState, error) {
+	if s == nil || s.repo == nil {
+		return nil, ErrAvailabilityRepoNil
+	}
+	platform = strings.TrimSpace(platform)
+	unique := make([]string, 0, len(modelIDs))
+	seen := make(map[string]struct{}, len(modelIDs))
+	for _, modelID := range modelIDs {
+		modelID = strings.TrimSpace(modelID)
+		if modelID == "" {
+			continue
+		}
+		if _, ok := seen[modelID]; ok {
+			continue
+		}
+		seen[modelID] = struct{}{}
+		unique = append(unique, modelID)
+	}
+	if len(unique) == 0 {
+		return map[string]AvailabilityState{}, nil
+	}
+	if cache, ok := ctx.Value(modelAvailabilityRequestCacheContextKey{}).(*modelAvailabilityRequestCache); ok && cache != nil {
+		return s.getAvailabilityBatchCached(ctx, cache, platform, unique)
+	}
+	return s.getAvailabilityBatchUncached(ctx, platform, unique)
+}
+
+func (s *PricingAvailabilityService) getAvailabilityBatchCached(
+	ctx context.Context,
+	cache *modelAvailabilityRequestCache,
+	platform string,
+	modelIDs []string,
+) (map[string]AvailabilityState, error) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	missing := make([]string, 0, len(modelIDs))
+	for _, modelID := range modelIDs {
+		if _, ok := cache.loaded[platform+"\x00"+modelID]; !ok {
+			missing = append(missing, modelID)
+		}
+	}
+	if len(missing) > 0 {
+		loaded, err := s.getAvailabilityBatchUncached(ctx, platform, missing)
+		if err != nil {
+			return nil, err
+		}
+		for _, modelID := range missing {
+			key := platform + "\x00" + modelID
+			cache.loaded[key] = struct{}{}
+			if state, ok := loaded[modelID]; ok {
+				cache.states[key] = state
+			}
+		}
+	}
+
+	out := make(map[string]AvailabilityState, len(modelIDs))
+	for _, modelID := range modelIDs {
+		if state, ok := cache.states[platform+"\x00"+modelID]; ok {
+			out[modelID] = state
+		}
+	}
+	return out, nil
+}
+
+func (s *PricingAvailabilityService) getAvailabilityBatchUncached(ctx context.Context, platform string, modelIDs []string) (map[string]AvailabilityState, error) {
+	if batchRepo, ok := s.repo.(modelAvailabilityBatchRepository); ok {
+		return batchRepo.GetBatch(ctx, platform, modelIDs)
+	}
+	out := make(map[string]AvailabilityState, len(modelIDs))
+	for _, modelID := range modelIDs {
+		state, err := s.repo.Get(ctx, platform, modelID)
+		if err != nil {
+			return nil, err
+		}
+		if state.ModelID != "" || state.Status != "" {
+			out[modelID] = state
+		}
+	}
+	return out, nil
 }
 
 // SuccessRate24h is a small helper for callers (catalog handler, frontend

--- a/backend/internal/service/pricing_catalog_candidates_tk.go
+++ b/backend/internal/service/pricing_catalog_candidates_tk.go
@@ -105,28 +105,44 @@ func ServableClientFacingIDs(ctx context.Context, platform string, availability 
 
 func servableClientFacingIDsStrict(ctx context.Context, platform string, availability MePricingAvailability, pricing *PricingCatalogService) ([]string, error) {
 	ids := tkServableCandidateIDs(ctx, platform, nil)
-	if availability != nil {
-		kept := make([]string, 0, len(ids))
+	if pricing != nil {
+		priced := make([]string, 0, len(ids))
 		for _, id := range ids {
-			state, err := availability.GetAvailability(ctx, platform, id)
-			if err != nil {
-				return nil, fmt.Errorf("read model availability for %s/%s: %w", platform, id, err)
+			if pricing.IsModelPriced(id, platform) {
+				priced = append(priced, id)
 			}
-			if tkAvailabilityStructurallyGone(state) {
-				continue
-			}
-			kept = append(kept, id)
 		}
-		ids = kept
+		ids = priced
 	}
-	if pricing == nil || len(ids) == 0 {
+	if availability == nil || len(ids) == 0 {
 		return ids, nil
 	}
-	out := make([]string, 0, len(ids))
+
+	if batchAvailability, ok := availability.(interface {
+		GetAvailabilityBatch(context.Context, string, []string) (map[string]AvailabilityState, error)
+	}); ok {
+		states, err := batchAvailability.GetAvailabilityBatch(ctx, platform, ids)
+		if err != nil {
+			return nil, fmt.Errorf("read model availability for %s: %w", platform, err)
+		}
+		kept := make([]string, 0, len(ids))
+		for _, id := range ids {
+			if !tkAvailabilityStructurallyGone(states[id]) {
+				kept = append(kept, id)
+			}
+		}
+		return kept, nil
+	}
+
+	kept := make([]string, 0, len(ids))
 	for _, id := range ids {
-		if pricing.IsModelPriced(id, platform) {
-			out = append(out, id)
+		state, err := availability.GetAvailability(ctx, platform, id)
+		if err != nil {
+			return nil, fmt.Errorf("read model availability for %s/%s: %w", platform, id, err)
+		}
+		if !tkAvailabilityStructurallyGone(state) {
+			kept = append(kept, id)
 		}
 	}
-	return out, nil
+	return kept, nil
 }

--- a/backend/internal/service/universal_capability_tk.go
+++ b/backend/internal/service/universal_capability_tk.go
@@ -135,6 +135,7 @@ func (s *UniversalCapabilityService) List(ctx context.Context, apiKey *APIKey, p
 		return nil, fmt.Errorf("%w: api key is nil", ErrUniversalCapabilityUnavailable)
 	}
 	ctx = withUniversalCapabilityAccountCache(ctx)
+	ctx = withModelAvailabilityRequestCache(ctx)
 
 	groups, err := s.groupsForKey(ctx, apiKey)
 	if err != nil {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3900,18 +3900,39 @@
       "path": "backend/internal/handler/gateway_handler.go",
       "must_contain": [
         "func (h *GatewayHandler) ensureForwardErrorResponse(c *gin.Context, streamStarted bool) bool",
-        "if isClientClosedRequest(c, nil) {",
-        "service.MarkOpsClientClosedRequest(c)",
-        "failoverClientGone(c)"
+        "func (h *GatewayHandler) ensureForwardErrorResponseForError(c *gin.Context, err error, streamStarted bool) bool",
+        "if isClientClosedRequest(c, err) {",
+        "markClientClosedForwardRequest(c)"
       ],
-      "rationale": "Client-cancel terminal response wiring: a Forward error after the inbound request context is canceled must bypass the generic 502 fallback, mark ops client-closed state, and finalize an uncommitted response as 499 without writing a body. This handler call site is shared by native Anthropic, Gemini, Responses, and compatibility surfaces; an upstream merge can delete the short-circuit while service tests still prove only that transport cancellation was propagated."
+      "rationale": "Client-cancel terminal response wiring: every Forward failure must pass the actual error chain into the shared fallback owner so a wrapped context.Canceled is classified as caller-owned even when the inbound request context has not yet observed cancellation. The compatibility wrapper remains for existing call sites, while native Anthropic, Gemini, Responses, and compatibility surfaces converge on markClientClosedForwardRequest instead of writing a generic 502."
+    },
+    {
+      "path": "backend/internal/handler/client_closed_request_tk.go",
+      "must_contain": [
+        "func markClientClosedForwardRequest(c *gin.Context)",
+        "service.MarkOpsClientClosedRequest(c)",
+        "service.StopOpenAICompactSSEKeepaliveCommitted(c)",
+        "c.Status(statusClientClosedRequest)"
+      ],
+      "rationale": "Single owner for Forward-time client cancellation finalization. It marks ops ownership, stops compact keepalive before touching the writer, preserves an already committed status, and otherwise emits bodyless 499. Both failoverClientGone and the direct Forward fallback must reuse this helper so cancellation behavior cannot drift by endpoint."
     },
     {
       "path": "backend/internal/handler/gateway_handler_error_fallback_test.go",
       "must_contain": [
-        "TestGatewayEnsureForwardErrorResponse_ClientCanceledWrites499WithoutBody"
+        "TestGatewayEnsureForwardErrorResponse_ClientCanceledWrites499WithoutBody",
+        "TestGatewayEnsureForwardErrorResponse_WrappedForwardCancellationWrites499",
+        "TestGatewayWrappedForwardCancellationDoesNotRecordAvailabilityFailure"
       ],
-      "rationale": "Focused handler regression proving canceled inbound requests terminate as 499, write no response body, and carry the ops client-closed marker instead of falling through to the generic upstream 502 response."
+      "rationale": "Focused handler regressions proving both an already-canceled inbound request and a wrapped Forward context.Canceled terminate as 499, write no response body, carry the ops client-closed marker, and do not mutate model availability instead of falling through to the generic upstream 502 response."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler_tk_forward_error.go",
+      "must_contain": [
+        "func TkRecordFailureFromErr(",
+        "if errors.Is(err, context.Canceled) {",
+        "svc.TKRecordForwardFailure(ctx, platform, model, accountID, statusCode, body, network)"
+      ],
+      "rationale": "Single passive availability failure tap owner. Caller-owned context cancellation must return before recording any model-health sample; real failover errors still preserve upstream status/body for canonical availability classification."
     },
     {
       "path": "backend/internal/service/gateway_forward.go",
@@ -3928,6 +3949,27 @@
         "return nil, err"
       ],
       "rationale": "Anthropic API-key and OAuth passthrough return before the canonical Forward loop, so their shared transport-error branch must independently propagate caller cancellation without writing 502. Omitting this anchor makes client-cancel semantics depend on account passthrough configuration."
+    },
+    {
+      "path": "backend/internal/service/gateway_anthropic_passthrough.go",
+      "must_contain": [
+        "var pendingStreamError *sseStreamErrorEventError",
+        "pendingStreamError = &sseStreamErrorEventError{}",
+        "pendingStreamError = &sseStreamErrorEventError{RawData: trimmed}",
+        "_ = s.sseStreamErrorFailover(c, account, resp, sseErr, http.StatusBadGateway)",
+        "MarkResponseCommitted(c)"
+      ],
+      "rationale": "Anthropic passthrough must treat upstream event:error (including an event-only frame) or data type=error as the terminal semantic outcome, forward the original SSE frame exactly once, mark the response committed, and reuse sseStreamErrorFailover only as the canonical ops evidence recorder. Losing these anchors turns real Kiro overload errors into misleading missing-terminal 502s or duplicate generic SSE errors."
+    },
+    {
+      "path": "backend/internal/service/gateway_anthropic_apikey_passthrough_test.go",
+      "must_contain": [
+        "TestGatewayService_AnthropicAPIKeyPassthrough_StreamErrorPreservesUpstreamFailure",
+        "TestGatewayService_AnthropicAPIKeyPassthrough_EventOnlyStreamErrorIsTerminal",
+        "TestGatewayService_AnthropicAPIKeyPassthrough_ForwardRecordsStreamErrorEvidence",
+        "MODEL_TEMPORARILY_UNAVAILABLE"
+      ],
+      "rationale": "Regression coverage pins the real Kiro high-load frame, event-only error boundary, canonical stream_error ops evidence, response-committed marker, and exactly-one-error-frame behavior."
     },
     {
       "path": "backend/internal/service/gateway_forward_client_cancel_test.go",
@@ -6858,9 +6900,28 @@
       "must_contain": [
         "func (f *ModelListFilter) FilterClientFacingStrict(",
         "func (f *ModelListFilter) ServableClientFacingIDsStrict(",
-        "f.availability.GetAvailability(ctx, platform, id)"
+        "states, err := f.availability.GetAvailabilityBatch(ctx, platform, priced)",
+        "return nil, fmt.Errorf(\"read model availability for %s: %w\", platform, err)"
       ],
-      "rationale": "Capability discovery must fail explicitly when the availability repository cannot answer. Runtime forwarding keeps the legacy fail-open filter, while these discovery-only strict entrypoints prevent a repository outage from being presented as a truthful callable menu."
+      "rationale": "Capability discovery must fail explicitly when the availability repository cannot answer, but must read the priced candidate set in one batch instead of issuing one query per model. Runtime forwarding keeps the legacy fail-open filter, while these discovery-only strict entrypoints preserve truthful callable menus without amplifying /v1/models database load."
+    },
+    {
+      "path": "backend/internal/service/pricing_catalog_candidates_tk.go",
+      "must_contain": [
+        "func servableClientFacingIDsStrict(",
+        "GetAvailabilityBatch(context.Context, string, []string) (map[string]AvailabilityState, error)",
+        "states, err := batchAvailability.GetAvailabilityBatch(ctx, platform, ids)"
+      ],
+      "rationale": "Strict catalog fallback is part of the same capability SSOT as mapped discovery. It must price first, batch availability reads through the request-local cache, and retain the single-read fallback only for narrow test/legacy implementations; otherwise multiple passthrough groups restore per-model query amplification."
+    },
+    {
+      "path": "backend/internal/service/model_list_filter_tk_batch_test.go",
+      "must_contain": [
+        "TestModelListFilterStrict_BatchesPricedAvailabilityReads",
+        "TestModelListFilterStrict_ReusesAvailabilityReadsWithinDiscoveryRequest",
+        "TestUniversalCapabilityList_ReusesBatchedAvailabilityForCatalogFallbackGroups"
+      ],
+      "rationale": "Behavioral regressions pin both mapped-model and catalog-fallback query shapes, including request-local deduplication across same-platform groups."
     },
     {
       "path": "backend/internal/handler/gateway_handler_tk_model_list.go",


### PR DESCRIPTION
## 摘要

- 在既有 capability / pricing / availability SSOT 内批量读取并按请求去重模型可用性，覆盖 mapped discovery 与 catalog fallback；Codex discovery 对客户端保持通用错误，同时为 ops 保留真实根因。
- Anthropic passthrough 正确认领带 data 与仅 event 的 SSE error 事件，原样单次转发，并复用现有 stream-error ops owner。
- wrapped context.Canceled 统一返回无 body 的 499，并阻止 caller cancellation 污染模型 availability。
- 已同步 #1836 的 forced-platform discovery isolation；Codex 根因只由本 PR 的专用 ops 路径拥有，不再产生双日志或双 sentinel 契约。
- 同步 gateway sentinel registry，机械守卫新的 owner、SSOT 路径与回归测试。

## 风险

- 高：涉及客户端模型发现、Anthropic 流式终止语义和取消分类；无 schema、Web 或公共响应结构变更。
- availability repository 失败仍严格 fail-closed；缺失 availability 行保持 untested 零值语义。
- 协议/能力真值继续由既有 owner 提供，本 PR 只优化读取形状并保存错误语义，不新增第二套路由或能力表。

## 验证

- `go test -tags=unit ./internal/handler -count=1`
- `go test -tags=unit ./internal/service -count=1`
- `go test -tags=unit ./internal/repository -count=1`
- `python3 scripts/sentinels/check-gateway-tk.py --quiet`
- protocol-routing SSOT 检查通过
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`（HEAD `0dd2e45ac` PASS）
- 与已合并 #1836 的联合内容树为 `214afc77`，无冲突且只有一个 Codex failure owner。

`no-web-impact`
`sentinel-registry-reviewed`

## 提交

- `ba48cc070 fix(gateway): preserve discovery and stream failure semantics`
- `0dd2e45ac chore(branch): sync origin/main after #1836`
- 最新提交：`0dd2e45ac`