### PR TITLE
chore(ci): move Docker release actions to Node 24

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -106,6 +106,7 @@ jobs:
           python3 -m unittest \
             scripts.test_preflight_ci_lint_skip \
             scripts.checks.test_cache_action_runtime \
+            scripts.checks.test_docker_action_runtime \
             scripts.checks.test_release_cache_key_parity \
             scripts.checks.test_go_rolling_cache_policy \
             scripts.test_preflight_ci_handoffs \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,14 +195,14 @@ jobs:
 
       # Docker setup for GoReleaser
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
         if: ${{ env.DOCKERHUB_USERNAME != '' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         with:
@@ -210,7 +210,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/scripts/checks/test_docker_action_runtime.py
+++ b/scripts/checks/test_docker_action_runtime.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Contract tests for Docker GitHub Actions using the Node 24 runtime major."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GITHUB_DIR = REPO_ROOT / ".github"
+DOCKER_ACTION = re.compile(
+    r"docker/(?P<action>login-action|setup-buildx-action|setup-qemu-action)"
+    r"@v(?P<major>\d+)"
+)
+REQUIRED_ACTIONS = {
+    "login-action",
+    "setup-buildx-action",
+    "setup-qemu-action",
+}
+REQUIRED_MAJOR = "4"
+
+
+class DockerActionRuntimeTest(unittest.TestCase):
+    def test_all_direct_docker_actions_use_node24_runtime_major(self) -> None:
+        found: set[str] = set()
+        outdated: list[str] = []
+
+        workflow_files = sorted(GITHUB_DIR.rglob("*.yml")) + sorted(
+            GITHUB_DIR.rglob("*.yaml")
+        )
+        for path in workflow_files:
+            for line_number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), start=1
+            ):
+                for match in DOCKER_ACTION.finditer(line):
+                    action_name = match.group("action")
+                    action = match.group(0)
+                    found.add(action_name)
+                    if match.group("major") != REQUIRED_MAJOR:
+                        relative = path.relative_to(REPO_ROOT)
+                        outdated.append(f"{relative}:{line_number}: {action}")
+
+        self.assertEqual(
+            found,
+            REQUIRED_ACTIONS,
+            "Docker action runtime contract must cover every managed action",
+        )
+        self.assertEqual(
+            outdated,
+            [],
+            "managed Docker actions must use v4 (Node 24 runtime):\n"
+            + "\n".join(outdated),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -3007,6 +3007,17 @@ else
     echo "  ok: all direct actions/cache references use the Node 24 runtime major"
 fi
 
+echo ""
+echo "=== sub2api: Docker action Node runtime ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required by Docker action runtime contract)"
+    errors=$((errors + 1))
+elif ! python3 -m unittest scripts.checks.test_docker_action_runtime >/dev/null; then
+    errors=$((errors + 1))
+else
+    echo "  ok: managed Docker actions use the Node 24 runtime major"
+fi
+
 # ---- sub2api: pnpm audit owner contract -------------------------------------
 # Project installs stay on pnpm 9, while security audit uses a pinned pnpm 11
 # owner because npm retired the quick-audit endpoint used by pnpm 9/10.


### PR DESCRIPTION
## 摘要

- 将 Release workflow 的 QEMU、Buildx 与 Registry Login actions 从 v3 升级到使用 Node 24 runtime 的 v4
- 新增全 `.github` Docker action runtime contract，并接入 backend CI 与 preflight
- 防止 Node 20 action major 再次进入 Release 路径

sentinel-registry-reviewed

## 风险

- 低风险 CI 依赖升级
- v4 所需 runner 版本为 2.327.1，当前 GitHub-hosted runner 版本满足要求
- Login 使用的 `registry`、`username`、`password` inputs 在 v4 保留；Buildx/QEMU 未使用 v4 删除的 deprecated inputs
- 无 Web 影响

## 验证

- TDD RED：测试准确捕获 Release workflow 四处 v3 引用
- CI orchestration contract tests：50 tests passed
- 完整 `./scripts/preflight.sh`：PASS
- Docker action runtime contract：PASS
- 独立代码复审：Critical / Important / Minor 均为 0

## 提交

- `78398d873` chore(ci): move Docker release actions to Node 24

最新提交：`78398d873`
