### PR TITLE
perf(ci): 缩短 preflight 与 unit 关键路径

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -43,7 +43,6 @@ jobs:
       ops: ${{ steps.classify.outputs.ops }}
       contracts: ${{ steps.classify.outputs.contracts }}
       preflight_go: ${{ steps.classify.outputs.preflight_go }}
-      service_unit_cold: ${{ steps.classify.outputs.service_unit_cold }}
       all: ${{ steps.classify.outputs.all }}
     steps:
       - uses: actions/checkout@v6
@@ -249,11 +248,11 @@ jobs:
       - name: Unit tests
         working-directory: backend
         env:
-          # PR service-cold runs prioritize the compile-once critical path.
-          # Main also uses shards: service tests inspect tracked source/fixture
-          # files at runtime, so checkout mtimes prevent cross-run result-cache
-          # hits even when the weekly Go build cache restores exactly.
-          UNIT_TEST_SERVICE_SHARD: ${{ (github.event_name == 'push' || needs.changes.outputs.service_unit_cold == 'true') && '1' || '0' }}
+          # Service tests inspect tracked source/fixture files at runtime, so
+          # checkout mtimes prevent cross-run result-cache hits even when the
+          # weekly Go build cache restores exactly. Always use the compile-once
+          # runner instead of gambling the critical path on test-result cache.
+          UNIT_TEST_SERVICE_SHARD: "1"
         run: make test-unit
       - name: Anthropic prompt surface fixture gateway
         run: python3 ops/anthropic/probe_prompt_surfaces.py --check-fixture-gateway

--- a/ops/archive/test_data_layer_archive_prod_export.py
+++ b/ops/archive/test_data_layer_archive_prod_export.py
@@ -409,14 +409,21 @@ class ProdArchiveExportTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp:
             batch_id = "prod-export-20260722T000000.000000Z-deadbeef0000"
             prefix = f"s3://test-backups/prod/pgdump/archive-export/{batch_id}"
-            with self.assertRaises(canary.CanaryError) as ctx:
+
+            def unavailable_download(_command: list[str]) -> str:
+                raise canary.CanaryError("deterministic download boundary")
+
+            with self.assertRaisesRegex(
+                canary.CanaryError,
+                "deterministic download boundary",
+            ):
                 canary._download_committed_batch(
                     prefix,
                     batch_id,
                     temp,
+                    command_runner=unavailable_download,
                     expected_manifest_sha256="a" * 64,
                 )
-            self.assertNotIn("do not match", str(ctx.exception))
 
     def test_post_legacy_plan_init_and_seal(self) -> None:
         as_of = "2026-08-08T03:00:00.000000Z"

--- a/scripts/ci/changed-surfaces.py
+++ b/scripts/ci/changed-surfaces.py
@@ -17,20 +17,8 @@ KEYS = (
     "ops",
     "contracts",
     "preflight_go",
-    "service_unit_cold",
     "all",
 )
-
-SERVICE_UNIT_COLD_FILES = {
-    ".github/workflows/backend-ci.yml",
-    ".new-api-ref",
-    "backend/Makefile",
-    "backend/go.mod",
-    "backend/go.sum",
-    "scripts/ci/list_go_tests.go",
-    "scripts/ci/test_unit_test_runner.py",
-    "scripts/ci/unit_test_runner.py",
-}
 
 CONTRACT_FILES = {
     "backend/internal/domain/constants.go",
@@ -83,11 +71,6 @@ def classify(paths: Iterable[str]) -> dict[str, bool]:
 
         if path in PREFLIGHT_GO_FILES:
             result["preflight_go"] = True
-
-        if path in SERVICE_UNIT_COLD_FILES or (
-            path.startswith("backend/") and path.endswith(".go")
-        ):
-            result["service_unit_cold"] = True
 
         if path == ".github/workflows/backend-ci.yml" or _starts(
             path,

--- a/scripts/ci/test_changed_surfaces.py
+++ b/scripts/ci/test_changed_surfaces.py
@@ -29,7 +29,6 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "ops": False,
                 "contracts": False,
                 "preflight_go": True,
-                "service_unit_cold": True,
                 "all": False,
             },
         )
@@ -44,7 +43,6 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "ops": False,
                 "contracts": False,
                 "preflight_go": False,
-                "service_unit_cold": False,
                 "all": False,
             },
         )
@@ -59,7 +57,6 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "ops": False,
                 "contracts": False,
                 "preflight_go": False,
-                "service_unit_cold": False,
                 "all": False,
             },
         )
@@ -74,7 +71,6 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "ops": False,
                 "contracts": True,
                 "preflight_go": True,
-                "service_unit_cold": True,
                 "all": False,
             },
         )
@@ -89,7 +85,6 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "ops": True,
                 "contracts": False,
                 "preflight_go": True,
-                "service_unit_cold": True,
                 "all": False,
             },
         )
@@ -104,7 +99,6 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "ops": False,
                 "contracts": False,
                 "preflight_go": False,
-                "service_unit_cold": False,
                 "all": False,
             },
         )
@@ -119,7 +113,6 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "ops": False,
                 "contracts": False,
                 "preflight_go": False,
-                "service_unit_cold": False,
                 "all": False,
             },
         )
@@ -139,7 +132,6 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "ops": False,
                 "contracts": False,
                 "preflight_go": True,
-                "service_unit_cold": True,
                 "all": False,
             },
         )
@@ -154,7 +146,6 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "ops": False,
                 "contracts": False,
                 "preflight_go": True,
-                "service_unit_cold": True,
                 "all": False,
             },
         )
@@ -170,7 +161,6 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "ops": False,
                 "contracts": False,
                 "preflight_go": True,
-                "service_unit_cold": False,
                 "all": True,
             },
         )
@@ -186,7 +176,6 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "ops": False,
                 "contracts": False,
                 "preflight_go": True,
-                "service_unit_cold": False,
                 "all": True,
             },
         )
@@ -202,12 +191,11 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "ops": False,
                 "contracts": False,
                 "preflight_go": True,
-                "service_unit_cold": False,
                 "all": True,
             },
         )
 
-    def test_backend_non_go_change_keeps_service_cache_path(self) -> None:
+    def test_backend_non_go_change_runs_backend_without_all_surfaces(self) -> None:
         self.assertEqual(
             changed_surfaces.classify(["backend/migrations/001.sql"]),
             {
@@ -217,7 +205,6 @@ class ChangedSurfacesTest(unittest.TestCase):
                 "ops": False,
                 "contracts": False,
                 "preflight_go": True,
-                "service_unit_cold": False,
                 "all": False,
             },
         )
@@ -233,21 +220,7 @@ class ChangedSurfacesTest(unittest.TestCase):
             with self.subTest(path=path):
                 self.assertTrue(changed_surfaces.classify([path])["preflight_go"])
 
-    def test_unit_runner_and_ci_entrypoints_force_service_cold_path(self) -> None:
-        for path in (
-            ".new-api-ref",
-            "backend/go.mod",
-            "backend/go.sum",
-            "scripts/ci/list_go_tests.go",
-            "scripts/ci/unit_test_runner.py",
-            "scripts/ci/test_unit_test_runner.py",
-            "backend/Makefile",
-            ".github/workflows/backend-ci.yml",
-        ):
-            with self.subTest(path=path):
-                self.assertTrue(changed_surfaces.classify([path])["service_unit_cold"])
-
-    def test_all_mode_marks_service_cold_path(self) -> None:
+    def test_all_mode_marks_only_active_surface_decisions(self) -> None:
         completed = subprocess.run(
             [sys.executable, str(MODULE_PATH), "--all"],
             input="",
@@ -258,7 +231,18 @@ class ChangedSurfacesTest(unittest.TestCase):
 
         self.assertEqual(completed.returncode, 0, completed.stderr)
         result = json.loads(completed.stdout)
-        self.assertEqual(set(result), set(changed_surfaces.KEYS))
+        self.assertEqual(
+            set(result),
+            {
+                "backend",
+                "frontend",
+                "deploy",
+                "ops",
+                "contracts",
+                "preflight_go",
+                "all",
+            },
+        )
         self.assertTrue(all(result.values()))
 
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -179,10 +179,35 @@ _bg_join() {  # _bg_join <key> [replay-on-failure] → sets _bg_rc; output in $_
 _bg_spawned() { [ -f "$_preflight_bg_dir/$1.pid" ]; }
 
 _archive_rehearsal_gate_run() {
-    local script
+    local script pid
+    local parallel_failed=0
+    # These suites own distinct container names, databases, and random host
+    # ports. Overlap only this measured Docker pair; keep the remaining archive
+    # contracts serial so external-command fixtures cannot add daemon pressure.
+    local -a parallel_scripts=(
+        ./ops/archive/test_data_layer_archive_rehearsal.py
+        ./ops/archive/test_data_layer_archive_prod_canary.py
+    )
+    local -a parallel_pids=()
+    for script in "${parallel_scripts[@]}"; do
+        (
+            if ! python3 "$script"; then
+                printf 'failed command: python3 %s\n' "${script#./}"
+                exit 1
+            fi
+        ) &
+        parallel_pids+=("$!")
+    done
+    for pid in "${parallel_pids[@]}"; do
+        if ! wait "$pid"; then
+            parallel_failed=1
+        fi
+    done
+    if [ "$parallel_failed" -ne 0 ]; then
+        return 1
+    fi
+
     for script in \
-        ./ops/archive/test_data_layer_archive_rehearsal.py \
-        ./ops/archive/test_data_layer_archive_prod_canary.py \
         ./ops/archive/test_data_layer_archive_prod_export.py \
         ./ops/archive/test_data_layer_archive_promote_batch.py \
         ./ops/archive/test_data_layer_archive_cleanup_hold.py; do

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -29,7 +29,6 @@ class BackendCIRoutingTest(unittest.TestCase):
                 "ops",
                 "contracts",
                 "preflight_go",
-                "service_unit_cold",
                 "all",
             },
         )
@@ -177,30 +176,14 @@ class BackendCIRoutingTest(unittest.TestCase):
         self.assertIn("integration-packages.py", target)
         self.assertNotIn("go test -tags=integration ./...", target)
 
-    def test_unit_job_passes_the_service_cold_path_decision(self) -> None:
+    def test_unit_job_always_uses_compile_once_service_shards(self) -> None:
         unit_step = next(
             step
             for step in self.jobs["test-unit"]["steps"]
             if step.get("name") == "Unit tests"
         )
 
-        self.assertIn(
-            "needs.changes.outputs.service_unit_cold",
-            unit_step["env"]["UNIT_TEST_SERVICE_SHARD"],
-        )
-
-    def test_unit_main_push_uses_service_shards(self) -> None:
-        unit_step = next(
-            step
-            for step in self.jobs["test-unit"]["steps"]
-            if step.get("name") == "Unit tests"
-        )
-
-        self.assertEqual(
-            unit_step["env"]["UNIT_TEST_SERVICE_SHARD"],
-            "${{ (github.event_name == 'push' || "
-            "needs.changes.outputs.service_unit_cold == 'true') && '1' || '0' }}",
-        )
+        self.assertEqual(unit_step["env"]["UNIT_TEST_SERVICE_SHARD"], "1")
 
     def test_unit_job_omits_dwarf_from_test_build_objects(self) -> None:
         self.assertEqual(

--- a/scripts/test_preflight_background_output.py
+++ b/scripts/test_preflight_background_output.py
@@ -124,6 +124,53 @@ printf 'errors=%s\n' "$errors"
     )
 
 
+def _run_archive_composite_with_docker_barrier(
+    failing_key: str = "",
+) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryDirectory() as tmp:
+        script = f"""
+set -u
+barrier_dir={tmp!s}
+failing_key={failing_key!s}
+python3() {{
+    case "$1" in
+        ./ops/archive/test_data_layer_archive_rehearsal.py)
+            key=rehearsal
+            ;;
+        ./ops/archive/test_data_layer_archive_prod_canary.py)
+            key=prod_canary
+            ;;
+        *)
+            printf 'serial=%s\n' "$1"
+            return 0
+            ;;
+    esac
+    touch "$barrier_dir/$key.started"
+    attempts=0
+    while [ ! -f "$barrier_dir/rehearsal.started" ] || [ ! -f "$barrier_dir/prod_canary.started" ]; do
+        attempts=$((attempts + 1))
+        if [ "$attempts" -ge 100 ]; then
+            printf 'docker scripts did not overlap\n' >&2
+            return 99
+        fi
+        sleep 0.01
+    done
+    printf 'overlapped=%s\n' "$key"
+    if [ "$key" = "$failing_key" ]; then
+        return 23
+    fi
+}}
+{_shell_function("_archive_rehearsal_gate_run")}
+_archive_rehearsal_gate_run
+"""
+        return subprocess.run(
+            ["bash", "-c", script],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+
 class PreflightBackgroundOutputTest(unittest.TestCase):
     def test_failure_replays_captured_output(self) -> None:
         result = _run_spawned_join(1, "replay-on-failure")
@@ -173,6 +220,21 @@ class PreflightBackgroundOutputTest(unittest.TestCase):
         )
         self.assertIn("FAIL: nonprod archive/restore rehearsal contracts", result.stdout)
         self.assertIn("errors=1", result.stdout)
+
+    def test_archive_composite_overlaps_independent_docker_suites(self) -> None:
+        result = _run_archive_composite_with_docker_barrier()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("overlapped=rehearsal", result.stdout)
+        self.assertIn("overlapped=prod_canary", result.stdout)
+
+    def test_archive_composite_propagates_parallel_suite_failure(self) -> None:
+        result = _run_archive_composite_with_docker_barrier("prod_canary")
+        self.assertEqual(result.returncode, 1, result.stderr)
+        self.assertIn(
+            "failed command: python3 ops/archive/test_data_layer_archive_prod_canary.py",
+            result.stdout,
+        )
+        self.assertNotIn("serial=", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 摘要

- warm main CI（run 33053959572）中，preflight job 为 119 秒，`Run preflight` 为 79 秒，`nonprod archive/restore rehearsal` join 等待约 33.6 秒。
- 仅并行两个相互隔离的 PostgreSQL Docker suites；export、promote、cleanup 与 SSOT 检查仍保持串行。最终 PR CI 中 archive join 等待降至 1.65 秒，`Run preflight` 降至 45 秒，preflight job 降至 93 秒。
- prod-export 测试的 AWS 下载失败边界改为确定性 fake，消除真实 AWS CLI 失败路径的 1–11 秒波动。
- PR 首轮 CI（run 33056258874）中 unit 因 `service_unit_cold=false` 走串行 `go test ./...`，`internal/service` 单包耗时 112.4 秒，unit job 达到 176 秒。
- unit CI 现固定走已有 compile-once + 8 shard runner，并删除失效的 `service_unit_cold` 分类、workflow output 和条件分支。最终 unit job 为 75 秒，缩短 101 秒（约 57%）。
- 最终 CI（run 33057784216）全绿：frontend 98 秒、preflight 93 秒、integration 89 秒、unit 75 秒、golangci-lint 32 秒。整体关键路径相对首轮 PR 从 176 秒降至 98 秒。
- 不删除检查、不缩小检查范围、不增加 CI job 数；本地 `make test-unit` 默认行为保持不变。

## 风险

- 两个 archive suite 使用不同容器名、数据库名和随机 host port；资源竞争范围仅限当前 preflight runner。
- 任一 archive 并行子进程失败时会汇总退出码并保留可操作的失败命令。
- unit runner 已在 main push 和 service-cold PR 使用；本次只取消依赖跨 checkout test-result cache 的串行分支。
- credits 预期下降：job 数不变，缩短现有 preflight 与 unit runner 占用时间。

## 验证

- PR CI run 33057784216：15 success、6 skipped、0 failed
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：PASS（提交后完整门禁，102.37 秒）
- `UNIT_TEST_SERVICE_SHARD=1 make -C backend test-unit`：PASS；8 个 service shard 本地最慢 19.1 秒，CI 最慢 21.1 秒
- CI 路由、changed-surfaces、unit runner 与 preflight 聚焦契约：78 tests PASS
- archive composite 真实 Docker 路径：PASS，本地 4.73 秒
- prod-export：10 tests PASS
- `bash -n scripts/preflight.sh`、Python compile、`git diff --check`：PASS
- 两轮独立只读审查均无 Critical / Important / Minor finding，merge-ready

## 提交

- `57babe061 perf(ci): 并行 archive rehearsal 容器测试`
- `af3260bc9 perf(ci): 固定 unit 使用 compile-once shards`

最新提交：`af3260bc9`