### PR TITLE
perf(ci): 移出 integration 缓存写入关键路径

### DIFF
--- a/.github/actions/go-rolling-cache/action.yml
+++ b/.github/actions/go-rolling-cache/action.yml
@@ -12,14 +12,15 @@
 #     GOMODCACHE against the 10GB/repo budget.
 #   - build/test cache: per-job (prefix) + UTC-week seed by default, avoiding
 #     repeated uploads of the 300MB-2.5GB preflight/unit/lint archives. The
-#     integration caller opts into a tracked-backend fingerprint because its
-#     stale weekly snapshot was measured adding ~40s of cold compilation; PRs
-#     restore but never upload, and main writes only when backend inputs change.
-#     Go's cache is content-addressed, so prior snapshots safely seed new keys.
+#     integration caller opts into a daily epoch and an isolated path. Required
+#     CI is restore-only; warm-release-cache-main.yml owns the non-blocking
+#     writer so a slow cache upload cannot extend the correctness gate. Go's
+#     cache is content-addressed, so prior snapshots safely seed new keys.
 #   - golangci analysis cache: optional, lint-only, and rolling for the same
 #     reason. golangci-lint-action's interval key is immutable after the first
 #     save, so changed-package analysis cannot be written back until the interval
-#     changes. Main owns the rolling writer; PRs restore but never save.
+#     changes. Main owns the rolling writer for the default callers; PRs and
+#     callers with save_build_cache=false restore but never save.
 #
 # Set `cache: false` on the calling job's actions/setup-go step and call this
 # AFTER it (mirrors warm-release-cache in backend-ci.yml).
@@ -38,6 +39,18 @@ inputs:
     description: Use the tracked backend input fingerprint instead of the weekly epoch.
     required: false
     default: "false"
+  refresh_daily:
+    description: Use a UTC-day cache epoch instead of the weekly epoch.
+    required: false
+    default: "false"
+  build_cache_path:
+    description: Go build/test cache path restored and optionally saved by this action.
+    required: false
+    default: ~/.cache/go-build
+  save_build_cache:
+    description: Allow main pushes to save the build/test cache; set false on required jobs whose tail must stay restore-only.
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -45,7 +58,9 @@ runs:
     - name: Resolve weekly build cache epoch
       id: cache_epoch
       shell: bash
-      run: echo "value=$(date -u +%G-W%V)" >> "$GITHUB_OUTPUT"
+      run: |
+        echo "week=$(date -u +%G-W%V)" >> "$GITHUB_OUTPUT"
+        echo "day=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
 
     - name: Restore Go module cache (non-main writer)
       if: github.event_name != 'push' || github.ref != 'refs/heads/main'
@@ -64,21 +79,21 @@ runs:
         restore-keys: ${{ runner.os }}-gomod-
 
     - name: Restore Go build/test cache (non-main writer, ${{ inputs.prefix }})
-      if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+      if: github.event_name != 'push' || github.ref != 'refs/heads/main' || inputs.save_build_cache != 'true'
       uses: actions/cache/restore@v6
       with:
-        path: ~/.cache/go-build
-        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ inputs.refresh_on_backend_change == 'true' && hashFiles('backend/**', '.new-api-ref') || steps.cache_epoch.outputs.value }}
+        path: ${{ inputs.build_cache_path }}
+        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ inputs.refresh_on_backend_change == 'true' && hashFiles('backend/**', '.new-api-ref') || inputs.refresh_daily == 'true' && steps.cache_epoch.outputs.day || steps.cache_epoch.outputs.week }}
         restore-keys: |
           ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
           ${{ runner.os }}-gobuild-${{ inputs.prefix }}-
 
     - name: Go build/test cache (main writer, ${{ inputs.prefix }})
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && inputs.save_build_cache == 'true'
       uses: actions/cache@v6
       with:
-        path: ~/.cache/go-build
-        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ inputs.refresh_on_backend_change == 'true' && hashFiles('backend/**', '.new-api-ref') || steps.cache_epoch.outputs.value }}
+        path: ${{ inputs.build_cache_path }}
+        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ inputs.refresh_on_backend_change == 'true' && hashFiles('backend/**', '.new-api-ref') || inputs.refresh_daily == 'true' && steps.cache_epoch.outputs.day || steps.cache_epoch.outputs.week }}
         restore-keys: |
           ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
           ${{ runner.os }}-gobuild-${{ inputs.prefix }}-

--- a/.github/actions/go-rolling-cache/action.yml
+++ b/.github/actions/go-rolling-cache/action.yml
@@ -20,7 +20,7 @@
 #     reason. golangci-lint-action's interval key is immutable after the first
 #     save, so changed-package analysis cannot be written back until the interval
 #     changes. Main owns the rolling writer for the default callers; PRs and
-#     callers with save_build_cache=false restore but never save.
+#     callers with save_caches=false restore but never save.
 #
 # Set `cache: false` on the calling job's actions/setup-go step and call this
 # AFTER it (mirrors warm-release-cache in backend-ci.yml).
@@ -47,8 +47,8 @@ inputs:
     description: Go build/test cache path restored and optionally saved by this action.
     required: false
     default: ~/.cache/go-build
-  save_build_cache:
-    description: Allow main pushes to save the build/test cache; set false on required jobs whose tail must stay restore-only.
+  save_caches:
+    description: Allow main pushes to save caches owned by this action; set false on required jobs whose tail must stay restore-only.
     required: false
     default: "true"
 
@@ -63,7 +63,7 @@ runs:
         echo "day=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
 
     - name: Restore Go module cache (non-main writer)
-      if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+      if: github.event_name != 'push' || github.ref != 'refs/heads/main' || inputs.save_caches != 'true'
       uses: actions/cache/restore@v6
       with:
         path: ~/go/pkg/mod
@@ -71,7 +71,7 @@ runs:
         restore-keys: ${{ runner.os }}-gomod-
 
     - name: Go module cache (main writer)
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && inputs.save_caches == 'true'
       uses: actions/cache@v6
       with:
         path: ~/go/pkg/mod
@@ -79,7 +79,7 @@ runs:
         restore-keys: ${{ runner.os }}-gomod-
 
     - name: Restore Go build/test cache (non-main writer, ${{ inputs.prefix }})
-      if: github.event_name != 'push' || github.ref != 'refs/heads/main' || inputs.save_build_cache != 'true'
+      if: github.event_name != 'push' || github.ref != 'refs/heads/main' || inputs.save_caches != 'true'
       uses: actions/cache/restore@v6
       with:
         path: ${{ inputs.build_cache_path }}
@@ -89,7 +89,7 @@ runs:
           ${{ runner.os }}-gobuild-${{ inputs.prefix }}-
 
     - name: Go build/test cache (main writer, ${{ inputs.prefix }})
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && inputs.save_build_cache == 'true'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && inputs.save_caches == 'true'
       uses: actions/cache@v6
       with:
         path: ${{ inputs.build_cache_path }}
@@ -99,7 +99,7 @@ runs:
           ${{ runner.os }}-gobuild-${{ inputs.prefix }}-
 
     - name: Restore golangci-lint analysis cache (non-main writer)
-      if: inputs.golangci_cache == 'true' && (github.event_name != 'push' || github.ref != 'refs/heads/main')
+      if: inputs.golangci_cache == 'true' && (github.event_name != 'push' || github.ref != 'refs/heads/main' || inputs.save_caches != 'true')
       uses: actions/cache/restore@v6
       with:
         path: ~/.cache/golangci-lint
@@ -109,7 +109,7 @@ runs:
           ${{ runner.os }}-golangci-
 
     - name: golangci-lint analysis cache (rolling main writer)
-      if: inputs.golangci_cache == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: inputs.golangci_cache == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' && inputs.save_caches == 'true'
       uses: actions/cache@v6
       with:
         path: ~/.cache/golangci-lint

--- a/.github/workflows/anthropic-cc-issue-watchdog.yml
+++ b/.github/workflows/anthropic-cc-issue-watchdog.yml
@@ -377,7 +377,7 @@ jobs:
           echo "cache_pr_url=$URL" >> "$GITHUB_OUTPUT"
           echo "cache PR: $URL"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: cc-issue-watchdog-scan-${{ github.run_id }}
@@ -454,7 +454,7 @@ jobs:
           git config user.name "tk-cc-issue-fix-agent[bot]"
           git config user.email "cc-issue-fix-agent@tokenkey.dev"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: cc-issue-watchdog-scan-${{ github.run_id }}
           path: .cache/anthropic-cc-issue-watchdog
@@ -520,7 +520,7 @@ jobs:
           gh_token: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
           output_file: /tmp/cc-issue-fix-agent-output.txt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: cc-issue-fix-agent-output-${{ github.run_id }}

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -262,6 +262,7 @@ jobs:
       # Integration failures retain file:line stacks without DWARF while the
       # package/test cache stays materially smaller to restore and refresh.
       GOFLAGS: -gcflags=all=-dwarf=false
+      GOCACHE: ${{ github.workspace }}/.cache/go-build-integration
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/cache-and-checkout-new-api
@@ -273,8 +274,12 @@ jobs:
           cache: false
       - uses: ./.github/actions/go-rolling-cache
         with:
-          prefix: integration-nodwarf-v1
-          refresh_on_backend_change: "true"
+          # Required CI restores the daily cache but never waits for its upload.
+          # warm-release-cache-main.yml owns the single non-blocking writer.
+          prefix: integration-nodwarf-v2
+          refresh_daily: "true"
+          build_cache_path: ${{ github.workspace }}/.cache/go-build-integration
+          save_build_cache: "false"
       - name: Verify Go version
         run: |
           expected=$(awk '/^go /{print $2; exit}' backend/go.mod)

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -279,7 +279,7 @@ jobs:
           prefix: integration-nodwarf-v2
           refresh_daily: "true"
           build_cache_path: ${{ github.workspace }}/.cache/go-build-integration
-          save_build_cache: "false"
+          save_caches: "false"
       - name: Verify Go version
         run: |
           expected=$(awk '/^go /{print $2; exit}' backend/go.mod)

--- a/.github/workflows/client-fidelity-watch.yml
+++ b/.github/workflows/client-fidelity-watch.yml
@@ -77,7 +77,7 @@ jobs:
             --umbrella \
             --links-json .cache/fingerprint/client-release-watch/links.json
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: client-fidelity-release-${{ github.run_id }}
@@ -163,7 +163,7 @@ jobs:
             --umbrella \
             --links-json .cache/prompt-surface-watch/links.json
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: client-fidelity-prompt-${{ github.run_id }}
@@ -260,7 +260,7 @@ jobs:
           echo "status=$status" >> "$GITHUB_OUTPUT"
           echo "prod observation status: $status"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always() && steps.precheck.outputs.skip == 'false'
         with:
           name: client-fidelity-prompt-${{ github.run_id }}
@@ -356,7 +356,7 @@ jobs:
           echo "status=$status" >> "$GITHUB_OUTPUT"
           echo "edge OAuth mimic observation status: $status"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always() && steps.precheck.outputs.skip == 'false'
         with:
           name: client-fidelity-oauth-mimic-${{ github.run_id }}
@@ -425,7 +425,7 @@ jobs:
           echo "status=$status" >> "$GITHUB_OUTPUT"
           echo "Kiro production-configured parity observation status: $status"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always() && steps.precheck.outputs.skip == 'false'
         with:
           name: client-fidelity-kiro-parity-${{ github.run_id }}
@@ -443,25 +443,25 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: client-fidelity-release-${{ github.run_id }}
           path: .cache/fingerprint/client-release-watch
         continue-on-error: true
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: client-fidelity-prompt-${{ github.run_id }}
           path: .cache/prompt-surface-watch
         continue-on-error: true
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: client-fidelity-oauth-mimic-${{ github.run_id }}
           path: .cache/oauth-mimic-watch
         continue-on-error: true
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: client-fidelity-kiro-parity-${{ github.run_id }}
           path: .cache/kiro-profile-parity
@@ -550,7 +550,7 @@ jobs:
           echo "fidelity_verdict=$FIDELITY_VERDICT" >> "$GITHUB_OUTPUT"
           cat .cache/fingerprint/client-fidelity-watch/report.md >> "$GITHUB_STEP_SUMMARY"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: client-fidelity-watch-${{ github.run_id }}

--- a/.github/workflows/ops-daily-diagnostics.yml
+++ b/.github/workflows/ops-daily-diagnostics.yml
@@ -762,7 +762,7 @@ jobs:
           PY
           cat "$OUT/target-report.md" >> "$GITHUB_STEP_SUMMARY"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: prod-ops-target-${{ matrix.target_id }}-${{ github.run_id }}
@@ -788,7 +788,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         continue-on-error: true
         with:
           pattern: prod-ops-target-*-${{ github.run_id }}
@@ -871,7 +871,7 @@ jobs:
           cat ops-report.md >> "$GITHUB_STEP_SUMMARY"
           cat daily-error-report.md >> "$GITHUB_STEP_SUMMARY"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: prod-ops-report-${{ github.run_id }}
           path: |
@@ -890,7 +890,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: prod-ops-report-${{ github.run_id }}
           path: .
@@ -1093,7 +1093,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           echo "captured $LINES lines / $BYTES bytes"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: prod-logs-${{ github.run_id }}
           path: logs.txt

--- a/.github/workflows/pricing-registry-sensor.yml
+++ b/.github/workflows/pricing-registry-sensor.yml
@@ -49,7 +49,7 @@ jobs:
           python3 scripts/checks/pricing-overlay.py
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: pricing-registry-sensor-${{ github.run_id }}

--- a/.github/workflows/upstream-issue-watchdog.yml
+++ b/.github/workflows/upstream-issue-watchdog.yml
@@ -344,7 +344,7 @@ jobs:
           echo "cache_pr_url=$URL" >> "$GITHUB_OUTPUT"
           echo "cache PR: $URL"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: upstream-issue-watchdog-scan-${{ github.run_id }}
@@ -421,7 +421,7 @@ jobs:
           git config user.name "tk-upstream-issue-fix-agent[bot]"
           git config user.email "upstream-issue-fix-agent@tokenkey.dev"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: upstream-issue-watchdog-scan-${{ github.run_id }}
           path: .cache/upstream-issue-watchdog
@@ -487,7 +487,7 @@ jobs:
           gh_token: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
           output_file: /tmp/upstream-issue-fix-agent-output.txt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: upstream-issue-fix-agent-output-${{ github.run_id }}

--- a/.github/workflows/warm-release-cache-main.yml
+++ b/.github/workflows/warm-release-cache-main.yml
@@ -1,8 +1,9 @@
 name: Warm Release Cache
 
 # Release tags can restore caches from the default branch, but not from older
-# tag refs. Keep the cross-arch cache warm on main only when backend build
-# inputs change; this is acceleration work, not a required CI correctness gate.
+# tag refs. Keep the cross-arch release cache and the daily integration build
+# cache warm on main only when backend build inputs change. This is acceleration
+# work, not a required CI correctness gate.
 on:
   push:
     branches: [main]
@@ -59,3 +60,30 @@ jobs:
             GOARCH="${arch}" go build -o /dev/null ./cmd/server
             echo "::endgroup::"
           done
+      - name: Resolve daily integration cache epoch
+        id: integration_epoch
+        run: echo "day=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+      - name: Daily integration build cache
+        id: integration_cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}/.cache/go-build-integration
+          key: ${{ runner.os }}-gobuild-integration-nodwarf-v2-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ steps.integration_epoch.outputs.day }}
+          restore-keys: |
+            ${{ runner.os }}-gobuild-integration-nodwarf-v2-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
+            ${{ runner.os }}-gobuild-integration-nodwarf-v2-
+      - name: Warm integration build cache
+        if: steps.integration_cache.outputs.cache-hit != 'true'
+        working-directory: backend
+        env:
+          GOCACHE: ${{ github.workspace }}/.cache/go-build-integration
+          GOFLAGS: -gcflags=all=-dwarf=false
+        run: |
+          set -euo pipefail
+          index=0
+          while IFS= read -r package; do
+            go test -c -tags=integration \
+              -o "${RUNNER_TEMP}/integration-cache-${index}.test" \
+              "$package"
+            index=$((index + 1))
+          done < <(python3 ../scripts/ci/integration-packages.py --root .)

--- a/scripts/checks/test_cache_action_runtime.py
+++ b/scripts/checks/test_cache_action_runtime.py
@@ -13,7 +13,11 @@ GITHUB_DIR = REPO_ROOT / ".github"
 CACHE_ACTION = re.compile(
     r"actions/cache(?P<variant>/(?:restore|save))?@v(?P<major>\d+)"
 )
+UPLOAD_ARTIFACT_ACTION = re.compile(r"actions/upload-artifact@v(?P<major>\d+)")
+DOWNLOAD_ARTIFACT_ACTION = re.compile(r"actions/download-artifact@v(?P<major>\d+)")
 REQUIRED_MAJOR = "6"
+MINIMUM_UPLOAD_ARTIFACT_MAJOR = 6
+REQUIRED_DOWNLOAD_ARTIFACT_MAJOR = "8"
 
 
 class CacheActionRuntimeTest(unittest.TestCase):
@@ -40,6 +44,58 @@ class CacheActionRuntimeTest(unittest.TestCase):
             outdated,
             [],
             "direct cache actions must use v6 (Node 24 runtime):\n"
+            + "\n".join(outdated),
+        )
+
+    def test_all_upload_artifact_actions_use_node24_runtime_major(self) -> None:
+        matches: list[tuple[Path, int, str]] = []
+        outdated: list[str] = []
+
+        workflow_files = sorted(GITHUB_DIR.rglob("*.yml")) + sorted(
+            GITHUB_DIR.rglob("*.yaml")
+        )
+        for path in workflow_files:
+            for line_number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), start=1
+            ):
+                for match in UPLOAD_ARTIFACT_ACTION.finditer(line):
+                    action = match.group(0)
+                    matches.append((path, line_number, action))
+                    if int(match.group("major")) < MINIMUM_UPLOAD_ARTIFACT_MAJOR:
+                        relative = path.relative_to(REPO_ROOT)
+                        outdated.append(f"{relative}:{line_number}: {action}")
+
+        self.assertTrue(matches, "expected at least one upload-artifact reference")
+        self.assertEqual(
+            outdated,
+            [],
+            "upload-artifact actions must use v6+ (Node 24 runtime):\n"
+            + "\n".join(outdated),
+        )
+
+    def test_all_download_artifact_actions_use_node24_runtime_major(self) -> None:
+        matches: list[tuple[Path, int, str]] = []
+        outdated: list[str] = []
+
+        workflow_files = sorted(GITHUB_DIR.rglob("*.yml")) + sorted(
+            GITHUB_DIR.rglob("*.yaml")
+        )
+        for path in workflow_files:
+            for line_number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), start=1
+            ):
+                for match in DOWNLOAD_ARTIFACT_ACTION.finditer(line):
+                    action = match.group(0)
+                    matches.append((path, line_number, action))
+                    if match.group("major") != REQUIRED_DOWNLOAD_ARTIFACT_MAJOR:
+                        relative = path.relative_to(REPO_ROOT)
+                        outdated.append(f"{relative}:{line_number}: {action}")
+
+        self.assertTrue(matches, "expected at least one download-artifact reference")
+        self.assertEqual(
+            outdated,
+            [],
+            "download-artifact actions must use v8 (Node 24 runtime):\n"
             + "\n".join(outdated),
         )
 

--- a/scripts/checks/test_go_rolling_cache_policy.py
+++ b/scripts/checks/test_go_rolling_cache_policy.py
@@ -12,14 +12,23 @@ import yaml
 ACTION = Path(__file__).resolve().parents[2] / ".github" / "actions" / "go-rolling-cache" / "action.yml"
 MAIN_WRITER_IF = "github.event_name == 'push' && github.ref == 'refs/heads/main'"
 NON_MAIN_IF = "github.event_name != 'push' || github.ref != 'refs/heads/main'"
+RESTORE_ONLY_IF = "inputs.save_build_cache != 'true'"
 
 
 class GoRollingCachePolicyTest(unittest.TestCase):
     def test_only_main_push_steps_can_save_caches(self) -> None:
-        steps = yaml.safe_load(ACTION.read_text(encoding="utf-8"))["runs"]["steps"]
+        action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
+        self.assertEqual(action["inputs"]["save_build_cache"]["default"], "true")
+        steps = action["runs"]["steps"]
         saving = [step for step in steps if step.get("uses") == "actions/cache@v6"]
         self.assertEqual(len(saving), 3)
         self.assertTrue(all(MAIN_WRITER_IF in step.get("if", "") for step in saving))
+        build_saver = next(
+            step
+            for step in saving
+            if step.get("with", {}).get("path") == "${{ inputs.build_cache_path }}"
+        )
+        self.assertIn("inputs.save_build_cache == 'true'", build_saver["if"])
 
     def test_non_main_events_restore_but_never_save_all_cache_layers(self) -> None:
         steps = yaml.safe_load(ACTION.read_text(encoding="utf-8"))["runs"]["steps"]
@@ -29,8 +38,18 @@ class GoRollingCachePolicyTest(unittest.TestCase):
         restored_paths = {step["with"]["path"] for step in restore_only}
         self.assertEqual(
             restored_paths,
-            {"~/go/pkg/mod", "~/.cache/go-build", "~/.cache/golangci-lint"},
+            {
+                "~/go/pkg/mod",
+                "${{ inputs.build_cache_path }}",
+                "~/.cache/golangci-lint",
+            },
         )
+        build_restore = next(
+            step
+            for step in restore_only
+            if step.get("with", {}).get("path") == "${{ inputs.build_cache_path }}"
+        )
+        self.assertIn(RESTORE_ONLY_IF, build_restore["if"])
 
     def test_golangci_cache_is_opt_in_and_rolls_from_main(self) -> None:
         action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
@@ -49,24 +68,32 @@ class GoRollingCachePolicyTest(unittest.TestCase):
                 self.assertIn("backend/go.sum", step["with"]["key"])
                 self.assertIn("backend/.golangci.yml", step["with"]["key"])
 
-    def test_build_caches_refresh_weekly_unless_caller_opts_into_backend_fingerprint(self) -> None:
+    def test_build_caches_support_daily_refresh_without_changing_other_callers(self) -> None:
         action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
         self.assertEqual(action["inputs"]["refresh_on_backend_change"]["default"], "false")
+        self.assertEqual(action["inputs"]["refresh_daily"]["default"], "false")
+        self.assertEqual(
+            action["inputs"]["build_cache_path"]["default"],
+            "~/.cache/go-build",
+        )
         steps = action["runs"]["steps"]
         epoch_step = next(step for step in steps if step.get("id") == "cache_epoch")
-        self.assertIn("date -u +%G-W%V", epoch_step["run"])
+        self.assertIn('week=$(date -u +%G-W%V)', epoch_step["run"])
+        self.assertIn('day=$(date -u +%Y-%m-%d)', epoch_step["run"])
 
         build_steps = [
             step
             for step in steps
-            if step.get("with", {}).get("path") == "~/.cache/go-build"
+            if step.get("with", {}).get("path") == "${{ inputs.build_cache_path }}"
         ]
         self.assertEqual(len(build_steps), 2)
         expected_key = (
             "${{ runner.os }}-gobuild-${{ inputs.prefix }}-"
             "${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-"
             "${{ inputs.refresh_on_backend_change == 'true' && "
-            "hashFiles('backend/**', '.new-api-ref') || steps.cache_epoch.outputs.value }}"
+            "hashFiles('backend/**', '.new-api-ref') || "
+            "inputs.refresh_daily == 'true' && steps.cache_epoch.outputs.day || "
+            "steps.cache_epoch.outputs.week }}"
         )
         for step in build_steps:
             with self.subTest(step=step["name"]):

--- a/scripts/checks/test_go_rolling_cache_policy.py
+++ b/scripts/checks/test_go_rolling_cache_policy.py
@@ -12,29 +12,27 @@ import yaml
 ACTION = Path(__file__).resolve().parents[2] / ".github" / "actions" / "go-rolling-cache" / "action.yml"
 MAIN_WRITER_IF = "github.event_name == 'push' && github.ref == 'refs/heads/main'"
 NON_MAIN_IF = "github.event_name != 'push' || github.ref != 'refs/heads/main'"
-RESTORE_ONLY_IF = "inputs.save_build_cache != 'true'"
+RESTORE_ONLY_IF = "inputs.save_caches != 'true'"
 
 
 class GoRollingCachePolicyTest(unittest.TestCase):
     def test_only_main_push_steps_can_save_caches(self) -> None:
         action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
-        self.assertEqual(action["inputs"]["save_build_cache"]["default"], "true")
+        self.assertEqual(action["inputs"]["save_caches"]["default"], "true")
         steps = action["runs"]["steps"]
         saving = [step for step in steps if step.get("uses") == "actions/cache@v6"]
         self.assertEqual(len(saving), 3)
         self.assertTrue(all(MAIN_WRITER_IF in step.get("if", "") for step in saving))
-        build_saver = next(
-            step
-            for step in saving
-            if step.get("with", {}).get("path") == "${{ inputs.build_cache_path }}"
+        self.assertTrue(
+            all("inputs.save_caches == 'true'" in step.get("if", "") for step in saving)
         )
-        self.assertIn("inputs.save_build_cache == 'true'", build_saver["if"])
 
-    def test_non_main_events_restore_but_never_save_all_cache_layers(self) -> None:
+    def test_non_main_or_restore_only_callers_never_save_any_cache_layer(self) -> None:
         steps = yaml.safe_load(ACTION.read_text(encoding="utf-8"))["runs"]["steps"]
         restore_only = [step for step in steps if step.get("uses") == "actions/cache/restore@v6"]
         self.assertEqual(len(restore_only), 3)
         self.assertTrue(all(NON_MAIN_IF in step.get("if", "") for step in restore_only))
+        self.assertTrue(all(RESTORE_ONLY_IF in step.get("if", "") for step in restore_only))
         restored_paths = {step["with"]["path"] for step in restore_only}
         self.assertEqual(
             restored_paths,
@@ -44,13 +42,6 @@ class GoRollingCachePolicyTest(unittest.TestCase):
                 "~/.cache/golangci-lint",
             },
         )
-        build_restore = next(
-            step
-            for step in restore_only
-            if step.get("with", {}).get("path") == "${{ inputs.build_cache_path }}"
-        )
-        self.assertIn(RESTORE_ONLY_IF, build_restore["if"])
-
     def test_golangci_cache_is_opt_in_and_rolls_from_main(self) -> None:
         action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
         self.assertEqual(action["inputs"]["golangci_cache"]["default"], "false")

--- a/scripts/checks/test_release_cache_key_parity.py
+++ b/scripts/checks/test_release_cache_key_parity.py
@@ -45,6 +45,43 @@ class ReleaseCacheWorkflowTest(unittest.TestCase):
         job = workflow["jobs"]["warm-release-cache"]
         self.assertEqual(job.get("if"), "github.ref == 'refs/heads/main'")
 
+    def test_warm_workflow_owns_daily_integration_cache_writes(self) -> None:
+        workflow = load_workflow(WARM_WORKFLOW)
+        steps = workflow["jobs"]["warm-release-cache"]["steps"]
+        epoch = next(step for step in steps if step.get("id") == "integration_epoch")
+        self.assertIn('day=$(date -u +%Y-%m-%d)', epoch["run"])
+
+        cache = next(step for step in steps if step.get("id") == "integration_cache")
+        self.assertEqual(cache["uses"], "actions/cache@v6")
+        self.assertEqual(
+            cache["with"]["path"],
+            "${{ github.workspace }}/.cache/go-build-integration",
+        )
+        dependency_hash = (
+            "${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}"
+        )
+        key_prefix = "${{ runner.os }}-gobuild-integration-nodwarf-v2-"
+        self.assertEqual(
+            cache["with"]["key"],
+            f"{key_prefix}{dependency_hash}-${{{{ steps.integration_epoch.outputs.day }}}}",
+        )
+        self.assertEqual(
+            cache["with"]["restore-keys"],
+            f"{key_prefix}{dependency_hash}-\n{key_prefix}\n",
+        )
+
+        warm = next(
+            step for step in steps if step.get("name") == "Warm integration build cache"
+        )
+        self.assertEqual(warm["if"], "steps.integration_cache.outputs.cache-hit != 'true'")
+        self.assertEqual(
+            warm["env"]["GOCACHE"],
+            "${{ github.workspace }}/.cache/go-build-integration",
+        )
+        self.assertEqual(warm["env"]["GOFLAGS"], "-gcflags=all=-dwarf=false")
+        self.assertIn("scripts/ci/integration-packages.py", warm["run"])
+        self.assertIn("go test -c -tags=integration", warm["run"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/fingerprint/test_client_fidelity_workflow.py
+++ b/scripts/fingerprint/test_client_fidelity_workflow.py
@@ -43,7 +43,7 @@ class ClientFidelityWorkflowContractTest(unittest.TestCase):
         self.assertIn("contents: read", self.text)
         self.assertIn("issues: write", self.text)
         self.assertIn("id-token: write", self.text)
-        self.assertIn("actions/upload-artifact@v4", self.text)
+        self.assertIn("actions/upload-artifact@v7", self.text)
         self.assertIn("open_client_release_watch_issues.py", self.text)
         self.assertIn("open_prompt_surface_watch_issues.py", self.text)
         self.assertIn("open_oauth_mimic_watch_issues.py", self.text)

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -378,7 +378,7 @@ class BackendCIRoutingTest(unittest.TestCase):
         expected_prefixes = {
             "preflight": "preflight-nodwarf-v1",
             "test-unit": "unit-nodwarf-v1",
-            "test-integration": "integration-nodwarf-v1",
+            "test-integration": "integration-nodwarf-v2",
             "golangci-lint": "lint-nodwarf-v1",
             "backend-security": "security-nodwarf-v1",
         }
@@ -398,11 +398,27 @@ class BackendCIRoutingTest(unittest.TestCase):
         )
         self.assertEqual(
             integration_cache["with"]["prefix"],
-            "integration-nodwarf-v1",
+            "integration-nodwarf-v2",
         )
         self.assertEqual(
-            integration_cache["with"]["refresh_on_backend_change"],
+            integration_cache["with"]["refresh_daily"],
             "true",
+        )
+        self.assertEqual(
+            integration_cache["with"]["save_build_cache"],
+            "false",
+        )
+        self.assertEqual(
+            integration_cache["with"]["build_cache_path"],
+            "${{ github.workspace }}/.cache/go-build-integration",
+        )
+        self.assertEqual(
+            self.jobs["test-integration"]["env"]["GOCACHE"],
+            "${{ github.workspace }}/.cache/go-build-integration",
+        )
+        self.assertNotIn(
+            "refresh_on_backend_change",
+            integration_cache.get("with", {}),
         )
 
         for job_name in ("preflight", "test-unit", "golangci-lint", "backend-security"):

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -405,7 +405,7 @@ class BackendCIRoutingTest(unittest.TestCase):
             "true",
         )
         self.assertEqual(
-            integration_cache["with"]["save_build_cache"],
+            integration_cache["with"]["save_caches"],
             "false",
         )
         self.assertEqual(


### PR DESCRIPTION
## 摘要

- 将 required `test-integration` 改为完整 restore-only：module、build/test 与可选 analysis cache writer 均由统一 `save_caches` 开关禁用。
- integration 使用独立 `GOCACHE`、`integration-nodwarf-v2` namespace 与 UTC 日级 key；复用非 required 的 `Warm Release Cache` 作为每日唯一 build-cache writer。
- 当天 exact key 命中时，warm workflow 跳过 integration 编译和缓存上传。
- 将仓库内 `actions/upload-artifact@v4` 升级到 `@v7`，`actions/download-artifact@v4` 升级到 `@v8`，消除 Node 20 runtime 弃用告警。
- 增加 writer/consumer 路由、完整 key/restore-key parity、全缓存层 restore-only 和 artifact Node 24 runtime 契约。
- sentinel-registry-reviewed：已检查 `client-fidelity-watch.yml`，本次只升级 artifact action major，不改变 load-bearing sentinel 语义，无需新增 registry anchor。

## 风险

- 不新增 required job 或 runner fan-out，required correctness gate 保持不变。
- required integration 不再注册任何 composite cache save post-step；缓存上传移到非 required warm workflow，每个 UTC 日最多写入一次。
- 目标是移除主分支实测约 120.98 秒的 integration cache-save 尾部；PR 阶段可验证 restore-only，warm writer 的首次每日 save 需合并后在 main workflow 实测。
- 若当天 primary key miss，required integration 仍可通过相同 dependency namespace 的 restore keys 回退；cache miss 只影响速度，不影响测试正确性。

## 验证

- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：PASS（修复后的最终 tree）。
- cache/routing 定向契约：28 tests，PASS；扩展工作流契约回归与 preflight 全绿。
- `GOFLAGS='-gcflags=all=-dwarf=false' make test-unit`：PASS。
- 显式使用本机 Colima socket 后，`make test-integration`：PASS。
- 独立临时 `GOCACHE` 实际执行 warm 命令，成功编译全部 integration-tagged packages。
- xj-review R-001 已修复：integration main push 的 module cache 不再保留 writer。
- `git diff --check origin/main..HEAD`：PASS。

## 提交

- `2d1cf948e` perf(ci): move integration cache writes off the critical path
- `92fe9e40e` fix(ci): keep integration fully restore-only
- 最新提交：`92fe9e40e`
