### PR TITLE
perf(ci): 并行前端与 repository 集成检查

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -141,7 +141,10 @@ jobs:
         run: python3 -m unittest scripts.ci.test_unit_test_runner
       - name: Integration package discovery contract tests
         if: needs.changes.outputs.preflight_go == 'true'
-        run: python3 -m unittest scripts.ci.test_integration_packages
+        run: >-
+          python3 -m unittest
+          scripts.ci.test_integration_packages
+          scripts.ci.test_integration_test_runner
       - name: Run preflight
         env:
           PREFLIGHT_FAST: ${{ github.event_name == 'pull_request' && '1' || '0' }}

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -311,8 +311,8 @@ jobs:
       - name: Install frontend dependencies
         working-directory: frontend
         run: pnpm install --frozen-lockfile
-      - name: Frontend typecheck and critical vitest
-        run: make test-frontend
+      - name: Frontend lint, typecheck, and critical vitest
+        run: make -j3 --output-sync=target test-frontend
 
   golangci-lint:
     needs: changes

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -139,12 +139,6 @@ jobs:
       - name: Unit runner contract tests
         if: needs.changes.outputs.preflight_go == 'true'
         run: python3 -m unittest scripts.ci.test_unit_test_runner
-      - name: Integration package discovery contract tests
-        if: needs.changes.outputs.preflight_go == 'true'
-        run: >-
-          python3 -m unittest
-          scripts.ci.test_integration_packages
-          scripts.ci.test_integration_test_runner
       - name: Run preflight
         env:
           PREFLIGHT_FAST: ${{ github.event_name == 'pull_request' && '1' || '0' }}
@@ -289,6 +283,11 @@ jobs:
         run: |
           expected=$(awk '/^go /{print $2; exit}' backend/go.mod)
           go version | grep -Fq "go${expected}"
+      - name: Integration runner contract tests
+        run: >-
+          python3 -m unittest
+          scripts.ci.test_integration_packages
+          scripts.ci.test_integration_test_runner
       - name: Integration tests
         working-directory: backend
         run: make test-integration

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-backend build-frontend build-datamanagementd test test-backend test-frontend test-frontend-critical test-datamanagementd
+.PHONY: build build-backend build-frontend build-datamanagementd test test-backend test-frontend test-frontend-lint test-frontend-typecheck test-frontend-critical test-datamanagementd
 
 FRONTEND_CRITICAL_VITEST := \
 	src/api/__tests__/client.spec.ts \
@@ -35,10 +35,13 @@ test: test-backend test-frontend
 test-backend:
 	@$(MAKE) -C backend test
 
-test-frontend:
+test-frontend: test-frontend-lint test-frontend-typecheck test-frontend-critical
+
+test-frontend-lint:
 	@pnpm --dir frontend run lint:check
+
+test-frontend-typecheck:
 	@pnpm --dir frontend run typecheck
-	@$(MAKE) test-frontend-critical
 
 test-frontend-critical:
 	@pnpm --dir frontend exec vitest run $(FRONTEND_CRITICAL_VITEST)

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -65,9 +65,7 @@ else
 endif
 
 test-integration:
-	@packages="$$(python3 ../scripts/ci/integration-packages.py --root .)" || exit $$?; \
-	printf 'integration packages:\n%s\n' "$$packages"; \
-	go test -tags=integration $$packages
+	python3 ../scripts/ci/integration_test_runner.py --root .
 
 lint: ensure-golangci-lint
 	$(GOLANGCI_LINT) run ./... $(GOLANGCI_LINT_FAST_ARGS)

--- a/backend/internal/repository/integration_harness_test.go
+++ b/backend/internal/repository/integration_harness_test.go
@@ -44,20 +44,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	if os.Getenv("SUB2API_TEST_REGISTRY_ONLY") == "1" {
-		listRequested := false
-		for _, argument := range os.Args[1:] {
-			if argument == "-test.list" || strings.HasPrefix(argument, "-test.list=") {
-				listRequested = true
-				break
-			}
-		}
-		if !listRequested {
-			log.Printf("SUB2API_TEST_REGISTRY_ONLY requires -test.list")
-			os.Exit(2)
-		}
-		os.Exit(m.Run())
-	}
+	runIntegrationRegistryOnlyIfRequested(m)
 
 	ctx := context.Background()
 

--- a/backend/internal/repository/integration_harness_test.go
+++ b/backend/internal/repository/integration_harness_test.go
@@ -44,6 +44,21 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	if os.Getenv("SUB2API_TEST_REGISTRY_ONLY") == "1" {
+		listRequested := false
+		for _, argument := range os.Args[1:] {
+			if argument == "-test.list" || strings.HasPrefix(argument, "-test.list=") {
+				listRequested = true
+				break
+			}
+		}
+		if !listRequested {
+			log.Printf("SUB2API_TEST_REGISTRY_ONLY requires -test.list")
+			os.Exit(2)
+		}
+		os.Exit(m.Run())
+	}
+
 	ctx := context.Background()
 
 	if err := timezone.Init("UTC"); err != nil {

--- a/backend/internal/repository/integration_registry_only_tk_contract_test.go
+++ b/backend/internal/repository/integration_registry_only_tk_contract_test.go
@@ -1,0 +1,50 @@
+//go:build integration
+
+package repository
+
+import "testing"
+
+func TestIntegrationRegistryOnlyRequestGuard(t *testing.T) {
+	tests := []struct {
+		name      string
+		enabled   bool
+		arguments []string
+		want      bool
+		wantError bool
+	}{
+		{
+			name:      "disabled ignores list flag",
+			arguments: []string{"-test.list", "TestOne"},
+		},
+		{
+			name:      "enabled accepts split list flag",
+			enabled:   true,
+			arguments: []string{"-test.list", "TestOne"},
+			want:      true,
+		},
+		{
+			name:      "enabled accepts assigned list flag",
+			enabled:   true,
+			arguments: []string{"-test.list=TestOne"},
+			want:      true,
+		},
+		{
+			name:      "enabled rejects ordinary test execution",
+			enabled:   true,
+			arguments: []string{"-test.run", "TestOne"},
+			wantError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := integrationRegistryOnlyRequested(test.enabled, test.arguments)
+			if (err != nil) != test.wantError {
+				t.Fatalf("error = %v, wantError %v", err, test.wantError)
+			}
+			if got != test.want {
+				t.Fatalf("requested = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/backend/internal/repository/integration_registry_only_tk_test.go
+++ b/backend/internal/repository/integration_registry_only_tk_test.go
@@ -1,0 +1,42 @@
+//go:build integration
+
+package repository
+
+import (
+	"errors"
+	"log"
+	"os"
+	"strings"
+	"testing"
+)
+
+const integrationRegistryOnlyEnv = "SUB2API_TEST_REGISTRY_ONLY"
+
+func runIntegrationRegistryOnlyIfRequested(m *testing.M) {
+	requested, err := integrationRegistryOnlyRequested(
+		os.Getenv(integrationRegistryOnlyEnv) == "1",
+		os.Args[1:],
+	)
+	if err != nil {
+		log.Printf("%v", err)
+		os.Exit(2)
+	}
+	if requested {
+		os.Exit(m.Run())
+	}
+}
+
+func integrationRegistryOnlyRequested(
+	enabled bool,
+	arguments []string,
+) (bool, error) {
+	if !enabled {
+		return false, nil
+	}
+	for _, argument := range arguments {
+		if argument == "-test.list" || strings.HasPrefix(argument, "-test.list=") {
+			return true, nil
+		}
+	}
+	return false, errors.New("SUB2API_TEST_REGISTRY_ONLY requires -test.list")
+}

--- a/scripts/ci/integration_test_runner.py
+++ b/scripts/ci/integration_test_runner.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Run integration tests while sharding the large repository package."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+
+from unit_test_runner import (
+    Command,
+    DEFAULT_MAX_REGEX_BYTES,
+    RunningCommand,
+    RunnerError,
+    _run_checked,
+    _terminate_processes,
+    _test_entries,
+    run_commands,
+    shard_service_tests,
+    verify_binary_registry,
+)
+
+
+DEFAULT_REPOSITORY_PACKAGE = "./internal/repository"
+DEFAULT_SHARDS = 3
+INTEGRATION_PACKAGES_HELPER = Path(__file__).resolve().with_name(
+    "integration-packages.py"
+)
+
+
+def _go_list_package(root: Path, package: str, tags: str | None = None) -> dict[str, object]:
+    argv = ["go", "list", "-json"]
+    if tags:
+        argv.append(f"-tags={tags}")
+    argv.append(package)
+    output = _run_checked(argv, root)
+    try:
+        result = json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise RunnerError(f"invalid go list output for {package}") from exc
+    if not isinstance(result, dict):
+        raise RunnerError(f"invalid go list output for {package}")
+    return result
+
+
+def _test_files(package: dict[str, object]) -> set[str]:
+    return {
+        *(str(name) for name in package.get("TestGoFiles", [])),
+        *(str(name) for name in package.get("XTestGoFiles", [])),
+    }
+
+
+def discover_test_plan(
+    root: Path,
+    repository_package: str,
+) -> tuple[list[str], Path, list[str], list[str]]:
+    package_output = _run_checked(
+        ["python3", str(INTEGRATION_PACKAGES_HELPER), "--root", str(root)],
+        root,
+    )
+    packages = sorted({line.strip() for line in package_output.splitlines() if line.strip()})
+    if repository_package not in packages:
+        raise RunnerError(
+            f"repository package not found in integration package discovery: "
+            f"{repository_package}"
+        )
+
+    baseline = _go_list_package(root, repository_package)
+    tagged = _go_list_package(root, repository_package, "integration")
+    try:
+        repository_dir = Path(str(tagged["Dir"])).resolve()
+    except KeyError as exc:
+        raise RunnerError(f"go list omitted Dir for {repository_package}") from exc
+
+    baseline_files = _test_files(baseline)
+    tagged_files = _test_files(tagged)
+    integration_files = tagged_files - baseline_files
+    if not integration_files:
+        raise RunnerError(
+            f"no integration-only test files discovered for {repository_package}"
+        )
+
+    all_entries, _ = _test_entries(
+        root,
+        [repository_dir / name for name in sorted(tagged_files)],
+    )
+    integration_entries, _ = _test_entries(
+        root,
+        [repository_dir / name for name in sorted(integration_files)],
+    )
+    if not integration_entries:
+        raise RunnerError(
+            f"no integration test entries discovered for {repository_package}"
+        )
+    return (
+        [package for package in packages if package != repository_package],
+        repository_dir,
+        all_entries,
+        integration_entries,
+    )
+
+
+def run_integration_tests(
+    root: Path,
+    repository_package: str,
+    shard_count: int,
+    max_regex_bytes: int,
+) -> int:
+    with tempfile.TemporaryDirectory(prefix="sub2api-repository-integration-") as temporary:
+        repository_binary = Path(temporary) / "repository.test"
+        with tempfile.TemporaryDirectory(
+            prefix="sub2api-integration-overlap-"
+        ) as overlap_temp:
+            compile_command = Command(
+                "repository-compile",
+                (
+                    "go",
+                    "test",
+                    "-c",
+                    "-tags=integration",
+                    "-o",
+                    str(repository_binary),
+                    repository_package,
+                ),
+                root,
+            )
+            compile_log = Path(overlap_temp) / "repository-compile.log"
+            compile_handle = compile_log.open("wb")
+            try:
+                compile_process = subprocess.Popen(
+                    compile_command.argv,
+                    cwd=compile_command.cwd,
+                    stdout=compile_handle,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except BaseException:
+                compile_handle.close()
+                raise
+            compile_running: RunningCommand = (
+                compile_command,
+                compile_process,
+                compile_log,
+                time.monotonic(),
+            )
+            background: list[RunningCommand] = [compile_running]
+            other_handle = None
+            try:
+                discovery_started_at = time.monotonic()
+                other_packages, repository_dir, all_entries, integration_entries = (
+                    discover_test_plan(root, repository_package)
+                )
+                patterns = shard_service_tests(
+                    integration_entries,
+                    shard_count,
+                    max_regex_bytes,
+                )
+                print(
+                    f"integration-test-runner: STAGE discovery "
+                    f"({time.monotonic() - discovery_started_at:.1f}s)",
+                    flush=True,
+                )
+
+                if other_packages:
+                    other_command = Command(
+                        "other-packages",
+                        tuple(["go", "test", "-tags=integration", *other_packages]),
+                        root,
+                    )
+                    other_log = Path(overlap_temp) / "other-packages.log"
+                    other_handle = other_log.open("wb")
+                    other_process = subprocess.Popen(
+                        other_command.argv,
+                        cwd=other_command.cwd,
+                        stdout=other_handle,
+                        stderr=subprocess.STDOUT,
+                        start_new_session=True,
+                    )
+                    background.append(
+                        (other_command, other_process, other_log, time.monotonic())
+                    )
+
+                compile_returncode = compile_process.wait()
+                compile_elapsed = time.monotonic() - compile_running[3]
+                if compile_returncode != 0:
+                    compile_output = compile_log.read_text(
+                        encoding="utf-8",
+                        errors="replace",
+                    )
+                    detail = (
+                        compile_output.strip()
+                        or f"command exited with status {compile_returncode}"
+                    )
+                    raise RunnerError(
+                        f"{' '.join(compile_command.argv)}: {detail}"
+                    )
+                background = background[1:]
+                print(
+                    f"integration-test-runner: STAGE repository-compile "
+                    f"({compile_elapsed:.1f}s)",
+                    flush=True,
+                )
+
+                registry_started_at = time.monotonic()
+                verify_binary_registry(
+                    repository_binary,
+                    repository_dir,
+                    all_entries,
+                    subject="repository",
+                    environment={"SUB2API_TEST_REGISTRY_ONLY": "1"},
+                )
+                print(
+                    f"integration-test-runner: STAGE registry-check "
+                    f"({time.monotonic() - registry_started_at:.1f}s)",
+                    flush=True,
+                )
+
+                repository_commands: list[Command] = []
+                width = len(str(len(patterns) - 1))
+                for index, pattern in enumerate(patterns):
+                    repository_commands.append(
+                        Command(
+                            f"repository-shard-{index:0{width}d}",
+                            (
+                                str(repository_binary),
+                                "-test.run",
+                                pattern,
+                                "-test.timeout=10m",
+                                "-test.paniconexit0",
+                            ),
+                            repository_dir,
+                        )
+                    )
+                return run_commands(
+                    repository_commands,
+                    background,
+                    runner_name="integration-test-runner",
+                    temporary_prefix="sub2api-integration-",
+                )
+            except BaseException:
+                _terminate_processes(background)
+                raise
+            finally:
+                compile_handle.close()
+                if other_handle is not None:
+                    other_handle.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--repository-package",
+        default=DEFAULT_REPOSITORY_PACKAGE,
+    )
+    parser.add_argument("--shards", type=int, default=DEFAULT_SHARDS)
+    parser.add_argument(
+        "--max-regex-bytes",
+        type=int,
+        default=DEFAULT_MAX_REGEX_BYTES,
+    )
+    args = parser.parse_args(argv)
+    try:
+        return run_integration_tests(
+            args.root.resolve(),
+            args.repository_package,
+            args.shards,
+            args.max_regex_bytes,
+        )
+    except (OSError, RunnerError) as exc:
+        print(f"integration-test-runner: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_integration_test_runner.py
+++ b/scripts/ci/test_integration_test_runner.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Behavior tests for the compile-once Go integration test runner."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parent / "integration_test_runner.py"
+
+
+class IntegrationTestRunnerTest(unittest.TestCase):
+    def test_compiles_repository_once_and_runs_only_integration_entries_in_three_shards(
+        self,
+    ) -> None:
+        integration_tests = [f"TestIntegration{i}" for i in range(9)]
+        with FakeGoFixture(integration_tests) as fixture:
+            first = fixture.run()
+            first_events = fixture.read_events()
+
+            fixture.events.write_text("", encoding="utf-8")
+            second = fixture.run()
+            second_events = fixture.read_events()
+
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertEqual(second.returncode, 0, second.stderr)
+
+        go_calls = [event["args"] for event in first_events if event["kind"] == "go"]
+        compile_calls = [call for call in go_calls if "-c" in call]
+        self.assertEqual(len(compile_calls), 1, go_calls)
+        self.assertIn("./internal/repository", compile_calls[0])
+        self.assertIn(
+            ["test", "-tags=integration", "./internal/other"],
+            go_calls,
+        )
+
+        registry_events = [
+            event
+            for event in first_events
+            if event["kind"] == "binary" and "-test.list" in event["args"]
+        ]
+        self.assertEqual(len(registry_events), 1, first_events)
+        self.assertEqual(registry_events[0]["registry_only"], "1")
+
+        first_patterns = self._binary_patterns(first_events)
+        second_patterns = self._binary_patterns(second_events)
+        self.assertEqual(first_patterns, second_patterns)
+        self.assertEqual(len(first_patterns), 3, first_patterns)
+
+        matched: list[str] = []
+        for pattern in first_patterns:
+            self.assertNotIn("TestBaseline", pattern)
+            self.assertNotIn("TestMain", pattern)
+            matched.extend(name for name in integration_tests if re.fullmatch(pattern, name))
+        self.assertCountEqual(matched, integration_tests)
+        self.assertEqual(len(matched), len(set(matched)))
+
+    def test_fails_closed_when_binary_registry_omits_an_integration_entry(self) -> None:
+        with FakeGoFixture(
+            ["TestVisible", "TestMissing"],
+            binary_tests=["TestBaseline", "TestVisible"],
+        ) as fixture:
+            result = fixture.run()
+            events = fixture.read_events()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("repository test registry mismatch", result.stderr)
+        self.assertIn("missing from binary registry: TestMissing", result.stderr)
+        self.assertFalse(
+            [
+                event
+                for event in events
+                if event["kind"] == "binary" and "-test.run" in event["args"]
+            ]
+        )
+
+    def test_failed_shard_expands_only_its_log_with_integration_label(self) -> None:
+        with FakeGoFixture(
+            ["TestPass", "TestFail"],
+            fail_test="TestFail",
+        ) as fixture:
+            result = fixture.run("--shards", "2")
+
+        combined = result.stdout + result.stderr
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("intentional TestFail failure", combined)
+        self.assertNotIn("successful shard noise", combined)
+        self.assertIn("integration-test-runner: FAIL", combined)
+
+    def test_overlaps_compile_with_discovery_and_other_packages(self) -> None:
+        with FakeGoFixture(
+            ["TestOne", "TestTwo", "TestThree"],
+            compile_delay=4.0,
+            discovery_delay=0.5,
+        ) as fixture:
+            result = fixture.run()
+            events = fixture.read_events()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        compile_started = next(
+            event["at"]
+            for event in events
+            if event["kind"] == "go" and "-c" in event["args"]
+        )
+        discovery_finished = max(
+            event["at"]
+            for event in events
+            if event["kind"] == "go-finished"
+            and event["args"]
+            and event["args"][0] in {"list", "run"}
+        )
+        compile_finished = next(
+            event["at"]
+            for event in events
+            if event["kind"] == "go-finished" and "-c" in event["args"]
+        )
+        other_started = next(
+            event["at"]
+            for event in events
+            if event["kind"] == "go" and "./internal/other" in event["args"]
+        )
+        self.assertLess(compile_started, discovery_finished, events)
+        self.assertLess(other_started, compile_finished, events)
+
+    @staticmethod
+    def _binary_patterns(events: list[dict[str, object]]) -> list[str]:
+        patterns = []
+        for event in events:
+            args = event["args"]
+            if event["kind"] != "binary" or "-test.run" not in args:
+                continue
+            patterns.append(args[args.index("-test.run") + 1])
+        return sorted(patterns)
+
+
+class FakeGoFixture:
+    def __init__(
+        self,
+        integration_tests: list[str],
+        *,
+        binary_tests: list[str] | None = None,
+        fail_test: str | None = None,
+        compile_delay: float = 0.0,
+        discovery_delay: float = 0.0,
+    ) -> None:
+        self.integration_tests = integration_tests
+        self.binary_tests = (
+            ["TestBaseline", *integration_tests]
+            if binary_tests is None
+            else binary_tests
+        )
+        self.fail_test = fail_test
+        self.compile_delay = compile_delay
+        self.discovery_delay = discovery_delay
+        self.temporary: tempfile.TemporaryDirectory[str] | None = None
+
+    def __enter__(self) -> "FakeGoFixture":
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.bin_dir = self.root / "bin"
+        self.bin_dir.mkdir()
+        self.events = self.root / "events.jsonl"
+        self.events.write_text("", encoding="utf-8")
+
+        repository = self.root / "internal" / "repository"
+        repository.mkdir(parents=True)
+        (repository / "baseline_test.go").write_text(
+            'package repository\n\nimport "testing"\n\n'
+            "func TestBaseline(t *testing.T) {}\n",
+            encoding="utf-8",
+        )
+        declarations = "\n".join(
+            f"func {name}(t *testing.T) {{}}" for name in self.integration_tests
+        )
+        (repository / "repository_integration_test.go").write_text(
+            "//go:build integration\n\n"
+            'package repository\n\nimport "testing"\n\n'
+            "func TestMain(m *testing.M) {}\n"
+            f"{declarations}\n",
+            encoding="utf-8",
+        )
+
+        other = self.root / "internal" / "other"
+        other.mkdir(parents=True)
+        (other / "other.go").write_text("package other\n", encoding="utf-8")
+        (other / "other_integration_test.go").write_text(
+            "//go:build integration\n\n"
+            'package other\n\nimport "testing"\n\n'
+            "func TestOtherIntegration(t *testing.T) {}\n",
+            encoding="utf-8",
+        )
+
+        fake_binary_source = textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import json
+            import os
+            from pathlib import Path
+            import sys
+            import time
+
+            args = sys.argv[1:]
+            with Path(os.environ["FAKE_GO_EVENTS"]).open("a", encoding="utf-8") as output:
+                output.write(json.dumps({
+                    "kind": "binary",
+                    "args": args,
+                    "cwd": os.getcwd(),
+                    "at": time.monotonic(),
+                    "registry_only": os.environ.get("SUB2API_TEST_REGISTRY_ONLY", ""),
+                }) + "\\n")
+            if "-test.list" in args:
+                for name in json.loads(os.environ["FAKE_GO_BINARY_TESTS"]):
+                    print(name)
+                raise SystemExit(0)
+            pattern = args[args.index("-test.run") + 1]
+            fail_test = os.environ.get("FAKE_GO_FAIL_TEST", "")
+            if fail_test and fail_test in pattern:
+                print(f"intentional {fail_test} failure")
+                raise SystemExit(1)
+            print("successful shard noise")
+            print("PASS")
+            """
+        )
+        fake_go_source = textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import json
+            import os
+            from pathlib import Path
+            import sys
+            import time
+
+            args = sys.argv[1:]
+            events = Path(os.environ["FAKE_GO_EVENTS"])
+            root = Path(os.environ["FAKE_GO_ROOT"])
+            with events.open("a", encoding="utf-8") as output:
+                output.write(json.dumps({"kind": "go", "args": args, "at": time.monotonic()}) + "\\n")
+
+            repository = {
+                "Dir": str(root / "internal" / "repository"),
+                "ImportPath": "example.com/fixture/internal/repository",
+                "TestGoFiles": ["baseline_test.go"],
+            }
+            other = {
+                "Dir": str(root / "internal" / "other"),
+                "ImportPath": "example.com/fixture/internal/other",
+            }
+            if "-tags=integration" in args:
+                repository["TestGoFiles"] = [
+                    "baseline_test.go",
+                    "repository_integration_test.go",
+                ]
+                other["TestGoFiles"] = ["other_integration_test.go"]
+
+            if args and args[0] == "list":
+                time.sleep(float(os.environ.get("FAKE_GO_DISCOVERY_DELAY", "0")))
+                print(json.dumps(repository))
+                if args[-1] == "./...":
+                    print(json.dumps(other))
+                with events.open("a", encoding="utf-8") as output:
+                    output.write(json.dumps({"kind": "go-finished", "args": args, "at": time.monotonic()}) + "\\n")
+                raise SystemExit(0)
+
+            if args and args[0] == "run":
+                time.sleep(float(os.environ.get("FAKE_GO_DISCOVERY_DELAY", "0")))
+                filenames = {Path(value).name for value in args if value.endswith("_test.go")}
+                entries = []
+                if "baseline_test.go" in filenames:
+                    entries.append("TestBaseline")
+                if "repository_integration_test.go" in filenames:
+                    entries.extend(json.loads(os.environ["FAKE_GO_INTEGRATION_TESTS"]))
+                print(json.dumps({
+                    "entries": entries,
+                    "has_test_main": "repository_integration_test.go" in filenames,
+                }))
+                with events.open("a", encoding="utf-8") as output:
+                    output.write(json.dumps({"kind": "go-finished", "args": args, "at": time.monotonic()}) + "\\n")
+                raise SystemExit(0)
+
+            if "-c" in args:
+                time.sleep(float(os.environ.get("FAKE_GO_COMPILE_DELAY", "0")))
+                binary = Path(args[args.index("-o") + 1])
+                binary.write_text(__BINARY_SOURCE__, encoding="utf-8")
+                binary.chmod(0o755)
+                with events.open("a", encoding="utf-8") as output:
+                    output.write(json.dumps({"kind": "go-finished", "args": args, "at": time.monotonic()}) + "\\n")
+                raise SystemExit(0)
+
+            print("ok  fake/package  0.001s")
+            """
+        ).replace("__BINARY_SOURCE__", repr(fake_binary_source))
+        fake_go = self.bin_dir / "go"
+        fake_go.write_text(fake_go_source, encoding="utf-8")
+        fake_go.chmod(0o755)
+        return self
+
+    def run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["PATH"] = f"{self.bin_dir}{os.pathsep}{env['PATH']}"
+        env["FAKE_GO_EVENTS"] = str(self.events)
+        env["FAKE_GO_ROOT"] = str(self.root)
+        env["FAKE_GO_INTEGRATION_TESTS"] = json.dumps(self.integration_tests)
+        env["FAKE_GO_BINARY_TESTS"] = json.dumps(self.binary_tests)
+        if self.fail_test:
+            env["FAKE_GO_FAIL_TEST"] = self.fail_test
+        if self.compile_delay:
+            env["FAKE_GO_COMPILE_DELAY"] = str(self.compile_delay)
+        if self.discovery_delay:
+            env["FAKE_GO_DISCOVERY_DELAY"] = str(self.discovery_delay)
+        return subprocess.run(
+            ["python3", str(SCRIPT), "--root", str(self.root), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def read_events(self) -> list[dict[str, object]]:
+        return [
+            json.loads(line)
+            for line in self.events.read_text(encoding="utf-8").splitlines()
+            if line
+        ]
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        assert self.temporary is not None
+        self.temporary.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_integration_test_runner.py
+++ b/scripts/ci/test_integration_test_runner.py
@@ -97,8 +97,8 @@ class IntegrationTestRunnerTest(unittest.TestCase):
     def test_overlaps_compile_with_discovery_and_other_packages(self) -> None:
         with FakeGoFixture(
             ["TestOne", "TestTwo", "TestThree"],
-            compile_delay=4.0,
-            discovery_delay=0.5,
+            compile_delay=0.75,
+            discovery_delay=0.05,
         ) as fixture:
             result = fixture.run()
             events = fixture.read_events()

--- a/scripts/ci/unit_test_runner.py
+++ b/scripts/ci/unit_test_runner.py
@@ -40,13 +40,22 @@ class Command:
 RunningCommand = tuple[Command, subprocess.Popen[bytes], Path, float]
 
 
-def _run_checked(argv: list[str], root: Path) -> str:
+def _run_checked(
+    argv: list[str],
+    root: Path,
+    environment: dict[str, str] | None = None,
+) -> str:
+    run_environment = None
+    if environment:
+        run_environment = os.environ.copy()
+        run_environment.update(environment)
     result = subprocess.run(
         argv,
         cwd=root,
         check=False,
         capture_output=True,
         text=True,
+        env=run_environment,
     )
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "command failed"
@@ -179,10 +188,13 @@ def verify_binary_registry(
     service_binary: Path,
     service_dir: Path,
     discovered_tests: list[str],
+    subject: str = "service",
+    environment: dict[str, str] | None = None,
 ) -> None:
     output = _run_checked(
         [str(service_binary), "-test.list", "^(Test|Fuzz|Example)"],
         service_dir,
+        environment,
     )
     registered_tests = sorted(
         {line.strip() for line in output.splitlines() if line.strip()}
@@ -199,7 +211,7 @@ def verify_binary_registry(
         details.append("missing from AST discovery: " + ", ".join(missing))
     if unexpected:
         details.append("missing from binary registry: " + ", ".join(unexpected))
-    raise RunnerError("service test registry mismatch; " + "; ".join(details))
+    raise RunnerError(f"{subject} test registry mismatch; " + "; ".join(details))
 
 
 def build_commands(
@@ -273,8 +285,10 @@ def _terminate_processes(
 def run_commands(
     commands: list[Command],
     initial_running: list[RunningCommand] | None = None,
+    runner_name: str = "unit-test-runner",
+    temporary_prefix: str = "sub2api-unit-",
 ) -> int:
-    with tempfile.TemporaryDirectory(prefix="sub2api-unit-") as temporary:
+    with tempfile.TemporaryDirectory(prefix=temporary_prefix) as temporary:
         log_dir = Path(temporary)
         running = list(initial_running or [])
         handles = []
@@ -314,12 +328,12 @@ def run_commands(
             output = log_path.read_text(encoding="utf-8", errors="replace")
             if returncode == 0:
                 print(
-                    f"unit-test-runner: PASS {command.label} "
+                    f"{runner_name}: PASS {command.label} "
                     f"({elapsed:.1f}s): {_last_summary(output)}"
                 )
                 continue
             print(
-                f"unit-test-runner: FAIL {command.label} ({elapsed:.1f}s)",
+                f"{runner_name}: FAIL {command.label} ({elapsed:.1f}s)",
                 file=sys.stderr,
             )
             print(output.rstrip(), file=sys.stderr)

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -3,6 +3,30 @@
   "rationale": "Load-bearing TokenKey gateway/service injections that intentionally live in upstream-shaped hotspot files. These touches are small and compile-clean if dropped, so upstream merges can silently revert them unless preflight and upstream-merge PR shape check their literal hooks.",
   "sentinels": [
     {
+      "path": "backend/internal/repository/integration_registry_only_tk_test.go",
+      "must_contain": [
+        "func runIntegrationRegistryOnlyIfRequested(m *testing.M)",
+        "const integrationRegistryOnlyEnv = \"SUB2API_TEST_REGISTRY_ONLY\"",
+        "SUB2API_TEST_REGISTRY_ONLY requires -test.list"
+      ],
+      "rationale": "CI repository sharding verifies the compiled test registry before starting shards. The repository TestMain normally starts PostgreSQL, Redis, and all migrations, so registry listing must bypass that harness only when the private registry env and -test.list are both present. Dropping this companion silently adds another full integration harness startup to every CI run or reopens a test-skipping path."
+    },
+    {
+      "path": "backend/internal/repository/integration_harness_test.go",
+      "must_contain": [
+        "runIntegrationRegistryOnlyIfRequested(m)"
+      ],
+      "rationale": "Minimal upstream-shaped call site for the registry-only companion. The companion remains compile-clean if an upstream merge drops this one line, but integration CI then spends another PostgreSQL/Redis/migration startup on -test.list before launching the real shards."
+    },
+    {
+      "path": "backend/internal/repository/integration_registry_only_tk_contract_test.go",
+      "must_contain": [
+        "TestIntegrationRegistryOnlyRequestGuard",
+        "enabled rejects ordinary test execution"
+      ],
+      "rationale": "Focused guard proving the private registry mode accepts only -test.list and cannot be reused to skip ordinary repository integration execution."
+    },
+    {
       "path": "backend/internal/service/ops_dlq_spill.go",
       "must_contain": [
         "defaultOpsDLQMaxFiles",

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -12,6 +12,7 @@ import yaml
 
 WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "backend-ci.yml"
 BACKEND_MAKEFILE = Path(__file__).resolve().parents[1] / "backend" / "Makefile"
+ROOT_MAKEFILE = Path(__file__).resolve().parents[1] / "Makefile"
 
 
 class BackendCIRoutingTest(unittest.TestCase):
@@ -51,6 +52,43 @@ class BackendCIRoutingTest(unittest.TestCase):
                 condition = job.get("if", "")
                 self.assertIn(f"needs.changes.outputs.{surface} == 'true'", condition)
                 self.assertIn("needs.changes.outputs.all == 'true'", condition)
+
+    def test_frontend_job_parallelizes_checks_on_one_runner(self) -> None:
+        frontend_step = next(
+            step
+            for step in self.jobs["frontend"]["steps"]
+            if "test-frontend" in step.get("run", "")
+        )
+
+        self.assertEqual(
+            frontend_step["name"],
+            "Frontend lint, typecheck, and critical vitest",
+        )
+        self.assertEqual(
+            frontend_step["run"],
+            "make -j3 --output-sync=target test-frontend",
+        )
+
+    def test_frontend_target_preserves_all_required_checks(self) -> None:
+        result = subprocess.run(
+            ["make", "-npRr", "-f", str(ROOT_MAKEFILE), "test-frontend"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        target_line = next(
+            line for line in result.stdout.splitlines() if line.startswith("test-frontend:")
+        )
+        self.assertEqual(
+            set(target_line.split(":", 1)[1].split()),
+            {
+                "test-frontend-lint",
+                "test-frontend-typecheck",
+                "test-frontend-critical",
+            },
+        )
 
     def test_required_preflight_owns_path_conditioned_contract_gates(self) -> None:
         preflight = self.jobs["preflight"]

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -231,11 +231,26 @@ class BackendCIRoutingTest(unittest.TestCase):
             "Go-backed preflight contracts must consume the restored build cache",
         )
 
-    def test_integration_target_uses_discovered_owner_packages(self) -> None:
-        makefile = BACKEND_MAKEFILE.read_text(encoding="utf-8")
-        target = makefile.split("test-integration:\n", 1)[1].split("\n\n", 1)[0]
-        self.assertIn("integration-packages.py", target)
-        self.assertNotIn("go test -tags=integration ./...", target)
+    def test_integration_target_uses_compile_once_repository_shards(self) -> None:
+        result = subprocess.run(
+            ["make", "-n", "-C", str(BACKEND_MAKEFILE.parent), "test-integration"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("integration_test_runner.py", result.stdout)
+        self.assertNotIn("go test -tags=integration", result.stdout)
+
+    def test_preflight_runs_integration_runner_contract_tests(self) -> None:
+        step = next(
+            step
+            for step in self.jobs["preflight"]["steps"]
+            if step.get("name") == "Integration package discovery contract tests"
+        )
+
+        self.assertIn("scripts.ci.test_integration_test_runner", step["run"])
 
     def test_unit_job_always_uses_compile_once_service_shards(self) -> None:
         unit_step = next(

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -114,11 +114,6 @@ class BackendCIRoutingTest(unittest.TestCase):
             next(
                 step
                 for step in steps
-                if step.get("name") == "Integration package discovery contract tests"
-            ),
-            next(
-                step
-                for step in steps
                 if step.get("uses") == "./.github/actions/go-rolling-cache"
             ),
         ]
@@ -187,24 +182,41 @@ class BackendCIRoutingTest(unittest.TestCase):
             orchestration.get("run", ""),
         )
 
-    def test_go_dependent_integration_contract_runs_after_pinned_setup(self) -> None:
-        steps = self.jobs["preflight"]["steps"]
-        orchestration = next(
-            step for step in steps if step.get("name") == "CI orchestration contract tests"
+    def test_go_dependent_integration_contract_runs_off_the_preflight_path(self) -> None:
+        preflight_steps = self.jobs["preflight"]["steps"]
+        self.assertFalse(
+            [
+                step
+                for step in preflight_steps
+                if "scripts.ci.test_integration_packages" in step.get("run", "")
+                or "scripts.ci.test_integration_test_runner" in step.get("run", "")
+            ]
         )
-        self.assertNotIn("scripts.ci.test_integration_packages", orchestration.get("run", ""))
 
-        setup_index = next(
-            index for index, step in enumerate(steps) if step.get("uses") == "actions/setup-go@v6"
+        steps = self.jobs["test-integration"]["steps"]
+        cache_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("uses") == "./.github/actions/go-rolling-cache"
         )
         contract_index = next(
             index
             for index, step in enumerate(steps)
-            if step.get("name") == "Integration package discovery contract tests"
+            if step.get("name") == "Integration runner contract tests"
         )
-        self.assertGreater(contract_index, setup_index)
+        integration_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("name") == "Integration tests"
+        )
+        self.assertGreater(contract_index, cache_index)
+        self.assertLess(contract_index, integration_index)
         self.assertIn(
             "scripts.ci.test_integration_packages",
+            steps[contract_index].get("run", ""),
+        )
+        self.assertIn(
+            "scripts.ci.test_integration_test_runner",
             steps[contract_index].get("run", ""),
         )
 
@@ -218,14 +230,10 @@ class BackendCIRoutingTest(unittest.TestCase):
         contract_indexes = [
             index
             for index, step in enumerate(steps)
-            if step.get("name")
-            in {
-                "Unit runner contract tests",
-                "Integration package discovery contract tests",
-            }
+            if step.get("name") == "Unit runner contract tests"
         ]
 
-        self.assertEqual(len(contract_indexes), 2)
+        self.assertEqual(len(contract_indexes), 1)
         self.assertTrue(
             all(cache_index < contract_index for contract_index in contract_indexes),
             "Go-backed preflight contracts must consume the restored build cache",
@@ -243,11 +251,11 @@ class BackendCIRoutingTest(unittest.TestCase):
         self.assertIn("integration_test_runner.py", result.stdout)
         self.assertNotIn("go test -tags=integration", result.stdout)
 
-    def test_preflight_runs_integration_runner_contract_tests(self) -> None:
+    def test_integration_job_runs_integration_runner_contract_tests(self) -> None:
         step = next(
             step
-            for step in self.jobs["preflight"]["steps"]
-            if step.get("name") == "Integration package discovery contract tests"
+            for step in self.jobs["test-integration"]["steps"]
+            if step.get("name") == "Integration runner contract tests"
         )
 
         self.assertIn("scripts.ci.test_integration_test_runner", step["run"])


### PR DESCRIPTION
## 摘要

- 将 frontend 的 ESLint、vue-tsc、critical Vitest 在同一个 runner 内并行执行。
- 新增 compile-once integration runner：精确发现 repository 的 integration 入口，稳定分成 3 个 shard 并行执行；其他 integration packages 保持原生 `go test`。
- binary registry 校验 fail closed，registry-only 模式只接受 `-test.list`，不会启动 PostgreSQL、Redis 和 migrations，也不能跳过普通测试。
- 不增加 GitHub Actions job，不减少检查范围；新增 runner 行为测试、CI 编排契约和 upstream 覆盖 sentinel。
- integration runner contracts 放在对应 integration job，避免给 preflight 关键路径增加串行时间。
- sentinel-registry-reviewed：已锚定 registry-only companion、`TestMain` 调用点及负向测试；根 Makefile 的 frontend 编排变更不承载新的业务语义。

## 风险

- integration job 会在同一 runner 内并发运行 3 组 PostgreSQL/Redis harness，增加瞬时 CPU/内存使用，但不增加并行 job credits。
- 稳定 SHA-256 分片不会改变测试集合；AST 与 compiled binary registry 不一致时直接失败。
- 变更仅影响 CI 测试编排，`git revert` 可直接回退；no-web-impact。

## 验证

- `python3 -m unittest scripts.ci.test_integration_test_runner scripts.ci.test_integration_packages`：6 项通过。
- `python3 -m unittest scripts.ci.test_unit_test_runner scripts.test_backend_ci_routing`：36 项通过。
- 真实 Docker integration runner：全部 shard、其他 packages 和 migrations 通过；wall time 20.27–24.55 秒。
- 同环境禁用 test-result cache 的旧命令：30.63 秒；本地完整 integration wall 缩短约 20%–34%。
- GitHub CI（`c0a401473`）：全部通过；integration job 99 → 76 秒，测试步骤 66 → 47 秒。该轮整体 115 秒，关键路径转为 preflight 99 秒。
- GitHub CI（`971c2d5f7`）：全部通过；runner contract 迁移后 preflight 99 → 85 秒，整体 115 → 110 秒。该轮 integration job 95 秒 / 测试步骤 54 秒；三个 shard 同比一致变慢，属于 runner/Docker 波动而非分片失衡。
- 相对 #1858 上一 HEAD 的 114 秒整体、99 秒 integration job、66 秒 integration step：最新样本分别为 110 / 95 / 54 秒；两个分片样本的 integration job 范围为 76–95 秒。
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：PASS。
- xj-review：normal / concise / merge-ready；R-001 已修复并由 gateway TK sentinel 固化。
- #1858 既有 frontend CI：组合检查 73 → 36 秒，frontend job 95 → 66 秒。

## 提交

- `b428ded7f` perf(ci): 并行执行前端检查
- `bc7198f30` perf(ci): 并行 repository 集成测试
- `c0a401473` fix(ci): anchor registry-only harness — R-001
- `971c2d5f7` fix(ci): move runner contracts off critical path

最新提交：971c2d5f7
