### PR TITLE
perf(ci): 合并 integration 冷编译构建图

### DIFF
--- a/.github/workflows/warm-release-cache-main.yml
+++ b/.github/workflows/warm-release-cache-main.yml
@@ -85,6 +85,6 @@ jobs:
             integration_packages+=("$package")
           done < <(python3 ../scripts/ci/integration-packages.py --root .)
           mkdir -p "${RUNNER_TEMP}/integration-cache"
-          go test -vet=off -c -tags=integration \
+          go test -c -tags=integration \
             -o "${RUNNER_TEMP}/integration-cache/" \
             "${integration_packages[@]}"

--- a/.github/workflows/warm-release-cache-main.yml
+++ b/.github/workflows/warm-release-cache-main.yml
@@ -80,10 +80,11 @@ jobs:
           GOFLAGS: -gcflags=all=-dwarf=false
         run: |
           set -euo pipefail
-          index=0
+          integration_packages=()
           while IFS= read -r package; do
-            go test -c -tags=integration \
-              -o "${RUNNER_TEMP}/integration-cache-${index}.test" \
-              "$package"
-            index=$((index + 1))
+            integration_packages+=("$package")
           done < <(python3 ../scripts/ci/integration-packages.py --root .)
+          mkdir -p "${RUNNER_TEMP}/integration-cache"
+          go test -vet=off -c -tags=integration \
+            -o "${RUNNER_TEMP}/integration-cache/" \
+            "${integration_packages[@]}"

--- a/scripts/checks/test_release_cache_key_parity.py
+++ b/scripts/checks/test_release_cache_key_parity.py
@@ -80,7 +80,10 @@ class ReleaseCacheWorkflowTest(unittest.TestCase):
         )
         self.assertEqual(warm["env"]["GOFLAGS"], "-gcflags=all=-dwarf=false")
         self.assertIn("scripts/ci/integration-packages.py", warm["run"])
-        self.assertIn("go test -c -tags=integration", warm["run"])
+        self.assertIn("integration_packages=()", warm["run"])
+        self.assertIn('integration_packages+=("$package")', warm["run"])
+        self.assertIn("go test -vet=off -c -tags=integration", warm["run"])
+        self.assertEqual(warm["run"].count("go test -vet=off -c"), 1)
 
 
 if __name__ == "__main__":

--- a/scripts/checks/test_release_cache_key_parity.py
+++ b/scripts/checks/test_release_cache_key_parity.py
@@ -82,8 +82,9 @@ class ReleaseCacheWorkflowTest(unittest.TestCase):
         self.assertIn("scripts/ci/integration-packages.py", warm["run"])
         self.assertIn("integration_packages=()", warm["run"])
         self.assertIn('integration_packages+=("$package")', warm["run"])
-        self.assertIn("go test -vet=off -c -tags=integration", warm["run"])
-        self.assertEqual(warm["run"].count("go test -vet=off -c"), 1)
+        self.assertIn("go test -c -tags=integration", warm["run"])
+        self.assertNotIn("-vet=off", warm["run"])
+        self.assertEqual(warm["run"].count("go test -c"), 1)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/integration_test_runner.py
+++ b/scripts/ci/integration_test_runner.py
@@ -149,7 +149,6 @@ def run_integration_tests(
             [
                 "go",
                 "test",
-                "-vet=off",
                 "-c",
                 "-tags=integration",
                 "-o",

--- a/scripts/ci/integration_test_runner.py
+++ b/scripts/ci/integration_test_runner.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-import subprocess
 import sys
 import tempfile
 import time
@@ -14,10 +13,8 @@ import time
 from unit_test_runner import (
     Command,
     DEFAULT_MAX_REGEX_BYTES,
-    RunningCommand,
     RunnerError,
     _run_checked,
-    _terminate_processes,
     _test_entries,
     run_commands,
     shard_service_tests,
@@ -52,6 +49,24 @@ def _test_files(package: dict[str, object]) -> set[str]:
         *(str(name) for name in package.get("TestGoFiles", [])),
         *(str(name) for name in package.get("XTestGoFiles", [])),
     }
+
+
+def _test_binary_paths(
+    build_dir: Path,
+    packages: list[str],
+) -> dict[str, Path]:
+    binaries: dict[str, Path] = {}
+    owners: dict[str, str] = {}
+    for package in packages:
+        binary_name = f"{Path(package).name}.test"
+        if binary_name in owners:
+            raise RunnerError(
+                f"integration packages share test binary name {binary_name}: "
+                f"{owners[binary_name]}, {package}"
+            )
+        owners[binary_name] = package
+        binaries[package] = build_dir / binary_name
+    return binaries
 
 
 def discover_test_plan(
@@ -110,144 +125,92 @@ def run_integration_tests(
     shard_count: int,
     max_regex_bytes: int,
 ) -> int:
-    with tempfile.TemporaryDirectory(prefix="sub2api-repository-integration-") as temporary:
-        repository_binary = Path(temporary) / "repository.test"
-        with tempfile.TemporaryDirectory(
-            prefix="sub2api-integration-overlap-"
-        ) as overlap_temp:
-            compile_command = Command(
-                "repository-compile",
+    discovery_started_at = time.monotonic()
+    other_packages, repository_dir, all_entries, integration_entries = (
+        discover_test_plan(root, repository_package)
+    )
+    patterns = shard_service_tests(
+        integration_entries,
+        shard_count,
+        max_regex_bytes,
+    )
+    print(
+        f"integration-test-runner: STAGE discovery "
+        f"({time.monotonic() - discovery_started_at:.1f}s)",
+        flush=True,
+    )
+
+    packages = [repository_package, *other_packages]
+    with tempfile.TemporaryDirectory(prefix="sub2api-integration-build-") as temporary:
+        build_dir = Path(temporary)
+        binaries = _test_binary_paths(build_dir, packages)
+        compile_started_at = time.monotonic()
+        _run_checked(
+            [
+                "go",
+                "test",
+                "-vet=off",
+                "-c",
+                "-tags=integration",
+                "-o",
+                str(build_dir),
+                *packages,
+            ],
+            root,
+        )
+        print(
+            f"integration-test-runner: STAGE shared-compile "
+            f"({time.monotonic() - compile_started_at:.1f}s)",
+            flush=True,
+        )
+
+        repository_binary = binaries[repository_package]
+        registry_started_at = time.monotonic()
+        verify_binary_registry(
+            repository_binary,
+            repository_dir,
+            all_entries,
+            subject="repository",
+            environment={"SUB2API_TEST_REGISTRY_ONLY": "1"},
+        )
+        print(
+            f"integration-test-runner: STAGE registry-check "
+            f"({time.monotonic() - registry_started_at:.1f}s)",
+            flush=True,
+        )
+
+        commands = [
+            Command(
+                f"other-{Path(package).name}",
                 (
-                    "go",
-                    "test",
-                    "-c",
-                    "-tags=integration",
-                    "-o",
-                    str(repository_binary),
-                    repository_package,
+                    str(binaries[package]),
+                    "-test.timeout=10m",
+                    "-test.paniconexit0",
                 ),
-                root,
+                root / package.removeprefix("./"),
             )
-            compile_log = Path(overlap_temp) / "repository-compile.log"
-            compile_handle = compile_log.open("wb")
-            try:
-                compile_process = subprocess.Popen(
-                    compile_command.argv,
-                    cwd=compile_command.cwd,
-                    stdout=compile_handle,
-                    stderr=subprocess.STDOUT,
-                    start_new_session=True,
-                )
-            except BaseException:
-                compile_handle.close()
-                raise
-            compile_running: RunningCommand = (
-                compile_command,
-                compile_process,
-                compile_log,
-                time.monotonic(),
-            )
-            background: list[RunningCommand] = [compile_running]
-            other_handle = None
-            try:
-                discovery_started_at = time.monotonic()
-                other_packages, repository_dir, all_entries, integration_entries = (
-                    discover_test_plan(root, repository_package)
-                )
-                patterns = shard_service_tests(
-                    integration_entries,
-                    shard_count,
-                    max_regex_bytes,
-                )
-                print(
-                    f"integration-test-runner: STAGE discovery "
-                    f"({time.monotonic() - discovery_started_at:.1f}s)",
-                    flush=True,
-                )
-
-                if other_packages:
-                    other_command = Command(
-                        "other-packages",
-                        tuple(["go", "test", "-tags=integration", *other_packages]),
-                        root,
-                    )
-                    other_log = Path(overlap_temp) / "other-packages.log"
-                    other_handle = other_log.open("wb")
-                    other_process = subprocess.Popen(
-                        other_command.argv,
-                        cwd=other_command.cwd,
-                        stdout=other_handle,
-                        stderr=subprocess.STDOUT,
-                        start_new_session=True,
-                    )
-                    background.append(
-                        (other_command, other_process, other_log, time.monotonic())
-                    )
-
-                compile_returncode = compile_process.wait()
-                compile_elapsed = time.monotonic() - compile_running[3]
-                if compile_returncode != 0:
-                    compile_output = compile_log.read_text(
-                        encoding="utf-8",
-                        errors="replace",
-                    )
-                    detail = (
-                        compile_output.strip()
-                        or f"command exited with status {compile_returncode}"
-                    )
-                    raise RunnerError(
-                        f"{' '.join(compile_command.argv)}: {detail}"
-                    )
-                background = background[1:]
-                print(
-                    f"integration-test-runner: STAGE repository-compile "
-                    f"({compile_elapsed:.1f}s)",
-                    flush=True,
-                )
-
-                registry_started_at = time.monotonic()
-                verify_binary_registry(
-                    repository_binary,
+            for package in other_packages
+        ]
+        width = len(str(len(patterns) - 1))
+        for index, pattern in enumerate(patterns):
+            commands.append(
+                Command(
+                    f"repository-shard-{index:0{width}d}",
+                    (
+                        str(repository_binary),
+                        "-test.run",
+                        pattern,
+                        "-test.timeout=10m",
+                        "-test.paniconexit0",
+                    ),
                     repository_dir,
-                    all_entries,
-                    subject="repository",
-                    environment={"SUB2API_TEST_REGISTRY_ONLY": "1"},
                 )
-                print(
-                    f"integration-test-runner: STAGE registry-check "
-                    f"({time.monotonic() - registry_started_at:.1f}s)",
-                    flush=True,
-                )
-
-                repository_commands: list[Command] = []
-                width = len(str(len(patterns) - 1))
-                for index, pattern in enumerate(patterns):
-                    repository_commands.append(
-                        Command(
-                            f"repository-shard-{index:0{width}d}",
-                            (
-                                str(repository_binary),
-                                "-test.run",
-                                pattern,
-                                "-test.timeout=10m",
-                                "-test.paniconexit0",
-                            ),
-                            repository_dir,
-                        )
-                    )
-                return run_commands(
-                    repository_commands,
-                    background,
-                    runner_name="integration-test-runner",
-                    temporary_prefix="sub2api-integration-",
-                )
-            except BaseException:
-                _terminate_processes(background)
-                raise
-            finally:
-                compile_handle.close()
-                if other_handle is not None:
-                    other_handle.close()
+            )
+        return run_commands(
+            commands,
+            runner_name="integration-test-runner",
+            temporary_prefix="sub2api-integration-",
+        )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/ci/test_integration_test_runner.py
+++ b/scripts/ci/test_integration_test_runner.py
@@ -17,7 +17,7 @@ SCRIPT = Path(__file__).resolve().parent / "integration_test_runner.py"
 
 
 class IntegrationTestRunnerTest(unittest.TestCase):
-    def test_compiles_all_integration_packages_once_without_duplicate_vet(
+    def test_compiles_all_integration_packages_once_with_tagged_vet_coverage(
         self,
     ) -> None:
         integration_tests = [f"TestIntegration{i}" for i in range(9)]
@@ -35,7 +35,7 @@ class IntegrationTestRunnerTest(unittest.TestCase):
         go_calls = [event["args"] for event in first_events if event["kind"] == "go"]
         compile_calls = [call for call in go_calls if "-c" in call]
         self.assertEqual(len(compile_calls), 1, go_calls)
-        self.assertIn("-vet=off", compile_calls[0])
+        self.assertNotIn("-vet=off", compile_calls[0])
         self.assertIn("./internal/repository", compile_calls[0])
         self.assertIn("./internal/other", compile_calls[0])
         self.assertFalse(

--- a/scripts/ci/test_integration_test_runner.py
+++ b/scripts/ci/test_integration_test_runner.py
@@ -17,7 +17,7 @@ SCRIPT = Path(__file__).resolve().parent / "integration_test_runner.py"
 
 
 class IntegrationTestRunnerTest(unittest.TestCase):
-    def test_compiles_repository_once_and_runs_only_integration_entries_in_three_shards(
+    def test_compiles_all_integration_packages_once_without_duplicate_vet(
         self,
     ) -> None:
         integration_tests = [f"TestIntegration{i}" for i in range(9)]
@@ -35,9 +35,15 @@ class IntegrationTestRunnerTest(unittest.TestCase):
         go_calls = [event["args"] for event in first_events if event["kind"] == "go"]
         compile_calls = [call for call in go_calls if "-c" in call]
         self.assertEqual(len(compile_calls), 1, go_calls)
+        self.assertIn("-vet=off", compile_calls[0])
         self.assertIn("./internal/repository", compile_calls[0])
-        self.assertIn(
-            ["test", "-tags=integration", "./internal/other"],
+        self.assertIn("./internal/other", compile_calls[0])
+        self.assertFalse(
+            [
+                call
+                for call in go_calls
+                if call and call[0] == "test" and "-c" not in call
+            ],
             go_calls,
         )
 
@@ -48,6 +54,15 @@ class IntegrationTestRunnerTest(unittest.TestCase):
         ]
         self.assertEqual(len(registry_events), 1, first_events)
         self.assertEqual(registry_events[0]["registry_only"], "1")
+
+        other_events = [
+            event
+            for event in first_events
+            if event["kind"] == "binary"
+            and Path(str(event["executable"])).name == "other.test"
+        ]
+        self.assertEqual(len(other_events), 1, first_events)
+        self.assertNotIn("-test.run", other_events[0]["args"])
 
         first_patterns = self._binary_patterns(first_events)
         second_patterns = self._binary_patterns(second_events)
@@ -94,7 +109,7 @@ class IntegrationTestRunnerTest(unittest.TestCase):
         self.assertNotIn("successful shard noise", combined)
         self.assertIn("integration-test-runner: FAIL", combined)
 
-    def test_overlaps_compile_with_discovery_and_other_packages(self) -> None:
+    def test_runs_test_binaries_only_after_the_shared_compile_finishes(self) -> None:
         with FakeGoFixture(
             ["TestOne", "TestTwo", "TestThree"],
             compile_delay=0.75,
@@ -104,30 +119,17 @@ class IntegrationTestRunnerTest(unittest.TestCase):
             events = fixture.read_events()
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        compile_started = next(
-            event["at"]
-            for event in events
-            if event["kind"] == "go" and "-c" in event["args"]
-        )
-        discovery_finished = max(
-            event["at"]
-            for event in events
-            if event["kind"] == "go-finished"
-            and event["args"]
-            and event["args"][0] in {"list", "run"}
-        )
         compile_finished = next(
             event["at"]
             for event in events
             if event["kind"] == "go-finished" and "-c" in event["args"]
         )
-        other_started = next(
+        first_binary_started = min(
             event["at"]
             for event in events
-            if event["kind"] == "go" and "./internal/other" in event["args"]
+            if event["kind"] == "binary"
         )
-        self.assertLess(compile_started, discovery_finished, events)
-        self.assertLess(other_started, compile_finished, events)
+        self.assertLessEqual(compile_finished, first_binary_started, events)
 
     @staticmethod
     def _binary_patterns(events: list[dict[str, object]]) -> list[str]:
@@ -210,6 +212,7 @@ class FakeGoFixture:
             with Path(os.environ["FAKE_GO_EVENTS"]).open("a", encoding="utf-8") as output:
                 output.write(json.dumps({
                     "kind": "binary",
+                    "executable": sys.argv[0],
                     "args": args,
                     "cwd": os.getcwd(),
                     "at": time.monotonic(),
@@ -218,6 +221,10 @@ class FakeGoFixture:
             if "-test.list" in args:
                 for name in json.loads(os.environ["FAKE_GO_BINARY_TESTS"]):
                     print(name)
+                raise SystemExit(0)
+            if "-test.run" not in args:
+                print("successful package noise")
+                print("PASS")
                 raise SystemExit(0)
             pattern = args[args.index("-test.run") + 1]
             fail_test = os.environ.get("FAKE_GO_FAIL_TEST", "")
@@ -286,9 +293,16 @@ class FakeGoFixture:
 
             if "-c" in args:
                 time.sleep(float(os.environ.get("FAKE_GO_COMPILE_DELAY", "0")))
-                binary = Path(args[args.index("-o") + 1])
-                binary.write_text(__BINARY_SOURCE__, encoding="utf-8")
-                binary.chmod(0o755)
+                output = Path(args[args.index("-o") + 1])
+                packages = [value for value in args if value.startswith("./")]
+                binaries = (
+                    [output / f"{Path(package).name}.test" for package in packages]
+                    if output.is_dir()
+                    else [output]
+                )
+                for binary in binaries:
+                    binary.write_text(__BINARY_SOURCE__, encoding="utf-8")
+                    binary.chmod(0o755)
                 with events.open("a", encoding="utf-8") as output:
                     output.write(json.dumps({"kind": "go-finished", "args": args, "at": time.monotonic()}) + "\\n")
                 raise SystemExit(0)


### PR DESCRIPTION
## 摘要

- 将全部 integration package 合并为一次 `go test -c`，复用同一个 Go 构建图，避免 repository 与 other-packages 两次冷编译重复解析和编译依赖。
- repository 仍保持 3 分片运行；其他 integration binary 仍并发执行。
- warm-cache writer 与 required CI 使用相同的单次编译形状和缓存参数。
- 根据代码审查恢复 integration-tagged 文件的 Go vet 覆盖；不再错误地将其视为 golangci-lint 的重复检查。

本地 Go 1.26.6、完全冷 GOCACHE 实测：旧双进程基线 50.79 秒，新单构建图（保留 vet）37.88 秒，冷编译墙钟下降约 25.4%。

## 风险

- 风险较低，变更仅影响 integration 测试的编译编排，不减少测试 package、测试分片、vet 覆盖或 required gate。
- 多 package 输出依赖 Go 的目录输出命名；runner 保留 binary 名称冲突检查和 repository binary registry fail-closed 校验。
- 本机缺少 rootless Docker，因此完整容器型 integration 执行交由本 PR 的 GitHub CI 验证。

## 验证

- `./scripts/preflight.sh`：通过。
- runner/package/cache 相关测试：9/9 通过。
- CI orchestration contract tests：24/24 通过。
- `go vet -tags=integration <integration-packages>`：通过。
- `git diff --check`：通过。
- 完全冷 GOCACHE 单次真实编译生成 6 个 integration binaries：archive、middleware、repository、routes、server、tlsfingerprint。
- 首轮 GitHub CI 在 `943ddbb5c` 全绿；review 修复提交推送后重新验证同一 HEAD。
- xj-review R-001：已修复，恢复 integration-tagged 文件的 vet 覆盖。

## 提交

- `943ddbb5c perf(ci): compile integration packages in one process`
- `3ae23ebef fix(ci): address R-001 — preserve integration vet coverage`

最新提交：`3ae23ebef`
