### PR TITLE
fix(newapi): Moonshot 欠费 429 走 newapi_arrears

### DIFF
--- a/backend/internal/service/account_incident_notifier_tk.go
+++ b/backend/internal/service/account_incident_notifier_tk.go
@@ -109,12 +109,12 @@ func classifyIncident(reason string, until time.Time, kind AccountIncidentKind) 
 	case "temp_unschedulable", "stream_timeout_temp_unschedulable":
 		return incidentClass{true, IncidentKindTemporaryCooldown, "temp", "临时不可调度", "观察是否自愈"}
 	case "newapi_arrears":
-		// TK (prod 2026-06-12, account 60 "Qwen" / DashScope arrears): an upstream
-		// account-standing / 欠费 failure that arrives as a 400 ("Arrearage"). Same
-		// penalty shape as bridge 402 (SetError disable) — recharge does NOT auto-
-		// recover scheduling. The ALERT must be IMMEDIATE + actionable; route through
-		// the permanent (immediate P0 card) path with the 1h per-account dedupe.
-		return incidentClass{true, IncidentKindPermanentDisable, "newapi_arrears", "上游账号欠费", "DashScope 等上游账号欠费(Arrearage),需在对应控制台(如阿里云百炼)充值/还款;" + tkUpstreamStandingDisableRecoveryAdvice}
+		// TK: upstream account-standing / 欠费 (DashScope 400 Arrearage, or Moonshot
+		// 429 insufficient-balance suspend). Same penalty shape as bridge 402
+		// (SetError disable) — recharge does NOT auto-recover scheduling. The ALERT
+		// must be IMMEDIATE + actionable; route through the permanent (immediate P0
+		// card) path with the 1h per-account dedupe.
+		return incidentClass{true, IncidentKindPermanentDisable, "newapi_arrears", "上游账号欠费", "DashScope/Moonshot 等上游账号欠费,需在对应控制台(阿里云百炼/platform.kimi.com)充值/还款;" + tkUpstreamStandingDisableRecoveryAdvice}
 	case "kiro_quota_limit":
 		// TK (prod 2026-06-25, edge-us4 account 9): Kiro OAuth subscription quota
 		// exhaustion is HTTP 402 + "You have reached the limit." — not an auth

--- a/backend/internal/service/newapi_bridge_arrears_tk.go
+++ b/backend/internal/service/newapi_bridge_arrears_tk.go
@@ -14,13 +14,15 @@ import (
 // TK: newapi fifth-platform bridge → upstream account-standing / arrears (欠费)
 // classifier + account-level penalty + immediate Feishu alert.
 //
-// Why this file exists (prod 2026-06-12, account 60 "Qwen" / Alibaba DashScope,
-// channel_type=17, base_url https://dashscope.aliyuncs.com):
-// when the upstream Alibaba account is in arrears, DashScope returns HTTP 400
-// with body
+// Why this file exists:
 //
-//	{"error":{"message":"Access denied, please make sure your account is in
-//	good standing. ...","type":"Arrearage","code":"Arrearage"}}
+//  1. prod 2026-06-12, account 60 "Qwen" / Alibaba DashScope (channel_type=17):
+//     arrears arrives as HTTP 400 + {"error":{"type":"Arrearage","code":"Arrearage",
+//     "message":"Access denied, please make sure your account is in good standing."}}.
+//  2. prod 2026-08-28, account 83 "kimi" / Moonshot China (channel_type=25):
+//     arrears arrives as HTTP 429 + type=exceeded_current_quota_error + message
+//     "is suspended due to insufficient balance, please recharge your account".
+//     GET /v1/models still 200 — the key is valid, billing standing is not.
 //
 // TokenKey classifies a bridge 400 as CLIENT-induced (see
 // tkBridgePenaltyStatusEligible — 400 is excluded from the penalty allowlist
@@ -32,16 +34,26 @@ import (
 // a confusing "400 bad request", AND operators get NO alert that the Alibaba
 // account needs a recharge.
 //
-// This file closes that gap WITHOUT widening the 400 allowlist (which would
-// re-open the #617 pool-drain). It is a separate, deliberately narrow exception:
+// A Moonshot billing 429 is worse if left on the generic 429 path: HandleUpstreamError
+// applyCNProviderReactive429 does not apply (platform=newapi is not IsCNProvider),
+// so the account gets a ~5s cooldown and keeps rotating. User-visible status is
+// "Upstream rate limit exceeded" while the real verdict is unpaid / suspended.
 //
-//   - Part A (penalty): the arrears signal is matched conservatively (upstream
-//     provider error code/type == "Arrearage" case-insensitive, OR message
-//     containing "account is in good standing" / "overdue" / "arrear"). On a
-//     match the account is DISABLED (SetError, same as bridge 402 balance) so
-//     recharge alone does not auto-recover — ops must clear error + re-test in
-//     Admin. Disabling takes the dead account out of rotation, enabling failover
-//     or a clean "no available accounts" response instead of a wall of 400s.
+// This file closes that gap WITHOUT widening the 400 allowlist (which would
+// re-open the #617 pool-drain) and WITHOUT treating every 429 quota type as
+// arrears (exceeded_current_quota_error is also used for RPM). It is a separate,
+// deliberately narrow exception:
+//
+//   - Part A (penalty): the arrears signal is matched conservatively.
+//     400/403: provider error code/type == "Arrearage" case-insensitive, OR
+//     message containing "account is in good standing" / "overdue" / "arrear",
+//     OR the billing-standing phrases below.
+//     429: ONLY billing-standing message phrases (insufficient balance /
+//     余额不足 / suspended due to / please recharge your account). Never match
+//     type/code alone — Moonshot RPM 429s reuse exceeded_current_quota_error.
+//     On a match the account is DISABLED (SetError, same as bridge 402 balance)
+//     so recharge alone does not auto-recover — ops must clear error + re-test
+//     in Admin.
 //   - Part B (alert): the same path routes the incident through the IMMEDIATE
 //     P0 Feishu card (classifyIncident "newapi_arrears" → IncidentKindPermanent
 //     Disable), NOT the self-healing temporary-cooldown digest that #730 made
@@ -51,7 +63,8 @@ import (
 //     spamming one card per request.
 //
 // Narrowness is the whole point: a false positive disables + alerts on a healthy
-// account, so the matcher must NEVER fire on a generic / legitimate client 400.
+// account, so the matcher must NEVER fire on a generic client 400 or a plain
+// rate-limit 429.
 
 // tkBridgeArrearsIncidentReason is the stable reason string classifyIncident
 // maps to the immediate "上游账号欠费" P0 card (NOT the temporary digest).
@@ -65,19 +78,18 @@ const tkBridgeArrearsIncidentReason = "newapi_arrears"
 // only ToOpenAIError() faithfully projects (NewAPIError.Error() returns the bare
 // error code when the underlying Err is nil).
 //
-// Match ONLY the account-standing signal — provider error code/type ==
-// "arrearage" (case-insensitive), OR message containing one of the
-// account-standing phrases. Generic invalid_request_error / bad-param / oversize
-// 400s carry none of these and must fall through to the client unchanged.
+// Match ONLY the account-standing signal. Generic invalid_request_error /
+// bad-param / oversize 400s and RPM 429s carry none of these and must fall
+// through unchanged.
 func tkIsBridgeUpstreamArrears(apiErr *newapitypes.NewAPIError) bool {
 	if apiErr == nil {
 		return false
 	}
-	// Conservative status gate: arrears is the 400 (and occasionally 403) shape
-	// for the DashScope/百炼 "account in arrears" verdict. Never let a 5xx
-	// upstream outage or a 429 rate-limit reach this account-standing matcher.
+	// Conservative status gate: DashScope/百炼 arrears is 400 (occasionally 403);
+	// Moonshot China billing standing-failure is 429 + billing text. Never let a
+	// 5xx outage or a 429 without billing-standing phrases reach SetError.
 	switch apiErr.StatusCode {
-	case 400, 403:
+	case 400, 403, 429:
 	default:
 		return false
 	}
@@ -85,12 +97,17 @@ func tkIsBridgeUpstreamArrears(apiErr *newapitypes.NewAPIError) bool {
 	if len(body) == 0 {
 		return false
 	}
+	msg := strings.ToLower(gjson.GetBytes(body, "error.message").String())
+	// 429: message-only. Do not trust error.type/code — Moonshot reuses
+	// exceeded_current_quota_error for both unpaid-account and RPM.
+	if apiErr.StatusCode == 429 {
+		return tkIsBridgeUpstreamArrearsBillingMessage(msg)
+	}
 	code := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.code").String()))
 	typ := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.type").String()))
 	if code == "arrearage" || typ == "arrearage" {
 		return true
 	}
-	msg := strings.ToLower(gjson.GetBytes(body, "error.message").String())
 	if msg == "" {
 		return false
 	}
@@ -98,6 +115,26 @@ func tkIsBridgeUpstreamArrears(apiErr *newapitypes.NewAPIError) bool {
 		"account is in good standing", // DashScope arrears verbatim phrase
 		"overdue",                     // overdue-payment
 		"arrear",                      // arrears / arrearage (substring)
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return tkIsBridgeUpstreamArrearsBillingMessage(msg)
+}
+
+// tkIsBridgeUpstreamArrearsBillingMessage is the 429-safe standing-failure set.
+// These phrases are billing/account-suspend, not RPM. "exceeded_current_quota_error"
+// alone is intentionally NOT a marker.
+func tkIsBridgeUpstreamArrearsBillingMessage(msg string) bool {
+	if msg == "" {
+		return false
+	}
+	for _, marker := range []string{
+		"insufficient balance",
+		"余额不足",
+		"suspended due to",
+		"please recharge your account",
 	} {
 		if strings.Contains(msg, marker) {
 			return true
@@ -148,9 +185,9 @@ func tkHandleBridgeArrearsPenalty(ctx context.Context, rls *RateLimitService, ac
 		return false
 	}
 	detail := tkBridgeArrearsDetail(apiErr)
-	errorMsg := "Account arrears (400): insufficient balance or billing issue"
+	errorMsg := fmt.Sprintf("Account arrears (%d): insufficient balance or billing issue", apiErr.StatusCode)
 	if detail != "" {
-		errorMsg = "Account arrears (400): " + detail
+		errorMsg = fmt.Sprintf("Account arrears (%d): %s", apiErr.StatusCode, detail)
 	}
 
 	stateCtx, cancel := openAIAccountStateContext(ctx)

--- a/backend/internal/service/newapi_bridge_arrears_tk_test.go
+++ b/backend/internal/service/newapi_bridge_arrears_tk_test.go
@@ -66,9 +66,9 @@ func TestTkIsBridgeUpstreamArrears_MessageAndCaseVariants(t *testing.T) {
 }
 
 // Part A NEGATIVE: genuine client / validation / oversize 400s, model-not-found
-// 404s, rate-limit 429s and 5xx outages must NEVER be classified as arrears —
-// they carry no account-standing signal and penalizing them re-opens the #617
-// pool-drain.
+// 404s, rate-limit 429s (including quota-type 429s without billing text) and 5xx
+// outages must NEVER be classified as arrears — they carry no account-standing
+// signal and penalizing them re-opens the #617 pool-drain or mis-disables RPM.
 func TestTkIsBridgeUpstreamArrears_NonArrearsNeverMatch(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -79,6 +79,7 @@ func TestTkIsBridgeUpstreamArrears_NonArrearsNeverMatch(t *testing.T) {
 		{"bad model name", arrearsBridgeError(400, "The supported API model names are ...", "invalid_request_error", "model_not_found")},
 		{"model not found 404", arrearsBridgeError(404, "model_not_found", "not_found", "model_not_found")},
 		{"rate limit 429", arrearsBridgeError(429, "Requests rate limit exceeded", "rate_limit_error", "rate_limit")},
+		{"quota 429 without billing text", arrearsBridgeError(429, "Requests rate limit exceeded, please retry later", "exceeded_current_quota_error", "exceeded_current_quota_error")},
 		{"server 500", arrearsBridgeError(500, "internal error", "server_error", "server_error")},
 		{"nil", nil},
 	} {
@@ -86,6 +87,74 @@ func TestTkIsBridgeUpstreamArrears_NonArrearsNeverMatch(t *testing.T) {
 			require.False(t, tkIsBridgeUpstreamArrears(tc.err))
 		})
 	}
+}
+
+const moonshotArrears429Message = "Your account org-ce9a5339d34042af92f21c9321c267f6 <ak-fbgy1mkyrfei11gu1to1> is suspended due to insufficient balance, please recharge your account or check your plan and billing details"
+
+func newKimiArrearsAccount() *Account {
+	// Mirrors prod account 83 "kimi": fifth-platform newapi apikey on
+	// Moonshot China (channel_type=25). 2026-08-28 live probe: GET /v1/models
+	// 200, chat 429 exceeded_current_quota_error + insufficient-balance suspend.
+	return &Account{
+		ID:          83,
+		Name:        "kimi",
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: 25,
+	}
+}
+
+// Part A POSITIVE (prod 2026-08-28 account 83): Moonshot bills standing-failure
+// as HTTP 429 + exceeded_current_quota_error. That must classify as arrears so
+// it is NOT treated as a 5s rate-limit cooldown.
+func TestTkIsBridgeUpstreamArrears_MoonshotInsufficientBalance429(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  *newapitypes.NewAPIError
+	}{
+		{"canonical moonshot 429", arrearsBridgeError(429, moonshotArrears429Message, "exceeded_current_quota_error", "")},
+		{"suspended due to phrase", arrearsBridgeError(429, "your account is suspended due to overdue invoices", "rate_limit_error", "")},
+		{"cn 余额不足 429", arrearsBridgeError(429, "账户余额不足，请充值后重试", "exceeded_current_quota_error", "")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.True(t, tkIsBridgeUpstreamArrears(tc.err))
+		})
+	}
+}
+
+// Part A: a Moonshot billing-standing 429 must DISABLE + alert via newapi_arrears,
+// not temp-cool as a generic 429.
+func TestTkHandleBridgeArrearsPenalty_Moonshot429DisablesAccountAndAlerts(t *testing.T) {
+	svc, repo, blocker, incidents := newBridgePenaltyTestService()
+	account := newKimiArrearsAccount()
+
+	handled := tkHandleBridgeArrearsPenalty(context.Background(), svc,
+		account, arrearsBridgeError(429, moonshotArrears429Message, "exceeded_current_quota_error", ""))
+
+	require.True(t, handled, "moonshot billing 429 must be handled as arrears")
+	require.Equal(t, 1, repo.setErrorCalls, "moonshot billing 429 must DISABLE via SetError")
+	require.Zero(t, repo.tempCalls, "moonshot billing 429 must NOT temp-cool")
+	require.Equal(t, []string{tkBridgeArrearsIncidentReason}, blocker.reasons)
+	require.Equal(t, []string{tkBridgeArrearsIncidentReason}, incidents.reasons)
+	require.Len(t, incidents.details, 1)
+	require.Contains(t, incidents.details[0], "Account arrears (429)")
+}
+
+// Part A integration: the bridge penalty entrypoint must route a Moonshot
+// billing-standing 429 through arrears BEFORE the generic 429 allowlist cooldown.
+func TestTkHandleBridgeUpstreamPenalty_Moonshot429ArrearsNotRateLimit(t *testing.T) {
+	require.True(t, tkBridgePenaltyStatusEligible(429),
+		"precondition: 429 is on the generic penalty allowlist (rate-limit cooldown)")
+
+	svc, repo, _, incidents := newBridgePenaltyTestService()
+	account := newKimiArrearsAccount()
+
+	tkHandleBridgeUpstreamPenalty(context.Background(), svc, account,
+		arrearsBridgeError(429, moonshotArrears429Message, "exceeded_current_quota_error", ""))
+
+	require.Equal(t, 1, repo.setErrorCalls, "moonshot billing 429 must disable via the arrears path")
+	require.Zero(t, repo.tempCalls, "must not fall through to handle429 cooldown")
+	require.Equal(t, []string{tkBridgeArrearsIncidentReason}, incidents.reasons)
 }
 
 // Part A: an arrears 400 must DISABLE the account (SetError, same as bridge 402)

--- a/backend/internal/service/newapi_bridge_penalty_tk.go
+++ b/backend/internal/service/newapi_bridge_penalty_tk.go
@@ -47,12 +47,12 @@ func tkHandleBridgeUpstreamPenalty(ctx context.Context, rls *RateLimitService, a
 	if rls == nil || account == nil || apiErr == nil {
 		return
 	}
-	// TK (prod 2026-06-12, account 60 "Qwen" / DashScope arrears): an upstream
-	// account-standing / arrears 400 ("Arrearage") is an ACCOUNT-level failure
-	// disguised as a client 400. It must be caught BEFORE the status allowlist
-	// below (which deliberately excludes 400 to avoid the #617 client-400
-	// pool-drain). This narrow exception disables the account + fires an immediate
-	// P0 Feishu card. See newapi_bridge_arrears_tk.go.
+	// TK: upstream account-standing / arrears (DashScope 400 Arrearage, or
+	// Moonshot 429 + insufficient-balance suspend) is an ACCOUNT-level failure.
+	// It must be caught BEFORE the status allowlist below (400 is excluded to
+	// avoid the #617 client-400 pool-drain; 429 otherwise becomes a 5s cooldown).
+	// This narrow exception disables the account + fires an immediate P0 Feishu
+	// card. See newapi_bridge_arrears_tk.go.
 	if tkHandleBridgeArrearsPenalty(ctx, rls, account, apiErr) {
 		return
 	}

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -499,7 +499,7 @@
         "tkHandleBridgeArrearsPenalty(ctx, rls, account, apiErr)",
         "bridgeWrapRelayErrorAfterPenalty"
       ],
-      "rationale": "TK companion that routes real bridge.Dispatch* upstream errors (401/402/429 allowlist) into RateLimitService.HandleUpstreamError so newapi accounts get disabled/cooled and the Feishu account-incident alert fires. Without it the fifth platform regresses to the 2026-06-11 prod incident: a 402 'Insufficient Balance' DeepSeek account stayed schedulable=true while the gateway hammered the exhausted upstream 6946 times in 2h with zero alerts. The narrow status allowlist is itself load-bearing: it is what keeps client-induced 400/404 (and the synthetic missing-credential/unsupported-channel 400s) from draining the pool (the #617 class). The tkHandleBridgeArrearsPenalty call MUST run BEFORE the tkBridgePenaltyStatusEligible allowlist (which excludes 400): an upstream DashScope arrears 400 ('Arrearage') is an account-standing failure disguised as a client 400 and must disable+alert (SetError, same as 402), not pass through. Reordering it after the allowlist (or dropping it) silently re-opens the 2026-06-12 prod incident where account 60 'Qwen' stayed schedulable with confusing 400s and no recharge alert. bridgeWrapRelayErrorAfterPenalty must turn those penalized account-level faults into UpstreamFailoverError so the handler can retry on a sibling account in the same request."
+      "rationale": "TK companion that routes real bridge.Dispatch* upstream errors (401/402/429 allowlist) into RateLimitService.HandleUpstreamError so newapi accounts get disabled/cooled and the Feishu account-incident alert fires. Without it the fifth platform regresses to the 2026-06-11 prod incident: a 402 'Insufficient Balance' DeepSeek account stayed schedulable=true while the gateway hammered the exhausted upstream 6946 times in 2h with zero alerts. The narrow status allowlist is itself load-bearing: it is what keeps client-induced 400/404 (and the synthetic missing-credential/unsupported-channel 400s) from draining the pool (the #617 class). The tkHandleBridgeArrearsPenalty call MUST run BEFORE the tkBridgePenaltyStatusEligible allowlist: DashScope arrears 400 ('Arrearage') is disguised as a client 400, and Moonshot billing-standing 429 would otherwise become a ~5s cooldown. Both must disable+alert (SetError, same as 402), not pass through. Reordering after the allowlist (or dropping it) silently re-opens the 2026-06-12 Qwen / 2026-08-28 kimi incidents. bridgeWrapRelayErrorAfterPenalty must turn those penalized account-level faults into UpstreamFailoverError so the handler can retry on a sibling account in the same request."
     },
     {
       "path": "backend/internal/service/newapi_bridge_failover_tk.go",
@@ -515,11 +515,23 @@
       "path": "backend/internal/service/newapi_bridge_arrears_tk.go",
       "must_contain": [
         "tkIsBridgeUpstreamArrears",
+        "tkIsBridgeUpstreamArrearsBillingMessage",
         "tkHandleBridgeArrearsPenalty",
         "tkBridgeArrearsIncidentReason",
-        "arrearage"
+        "arrearage",
+        "case 400, 403, 429",
+        "suspended due to"
       ],
-      "rationale": "TK companion implementing the narrow upstream account-standing / arrears (欠费) classifier + account-level penalty + immediate Feishu alert for the fifth platform. tkIsBridgeUpstreamArrears matches ONLY the DashScope/百炼 arrears verdict (provider code/type == 'Arrearage' case-insensitive, OR message containing 'account is in good standing' / 'overdue' / 'arrear') — never a generic client 400, which would re-open the #617 pool-drain. tkHandleBridgeArrearsPenalty disables the account (SetError, same as bridge 402 balance — recharge alone does NOT auto-recover; ops must clear error in Admin) and funnels the incident through notifyAccountSchedulingBlocked with reason 'newapi_arrears'. Dropping any symbol or weakening the matcher regresses the 2026-06-12 prod incident (account 60 'Qwen' arrears → confusing pass-through 400 + no alert) or, if widened, drains the pool on legitimate client 400s."
+      "rationale": "TK companion implementing the narrow upstream account-standing / arrears (欠费) classifier + account-level penalty + immediate Feishu alert for the fifth platform. 400/403 matches DashScope/百炼 Arrearage (code/type or 'account is in good standing' / 'overdue' / 'arrear'). 429 matches ONLY billing-standing phrases via tkIsBridgeUpstreamArrearsBillingMessage (insufficient balance / 余额不足 / suspended due to / please recharge your account) — never error.type/code alone, because Moonshot reuses exceeded_current_quota_error for RPM. Generic client 400s and plain rate-limit 429s must not match (#617 pool-drain / false SetError). tkHandleBridgeArrearsPenalty disables the account (SetError, same as bridge 402 — recharge does NOT auto-recover) and funnels reason 'newapi_arrears'. Dropping the 429 billing branch regresses the 2026-08-28 account 83 kimi incident (unpaid Moonshot stayed on a 5s cooldown); widening the matcher drains the pool or mis-disables RPM."
+    },
+    {
+      "path": "backend/internal/service/newapi_bridge_arrears_tk_test.go",
+      "must_contain": [
+        "TestTkIsBridgeUpstreamArrears_MoonshotInsufficientBalance429",
+        "TestTkHandleBridgeUpstreamPenalty_Moonshot429ArrearsNotRateLimit",
+        "quota 429 without billing text"
+      ],
+      "rationale": "Focused regression for Moonshot billing-standing 429 (prod 2026-08-28 account 83). The matcher test pins the live insufficient-balance suspend text; the entrypoint test asserts SetError + newapi_arrears instead of handle429 cooldown; the negative case keeps exceeded_current_quota_error without billing text on the rate-limit path. Dropping these tests lets a revert of the 429 billing branch stay green."
     },
     {
       "path": "backend/internal/service/account_incident_notifier_tk.go",


### PR DESCRIPTION
sentinel-registry-reviewed
Web impact: none

## 摘要
Moonshot 国内欠费会返回 HTTP 429 + `insufficient balance` / `suspended due to` 文案，而不是 DashScope 的 400 `Arrearage`。现有 `newapi_arrears` 只认 400/403，账号 83 这类请求会落入约 5 秒的普通 429 冷却，既不 SetError 也不发即时 P0 飞书。

本 PR 把「429 + 计费站立失败文案」并进既有 `newapi_arrears`：SetError 停调度 + 即时 P0。不按 `exceeded_current_quota_error` 单独匹配，避免误伤 RPM 限流。newapi sentinel 已锚住 429 billing 分支与回归测试，避免下次 upstream/refactor 静默回退。

## 风险
常规。调度/告警行为变化，限于 newapi bridge 欠费分类；无 WebUI / API / CLI 契约变化。429 仅匹配 `insufficient balance` / `余额不足` / `suspended due to` / `please recharge your account`。普通 `Requests rate limit exceeded` 以及「quota type 但无欠费文案」继续走限流冷却。

## 验证
- `go test -tags=unit -count=1 -run 'TestTkIsBridgeUpstreamArrears_|TestTkHandleBridgeArrearsPenalty_|TestTkHandleBridgeUpstreamPenalty_Moonshot|TestClassifyIncident_NewAPIArrears|TestHandlePermanent_NewAPIArrears|TestTkBridgeArrearsDetail_' ./internal/service/`：通过（先红后绿）
- `python3 scripts/sentinels/check-newapi.py --quiet`：通过
- `./scripts/preflight.sh`：PASS
- 线上账号 83 已人工 SetError + 飞书；本 PR 修的是后续同类 429 自动走同一路径

## 提交
- `81194c5ca` fix(newapi): treat Moonshot billing 429 as arrears
- `55ec358cb` fix(newapi): address R-001 — anchor Moonshot 429 arrears in sentinel
- 最新提交：55ec358cb