### PR TITLE
perf(ci): 让 preflight contract 复用构建缓存

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -132,16 +132,16 @@ jobs:
           go-version-file: backend/go.mod
           check-latest: false
           cache: false
+      - uses: ./.github/actions/go-rolling-cache
+        if: needs.changes.outputs.preflight_go == 'true'
+        with:
+          prefix: preflight-nodwarf-v1
       - name: Unit runner contract tests
         if: needs.changes.outputs.preflight_go == 'true'
         run: python3 -m unittest scripts.ci.test_unit_test_runner
       - name: Integration package discovery contract tests
         if: needs.changes.outputs.preflight_go == 'true'
         run: python3 -m unittest scripts.ci.test_integration_packages
-      - uses: ./.github/actions/go-rolling-cache
-        if: needs.changes.outputs.preflight_go == 'true'
-        with:
-          prefix: preflight-nodwarf-v1
       - name: Run preflight
         env:
           PREFLIGHT_FAST: ${{ github.event_name == 'pull_request' && '1' || '0' }}

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -170,6 +170,29 @@ class BackendCIRoutingTest(unittest.TestCase):
             steps[contract_index].get("run", ""),
         )
 
+    def test_preflight_restores_go_cache_before_go_backed_contracts(self) -> None:
+        steps = self.jobs["preflight"]["steps"]
+        cache_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("uses") == "./.github/actions/go-rolling-cache"
+        )
+        contract_indexes = [
+            index
+            for index, step in enumerate(steps)
+            if step.get("name")
+            in {
+                "Unit runner contract tests",
+                "Integration package discovery contract tests",
+            }
+        ]
+
+        self.assertEqual(len(contract_indexes), 2)
+        self.assertTrue(
+            all(cache_index < contract_index for contract_index in contract_indexes),
+            "Go-backed preflight contracts must consume the restored build cache",
+        )
+
     def test_integration_target_uses_discovered_owner_packages(self) -> None:
         makefile = BACKEND_MAKEFILE.read_text(encoding="utf-8")
         target = makefile.split("test-integration:\n", 1)[1].split("\n\n", 1)[0]


### PR DESCRIPTION
## 摘要

- 将 preflight 的 rolling Go cache 恢复移动到 Go-backed contract tests 之前。
- 避免 unit runner contract 在可复用缓存尚未恢复时冷编译 Go discovery helper。
- 新增编排契约，阻止 cache 顺序退化。

## 风险

- 低风险，仅调整同一 preflight job 内的步骤顺序。
- 不增加 job，不减少检查范围；cache 的 post-job 保存仍覆盖后续 contracts 与 preflight 产生的对象。
- no-web-impact：不改变产品或前端行为。
- no-upstream-touch：未修改上游业务实现。

## 验证

- TDD RED：旧顺序触发 `test_preflight_restores_go_cache_before_go_backed_contracts` 预期失败。
- `python3 -m unittest scripts.test_backend_ci_routing`：19 项通过。
- CI 编排/cache policy 测试：61 项通过。
- Go-backed contract tests：16 项通过。
- `./scripts/preflight.sh`：提交态完整通过。
- 独立代码审查：merge-ready，无 finding。

## 提交

- `c35a3b751` perf(ci): 让 preflight contract 复用构建缓存

最新提交：`c35a3b751`