### PR TITLE
perf(ci): 缩小 heavy Go job 编译缓存

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -93,6 +93,10 @@ jobs:
     # Mechanical gate for process / quality rules from dev-rules submodule.
     # See CLAUDE.md § 10 and dev-rules/rules/dev-rules-convention.mdc.
     runs-on: ubuntu-latest
+    env:
+      # Preflight only executes generators, contracts, and tests; failure stacks
+      # retain file:line data without storing DWARF in the rolling Go cache.
+      GOFLAGS: -gcflags=all=-dwarf=false
     steps:
       - name: Require changed-surface classification
         if: needs.changes.result != 'success'
@@ -138,7 +142,7 @@ jobs:
       - uses: ./.github/actions/go-rolling-cache
         if: needs.changes.outputs.preflight_go == 'true'
         with:
-          prefix: preflight
+          prefix: preflight-nodwarf-v1
       - name: Run preflight
         env:
           PREFLIGHT_FAST: ${{ github.event_name == 'pull_request' && '1' || '0' }}
@@ -262,6 +266,10 @@ jobs:
     needs: changes
     if: (github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'ci'))) && (needs.changes.outputs.all == 'true' || needs.changes.outputs.backend == 'true')
     runs-on: ubuntu-latest
+    env:
+      # Integration failures retain file:line stacks without DWARF while the
+      # package/test cache stays materially smaller to restore and refresh.
+      GOFLAGS: -gcflags=all=-dwarf=false
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/cache-and-checkout-new-api
@@ -273,7 +281,7 @@ jobs:
           cache: false
       - uses: ./.github/actions/go-rolling-cache
         with:
-          prefix: integration
+          prefix: integration-nodwarf-v1
           refresh_on_backend_change: "true"
       - name: Verify Go version
         run: |
@@ -314,6 +322,10 @@ jobs:
       contents: read
       pull-requests: read
     runs-on: ubuntu-latest
+    env:
+      # golangci-lint consumes export/type data, not DWARF. Omitting it targets
+      # the measured 2.25GB lint build cache and its 41s restore bottleneck.
+      GOFLAGS: -gcflags=all=-dwarf=false
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/cache-and-checkout-new-api
@@ -328,7 +340,7 @@ jobs:
           cache: false
       - uses: ./.github/actions/go-rolling-cache
         with:
-          prefix: lint
+          prefix: lint-nodwarf-v1
           golangci_cache: "true"
       - name: Verify Go version
         run: |

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -208,7 +208,7 @@ class BackendCIRoutingTest(unittest.TestCase):
             "-gcflags=all=-dwarf=false",
         )
 
-    def test_unit_dwarf_flags_do_not_leak_to_other_go_jobs(self) -> None:
+    def test_heavy_go_jobs_omit_dwarf_from_cached_build_objects(self) -> None:
         declarations = []
         for job_name, job in self.jobs.items():
             if "GOFLAGS" in job.get("env", {}):
@@ -221,24 +221,39 @@ class BackendCIRoutingTest(unittest.TestCase):
 
         self.assertEqual(
             declarations,
-            [("test-unit", "job", "-gcflags=all=-dwarf=false")],
+            [
+                ("preflight", "job", "-gcflags=all=-dwarf=false"),
+                ("test-unit", "job", "-gcflags=all=-dwarf=false"),
+                ("test-integration", "job", "-gcflags=all=-dwarf=false"),
+                ("golangci-lint", "job", "-gcflags=all=-dwarf=false"),
+            ],
         )
 
-    def test_unit_job_uses_dwarf_specific_build_cache_namespace(self) -> None:
-        rolling_cache = next(
-            step
-            for step in self.jobs["test-unit"]["steps"]
-            if step.get("uses") == "./.github/actions/go-rolling-cache"
-        )
-
-        self.assertEqual(rolling_cache["with"]["prefix"], "unit-nodwarf-v1")
+    def test_heavy_go_jobs_use_nodwarf_build_cache_namespaces(self) -> None:
+        expected_prefixes = {
+            "preflight": "preflight-nodwarf-v1",
+            "test-unit": "unit-nodwarf-v1",
+            "test-integration": "integration-nodwarf-v1",
+            "golangci-lint": "lint-nodwarf-v1",
+        }
+        for job_name, expected_prefix in expected_prefixes.items():
+            cache_step = next(
+                step
+                for step in self.jobs[job_name]["steps"]
+                if step.get("uses") == "./.github/actions/go-rolling-cache"
+            )
+            with self.subTest(job=job_name):
+                self.assertEqual(cache_step["with"]["prefix"], expected_prefix)
 
         integration_cache = next(
             step
             for step in self.jobs["test-integration"]["steps"]
             if step.get("uses") == "./.github/actions/go-rolling-cache"
         )
-        self.assertEqual(integration_cache["with"]["prefix"], "integration")
+        self.assertEqual(
+            integration_cache["with"]["prefix"],
+            "integration-nodwarf-v1",
+        )
         self.assertEqual(
             integration_cache["with"]["refresh_on_backend_change"],
             "true",
@@ -317,7 +332,7 @@ class BackendCIRoutingTest(unittest.TestCase):
             for step in steps
             if step.get("uses") == "./.github/actions/go-rolling-cache"
         )
-        self.assertEqual(rolling_cache["with"]["prefix"], "lint")
+        self.assertEqual(rolling_cache["with"]["prefix"], "lint-nodwarf-v1")
         self.assertEqual(rolling_cache["with"]["golangci_cache"], "true")
 
         lint_action = next(


### PR DESCRIPTION
## 摘要

- 将 unit 已验证的 `GOFLAGS=-gcflags=all=-dwarf=false` 扩展到 preflight、integration 与 golangci-lint，减少不参与 CI 判定的 DWARF 编译对象。
- 为四个 heavy Go job 使用独立的 `*-nodwarf-v1` build cache namespace，避免恢复与新编译 flags 不兼容的旧缓存。
- 保持完整 lint、unit、integration 与 preflight 覆盖不变；重点针对最新 main run 中 lint 约 2.25GB build cache / 41 秒恢复瓶颈。

## 风险

- PR 事件按现有策略只 restore、不保存 cache；新 namespace 因此是冷路径。合并后的首次 main run 负责写入，下一次 main/PR 才能量化 warm-cache 收益。
- 仅移除 DWARF 调试段；Go 测试失败仍保留 file:line 栈，lint 所需 export/type data 不变。
- 不删检查、不缩小测试或 lint 范围。

## 验证

- TDD RED：契约测试分别捕获缺失的 heavy-job GOFLAGS 与旧 cache namespace。
- `python3 -m unittest scripts.checks.test_go_rolling_cache_policy scripts.test_backend_ci_routing`：23 项通过。
- `GOFLAGS=-gcflags=all=-dwarf=false make lint`：0 issues。
- `GOFLAGS=-gcflags=all=-dwarf=false PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：完整通过。
- GitHub PR CI 全绿。冷路径：unit 86s；lint 151s（cache 7s、lint 129s）；integration 182s（cache 9s、tests 149s）；preflight 314s（cache 9s、run 266s）。
- 对比旧 warm main：lint cache step 52s（其中 2.25GB build cache 41s）、lint 本体 67s。当前 PR 不能声称 warm 加速，需 main 写入新 namespace 后复测。

## 提交

- `749d4c722 perf(ci): 缩小 heavy Go job 编译缓存`
- 最新提交：`749d4c722`