### PR TITLE
perf(ci): 缩短 main unit 关键路径

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -234,9 +234,10 @@ jobs:
         working-directory: backend
         env:
           # PR service-cold runs prioritize the compile-once critical path.
-          # Main is the rolling-cache writer, so it always uses native go test
-          # to seed result entries before the weekly archive is saved.
-          UNIT_TEST_SERVICE_SHARD: ${{ github.event_name != 'push' && needs.changes.outputs.service_unit_cold == 'true' && '1' || '0' }}
+          # Main also uses shards: service tests inspect tracked source/fixture
+          # files at runtime, so checkout mtimes prevent cross-run result-cache
+          # hits even when the weekly Go build cache restores exactly.
+          UNIT_TEST_SERVICE_SHARD: ${{ (github.event_name == 'push' || needs.changes.outputs.service_unit_cold == 'true') && '1' || '0' }}
         run: make test-unit
       - name: Anthropic prompt surface fixture gateway
         run: python3 ops/anthropic/probe_prompt_surfaces.py --check-fixture-gateway

--- a/backend/internal/service/openai_responses_tool_schema_test.go
+++ b/backend/internal/service/openai_responses_tool_schema_test.go
@@ -586,8 +586,9 @@ func TestSanitizeOpenAIResponsesToolParameterTypes_RewriteCountIndependentOfHits
 		_, _, _ = sanitizeOpenAIResponsesToolParameterTypes(large)
 	})
 
-	// 命中切片扩容是对数级，留出充裕余量；线性写法在这里会是 2000 量级。
-	require.Less(t, largeAllocs, smallAllocs+40,
+	// 命中切片扩容是对数级；不同 OS/架构和分片进程的标准库分配基线会有
+	// 差异，因此保留有界余量。逐命中全量重写仍会达到 2000 量级。
+	require.Less(t, largeAllocs, smallAllocs+100,
 		"分配次数随命中数线性增长，说明退回了逐路径全量重写 (small=%v large=%v)", smallAllocs, largeAllocs)
 
 	// 同时确认大 body 的结果确实全部修好了。

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -188,7 +188,7 @@ class BackendCIRoutingTest(unittest.TestCase):
             unit_step["env"]["UNIT_TEST_SERVICE_SHARD"],
         )
 
-    def test_unit_main_push_seeds_native_result_cache(self) -> None:
+    def test_unit_main_push_uses_service_shards(self) -> None:
         unit_step = next(
             step
             for step in self.jobs["test-unit"]["steps"]
@@ -197,8 +197,8 @@ class BackendCIRoutingTest(unittest.TestCase):
 
         self.assertEqual(
             unit_step["env"]["UNIT_TEST_SERVICE_SHARD"],
-            "${{ github.event_name != 'push' && "
-            "needs.changes.outputs.service_unit_cold == 'true' && '1' || '0' }}",
+            "${{ (github.event_name == 'push' || "
+            "needs.changes.outputs.service_unit_cold == 'true') && '1' || '0' }}",
         )
 
     def test_lint_uses_rolling_analysis_cache_instead_of_action_cache(self) -> None:


### PR DESCRIPTION
## 摘要
- main push 改用现有 compile-once 的 8 路 service shard runner，避免 internal/service 每次串行重跑。
- PR 保留 service_unit_cold 条件路由；不增加 job、runner 或检查项，不增加 GitHub Actions credits 消耗。
- 调整 shard 暴露的 allocation 复杂度守卫，使其兼容 Linux 分片进程及不同 OS/架构的固定分配基线。
- 保留 golangci-lint 的完整配置 schema verify，不以削弱配置校验换取稳定性。

## 风险
- 常规风险，仅影响 CI 编排与测试稳定性；测试集合、生产实现和产品行为不变。
- allocation 守卫余量从 40 调整为 100；线性退化约为 2000 次分配，仍有明显数量级差距。
- upstream-conflict-surface-accepted：原断言位于上游共享测试文件，companion 文件无法覆盖已有测试；本次只调整跨平台测试容差，不修改生产代码。

## 验证
- ./scripts/preflight.sh：PASS（最终本地 HEAD adb804674）。
- python3 -m unittest scripts.ci.test_unit_test_runner scripts.checks.test_go_rolling_cache_policy scripts.test_backend_ci_routing：32/32 PASS。
- GOTOOLCHAIN=go1.26.6 UNIT_TEST_SERVICE_SHARD=1 make test-unit：全部 package 与 8 个 service shard 通过。
- allocation 守卫在 Go 1.26.6 ARM64、AMD64 下分别连续运行 20 次通过；独立复核再次执行 -count=20 通过。
- 独立复核：0 Critical / 0 Important / 0 Minor；确认 workflow 与 routing 测试中不存在 verify: false。

## 提交
- 6291a30dc perf(ci): shard service tests on main
- adb804674 fix(ci): stabilize sharded allocation guard
- 最新提交：adb804674