### PR TITLE
perf(ci): 缩短 unit 冷路径关键链路

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Unit tests
         working-directory: backend
         env:
-          UNIT_TEST_SERVICE_SHARD: ${{ github.event_name != 'push' && needs.changes.outputs.service_unit_cold == 'true' && '1' || '0' }}
+          UNIT_TEST_SERVICE_SHARD: ${{ needs.changes.outputs.service_unit_cold == 'true' && '1' || '0' }}
         run: make test-unit
       - name: Anthropic prompt surface fixture gateway
         run: python3 ops/anthropic/probe_prompt_surfaces.py --check-fixture-gateway

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -232,6 +232,9 @@ jobs:
       - name: Unit tests
         working-directory: backend
         env:
+          # Service-cold runs prioritize the compile-once critical path. They
+          # warm build artifacts but intentionally do not seed native go test
+          # result entries; service-neutral runs retain the native cache path.
           UNIT_TEST_SERVICE_SHARD: ${{ needs.changes.outputs.service_unit_cold == 'true' && '1' || '0' }}
         run: make test-unit
       - name: Anthropic prompt surface fixture gateway

--- a/scripts/ci/test_unit_test_runner.py
+++ b/scripts/ci/test_unit_test_runner.py
@@ -100,6 +100,7 @@ class UnitTestRunnerTest(unittest.TestCase):
             ["TestOne"],
             has_test_main=True,
             compile_delay=5.0,
+            compile_child=True,
         ) as fixture:
             result = self._run(fixture)
             events = self._events(fixture.events)
@@ -114,6 +115,10 @@ class UnitTestRunnerTest(unittest.TestCase):
                 for event in events
                 if event["kind"] == "go-terminated" and "-c" in event["args"]
             ],
+            events,
+        )
+        self.assertTrue(
+            [event for event in events if event["kind"] == "go-child-terminated"],
             events,
         )
         self.assertFalse(self._binary_events(events))
@@ -189,13 +194,21 @@ class UnitTestRunnerTest(unittest.TestCase):
         )
 
     def test_compile_failure_stops_before_any_service_shard(self) -> None:
-        with self._fake_go(["TestOne", "TestTwo"], fail_compile=True) as fixture:
+        with self._fake_go(
+            ["TestOne", "TestTwo"],
+            fail_compile=True,
+            compile_child=True,
+        ) as fixture:
             result = self._run(fixture, "--min-shards", "2")
             events = self._events(fixture.events)
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("intentional compile failure", result.stderr)
         self.assertEqual(len([call for call in self._go_calls(events) if "-c" in call]), 1)
+        self.assertTrue(
+            [event for event in events if event["kind"] == "go-child-terminated"],
+            events,
+        )
         self.assertFalse(self._binary_events(events))
 
     def test_partial_start_failure_terminates_started_processes(self) -> None:
@@ -317,6 +330,7 @@ class UnitTestRunnerTest(unittest.TestCase):
             fail_discovery=True,
             discovery_delay=0.25,
             compile_delay=5.0,
+            compile_child=True,
         ) as fixture:
             result = self._run(fixture)
             events = self._events(fixture.events)
@@ -329,6 +343,10 @@ class UnitTestRunnerTest(unittest.TestCase):
                 for event in events
                 if event["kind"] == "go-terminated" and "-c" in event["args"]
             ],
+            events,
+        )
+        self.assertTrue(
+            [event for event in events if event["kind"] == "go-child-terminated"],
             events,
         )
         self.assertFalse(self._binary_events(events))
@@ -363,6 +381,8 @@ class UnitTestRunnerTest(unittest.TestCase):
             env["FAKE_GO_DISCOVERY_DELAY"] = str(fixture.discovery_delay)
         if fixture.fail_discovery:
             env["FAKE_GO_FAIL_DISCOVERY"] = "1"
+        if fixture.compile_child:
+            env["FAKE_GO_COMPILE_CHILD"] = "1"
         return subprocess.run(
             ["python3", str(SCRIPT), "--root", str(fixture.root), *args],
             check=False,
@@ -411,6 +431,7 @@ class UnitTestRunnerTest(unittest.TestCase):
         compile_delay: float = 0.0,
         discovery_delay: float = 0.0,
         fail_discovery: bool = False,
+        compile_child: bool = False,
     ) -> "FakeGoFixtureContext":
         return FakeGoFixtureContext(
             test_names,
@@ -422,6 +443,7 @@ class UnitTestRunnerTest(unittest.TestCase):
             compile_delay,
             discovery_delay,
             fail_discovery,
+            compile_child,
         )
 
 
@@ -438,6 +460,7 @@ class FakeGoFixture:
         compile_delay: float,
         discovery_delay: float,
         fail_discovery: bool,
+        compile_child: bool,
     ) -> None:
         self._temporary = temporary
         self.root = Path(temporary.name)
@@ -454,6 +477,7 @@ class FakeGoFixture:
         self.compile_delay = compile_delay
         self.discovery_delay = discovery_delay
         self.fail_discovery = fail_discovery
+        self.compile_child = compile_child
         service_dir = self.root / "internal" / "service"
         service_dir.mkdir(parents=True)
         declarations = []
@@ -488,6 +512,7 @@ class FakeGoFixtureContext:
         compile_delay: float,
         discovery_delay: float,
         fail_discovery: bool,
+        compile_child: bool,
     ) -> None:
         self.test_names = test_names
         self.has_test_main = has_test_main
@@ -498,6 +523,7 @@ class FakeGoFixtureContext:
         self.compile_delay = compile_delay
         self.discovery_delay = discovery_delay
         self.fail_discovery = fail_discovery
+        self.compile_child = compile_child
         self.temporary: tempfile.TemporaryDirectory[str] | None = None
 
     def __enter__(self) -> FakeGoFixture:
@@ -513,6 +539,7 @@ class FakeGoFixtureContext:
             self.compile_delay,
             self.discovery_delay,
             self.fail_discovery,
+            self.compile_child,
         )
         fake_binary_source = textwrap.dedent(
             """\
@@ -549,6 +576,7 @@ class FakeGoFixtureContext:
                 import os
                 from pathlib import Path
                 import signal
+                import subprocess
                 import sys
                 import time
 
@@ -556,13 +584,20 @@ class FakeGoFixtureContext:
                 events = Path(os.environ["FAKE_GO_EVENTS"])
 
                 def terminate(_signum, _frame):
+                    kind = "go-child-terminated" if args == ["fake-go-child"] else "go-terminated"
                     with events.open("a", encoding="utf-8") as output:
-                        output.write(json.dumps({"kind": "go-terminated", "args": args, "at": time.monotonic()}) + "\\n")
+                        output.write(json.dumps({"kind": kind, "args": args, "at": time.monotonic()}) + "\\n")
                     raise SystemExit(143)
 
                 signal.signal(signal.SIGTERM, terminate)
                 with events.open("a", encoding="utf-8") as output:
                     output.write(json.dumps({"kind": "go", "args": args, "at": time.monotonic()}) + "\\n")
+
+                if args == ["fake-go-child"]:
+                    with events.open("a", encoding="utf-8") as output:
+                        output.write(json.dumps({"kind": "go-child-started", "pid": os.getpid(), "at": time.monotonic()}) + "\\n")
+                    time.sleep(3)
+                    raise SystemExit(0)
 
                 if args and args[0] == "run":
                     time.sleep(float(os.environ.get("FAKE_GO_DISCOVERY_DELAY", "0")))
@@ -591,6 +626,8 @@ class FakeGoFixtureContext:
                     raise SystemExit(0)
 
                 if "-c" in args:
+                    if os.environ.get("FAKE_GO_COMPILE_CHILD") == "1":
+                        subprocess.Popen([sys.executable, __file__, "fake-go-child"])
                     time.sleep(float(os.environ.get("FAKE_GO_COMPILE_DELAY", "0")))
                     with events.open("a", encoding="utf-8") as output:
                         output.write(json.dumps({"kind": "go-finished", "args": args, "at": time.monotonic()}) + "\\n")

--- a/scripts/ci/test_unit_test_runner.py
+++ b/scripts/ci/test_unit_test_runner.py
@@ -96,14 +96,26 @@ class UnitTestRunnerTest(unittest.TestCase):
         self.assertEqual(len(matched), len(set(matched)))
 
     def test_test_main_falls_back_to_one_native_go_test(self) -> None:
-        with self._fake_go(["TestOne"], has_test_main=True) as fixture:
+        with self._fake_go(
+            ["TestOne"],
+            has_test_main=True,
+            compile_delay=5.0,
+        ) as fixture:
             result = self._run(fixture)
             events = self._events(fixture.events)
 
         self.assertEqual(result.returncode, 0, result.stderr)
         go_calls = self._go_calls(events)
         self.assertIn(["test", "-tags=unit", "./..."], go_calls)
-        self.assertFalse([call for call in go_calls if "-c" in call])
+        self.assertEqual(len([call for call in go_calls if "-c" in call]), 1)
+        self.assertTrue(
+            [
+                event
+                for event in events
+                if event["kind"] == "go-terminated" and "-c" in event["args"]
+            ],
+            events,
+        )
         self.assertFalse(self._binary_events(events))
 
     def test_fails_closed_when_ast_discovery_differs_from_binary_registry(self) -> None:
@@ -276,6 +288,51 @@ class UnitTestRunnerTest(unittest.TestCase):
         )
         self.assertLess(other_started, compile_finished, events)
 
+    def test_starts_service_compile_before_discovery_finishes(self) -> None:
+        with self._fake_go(
+            ["TestOne", "TestTwo"],
+            discovery_delay=0.75,
+        ) as fixture:
+            result = self._run(fixture, "--min-shards", "2")
+            events = self._events(fixture.events)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        compile_started = next(
+            event["at"]
+            for event in events
+            if event["kind"] == "go" and "-c" in event["args"]
+        )
+        discovery_finished = next(
+            event["at"]
+            for event in events
+            if event["kind"] == "go-finished"
+            and event["args"]
+            and event["args"][0] == "run"
+        )
+        self.assertLess(compile_started, discovery_finished, events)
+
+    def test_discovery_failure_terminates_service_compile(self) -> None:
+        with self._fake_go(
+            ["TestOne"],
+            fail_discovery=True,
+            discovery_delay=0.25,
+            compile_delay=5.0,
+        ) as fixture:
+            result = self._run(fixture)
+            events = self._events(fixture.events)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid Go test discovery output", result.stderr)
+        self.assertTrue(
+            [
+                event
+                for event in events
+                if event["kind"] == "go-terminated" and "-c" in event["args"]
+            ],
+            events,
+        )
+        self.assertFalse(self._binary_events(events))
+
     def test_reports_discovery_compile_and_registry_stage_durations(self) -> None:
         with self._fake_go(["TestOne"]) as fixture:
             result = self._run(fixture)
@@ -302,6 +359,10 @@ class UnitTestRunnerTest(unittest.TestCase):
             env["FAKE_GO_SLOW_TEST"] = fixture.slow_test
         if fixture.compile_delay:
             env["FAKE_GO_COMPILE_DELAY"] = str(fixture.compile_delay)
+        if fixture.discovery_delay:
+            env["FAKE_GO_DISCOVERY_DELAY"] = str(fixture.discovery_delay)
+        if fixture.fail_discovery:
+            env["FAKE_GO_FAIL_DISCOVERY"] = "1"
         return subprocess.run(
             ["python3", str(SCRIPT), "--root", str(fixture.root), *args],
             check=False,
@@ -348,6 +409,8 @@ class UnitTestRunnerTest(unittest.TestCase):
         fail_test: str | None = None,
         slow_test: str | None = None,
         compile_delay: float = 0.0,
+        discovery_delay: float = 0.0,
+        fail_discovery: bool = False,
     ) -> "FakeGoFixtureContext":
         return FakeGoFixtureContext(
             test_names,
@@ -357,6 +420,8 @@ class UnitTestRunnerTest(unittest.TestCase):
             fail_test,
             slow_test,
             compile_delay,
+            discovery_delay,
+            fail_discovery,
         )
 
 
@@ -371,6 +436,8 @@ class FakeGoFixture:
         fail_test: str | None,
         slow_test: str | None,
         compile_delay: float,
+        discovery_delay: float,
+        fail_discovery: bool,
     ) -> None:
         self._temporary = temporary
         self.root = Path(temporary.name)
@@ -385,6 +452,8 @@ class FakeGoFixture:
         self.fail_test = fail_test
         self.slow_test = slow_test
         self.compile_delay = compile_delay
+        self.discovery_delay = discovery_delay
+        self.fail_discovery = fail_discovery
         service_dir = self.root / "internal" / "service"
         service_dir.mkdir(parents=True)
         declarations = []
@@ -417,6 +486,8 @@ class FakeGoFixtureContext:
         fail_test: str | None,
         slow_test: str | None,
         compile_delay: float,
+        discovery_delay: float,
+        fail_discovery: bool,
     ) -> None:
         self.test_names = test_names
         self.has_test_main = has_test_main
@@ -425,6 +496,8 @@ class FakeGoFixtureContext:
         self.fail_test = fail_test
         self.slow_test = slow_test
         self.compile_delay = compile_delay
+        self.discovery_delay = discovery_delay
+        self.fail_discovery = fail_discovery
         self.temporary: tempfile.TemporaryDirectory[str] | None = None
 
     def __enter__(self) -> FakeGoFixture:
@@ -438,6 +511,8 @@ class FakeGoFixtureContext:
             self.fail_test,
             self.slow_test,
             self.compile_delay,
+            self.discovery_delay,
+            self.fail_discovery,
         )
         fake_binary_source = textwrap.dedent(
             """\
@@ -473,15 +548,29 @@ class FakeGoFixtureContext:
                 import json
                 import os
                 from pathlib import Path
+                import signal
                 import sys
                 import time
 
                 args = sys.argv[1:]
                 events = Path(os.environ["FAKE_GO_EVENTS"])
+
+                def terminate(_signum, _frame):
+                    with events.open("a", encoding="utf-8") as output:
+                        output.write(json.dumps({"kind": "go-terminated", "args": args, "at": time.monotonic()}) + "\\n")
+                    raise SystemExit(143)
+
+                signal.signal(signal.SIGTERM, terminate)
                 with events.open("a", encoding="utf-8") as output:
                     output.write(json.dumps({"kind": "go", "args": args, "at": time.monotonic()}) + "\\n")
 
                 if args and args[0] == "run":
+                    time.sleep(float(os.environ.get("FAKE_GO_DISCOVERY_DELAY", "0")))
+                    with events.open("a", encoding="utf-8") as output:
+                        output.write(json.dumps({"kind": "go-finished", "args": args, "at": time.monotonic()}) + "\\n")
+                    if os.environ.get("FAKE_GO_FAIL_DISCOVERY") == "1":
+                        print("not-json")
+                        raise SystemExit(0)
                     print(json.dumps({
                         "entries": json.loads(os.environ["FAKE_GO_TESTS"]),
                         "has_test_main": os.environ.get("FAKE_GO_HAS_TEST_MAIN") == "1",

--- a/scripts/ci/unit_test_runner.py
+++ b/scripts/ci/unit_test_runner.py
@@ -8,8 +8,10 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 import hashlib
 import json
+import os
 from pathlib import Path
 import re
+import signal
 import subprocess
 import sys
 import tempfile
@@ -244,18 +246,28 @@ def _terminate_processes(
     running: list[RunningCommand],
 ) -> None:
     for _, process, _, _ in running:
-        if process.poll() is not None:
-            continue
         try:
-            process.terminate()
-        except ProcessLookupError:
-            continue
+            os.killpg(process.pid, signal.SIGTERM)
+        except AttributeError:
+            if process.poll() is None:
+                process.terminate()
+        except (PermissionError, ProcessLookupError):
+            if process.poll() is None:
+                process.terminate()
     for _, process, _, _ in running:
         try:
             process.wait(timeout=5)
         except subprocess.TimeoutExpired:
-            process.kill()
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except (AttributeError, PermissionError, ProcessLookupError):
+                process.kill()
             process.wait()
+    for _, process, _, _ in running:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except (AttributeError, PermissionError, ProcessLookupError):
+            pass
 
 
 def run_commands(
@@ -276,6 +288,7 @@ def run_commands(
                     cwd=command.cwd,
                     stdout=handle,
                     stderr=subprocess.STDOUT,
+                    start_new_session=True,
                 )
                 running.append((command, process, log_path, time.monotonic()))
 
@@ -343,6 +356,7 @@ def run_unit_tests(
                     cwd=compile_command.cwd,
                     stdout=compile_handle,
                     stderr=subprocess.STDOUT,
+                    start_new_session=True,
                 )
             except BaseException:
                 compile_handle.close()
@@ -400,6 +414,7 @@ def run_unit_tests(
                         cwd=other_command.cwd,
                         stdout=other_handle,
                         stderr=subprocess.STDOUT,
+                        start_new_session=True,
                     )
                     background.append(
                         (other_command, other_process, other_log, time.monotonic())
@@ -419,6 +434,7 @@ def run_unit_tests(
                     raise RunnerError(
                         f"{' '.join(compile_command.argv)}: {detail}"
                     )
+                background = background[1:]
                 print(
                     f"unit-test-runner: STAGE service-compile "
                     f"({compile_elapsed:.1f}s)",
@@ -432,7 +448,7 @@ def run_unit_tests(
                     f"({time.monotonic() - registry_started_at:.1f}s)",
                     flush=True,
                 )
-                return run_commands(service_commands, background[1:])
+                return run_commands(service_commands, background)
             except BaseException:
                 _terminate_processes(background)
                 raise

--- a/scripts/ci/unit_test_runner.py
+++ b/scripts/ci/unit_test_runner.py
@@ -319,40 +319,78 @@ def run_unit_tests(
     min_shards: int,
     max_regex_bytes: int,
 ) -> int:
-    discovery_started_at = time.monotonic()
-    other_packages, service_tests, patterns, has_test_main = build_test_plan(
-        root,
-        service_package,
-        min_shards,
-        max_regex_bytes,
-    )
-    print(
-        f"unit-test-runner: STAGE discovery "
-        f"({time.monotonic() - discovery_started_at:.1f}s)",
-        flush=True,
-    )
-    if has_test_main:
-        print("unit-test-runner: TestMain detected; using native go test")
-        return subprocess.run(
-            ["go", "test", "-tags=unit", "./..."],
-            cwd=root,
-            check=False,
-        ).returncode
     with tempfile.TemporaryDirectory(prefix="sub2api-service-test-") as temporary:
         service_binary = Path(temporary) / "service.test"
-        commands = build_commands(
-            root,
-            service_package,
-            service_binary,
-            other_packages,
-            patterns,
-        )
-        other_commands = [command for command in commands if command.label == "other-packages"]
-        service_commands = [command for command in commands if command.label != "other-packages"]
         with tempfile.TemporaryDirectory(prefix="sub2api-unit-overlap-") as overlap_temp:
-            initial_running: list[RunningCommand] = []
+            compile_command = Command(
+                "service-compile",
+                (
+                    "go",
+                    "test",
+                    "-c",
+                    "-tags=unit",
+                    "-o",
+                    str(service_binary),
+                    service_package,
+                ),
+                root,
+            )
+            compile_log = Path(overlap_temp) / "service-compile.log"
+            compile_handle = compile_log.open("wb")
+            try:
+                compile_process = subprocess.Popen(
+                    compile_command.argv,
+                    cwd=compile_command.cwd,
+                    stdout=compile_handle,
+                    stderr=subprocess.STDOUT,
+                )
+            except BaseException:
+                compile_handle.close()
+                raise
+            compile_running: RunningCommand = (
+                compile_command,
+                compile_process,
+                compile_log,
+                time.monotonic(),
+            )
+            background: list[RunningCommand] = [compile_running]
             other_handle = None
             try:
+                discovery_started_at = time.monotonic()
+                other_packages, service_tests, patterns, has_test_main = build_test_plan(
+                    root,
+                    service_package,
+                    min_shards,
+                    max_regex_bytes,
+                )
+                print(
+                    f"unit-test-runner: STAGE discovery "
+                    f"({time.monotonic() - discovery_started_at:.1f}s)",
+                    flush=True,
+                )
+                if has_test_main:
+                    _terminate_processes(background)
+                    background.clear()
+                    print("unit-test-runner: TestMain detected; using native go test")
+                    return subprocess.run(
+                        ["go", "test", "-tags=unit", "./..."],
+                        cwd=root,
+                        check=False,
+                    ).returncode
+
+                commands = build_commands(
+                    root,
+                    service_package,
+                    service_binary,
+                    other_packages,
+                    patterns,
+                )
+                other_commands = [
+                    command for command in commands if command.label == "other-packages"
+                ]
+                service_commands = [
+                    command for command in commands if command.label != "other-packages"
+                ]
                 if other_commands:
                     other_command = other_commands[0]
                     other_log = Path(overlap_temp) / "other-packages.log"
@@ -363,26 +401,27 @@ def run_unit_tests(
                         stdout=other_handle,
                         stderr=subprocess.STDOUT,
                     )
-                    initial_running.append(
+                    background.append(
                         (other_command, other_process, other_log, time.monotonic())
                     )
 
-                compile_started_at = time.monotonic()
-                _run_checked(
-                    [
-                        "go",
-                        "test",
-                        "-c",
-                        "-tags=unit",
-                        "-o",
-                        str(service_binary),
-                        service_package,
-                    ],
-                    root,
-                )
+                compile_returncode = compile_process.wait()
+                compile_elapsed = time.monotonic() - compile_running[3]
+                if compile_returncode != 0:
+                    compile_output = compile_log.read_text(
+                        encoding="utf-8",
+                        errors="replace",
+                    )
+                    detail = (
+                        compile_output.strip()
+                        or f"command exited with status {compile_returncode}"
+                    )
+                    raise RunnerError(
+                        f"{' '.join(compile_command.argv)}: {detail}"
+                    )
                 print(
                     f"unit-test-runner: STAGE service-compile "
-                    f"({time.monotonic() - compile_started_at:.1f}s)",
+                    f"({compile_elapsed:.1f}s)",
                     flush=True,
                 )
                 service_dir = root / service_package.removeprefix("./")
@@ -393,11 +432,12 @@ def run_unit_tests(
                     f"({time.monotonic() - registry_started_at:.1f}s)",
                     flush=True,
                 )
-                return run_commands(service_commands, initial_running)
+                return run_commands(service_commands, background[1:])
             except BaseException:
-                _terminate_processes(initial_running)
+                _terminate_processes(background)
                 raise
             finally:
+                compile_handle.close()
                 if other_handle is not None:
                     other_handle.close()
 

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -188,16 +188,16 @@ class BackendCIRoutingTest(unittest.TestCase):
             unit_step["env"]["UNIT_TEST_SERVICE_SHARD"],
         )
 
-    def test_unit_main_writer_uses_native_path_to_seed_result_cache(self) -> None:
+    def test_unit_main_push_uses_compile_once_shards_when_service_is_cold(self) -> None:
         unit_step = next(
             step
             for step in self.jobs["test-unit"]["steps"]
             if step.get("name") == "Unit tests"
         )
 
-        self.assertIn(
-            "github.event_name != 'push'",
+        self.assertEqual(
             unit_step["env"]["UNIT_TEST_SERVICE_SHARD"],
+            "${{ needs.changes.outputs.service_unit_cold == 'true' && '1' || '0' }}",
         )
 
     def test_lint_uses_rolling_analysis_cache_instead_of_action_cache(self) -> None:

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -188,7 +188,7 @@ class BackendCIRoutingTest(unittest.TestCase):
             unit_step["env"]["UNIT_TEST_SERVICE_SHARD"],
         )
 
-    def test_unit_main_push_uses_compile_once_shards_when_service_is_cold(self) -> None:
+    def test_unit_main_push_prioritizes_shards_over_native_result_cache(self) -> None:
         unit_step = next(
             step
             for step in self.jobs["test-unit"]["steps"]


### PR DESCRIPTION
## 摘要

- main push 的 service-cold unit 路径改用现有 compile-once 分片 runner。
- service test binary 编译在 package discovery 开始前启动，随后与 other packages 测试重叠。
- discovery、TestMain 回退及 compile 失败时按进程组终止编译器子进程，保持 fail-closed。

## 风险

- service-cold main run 会保留 Go build cache，但不再写入 native `go test` 的 service test-result cache；这是为缩短 main 关键路径而接受的明确取舍。service-neutral 路径仍使用 native cache。
- 不增加 job、runner 或检查项，不增加并行 GitHub Actions credits。
- no-web-impact：仅调整 CI 编排，无产品或前端行为变化。

## 验证

- `python3 -m unittest scripts.test_backend_ci_routing scripts.ci.test_unit_test_runner`：28/28 通过。
- `make -C backend UNIT_TEST_SERVICE_SHARD=1 test-unit`：通过。
- `./scripts/preflight.sh`：最终 HEAD 完整门禁通过。
- xj-review：normal / concise，零 medium+ finding，merge-ready。
- PR CI run `32942103029`：全部 21 个检查通过，workflow 约 128 秒。
- `test-unit` job：96 秒；此前 #1839 同类 run 为 234 秒，减少 138 秒（约 59%）。
- `Unit tests` step：39 秒；此前 #1839 为 148 秒，减少 109 秒（约 74%）。
- CI 内部阶段：discovery 5.9s、service compile 14.3s、registry 0.1s、other packages 28.7s、最慢 service shard 21.4s。
- 优化后最长 job 为 preflight 114 秒，unit 已不再是整体关键路径。

## 提交

- `8e0772c0c` perf(ci): overlap service compile with discovery
- `389575296` fix(ci): terminate unit runner process trees

最新提交：`389575296`