### PR TITLE
perf(ci): 缩短缓存与 preflight 尾部耗时

### DIFF
--- a/.github/actions/go-rolling-cache/action.yml
+++ b/.github/actions/go-rolling-cache/action.yml
@@ -10,9 +10,10 @@
 #   - module cache: identical across all jobs, only changes with go.sum, so one
 #     shared immutable entry is correct and avoids triplicating ~1GB of
 #     GOMODCACHE against the 10GB/repo budget.
-#   - build/test cache: per-job (prefix) + run_id-unique save key so it ROLLS
-#     forward every run; restore-keys seeds from the previous run (incremental,
-#     not cold). Go's cache is content-addressed, so a stale entry is unused,
+#   - build/test cache: per-job (prefix) + UTC-week seed. The first main run of
+#     each week refreshes the large archive; later runs hit the exact key and
+#     avoid uploading 300MB-2.5GB again. restore-keys seed a new week from the
+#     previous one. Go's cache is content-addressed, so stale entries are unused,
 #     never wrong.
 #   - golangci analysis cache: optional, lint-only, and rolling for the same
 #     reason. golangci-lint-action's interval key is immutable after the first
@@ -36,6 +37,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Resolve weekly build cache epoch
+      id: cache_epoch
+      shell: bash
+      run: echo "value=$(date -u +%G-W%V)" >> "$GITHUB_OUTPUT"
+
     - name: Restore Go module cache (non-main writer)
       if: github.event_name != 'push' || github.ref != 'refs/heads/main'
       uses: actions/cache/restore@v6
@@ -57,19 +63,19 @@ runs:
       uses: actions/cache/restore@v6
       with:
         path: ~/.cache/go-build
-        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
+        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ steps.cache_epoch.outputs.value }}
         restore-keys: |
-          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.sum') }}-
+          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
           ${{ runner.os }}-gobuild-${{ inputs.prefix }}-
 
-    - name: Go build/test cache (rolling main writer, ${{ inputs.prefix }})
+    - name: Go build/test cache (weekly main writer, ${{ inputs.prefix }})
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: actions/cache@v6
       with:
         path: ~/.cache/go-build
-        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
+        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ steps.cache_epoch.outputs.value }}
         restore-keys: |
-          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.sum') }}-
+          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
           ${{ runner.os }}-gobuild-${{ inputs.prefix }}-
 
     - name: Restore golangci-lint analysis cache (non-main writer)

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -233,10 +233,10 @@ jobs:
       - name: Unit tests
         working-directory: backend
         env:
-          # Service-cold runs prioritize the compile-once critical path. They
-          # warm build artifacts but intentionally do not seed native go test
-          # result entries; service-neutral runs retain the native cache path.
-          UNIT_TEST_SERVICE_SHARD: ${{ needs.changes.outputs.service_unit_cold == 'true' && '1' || '0' }}
+          # PR service-cold runs prioritize the compile-once critical path.
+          # Main is the rolling-cache writer, so it always uses native go test
+          # to seed result entries before the weekly archive is saved.
+          UNIT_TEST_SERVICE_SHARD: ${{ github.event_name != 'push' && needs.changes.outputs.service_unit_cold == 'true' && '1' || '0' }}
         run: make test-unit
       - name: Anthropic prompt surface fixture gateway
         run: python3 ops/anthropic/probe_prompt_surfaces.py --check-fixture-gateway

--- a/ops/qa/test_qa_phase_ops.py
+++ b/ops/qa/test_qa_phase_ops.py
@@ -34,6 +34,12 @@ def _load_closeout_module():
     return _load_module("prod_qa_archive_closeout", "ops/qa/prod_qa_archive_closeout.py")
 
 
+def _install_noop_sleep(bin_dir: Path) -> None:
+    sleep = bin_dir / "sleep"
+    sleep.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    sleep.chmod(0o755)
+
+
 class TestQAPhaseOps(unittest.TestCase):
     def test_prod_rollout_separates_repository_readiness_from_live_activation(self) -> None:
         import yaml
@@ -651,6 +657,7 @@ class TestQAPhaseOps(unittest.TestCase):
             output = root / "output"
             fake_bin.mkdir()
             output.mkdir()
+            _install_noop_sleep(fake_bin)
             fake_aws = fake_bin / "aws"
             fake_aws.write_text(
                 """#!/usr/bin/env bash
@@ -775,6 +782,7 @@ exit 0
             output = root / "output"
             fake_bin.mkdir()
             output.mkdir()
+            _install_noop_sleep(fake_bin)
             fake_aws = fake_bin / "aws"
             fake_aws.write_text(
                 """#!/usr/bin/env bash
@@ -819,6 +827,7 @@ exit 0
             output = root / "output"
             fake_bin.mkdir()
             output.mkdir()
+            _install_noop_sleep(fake_bin)
             (fake_bin / "aws").write_text(
                 """#!/usr/bin/env bash
 if [[ "$*" == *"ssm send-command"* ]]; then echo cmd-test; exit 0; fi
@@ -904,6 +913,7 @@ exit 0
             fake_bin = root / "bin"
             output = root / "output"
             fake_bin.mkdir()
+            _install_noop_sleep(fake_bin)
             fake_aws = fake_bin / "aws"
             fake_aws.write_text(
                 """#!/usr/bin/env bash
@@ -1213,6 +1223,7 @@ esac
             root = Path(temp_dir)
             fake_bin = root / "bin"
             fake_bin.mkdir()
+            _install_noop_sleep(fake_bin)
             fake_aws = fake_bin / "aws"
             fake_aws.write_text(
                 """#!/usr/bin/env bash

--- a/scripts/checks/test_go_rolling_cache_policy.py
+++ b/scripts/checks/test_go_rolling_cache_policy.py
@@ -49,6 +49,37 @@ class GoRollingCachePolicyTest(unittest.TestCase):
                 self.assertIn("backend/go.sum", step["with"]["key"])
                 self.assertIn("backend/.golangci.yml", step["with"]["key"])
 
+    def test_large_build_caches_refresh_weekly_instead_of_every_run(self) -> None:
+        action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
+        steps = action["runs"]["steps"]
+        epoch_step = next(step for step in steps if step.get("id") == "cache_epoch")
+        self.assertIn("date -u +%G-W%V", epoch_step["run"])
+
+        build_steps = [
+            step
+            for step in steps
+            if step.get("with", {}).get("path") == "~/.cache/go-build"
+        ]
+        self.assertEqual(len(build_steps), 2)
+        for step in build_steps:
+            with self.subTest(step=step["name"]):
+                cache_config = step["with"]
+                key = cache_config["key"]
+                self.assertIn("steps.cache_epoch.outputs.value", key)
+                self.assertNotIn("github.run_id", key)
+                self.assertIn("backend/go.mod", key)
+                self.assertIn("backend/go.sum", key)
+                self.assertIn(".new-api-ref", key)
+
+                restore_keys = cache_config["restore-keys"].splitlines()
+                self.assertEqual(
+                    restore_keys[0],
+                    "${{ runner.os }}-gobuild-${{ inputs.prefix }}-"
+                    "${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-",
+                )
+                self.assertNotIn("steps.cache_epoch.outputs.value", cache_config["restore-keys"])
+                self.assertNotIn("github.run_id", str(cache_config))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -188,7 +188,7 @@ class BackendCIRoutingTest(unittest.TestCase):
             unit_step["env"]["UNIT_TEST_SERVICE_SHARD"],
         )
 
-    def test_unit_main_push_prioritizes_shards_over_native_result_cache(self) -> None:
+    def test_unit_main_push_seeds_native_result_cache(self) -> None:
         unit_step = next(
             step
             for step in self.jobs["test-unit"]["steps"]
@@ -197,7 +197,8 @@ class BackendCIRoutingTest(unittest.TestCase):
 
         self.assertEqual(
             unit_step["env"]["UNIT_TEST_SERVICE_SHARD"],
-            "${{ needs.changes.outputs.service_unit_cold == 'true' && '1' || '0' }}",
+            "${{ github.event_name != 'push' && "
+            "needs.changes.outputs.service_unit_cold == 'true' && '1' || '0' }}",
         )
 
     def test_lint_uses_rolling_analysis_cache_instead_of_action_cache(self) -> None:


### PR DESCRIPTION
## 摘要

- 将大型 Go build/test cache 从每次 main run 刷新改为按 UTC 周刷新；同周后续 run 命中 exact key，避免重复上传 2GB 级缓存。
- 缓存 key 同时绑定 `backend/go.mod`、`backend/go.sum` 与 `.new-api-ref`；依赖或 Go 版本变化仍会立即刷新。
- 保留 golangci-lint 小型 analysis cache 的逐 run 滚动策略。
- 在 hermetic SSM QA fixture 中注入 fake `sleep`，去掉测试中的真实 3 秒轮询等待，不改变生产脚本轮询行为。
- main push 始终走原生 `go test`，确保每周缓存写入者播种可复用的 service test result；PR service 冷路径仍保留 compile-once shard。
- 补充 weekly key、跨周 restore prefix、`github.run_id` 隔离与 main result-cache writer 的契约测试。

## 风险

- 常规风险，仅影响 CI 缓存策略、单测路由与测试 fixture。每个 UTC 周首个 main run 仍会保存一次大型缓存；后续 main run 才获得 exact-hit 收益。
- main 的 service 变更 run 不再使用 shard，单次写入可能更慢，但它会生成原生 test result entry，避免不完整缓存锁定一整周；PR 冷路径仍使用 shard。
- restore key 保留依赖哈希并回退上一周缓存；Go build cache 为 content-addressed，旧对象不会造成错误复用。
- 不新增 job、runner 或 check，不增加 GitHub Actions credits 消耗。
- 无产品与 Web 行为变化。

## 验证

- `python3 -m unittest scripts.test_backend_ci_routing scripts.checks.test_go_rolling_cache_policy ops.qa.test_qa_phase_ops`：63/63 通过。
- `PREFLIGHT_BASE=origin/main ./scripts/preflight.sh`：通过。
- `git diff --check origin/main...HEAD`：通过。
- 首轮 PR CI（`ad5b8a500`）：全部 checks 通过；计时复盘定位到 service result cache 未播种问题，并由第二个提交修复。

## 提交

- `ad5b8a500 perf(ci): shorten cache and preflight tail latency`
- `52b6c968c perf(ci): keep main as unit result-cache writer`

最新提交：`52b6c968c`