### PR TITLE
fix(ops): 修复 Edge native smoke companion 投递

### DIFF
--- a/ops/stage0/edge_post_deploy_smoke.sh
+++ b/ops/stage0/edge_post_deploy_smoke.sh
@@ -181,6 +181,7 @@ run_edge_native_anthropic_smoke() {
     --timeout-seconds 600 \
     --script "${SCRIPT_DIR}/edge_native_anthropic_smoke.sh" \
     --with "${SCRIPT_DIR}/probe_account_model.sh" \
+    --with "${REPO_ROOT}/ops/pricing/probe_reserved_resources.sh" \
     --with "${SCRIPT_DIR}/probe_account_model_verdict.py" \
     --with "${SCRIPT_DIR}/smoke_anthropic_realistic.py" \
     --env "ANTHROPIC_MODELS=${TK_SMOKE_EDGE_LOCAL_CHAT_MODELS}" \

--- a/ops/stage0/probe_account_model.sh
+++ b/ops/stage0/probe_account_model.sh
@@ -30,6 +30,15 @@ LOG_WINDOW="${LOG_WINDOW:-3m}"
 REQUEST_TIMEOUT_SECONDS="${REQUEST_TIMEOUT_SECONDS:-90}"
 PROBE_USER_ID=1
 
+fail_json() {
+  local message="$1"
+  python3 - "$message" <<'PY'
+import json, sys
+print(json.dumps({"verdict": "setup_error", "error": sys.argv[1]}, ensure_ascii=False))
+PY
+  exit 0
+}
+
 PSQL=(sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -q -A -t -v ON_ERROR_STOP=1)
 PSQL_ARRAY=("${PSQL[@]}")
 PROBE_RESOURCES="${SCRIPT_DIR}/../pricing/probe_reserved_resources.sh"
@@ -52,15 +61,6 @@ import secrets
 print(secrets.token_urlsafe(18).replace("-", "").replace("_", "")[:24])
 PY
 )"
-}
-
-fail_json() {
-  local message="$1"
-  python3 - "$message" <<'PY'
-import json, sys
-print(json.dumps({"verdict": "setup_error", "error": sys.argv[1]}, ensure_ascii=False))
-PY
-  exit 0
 }
 
 psql_capture_numeric() {

--- a/ops/stage0/test_edge_post_deploy_smoke.py
+++ b/ops/stage0/test_edge_post_deploy_smoke.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Behavioral tests for edge_post_deploy_smoke.sh orchestration."""
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+_STAGE0_DIR = pathlib.Path(__file__).resolve().parent
+_SCRIPT = _STAGE0_DIR / "edge_post_deploy_smoke.sh"
+
+
+class EdgePostDeploySmokeTest(unittest.TestCase):
+    def test_native_oauth_smoke_delivers_reserved_resources_companion(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="edge-post-deploy-smoke-test-") as td:
+            repo_root = pathlib.Path(td) / "repo"
+            stage0_dir = repo_root / "ops" / "stage0"
+            observability_dir = repo_root / "ops" / "observability"
+            fake_bin = repo_root / "fake-bin"
+            stage0_dir.mkdir(parents=True)
+            observability_dir.mkdir(parents=True)
+            fake_bin.mkdir()
+
+            for name in (
+                "edge_post_deploy_smoke.sh",
+                "smoke_env.sh",
+                "ssm_resolve_invocation_mi.inc.sh",
+            ):
+                shutil.copy2(_STAGE0_DIR / name, stage0_dir / name)
+
+            args_log = repo_root / "run-probe-args.txt"
+            run_probe = observability_dir / "run-probe.sh"
+            run_probe.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    printf '%s\n' "$@" > "${RUN_PROBE_ARGS_LOG}"
+                    """
+                )
+            )
+
+            for command in ("aws", "curl", "jq"):
+                fake_command = fake_bin / command
+                fake_command.write_text("#!/usr/bin/env bash\nexit 0\n")
+                fake_command.chmod(0o755)
+
+            env = {
+                **os.environ,
+                "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+                "AWS_REGION": "us-east-1",
+                "EDGE_API_URL": "https://us5.example.test",
+                "EDGE_ID": "us5",
+                "EDGE_INSTANCE_ID": "mi-test",
+                "EDGE_SMOKE_PHASE": "edge-native-oauth",
+                "RUN_PROBE_ARGS_LOG": str(args_log),
+            }
+            proc = subprocess.run(
+                ["bash", str(stage0_dir / _SCRIPT.name)],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            delivered_args = args_log.read_text().splitlines() if args_log.exists() else []
+
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertIn("tk_edge_post_deploy_smoke: OK phase=edge-native-oauth", proc.stdout)
+        companion = str(repo_root / "ops" / "pricing" / "probe_reserved_resources.sh")
+        self.assertIn(companion, delivered_args)
+        companion_at = delivered_args.index(companion)
+        self.assertGreater(companion_at, 0)
+        self.assertEqual(delivered_args[companion_at - 1], "--with")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/stage0/test_probe_account_model.py
+++ b/ops/stage0/test_probe_account_model.py
@@ -1,14 +1,36 @@
 #!/usr/bin/env python3
-"""Static regression tests for probe_account_model.sh."""
+"""Regression tests for probe_account_model.sh."""
 from __future__ import annotations
 
+import json
 import pathlib
+import shutil
+import subprocess
+import tempfile
 import unittest
 
 _SCRIPT = pathlib.Path(__file__).resolve().parent / "probe_account_model.sh"
 
 
 class ProbeAccountModelTest(unittest.TestCase):
+    def test_missing_reserved_resources_reports_structured_setup_error(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="probe-account-model-test-") as td:
+            isolated_script = pathlib.Path(td) / "probe_account_model.sh"
+            shutil.copy2(_SCRIPT, isolated_script)
+
+            proc = subprocess.run(
+                ["bash", str(isolated_script)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        payload = json.loads(proc.stdout)
+        self.assertEqual(payload["verdict"], "setup_error")
+        self.assertIn("missing probe_reserved_resources.sh companion", payload["error"])
+        self.assertNotIn("command not found", proc.stderr)
+
     def test_reusable_group_ensure_uses_two_step_returning_id(self) -> None:
         script = _SCRIPT.read_text()
         start = script.index('if [[ "$PROBE_REUSE_MODE" == "1" ]]; then\n  GROUP_ID=')


### PR DESCRIPTION
## 摘要

- 修复 Edge canonical full smoke 调用 run-probe.sh 时遗漏 ops/pricing/probe_reserved_resources.sh，确保 native account-model probe 的 companion 被投递到远端。
- 将 fail_json 定义提前到 companion 校验之前；即使交付再次缺失，也会返回结构化 setup_error，不再退化为 shell 127。
- 新增两条行为回归测试，分别执行真实 probe 脚本和 Edge smoke 编排脚本，锁住错误输出与运行时参数投递契约。

## 风险

- 低风险：仅修改 Stage0 Edge smoke harness 和诊断失败路径，不改变网关运行时、API、数据库或 Web 行为。
- no-web-impact。
- v1.8.176 的 prod 与其余 Edge rollout 继续保持暂停；本 PR 合并后仍需重跑 us5 canonical full smoke 并出现 tk_edge_post_deploy_smoke: OK phase=full，才可恢复 rollout。

## 验证

- TDD RED：缺 companion 时复现 fail_json: command not found / exit 127；Edge runtime 参数中确认 companion 缺失。
- 聚焦测试：python3 -m unittest ops.stage0.test_probe_account_model ops.stage0.test_edge_post_deploy_smoke（8 tests，OK）。
- 相邻 smoke 测试：python3 -m unittest ops.stage0.test_edge_native_anthropic_smoke scripts.test_edge_smoke_phase_contract（9 tests，OK）。
- 完整门禁：bash scripts/preflight.sh（PASS，提交前与提交后各一次）。
- 独立只读代码审查：无 Critical / Important / Minor finding，结论 Ready to merge。

## 提交

- fdfd7c44b01505005757b6b9f0674f48efa03bbc fix(ops): deliver reserved probe companion to edge smoke
- 最新提交：fdfd7c44b01505005757b6b9f0674f48efa03bbc
