### PR TITLE
perf(ci): 复用 unit 编译完成的 Go artifact 检查

### DIFF
--- a/.github/actions/go-rolling-cache/action.yml
+++ b/.github/actions/go-rolling-cache/action.yml
@@ -10,12 +10,12 @@
 #   - module cache: identical across all jobs, only changes with go.sum, so one
 #     shared immutable entry is correct and avoids triplicating ~1GB of
 #     GOMODCACHE against the 10GB/repo budget.
-#   - build/test cache: per-job (prefix) + tracked backend input fingerprint.
-#     Main writes a new archive only when backend inputs change; PRs restore the
-#     newest matching main snapshot but never upload. This avoids a fixed weekly
-#     key pinning the cache before later source changes while also avoiding
-#     per-run uploads for VERSION/CI-only changes. Go's cache is content-addressed,
-#     so restoring the prior backend snapshot safely seeds changed PRs.
+#   - build/test cache: per-job (prefix) + UTC-week seed by default, avoiding
+#     repeated uploads of the 300MB-2.5GB preflight/unit/lint archives. The
+#     integration caller opts into a tracked-backend fingerprint because its
+#     stale weekly snapshot was measured adding ~40s of cold compilation; PRs
+#     restore but never upload, and main writes only when backend inputs change.
+#     Go's cache is content-addressed, so prior snapshots safely seed new keys.
 #   - golangci analysis cache: optional, lint-only, and rolling for the same
 #     reason. golangci-lint-action's interval key is immutable after the first
 #     save, so changed-package analysis cannot be written back until the interval
@@ -34,10 +34,19 @@ inputs:
     description: Also roll ~/.cache/golangci-lint (enable only for the lint job).
     required: false
     default: "false"
+  refresh_on_backend_change:
+    description: Use the tracked backend input fingerprint instead of the weekly epoch.
+    required: false
+    default: "false"
 
 runs:
   using: composite
   steps:
+    - name: Resolve weekly build cache epoch
+      id: cache_epoch
+      shell: bash
+      run: echo "value=$(date -u +%G-W%V)" >> "$GITHUB_OUTPUT"
+
     - name: Restore Go module cache (non-main writer)
       if: github.event_name != 'push' || github.ref != 'refs/heads/main'
       uses: actions/cache/restore@v6
@@ -59,16 +68,20 @@ runs:
       uses: actions/cache/restore@v6
       with:
         path: ~/.cache/go-build
-        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/**', '.new-api-ref') }}
-        restore-keys: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-
+        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ inputs.refresh_on_backend_change == 'true' && hashFiles('backend/**', '.new-api-ref') || steps.cache_epoch.outputs.value }}
+        restore-keys: |
+          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
+          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-
 
-    - name: Go build/test cache (backend-input main writer, ${{ inputs.prefix }})
+    - name: Go build/test cache (main writer, ${{ inputs.prefix }})
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: actions/cache@v6
       with:
         path: ~/.cache/go-build
-        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/**', '.new-api-ref') }}
-        restore-keys: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-
+        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ inputs.refresh_on_backend_change == 'true' && hashFiles('backend/**', '.new-api-ref') || steps.cache_epoch.outputs.value }}
+        restore-keys: |
+          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
+          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-
 
     - name: Restore golangci-lint analysis cache (non-main writer)
       if: inputs.golangci_cache == 'true' && (github.event_name != 'push' || github.ref != 'refs/heads/main')

--- a/.github/actions/go-rolling-cache/action.yml
+++ b/.github/actions/go-rolling-cache/action.yml
@@ -10,11 +10,12 @@
 #   - module cache: identical across all jobs, only changes with go.sum, so one
 #     shared immutable entry is correct and avoids triplicating ~1GB of
 #     GOMODCACHE against the 10GB/repo budget.
-#   - build/test cache: per-job (prefix) + UTC-week seed. The first main run of
-#     each week refreshes the large archive; later runs hit the exact key and
-#     avoid uploading 300MB-2.5GB again. restore-keys seed a new week from the
-#     previous one. Go's cache is content-addressed, so stale entries are unused,
-#     never wrong.
+#   - build/test cache: per-job (prefix) + tracked backend input fingerprint.
+#     Main writes a new archive only when backend inputs change; PRs restore the
+#     newest matching main snapshot but never upload. This avoids a fixed weekly
+#     key pinning the cache before later source changes while also avoiding
+#     per-run uploads for VERSION/CI-only changes. Go's cache is content-addressed,
+#     so restoring the prior backend snapshot safely seeds changed PRs.
 #   - golangci analysis cache: optional, lint-only, and rolling for the same
 #     reason. golangci-lint-action's interval key is immutable after the first
 #     save, so changed-package analysis cannot be written back until the interval
@@ -37,11 +38,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Resolve weekly build cache epoch
-      id: cache_epoch
-      shell: bash
-      run: echo "value=$(date -u +%G-W%V)" >> "$GITHUB_OUTPUT"
-
     - name: Restore Go module cache (non-main writer)
       if: github.event_name != 'push' || github.ref != 'refs/heads/main'
       uses: actions/cache/restore@v6
@@ -63,20 +59,16 @@ runs:
       uses: actions/cache/restore@v6
       with:
         path: ~/.cache/go-build
-        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ steps.cache_epoch.outputs.value }}
-        restore-keys: |
-          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
-          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-
+        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/**', '.new-api-ref') }}
+        restore-keys: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-
 
-    - name: Go build/test cache (weekly main writer, ${{ inputs.prefix }})
+    - name: Go build/test cache (backend-input main writer, ${{ inputs.prefix }})
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: actions/cache@v6
       with:
         path: ~/.cache/go-build
-        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ steps.cache_epoch.outputs.value }}
-        restore-keys: |
-          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
-          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-
+        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/**', '.new-api-ref') }}
+        restore-keys: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-
 
     - name: Restore golangci-lint analysis cache (non-main writer)
       if: inputs.golangci_cache == 'true' && (github.event_name != 'push' || github.ref != 'refs/heads/main')

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -109,6 +109,7 @@ jobs:
             scripts.checks.test_docker_action_runtime \
             scripts.checks.test_release_cache_key_parity \
             scripts.checks.test_go_rolling_cache_policy \
+            scripts.checks.test_model_surface_bundle_check \
             scripts.test_preflight_ci_handoffs \
             scripts.test_preflight_background_output \
             scripts.test_ci_gate_handoffs \
@@ -151,6 +152,11 @@ jobs:
           PREFLIGHT_SKIP_MAIN_ANCESTRY: "1"
           PREFLIGHT_SKIP_AGENT_CONTRACT: ${{ needs.changes.outputs.all != 'true' && needs.changes.outputs.contracts != 'true' && '1' || '0' }}
           PREFLIGHT_SKIP_GO_CONTRACTS: ${{ needs.changes.outputs.preflight_go != 'true' && '1' || '0' }}
+          # Backend/all runs already compile the service-backed Go owners in
+          # test-unit. Move both generated-artifact drift checks together so
+          # their shared cold compile cannot simply fall through to the next
+          # preflight check. Artifact-only changes keep the strict fallback.
+          PREFLIGHT_DEFER_GO_ARTIFACT_DRIFT: ${{ (needs.changes.outputs.all == 'true' || needs.changes.outputs.backend == 'true') && '1' || '0' }}
         run: |
           if [ -x scripts/preflight.sh ]; then
             ./scripts/preflight.sh
@@ -247,6 +253,10 @@ jobs:
         run: make test-unit
       - name: Anthropic prompt surface fixture gateway
         run: python3 ops/anthropic/probe_prompt_surfaces.py --check-fixture-gateway
+      - name: Model surface bundle drift
+        run: bash scripts/checks/check-model-surface-bundle.sh
+      - name: Model family alert artifact drift
+        run: bash scripts/sentinels/check-model-family-rules.sh
 
   test-integration:
     needs: changes

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -274,6 +274,7 @@ jobs:
       - uses: ./.github/actions/go-rolling-cache
         with:
           prefix: integration
+          refresh_on_backend_change: "true"
       - name: Verify Go version
         run: |
           expected=$(awk '/^go /{print $2; exit}' backend/go.mod)

--- a/scripts/checks/check-model-surface-bundle.sh
+++ b/scripts/checks/check-model-surface-bundle.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$repo_root/backend"
+exec go run ./cmd/account-model-mapping bundle --check ../ops/pricing/model-surface-bundle.json

--- a/scripts/checks/test_go_rolling_cache_policy.py
+++ b/scripts/checks/test_go_rolling_cache_policy.py
@@ -49,11 +49,10 @@ class GoRollingCachePolicyTest(unittest.TestCase):
                 self.assertIn("backend/go.sum", step["with"]["key"])
                 self.assertIn("backend/.golangci.yml", step["with"]["key"])
 
-    def test_large_build_caches_refresh_weekly_instead_of_every_run(self) -> None:
+    def test_build_caches_follow_backend_inputs_without_per_run_churn(self) -> None:
         action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
         steps = action["runs"]["steps"]
-        epoch_step = next(step for step in steps if step.get("id") == "cache_epoch")
-        self.assertIn("date -u +%G-W%V", epoch_step["run"])
+        self.assertFalse(any(step.get("id") == "cache_epoch" for step in steps))
 
         build_steps = [
             step
@@ -61,23 +60,22 @@ class GoRollingCachePolicyTest(unittest.TestCase):
             if step.get("with", {}).get("path") == "~/.cache/go-build"
         ]
         self.assertEqual(len(build_steps), 2)
+        expected_key = (
+            "${{ runner.os }}-gobuild-${{ inputs.prefix }}-"
+            "${{ hashFiles('backend/**', '.new-api-ref') }}"
+        )
         for step in build_steps:
             with self.subTest(step=step["name"]):
                 cache_config = step["with"]
                 key = cache_config["key"]
-                self.assertIn("steps.cache_epoch.outputs.value", key)
+                self.assertEqual(key, expected_key)
                 self.assertNotIn("github.run_id", key)
-                self.assertIn("backend/go.mod", key)
-                self.assertIn("backend/go.sum", key)
-                self.assertIn(".new-api-ref", key)
 
                 restore_keys = cache_config["restore-keys"].splitlines()
                 self.assertEqual(
                     restore_keys[0],
-                    "${{ runner.os }}-gobuild-${{ inputs.prefix }}-"
-                    "${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-",
+                    "${{ runner.os }}-gobuild-${{ inputs.prefix }}-",
                 )
-                self.assertNotIn("steps.cache_epoch.outputs.value", cache_config["restore-keys"])
                 self.assertNotIn("github.run_id", str(cache_config))
 
 

--- a/scripts/checks/test_go_rolling_cache_policy.py
+++ b/scripts/checks/test_go_rolling_cache_policy.py
@@ -49,10 +49,12 @@ class GoRollingCachePolicyTest(unittest.TestCase):
                 self.assertIn("backend/go.sum", step["with"]["key"])
                 self.assertIn("backend/.golangci.yml", step["with"]["key"])
 
-    def test_build_caches_follow_backend_inputs_without_per_run_churn(self) -> None:
+    def test_build_caches_refresh_weekly_unless_caller_opts_into_backend_fingerprint(self) -> None:
         action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
+        self.assertEqual(action["inputs"]["refresh_on_backend_change"]["default"], "false")
         steps = action["runs"]["steps"]
-        self.assertFalse(any(step.get("id") == "cache_epoch" for step in steps))
+        epoch_step = next(step for step in steps if step.get("id") == "cache_epoch")
+        self.assertIn("date -u +%G-W%V", epoch_step["run"])
 
         build_steps = [
             step
@@ -62,7 +64,9 @@ class GoRollingCachePolicyTest(unittest.TestCase):
         self.assertEqual(len(build_steps), 2)
         expected_key = (
             "${{ runner.os }}-gobuild-${{ inputs.prefix }}-"
-            "${{ hashFiles('backend/**', '.new-api-ref') }}"
+            "${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-"
+            "${{ inputs.refresh_on_backend_change == 'true' && "
+            "hashFiles('backend/**', '.new-api-ref') || steps.cache_epoch.outputs.value }}"
         )
         for step in build_steps:
             with self.subTest(step=step["name"]):
@@ -74,7 +78,8 @@ class GoRollingCachePolicyTest(unittest.TestCase):
                 restore_keys = cache_config["restore-keys"].splitlines()
                 self.assertEqual(
                     restore_keys[0],
-                    "${{ runner.os }}-gobuild-${{ inputs.prefix }}-",
+                    "${{ runner.os }}-gobuild-${{ inputs.prefix }}-"
+                    "${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-",
                 )
                 self.assertNotIn("github.run_id", str(cache_config))
 

--- a/scripts/checks/test_model_surface_bundle_check.py
+++ b/scripts/checks/test_model_surface_bundle_check.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Behavior tests for the model-surface bundle drift command owner."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECK = REPO_ROOT / "scripts" / "checks" / "check-model-surface-bundle.sh"
+
+
+class ModelSurfaceBundleCheckTest(unittest.TestCase):
+    def fake_go_env(self, temp_dir: Path) -> tuple[dict[str, str], Path]:
+        capture = temp_dir / "go.capture"
+        fake_go = temp_dir / "go"
+        fake_go.write_text(
+            "#!/bin/sh\n"
+            "{ printf '%s\\n' \"$PWD\"; printf '%s\\n' \"$@\"; } > \"$GO_CAPTURE\"\n",
+            encoding="utf-8",
+        )
+        fake_go.chmod(fake_go.stat().st_mode | stat.S_IXUSR)
+        env = os.environ.copy()
+        env["PATH"] = f"{temp_dir}{os.pathsep}{env['PATH']}"
+        env["GO_CAPTURE"] = str(capture)
+        return env, capture
+
+    def test_default_check_invokes_go_owner_from_backend(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp_dir:
+            temp_dir = Path(raw_temp_dir)
+            env, capture = self.fake_go_env(temp_dir)
+
+            completed = subprocess.run(
+                ["bash", str(CHECK)],
+                cwd=REPO_ROOT,
+                env=env,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual(
+                capture.read_text(encoding="utf-8").splitlines(),
+                [
+                    str(REPO_ROOT / "backend"),
+                    "run",
+                    "./cmd/account-model-mapping",
+                    "bundle",
+                    "--check",
+                    "../ops/pricing/model-surface-bundle.json",
+                ],
+            )
+
+    def test_shared_defer_env_cannot_skip_direct_check(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp_dir:
+            temp_dir = Path(raw_temp_dir)
+            env, capture = self.fake_go_env(temp_dir)
+            env["PREFLIGHT_DEFER_GO_ARTIFACT_DRIFT"] = "1"
+            env["GITHUB_ACTIONS"] = "true"
+
+            completed = subprocess.run(
+                ["bash", str(CHECK)],
+                cwd=REPO_ROOT,
+                env=env,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertTrue(capture.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/changed-surfaces.py
+++ b/scripts/ci/changed-surfaces.py
@@ -53,6 +53,7 @@ PREFLIGHT_GO_FILES = {
     # preflight toolchain path even though they live outside backend/.
     "ops/observability/generated/model-family-rules.json",
     "ops/pricing/model-surface-bundle.json",
+    "scripts/checks/check-model-surface-bundle.sh",
     "scripts/preflight.sh",
     "scripts/sentinels/check-model-family-rules.sh",
 }

--- a/scripts/ci/test_changed_surfaces.py
+++ b/scripts/ci/test_changed_surfaces.py
@@ -226,6 +226,7 @@ class ChangedSurfacesTest(unittest.TestCase):
         for path in (
             "ops/pricing/model-surface-bundle.json",
             "ops/observability/generated/model-family-rules.json",
+            "scripts/checks/check-model-surface-bundle.sh",
             "scripts/sentinels/check-model-family-rules.sh",
             "scripts/preflight.sh",
         ):

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -831,12 +831,20 @@ fi
 # model list.
 echo ""
 echo "=== sub2api: generated model-surface bundle drift ==="
+_preflight_defer_go_artifact_drift=0
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    case "${PREFLIGHT_DEFER_GO_ARTIFACT_DRIFT:-}" in
+        1|true|yes|TRUE|YES) _preflight_defer_go_artifact_drift=1 ;;
+    esac
+fi
 if [ "$_preflight_skip_go_contracts" -eq 1 ]; then
     echo "  skip: unchanged Go preflight surface"
+elif [ "$_preflight_defer_go_artifact_drift" -eq 1 ]; then
+    echo "  ok: model-surface bundle drift delegated to CI test-unit"
 elif ! command -v go >/dev/null 2>&1; then
     echo "  FAIL: go not on PATH (required for model-surface bundle drift check)"
     errors=$((errors + 1))
-elif ! (cd backend && go run ./cmd/account-model-mapping bundle --check ../ops/pricing/model-surface-bundle.json); then
+elif ! bash ./scripts/checks/check-model-surface-bundle.sh; then
     echo "  FAIL: ops/pricing/model-surface-bundle.json drifted from the Go owner"
     echo "        — run: cd backend && go run ./cmd/account-model-mapping bundle --output ../ops/pricing/model-surface-bundle.json"
     errors=$((errors + 1))
@@ -851,6 +859,8 @@ echo ""
 echo "=== sub2api: model-family alert artifact drift ==="
 if [ "$_preflight_skip_go_contracts" -eq 1 ]; then
     echo "  skip: unchanged Go preflight surface"
+elif [ "$_preflight_defer_go_artifact_drift" -eq 1 ]; then
+    echo "  ok: model-family alert artifact drift delegated to CI test-unit"
 elif ! command -v go >/dev/null 2>&1; then
     echo "  FAIL: go not on PATH (required for model-family artifact drift check)"
     errors=$((errors + 1))

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -239,6 +239,19 @@ class BackendCIRoutingTest(unittest.TestCase):
             if step.get("uses") == "./.github/actions/go-rolling-cache"
         )
         self.assertEqual(integration_cache["with"]["prefix"], "integration")
+        self.assertEqual(
+            integration_cache["with"]["refresh_on_backend_change"],
+            "true",
+        )
+
+        for job_name in ("preflight", "test-unit", "golangci-lint"):
+            cache_step = next(
+                step
+                for step in self.jobs[job_name]["steps"]
+                if step.get("uses") == "./.github/actions/go-rolling-cache"
+            )
+            with self.subTest(job=job_name):
+                self.assertNotIn("refresh_on_backend_change", cache_step.get("with", {}))
 
     def test_unit_reuses_service_objects_for_go_artifact_drift(self) -> None:
         steps = self.jobs["test-unit"]["steps"]

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -110,6 +110,7 @@ class BackendCIRoutingTest(unittest.TestCase):
             "scripts.test_ci_gate_handoffs",
             "scripts.ci.test_changed_surfaces",
             "scripts.test_backend_ci_routing",
+            "scripts.checks.test_model_surface_bundle_check",
         }
         for module in expected_modules:
             with self.subTest(module=module):
@@ -238,6 +239,63 @@ class BackendCIRoutingTest(unittest.TestCase):
             if step.get("uses") == "./.github/actions/go-rolling-cache"
         )
         self.assertEqual(integration_cache["with"]["prefix"], "integration")
+
+    def test_unit_reuses_service_objects_for_go_artifact_drift(self) -> None:
+        steps = self.jobs["test-unit"]["steps"]
+        fixture_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("name") == "Anthropic prompt surface fixture gateway"
+        )
+        bundle_index, bundle_step = next(
+            (index, step)
+            for index, step in enumerate(steps)
+            if step.get("name") == "Model surface bundle drift"
+        )
+        family_index, family_step = next(
+            (index, step)
+            for index, step in enumerate(steps)
+            if step.get("name") == "Model family alert artifact drift"
+        )
+
+        self.assertGreater(bundle_index, fixture_index)
+        self.assertGreater(family_index, bundle_index)
+        self.assertEqual(
+            bundle_step["run"],
+            "bash scripts/checks/check-model-surface-bundle.sh",
+        )
+        self.assertEqual(
+            family_step["run"],
+            "bash scripts/sentinels/check-model-family-rules.sh",
+        )
+
+    def test_unit_is_the_only_workflow_owner_for_go_artifact_drift(self) -> None:
+        owners = []
+        for job_name, job in self.jobs.items():
+            for step in job.get("steps", []):
+                command = step.get("run", "")
+                for helper in (
+                    "scripts/checks/check-model-surface-bundle.sh",
+                    "scripts/sentinels/check-model-family-rules.sh",
+                ):
+                    if helper in command:
+                        owners.append((helper, job_name, step.get("name")))
+
+        self.assertEqual(
+            owners,
+            [
+                (
+                    "scripts/checks/check-model-surface-bundle.sh",
+                    "test-unit",
+                    "Model surface bundle drift",
+                ),
+                (
+                    "scripts/sentinels/check-model-family-rules.sh",
+                    "test-unit",
+                    "Model family alert artifact drift",
+                ),
+            ],
+        )
 
     def test_lint_uses_rolling_analysis_cache_instead_of_action_cache(self) -> None:
         steps = self.jobs["golangci-lint"]["steps"]

--- a/scripts/test_preflight_ci_handoffs.py
+++ b/scripts/test_preflight_ci_handoffs.py
@@ -11,6 +11,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BACKEND_CI = REPO_ROOT / ".github" / "workflows" / "backend-ci.yml"
+PREFLIGHT = REPO_ROOT / "scripts" / "preflight.sh"
 
 
 def load_workflow(path: Path) -> dict:
@@ -38,6 +39,41 @@ class PreflightCIHandoffTest(unittest.TestCase):
         self.assertEqual(
             run_preflight["env"]["PREFLIGHT_SKIP_GO_CONTRACTS"],
             "${{ needs.changes.outputs.preflight_go != 'true' && '1' || '0' }}",
+        )
+
+    def test_required_preflight_defers_go_artifacts_only_when_unit_runs(self) -> None:
+        workflow = load_workflow(BACKEND_CI)
+        run_preflight = next(
+            step
+            for step in workflow["jobs"]["preflight"]["steps"]
+            if step.get("name") == "Run preflight"
+        )
+        self.assertEqual(
+            run_preflight["env"]["PREFLIGHT_DEFER_GO_ARTIFACT_DRIFT"],
+            "${{ (needs.changes.outputs.all == 'true' || "
+            "needs.changes.outputs.backend == 'true') && '1' || '0' }}",
+        )
+
+        declarations = []
+        for job_name, job in workflow["jobs"].items():
+            if "PREFLIGHT_DEFER_GO_ARTIFACT_DRIFT" in job.get("env", {}):
+                declarations.append((job_name, "job"))
+            for step in job.get("steps", []):
+                if "PREFLIGHT_DEFER_GO_ARTIFACT_DRIFT" in step.get("env", {}):
+                    declarations.append((job_name, step.get("name")))
+        self.assertEqual(declarations, [("preflight", "Run preflight")])
+
+    def test_local_preflight_does_not_honor_ci_go_artifact_delegation(self) -> None:
+        script = PREFLIGHT.read_text(encoding="utf-8")
+        artifact_sections = script.split(
+            "# ---- sub2api: generated model-surface bundle drift", 1
+        )[1].split("# ---- sub2api: frontend TK sentinel registry", 1)[0]
+
+        self.assertIn('"${GITHUB_ACTIONS:-}" = "true"', artifact_sections)
+        self.assertIn("PREFLIGHT_DEFER_GO_ARTIFACT_DRIFT", artifact_sections)
+        self.assertEqual(
+            artifact_sections.count("_preflight_defer_go_artifact_drift"),
+            4,
         )
 
 


### PR DESCRIPTION
## 摘要

- 将两个共享重型 Go 编译链的 drift 检查作为一个原子 handoff，从 backend/all 的 preflight 关键路径委托给已有 `test-unit` job：
  - generated model-surface bundle drift
  - model-family alert artifact drift
- 两项检查均安排在 unit 编译完成后执行，复用同一 `GOCACHE`。
- artifact-only / 本地完整 preflight 仍执行严格真实检查；不拆 job、不增加 GitHub Actions credits。
- 新增 helper、changed-surface 路由，以及唯一 owner / env 作用域 / 本地不可跳过回归门禁。

## 根因

首轮 CI 证明只迁移 bundle 不够：

- 迁移前：bundle `35.65s`，随后 model-family `2.42s`
- 只迁移 bundle 后：bundle约 `0s`，但 model-family 升至 `40.55s`

两者共享重型 Go 编译链；只迁移一个会让冷编译顺延到另一个。本版因此使用同一个 handoff 原子迁移两项检查。

## CI 实测

对比 #1854 同一 PR 的前后两轮：

| 指标 | 单项迁移 | 原子迁移 | 变化 |
| --- | ---: | ---: | ---: |
| preflight job | 147s | 120s | **-27s** |
| `Run preflight` step | 106s | 75s | **-31s** |
| test-unit job | 78s | 81s | +3s |
| 两项 preflight drift | 约 40.6s | 约 0s | **约 -40.6s** |
| unit bundle / family | 12s / 无 | 15s / 2s | 编译后复用 |

第二轮整体关键路径为 integration `134s`，相比首轮整体 `147s` 净改善 `13s`；integration 自身从 `121s` 波动到 `134s`，抵消了部分 preflight 收益。新的最大内部单点是 integration 的 `internal/repository` 包（`51.82s`）。

CI run：`33044196083`，全绿。

## Credits

- 不新增 job 或 runner。
- 只是把两个必做检查移到已存在且已完成相关编译的 unit job。
- 总 runner 工作量减少约 24 秒（preflight -27s、unit +3s），GitHub credits 不增加。

## 风险

- 风险较低，主要是检查 owner 的条件路由。
- helper 本身不可跳过；仅 GitHub Actions 的 preflight 路由层可在 backend/all 时委托。
- 两项检查共用一个 handoff 开关，避免只迁移一个后冷编译落到另一个。
- 回归测试保证 handoff env 只存在于 preflight 的 `Run preflight` step，且 `test-unit` 是两个 helper 的唯一 workflow owner。

## 验证

- CI orchestration 回归：54 项通过
- 聚焦 routing/helper/classifier 回归：41 项通过
- `bash -n scripts/checks/check-model-surface-bundle.sh scripts/sentinels/check-model-family-rules.sh scripts/preflight.sh`
- `PREFLIGHT_DEFER_GO_ARTIFACT_DRIFT=1 PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：完整 PASS；本地仍实际执行两项检查
- 独立代码复审：无 Critical / Important / Minor finding，merge-ready
- GitHub CI：全绿

## 提交

- `cde740052 perf(ci): 复用 unit 编译完成的 Go artifact 检查`

## 最新提交锚点

`cde7400524430f45ad6db6bedf917f7522c5374b`

## 后续：Go build cache 跟随 backend 输入

- 根因：原 build/test cache 使用每周固定且不可覆盖的 key；周内 Go 源码变化后，后续 run 持续恢复旧快照并重新冷编译。
- 修复：build/test cache key 改为 backend 全量输入与 .new-api-ref 的内容 hash；main 仅在输入变化时保存新快照，PR 继续 restore-only。
- 不使用 github.run_id 作为 build cache key，避免 VERSION/CI-only main run 重复上传大型缓存。
- CI run 33047586398 全绿；本轮 PR 仍回退恢复旧周缓存，合并后的 main run 才会首次写入新 key，后续 backend CI 才能验证约 39-42 秒冷编译消除收益。
- 契约测试：27 项通过；完整 scripts/preflight.sh：PASS。

## 当前提交锚点

d20f2311628a1cee99cd182bc93ad05f915409db