### PR TITLE
perf(ci): 缩小 unit 编译缓存

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -225,7 +225,9 @@ jobs:
           cache: false
       - uses: ./.github/actions/go-rolling-cache
         with:
-          prefix: unit
+          # Unit test archives omit DWARF below, so keep them out of the old
+          # 2.6GB namespace whose objects were built with different gcflags.
+          prefix: unit-nodwarf-v1
       - name: Verify Go version
         run: |
           expected=$(awk '/^go /{print $2; exit}' backend/go.mod)
@@ -238,6 +240,9 @@ jobs:
           # files at runtime, so checkout mtimes prevent cross-run result-cache
           # hits even when the weekly Go build cache restores exactly.
           UNIT_TEST_SERVICE_SHARD: ${{ (github.event_name == 'push' || needs.changes.outputs.service_unit_cold == 'true') && '1' || '0' }}
+          # Test failures retain file:line stacks without DWARF. Omitting it
+          # shrinks the large unit build cache and the service test binary.
+          GOFLAGS: -gcflags=all=-dwarf=false
         run: make test-unit
       - name: Anthropic prompt surface fixture gateway
         run: python3 ops/anthropic/probe_prompt_surfaces.py --check-fixture-gateway

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -211,6 +211,10 @@ jobs:
     needs: changes
     if: (github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'ci'))) && (needs.changes.outputs.all == 'true' || needs.changes.outputs.backend == 'true')
     runs-on: ubuntu-latest
+    env:
+      # Test failures retain file:line stacks without DWARF. Apply the flag to
+      # every Go command in this job so the fixture gateway reuses unit objects.
+      GOFLAGS: -gcflags=all=-dwarf=false
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/cache-and-checkout-new-api
@@ -240,9 +244,6 @@ jobs:
           # files at runtime, so checkout mtimes prevent cross-run result-cache
           # hits even when the weekly Go build cache restores exactly.
           UNIT_TEST_SERVICE_SHARD: ${{ (github.event_name == 'push' || needs.changes.outputs.service_unit_cold == 'true') && '1' || '0' }}
-          # Test failures retain file:line stacks without DWARF. Omitting it
-          # shrinks the large unit build cache and the service test binary.
-          GOFLAGS: -gcflags=all=-dwarf=false
         run: make test-unit
       - name: Anthropic prompt surface fixture gateway
         run: python3 ops/anthropic/probe_prompt_surfaces.py --check-fixture-gateway

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -201,6 +201,27 @@ class BackendCIRoutingTest(unittest.TestCase):
             "needs.changes.outputs.service_unit_cold == 'true') && '1' || '0' }}",
         )
 
+    def test_unit_job_omits_dwarf_from_test_build_objects(self) -> None:
+        unit_step = next(
+            step
+            for step in self.jobs["test-unit"]["steps"]
+            if step.get("name") == "Unit tests"
+        )
+
+        self.assertEqual(
+            unit_step["env"]["GOFLAGS"],
+            "-gcflags=all=-dwarf=false",
+        )
+
+    def test_unit_job_uses_dwarf_specific_build_cache_namespace(self) -> None:
+        rolling_cache = next(
+            step
+            for step in self.jobs["test-unit"]["steps"]
+            if step.get("uses") == "./.github/actions/go-rolling-cache"
+        )
+
+        self.assertEqual(rolling_cache["with"]["prefix"], "unit-nodwarf-v1")
+
     def test_lint_uses_rolling_analysis_cache_instead_of_action_cache(self) -> None:
         steps = self.jobs["golangci-lint"]["steps"]
         rolling_cache = next(

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -202,15 +202,25 @@ class BackendCIRoutingTest(unittest.TestCase):
         )
 
     def test_unit_job_omits_dwarf_from_test_build_objects(self) -> None:
-        unit_step = next(
-            step
-            for step in self.jobs["test-unit"]["steps"]
-            if step.get("name") == "Unit tests"
+        self.assertEqual(
+            self.jobs["test-unit"]["env"]["GOFLAGS"],
+            "-gcflags=all=-dwarf=false",
         )
 
+    def test_unit_dwarf_flags_do_not_leak_to_other_go_jobs(self) -> None:
+        declarations = []
+        for job_name, job in self.jobs.items():
+            if "GOFLAGS" in job.get("env", {}):
+                declarations.append((job_name, "job", job["env"]["GOFLAGS"]))
+            for step in job.get("steps", []):
+                if "GOFLAGS" in step.get("env", {}):
+                    declarations.append(
+                        (job_name, step.get("name", step.get("uses")), step["env"]["GOFLAGS"])
+                    )
+
         self.assertEqual(
-            unit_step["env"]["GOFLAGS"],
-            "-gcflags=all=-dwarf=false",
+            declarations,
+            [("test-unit", "job", "-gcflags=all=-dwarf=false")],
         )
 
     def test_unit_job_uses_dwarf_specific_build_cache_namespace(self) -> None:
@@ -221,6 +231,13 @@ class BackendCIRoutingTest(unittest.TestCase):
         )
 
         self.assertEqual(rolling_cache["with"]["prefix"], "unit-nodwarf-v1")
+
+        integration_cache = next(
+            step
+            for step in self.jobs["test-integration"]["steps"]
+            if step.get("uses") == "./.github/actions/go-rolling-cache"
+        )
+        self.assertEqual(integration_cache["with"]["prefix"], "integration")
 
     def test_lint_uses_rolling_analysis_cache_instead_of_action_cache(self) -> None:
         steps = self.jobs["golangci-lint"]["steps"]


### PR DESCRIPTION
## 摘要

- unit 测试统一使用 `-gcflags=all=-dwarf=false`，减少测试编译对象与 service test binary 体积。
- unit build cache namespace 滚动为 `unit-nodwarf-v1`，避免继续恢复旧的约 2.72GB DWARF cache。
- `GOFLAGS` 限定在 `test-unit` job，并覆盖 fixture gateway，使其复用 unit 编译对象；integration 与 golangci-lint 保持原配置。
- 不调整测试集合、shard 数量或业务代码。

## 风险

- 低风险。DWARF 仅用于二进制调试信息；已实跑完整 service unit binary，测试通过且运行时栈仍保留文件名与行号。
- PR 分支保持 cache 只读；最终改动没有放开任何非 main cache 写权限。用于测量的 writer 仅存在于独立 benchmark 分支，不属于本 PR。
- 合并后的首次 main run 需要冷生成 `unit-nodwarf-v1` cache；明显收益从后续 warm run 开始。

## 验证

- `python3 -m unittest scripts.test_backend_ci_routing scripts.checks.test_go_rolling_cache_policy scripts.ci.test_changed_surfaces`（37 项通过）
- `GOFLAGS=-gcflags=all=-dwarf=false UNIT_TEST_SERVICE_SHARD=1 make test-unit`（other packages + 8 个 service shards 全通过）
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`（最新提交 `e870520a0` 通过）
- #1849 最新 PR CI run `33038303659` 全绿；PR cache 只读且 namespace 首次出现，因此 `test-unit` 为 cold 364 秒。
- 隔离 benchmark cold run `33038691668`：`test-unit` 360 秒；build cache miss 后保存 337,884,723 bytes；Unit tests 327 秒，fixture 4 秒。
- 同一 commit warm run `33039076910`：build cache 命中约 322 MiB；`test-unit` 61 秒，其中 cache restore 11 秒、Unit tests 29 秒、fixture 4 秒；service compile 8.2 秒，other packages 23.2 秒。
- 当前 main 基线 run `32984517107` attempt 2：`test-unit` 156 秒，其中 cache restore 47 秒、Unit tests 92 秒、fixture 5 秒；service compile 70.2 秒，other packages 62.3 秒。
- warm 总时长 156 → 61 秒，缩短 95 秒（约 60.9%）；cache 2,716,326,553 → 337,884,723 bytes，缩小约 87.6%，均明显超过保留门槛。
- 本地独立空 GOCACHE 对照：默认 47 秒 / 1.69GB，`-dwarf=false` 38 秒 / 1.14GB；编译约快 19%，cache 小约 32%。

## 提交

- `182e004a3 perf(ci): 缩小 unit 编译缓存`
- `e870520a0 fix(ci): 复用 unit fixture 编译对象`
- 最新提交：`e870520a0`
