### PR TITLE
fix(openai): locally count Codex response input tokens

### DIFF
--- a/backend/internal/engine/protocolrouter/endpoints.go
+++ b/backend/internal/engine/protocolrouter/endpoints.go
@@ -26,6 +26,11 @@ func resolveEndpoint(account AccountSnapshot, target Protocol, responsesPath Res
 			return "https://chatgpt.com/backend-api/codex/responses", nil
 		case ResponsesPathCompact:
 			return "https://chatgpt.com/backend-api/codex/responses/compact", nil
+		case ResponsesPathInputTokens:
+			// Codex has no input_tokens endpoint. The root endpoint is only the
+			// validated account-route anchor; the token-count executor estimates
+			// locally and never sends this request upstream.
+			return "https://chatgpt.com/backend-api/codex/responses", nil
 		default:
 			return "", fmt.Errorf("OpenAI Codex official profile does not support responses path %q", responsesPath)
 		}

--- a/backend/internal/engine/protocolrouter/router_test.go
+++ b/backend/internal/engine/protocolrouter/router_test.go
@@ -166,6 +166,25 @@ func TestPlanUsesFixedOpenAICodexEndpointOnlyForResponses(t *testing.T) {
 	if chatPlan.TargetProtocol() != ProtocolResponses || chatPlan.Endpoint() != "https://chatgpt.com/backend-api/codex/responses" {
 		t.Fatalf("chat plan target/endpoint = %q/%q, want responses on fixed Codex endpoint", chatPlan.TargetProtocol(), chatPlan.Endpoint())
 	}
+
+	inputTokensRequest, err := NewCanonicalRequest(CanonicalRequestInput{
+		InboundProtocol: ProtocolResponses,
+		RequestedModel:  "gpt-5.4",
+		ResponsesPath:   ResponsesPathInputTokens,
+		Profile:         RequestProfile{ContentKinds: ContentText},
+		Body:            []byte(`{"model":"gpt-5.4","input":"hello"}`),
+	})
+	if err != nil {
+		t.Fatalf("NewCanonicalRequest input_tokens: %v", err)
+	}
+	inputTokensPlan, err := New(allTestAdapters()).Plan(inputTokensRequest, account)
+	if err != nil {
+		t.Fatalf("Plan input_tokens: %v", err)
+	}
+	if inputTokensPlan.ResponsesPath() != ResponsesPathInputTokens ||
+		inputTokensPlan.Endpoint() != "https://chatgpt.com/backend-api/codex/responses" {
+		t.Fatalf("input_tokens plan path/endpoint = %q/%q, want input_tokens anchored to Codex responses", inputTokensPlan.ResponsesPath(), inputTokensPlan.Endpoint())
+	}
 }
 
 func TestPlanSkipsRouteWithoutAdapter(t *testing.T) {

--- a/backend/internal/handler/openai_responses_input_tokens_legacy_protocol_fallback_test.go
+++ b/backend/internal/handler/openai_responses_input_tokens_legacy_protocol_fallback_test.go
@@ -18,6 +18,67 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+func TestResponsesInputTokensOpenAICodexOAuthUsesRootRouteForLocalEstimate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	groupID := int64(19)
+	group := &service.Group{ID: groupID, Hydrated: true, Platform: service.PlatformOpenAI, Status: service.StatusActive}
+	account := service.Account{
+		ID:          73,
+		Name:        "Codex OAuth",
+		Platform:    service.PlatformOpenAI,
+		Type:        service.AccountTypeOAuth,
+		Status:      service.StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{"access_token": "test-token"},
+		Extra:       map[string]any{service.SupportedProtocolsExtraKey: []any{"responses"}},
+	}
+	accountRepo := &openAIWSFailoverHandlerAccountRepoStub{accounts: []service.Account{account}}
+	cfg := &config.Config{RunMode: config.RunModeSimple}
+	cfg.Default.RateMultiplier = 1
+	schedulerSnapshot := service.NewSchedulerSnapshotService(
+		&fakeSchedulerCache{accounts: []*service.Account{&account}},
+		nil,
+		accountRepo,
+		&fakeGroupRepo{group: group},
+		cfg,
+	)
+	billingCache := service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, cfg, nil)
+	t.Cleanup(billingCache.Stop)
+	gateway := service.NewOpenAIGatewayService(
+		accountRepo, nil, nil, nil, nil, nil, nil, cfg, schedulerSnapshot, nil,
+		service.NewBillingService(cfg, nil), nil, billingCache, nil,
+		&service.DeferredService{}, nil, nil, nil, nil, nil, nil, nil,
+	)
+	h := NewOpenAIGatewayHandler(
+		gateway,
+		service.NewConcurrencyService(nil),
+		billingCache,
+		&service.APIKeyService{},
+		nil, nil, nil, nil,
+		cfg,
+	)
+	h.SetProtocolRouter(service.NewProtocolRouter())
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses/input_tokens", strings.NewReader(
+		`{"model":"gpt-5.6-sol","input":"hello"}`,
+	))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set(string(middleware.ContextKeyAPIKey), &service.APIKey{
+		ID: 1818, GroupID: &groupID,
+		User:  &service.User{ID: 1718, Status: service.StatusActive},
+		Group: group,
+	})
+	c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{UserID: 1718, Concurrency: 1})
+
+	h.ResponsesInputTokens(c)
+
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	require.Greater(t, gjson.GetBytes(recorder.Body.Bytes(), "input_tokens").Int(), int64(0), recorder.Body.String())
+}
+
 func TestResponsesInputTokensCutoverDisabledKeepsLegacyExecutor(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	groupID := int64(18)

--- a/backend/internal/service/openai_gateway_count_tokens.go
+++ b/backend/internal/service/openai_gateway_count_tokens.go
@@ -60,6 +60,10 @@ func (s *OpenAIGatewayService) ForwardResponsesInputTokens(
 		return err
 	}
 
+	if account.IsOpenAIOAuthLike() {
+		writeOpenAIResponsesInputTokensFallback(c, account, prepared, 0, "codex_endpoint_unsupported")
+		return nil
+	}
 	if shouldEstimateOpenAIInputTokensLocally(account) {
 		writeOpenAIResponsesInputTokensFallback(c, account, prepared, 0, "custom_relay")
 		return nil

--- a/backend/internal/service/openai_responses_input_tokens_test.go
+++ b/backend/internal/service/openai_responses_input_tokens_test.go
@@ -66,6 +66,26 @@ func TestForwardResponsesInputTokensGrokOAuthUsesLocalEstimate(t *testing.T) {
 	require.Nil(t, upstream.lastReq)
 }
 
+func TestForwardResponsesInputTokensOpenAICodexOAuthUsesLocalEstimate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/input_tokens", nil)
+
+	upstream := &httpUpstreamRecorder{}
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := &Account{ID: 170, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	body := []byte(`{"model":"gpt-5.6-sol","input":"hello world"}`)
+
+	err := svc.ForwardResponsesInputTokens(context.Background(), c, account, body)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, "response.input_tokens", gjson.Get(recorder.Body.String(), "object").String())
+	require.Positive(t, gjson.Get(recorder.Body.String(), "input_tokens").Int())
+	require.Nil(t, upstream.lastReq, "Codex OAuth has no responses input_tokens endpoint")
+}
+
 func TestForwardResponsesInputTokensUpstream404FallsBackLocally(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()


### PR DESCRIPTION
## Summary
- let Responses-only Codex OAuth accounts pass governed `/v1/responses/input_tokens` selection without inventing an upstream token-count endpoint
- use the existing local estimator before any OAuth upstream request
- add router, service, and handler regressions for the live us6 failure shape

## Root cause
The Codex official endpoint profile supports Responses generation but has no `input_tokens` endpoint. Protocol routing therefore rejected the only eligible OAuth account before the existing local estimator could run, producing `no_legal_protocol_route` and HTTP 503.

The selected plan keeps `ResponsesPathInputTokens`; the Codex root Responses URL is only a validated route anchor. `ForwardResponsesInputTokens` recognizes OAuth/SetupToken first and returns a local estimate without sending the request upstream.

## Validation
- `go test -tags=unit ./internal/service ./internal/engine/protocolrouter ./internal/handler`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- `make test`
- `git diff --check`

## Risk
Normal. Additive behavior limited to OpenAI OAuth-like accounts on `/v1/responses/input_tokens`; normal Responses generation, compact, API-key native token counting, and non-governed fallback remain unchanged.

## Web impact
no-web-impact

sentinel-registry-reviewed

ai