### PR TITLE
fix(scheduler): preserve protocol routing metadata

### DIFF
--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -1042,6 +1042,7 @@ func filterSchedulerExtra(extra map[string]any) map[string]any {
 		"openai_responses_mode",
 		"openai_responses_supported",
 		"openai_native_messages_supported",
+		service.SupportedProtocolsExtraKey,
 		"codex_fingerprint_mode",
 		"codex_fingerprint_seed",
 		"codex_5h_used_percent",

--- a/backend/internal/repository/scheduler_cache_unit_test.go
+++ b/backend/internal/repository/scheduler_cache_unit_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/alicebob/miniredis/v2"
 	"github.com/redis/go-redis/v9"
@@ -497,6 +498,33 @@ func TestBuildSchedulerMetadataAccount_KeepsQuotaAutoPauseFields(t *testing.T) {
 	require.Equal(t, 0.96, got.Extra["auto_pause_7d_threshold"])
 	require.Equal(t, true, got.Extra["auto_pause_5h_disabled"])
 	require.Equal(t, false, got.Extra["auto_pause_7d_disabled"])
+}
+
+func TestSchedulerCacheSnapshotKeepsSupportedProtocolsForRouting(t *testing.T) {
+	account := service.Account{
+		ID:          89,
+		Platform:    service.PlatformOpenAI,
+		Type:        service.AccountTypeOAuth,
+		Status:      service.StatusActive,
+		Schedulable: true,
+		Extra: map[string]any{
+			service.SupportedProtocolsExtraKey: []any{"responses"},
+			"unrelated":                        "drop-me",
+		},
+	}
+	cache := newSchedulerCacheUnit(t)
+	ctx := context.Background()
+	bucket := service.SchedulerBucket{GroupID: 89, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeSingle}
+	token, err := cache.CaptureBucketWriteToken(ctx, bucket)
+	require.NoError(t, err)
+	require.NoError(t, cache.SetSnapshot(ctx, bucket, token, []service.Account{account}))
+
+	snapshot, hit, err := cache.GetSnapshot(ctx, bucket)
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Len(t, snapshot, 1)
+	require.Equal(t, []protocolrouter.Protocol{protocolrouter.ProtocolResponses}, snapshot[0].SupportedProtocols())
+	require.NotContains(t, snapshot[0].Extra, "unrelated")
 }
 
 func TestBuildSchedulerMetadataAccount_KeepsQuotaStateForCachedAccounts(t *testing.T) {


### PR DESCRIPTION
## Summary
- Preserve the canonical `supported_protocols` field in slim scheduler metadata snapshots.
- Keep Responses-only OpenAI OAuth/Codex accounts eligible before full-account hydration.
- Add a Redis snapshot round-trip regression while still proving unrelated metadata is filtered.

## Root cause
The database and full account cache correctly held `supported_protocols=[responses]`, but `filterSchedulerExtra` removed that field from the slim metadata accounts used during candidate eligibility. `ProtocolRouteLegal` therefore saw an empty protocol set and rejected every route with `no_legal_protocol_route` before full-account hydration could occur.

## Validation
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- `make test`
- Focused repository and protocol-routing regressions

no-web-impact

ai