### PR TITLE
fix(ci): 修复并行前端检查的 Vite 临时文件竞态

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ test-frontend-typecheck:
 
 test-frontend-critical:
 	@pnpm --dir frontend exec vitest run $(FRONTEND_CRITICAL_VITEST)
+	@node --test scripts/ci/test_frontend_eslint_ignore.mjs
 
 test-datamanagementd:
 	@cd datamanagement && go test ./...

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 707,
-  "hash": "928aacbd34bb7249a80904b25499cc7dbec85ee7e379c7c3353cb13621c0f7f5",
+  "hash": "033696042eb7d2c895c153903989da8d2deaf581e3309d1e526c1d47d9328639",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -1,6 +1,9 @@
 # 忽略编译后的文件
 vite.config.js
 vite.config.d.ts
+# Vitest's Vite config loader creates and deletes this beside the config while
+# the parallel ESLint target scans the frontend tree.
+/vitest.config.ts.timestamp-*.mjs
 
 # 忽略依赖
 node_modules/

--- a/scripts/ci/test_frontend_eslint_ignore.mjs
+++ b/scripts/ci/test_frontend_eslint_ignore.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { test } from 'node:test'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const frontendRoot = resolve(repositoryRoot, 'frontend')
+const requireFromFrontend = createRequire(resolve(frontendRoot, 'package.json'))
+const { ESLint } = requireFromFrontend('eslint')
+
+test('ESLint ignores timestamped config modules created during parallel Vitest startup', async () => {
+  const eslint = new ESLint({ cwd: frontendRoot })
+  const volatileConfig = resolve(
+    frontendRoot,
+    'vitest.config.ts.timestamp-123456-deadbeef.mjs'
+  )
+
+  assert.equal(await eslint.isPathIgnored(volatileConfig), true)
+})


### PR DESCRIPTION
## 摘要

- 修复 #1858 合并后 `main` frontend job 暴露的并发竞态：Vitest 创建并删除 `vitest.config.ts.timestamp-*.mjs` 时，ESLint 可能先枚举后读取并触发 `ENOENT`。
- 仅忽略 frontend 根目录下的该类 Vite 临时配置，不忽略正常 `vitest.config.ts` 或其他源码模块。
- 新增基于真实 ESLint `isPathIgnored` 的行为回归测试，并接入现有 frontend critical target。
- 保留 lint、vue-tsc、critical Vitest 三路并行，不增加 GitHub Actions job 或 credits fan-out。
- 标准 frontend build 仅刷新 `frontend-source.json` 确定性 hash，JS/CSS bundles 未变化。

## 风险

- ignore pattern 精确限定为 `/vitest.config.ts.timestamp-*.mjs`，不会扩大到嵌套目录或普通 `.mjs` 文件。
- 变更仅影响 CI lint 对短生命周期 Vite 配置的处理；no-web-impact，可通过 revert 单提交回退。
- sentinel-registry-reviewed：Makefile 只接入 CI 行为测试，不承载新的用户界面或上游 load-bearing 业务语义，无需新增 frontend sentinel。

## 验证

- 红测：修复前 `node --test scripts/ci/test_frontend_eslint_ignore.mjs` 以 `false !== true` 失败。
- 绿测：同一命令通过。
- `make -j3 test-frontend`：16 个 Vitest 文件 / 180 项测试及 ESLint guard 全部通过；lint、typecheck 通过。
- `python3 -m unittest scripts.test_backend_ci_routing`：22 项通过。
- `python3 scripts/checks/frontend-dist-freshness.py --check backend/internal/web/dist`：通过。
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：PASS。
- 独立 code review：无 Critical / Important / Minor finding。

## 提交

- `0fb7a5423` fix(ci): ignore transient Vitest config during parallel lint

最新提交：0fb7a5423