### PR TITLE
perf(ci): 复用 archive 集成测试 PostgreSQL

### DIFF
--- a/backend/internal/observability/qa/archive/control_schema_test.go
+++ b/backend/internal/observability/qa/archive/control_schema_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package archive_test
+package archive
 
 import (
 	"context"
@@ -12,7 +12,6 @@ import (
 	"github.com/Wei-Shaw/sub2api/migrations"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
 )
 
 func TestUS045_QAArchiveForwardCutoverMigrationFollowsBothTK071Migrations(t *testing.T) {
@@ -47,23 +46,7 @@ func TestUS045_QAArchiveForwardCutoverMigrationFollowsBothTK071Migrations(t *tes
 
 func TestQAArchiveCloseoutControlMigrationIsAdditiveAndIdempotent(t *testing.T) {
 	ctx := context.Background()
-	container, err := postgres.Run(
-		ctx,
-		"postgres:18.1-alpine3.23",
-		postgres.WithDatabase("qa_archive_control"),
-		postgres.WithUsername("postgres"),
-		postgres.WithPassword("postgres"),
-		postgres.BasicWaitStrategies(),
-	)
-	if err != nil {
-		t.Skipf("start postgres: %v", err)
-	}
-	defer func() { _ = container.Terminate(ctx) }()
-
-	dsn, err := container.ConnectionString(ctx, "sslmode=disable", "TimeZone=UTC")
-	require.NoError(t, err)
-	db, err := sql.Open("postgres", dsn)
-	require.NoError(t, err)
+	db := openArchiveIntegrationDB(t, "qa_archive_control")
 	defer func() { _ = db.Close() }()
 
 	applyMigration(t, ctx, db, "tk_069_create_qa_archive_shards.sql")
@@ -91,23 +74,7 @@ func TestQAArchiveCloseoutControlMigrationIsAdditiveAndIdempotent(t *testing.T) 
 
 func TestUS045_QAArchiveForwardCutoverMigrationIsAdditiveValidAndImmutable(t *testing.T) {
 	ctx := context.Background()
-	container, err := postgres.Run(
-		ctx,
-		"postgres:18.1-alpine3.23",
-		postgres.WithDatabase("qa_archive_cutover"),
-		postgres.WithUsername("postgres"),
-		postgres.WithPassword("postgres"),
-		postgres.BasicWaitStrategies(),
-	)
-	if err != nil {
-		t.Skipf("start postgres: %v", err)
-	}
-	defer func() { _ = container.Terminate(ctx) }()
-
-	dsn, err := container.ConnectionString(ctx, "sslmode=disable", "TimeZone=UTC")
-	require.NoError(t, err)
-	db, err := sql.Open("postgres", dsn)
-	require.NoError(t, err)
+	db := openArchiveIntegrationDB(t, "qa_archive_cutover")
 	defer func() { _ = db.Close() }()
 
 	applyMigration(t, ctx, db, "tk_069_create_qa_archive_shards.sql")
@@ -136,7 +103,7 @@ RETURNING id`, start, start.Add(time.Hour), state, restoreAt).Scan(&id))
 	}
 
 	pendingID := insertShard(approved.Add(-2*time.Hour), "pending", true)
-	_, err = db.ExecContext(ctx, `UPDATE qa_archive_shards SET forward_cutover=true WHERE id=$1`, pendingID)
+	_, err := db.ExecContext(ctx, `UPDATE qa_archive_shards SET forward_cutover=true WHERE id=$1`, pendingID)
 	require.Error(t, err, "pending shard must not become the cutover")
 
 	unrestoredID := insertShard(approved.Add(-time.Hour), "committed", false)
@@ -159,23 +126,7 @@ RETURNING id`, start, start.Add(time.Hour), state, restoreAt).Scan(&id))
 
 func TestUS045_QAArchiveGapDecisionReceiptsAreAppendOnlyAndNotASecondStateMachine(t *testing.T) {
 	ctx := context.Background()
-	container, err := postgres.Run(
-		ctx,
-		"postgres:18.1-alpine3.23",
-		postgres.WithDatabase("qa_archive_gap_receipts"),
-		postgres.WithUsername("postgres"),
-		postgres.WithPassword("postgres"),
-		postgres.BasicWaitStrategies(),
-	)
-	if err != nil {
-		t.Skipf("start postgres: %v", err)
-	}
-	defer func() { _ = container.Terminate(ctx) }()
-
-	dsn, err := container.ConnectionString(ctx, "sslmode=disable", "TimeZone=UTC")
-	require.NoError(t, err)
-	db, err := sql.Open("postgres", dsn)
-	require.NoError(t, err)
+	db := openArchiveIntegrationDB(t, "qa_archive_gap_receipts")
 	defer func() { _ = db.Close() }()
 
 	applyMigration(t, ctx, db, "tk_069_create_qa_archive_shards.sql")
@@ -185,7 +136,7 @@ func TestUS045_QAArchiveGapDecisionReceiptsAreAppendOnlyAndNotASecondStateMachin
 
 	planHash := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	planJSON := `{"schema_version":"qa-archive-gap-decision-v1","plan_hash":"` + planHash + `","windows":[{}]}`
-	_, err = db.ExecContext(ctx, `
+	_, err := db.ExecContext(ctx, `
 INSERT INTO qa_archive_gap_decision_receipts
     (plan_hash, plan_schema_version, plan_json, approved_by, window_count)
 VALUES ($1,'qa-archive-gap-decision-v1',$2::jsonb,'feng',1)`, planHash, planJSON)

--- a/backend/internal/observability/qa/archive/control_store_test.go
+++ b/backend/internal/observability/qa/archive/control_store_test.go
@@ -15,25 +15,11 @@ import (
 	"github.com/Wei-Shaw/sub2api/migrations"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
 )
 
 func TestSQLControlStorePersistsVerifiedCommitParity(t *testing.T) {
 	ctx := context.Background()
-	container, err := postgres.Run(
-		ctx, "postgres:18.1-alpine3.23",
-		postgres.WithDatabase("qa_archive_control_store"),
-		postgres.WithUsername("postgres"), postgres.WithPassword("postgres"),
-		postgres.BasicWaitStrategies(),
-	)
-	if err != nil {
-		t.Skipf("start postgres: %v", err)
-	}
-	defer func() { _ = container.Terminate(ctx) }()
-	dsn, err := container.ConnectionString(ctx, "sslmode=disable", "TimeZone=UTC")
-	require.NoError(t, err)
-	db, err := sql.Open("postgres", dsn)
-	require.NoError(t, err)
+	db := openArchiveIntegrationDB(t, "qa_archive_control_store")
 	defer func() { _ = db.Close() }()
 	for _, migration := range []string{"tk_069_create_qa_archive_shards.sql", "tk_070_qa_archive_closeout_control.sql"} {
 		body, readErr := migrations.FS.ReadFile(migration)

--- a/backend/internal/observability/qa/archive/cutover_test.go
+++ b/backend/internal/observability/qa/archive/cutover_test.go
@@ -4,32 +4,17 @@ package archive
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/migrations"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
 )
 
 func TestUS045_SQLControlStoreSetsOnlyApprovedForwardCutover(t *testing.T) {
 	ctx := context.Background()
-	container, err := postgres.Run(
-		ctx, "postgres:18.1-alpine3.23",
-		postgres.WithDatabase("qa_archive_cutover_store"),
-		postgres.WithUsername("postgres"), postgres.WithPassword("postgres"),
-		postgres.BasicWaitStrategies(),
-	)
-	if err != nil {
-		t.Skipf("start postgres: %v", err)
-	}
-	defer func() { _ = container.Terminate(ctx) }()
-	dsn, err := container.ConnectionString(ctx, "sslmode=disable", "TimeZone=UTC")
-	require.NoError(t, err)
-	db, err := sql.Open("postgres", dsn)
-	require.NoError(t, err)
+	db := openArchiveIntegrationDB(t, "qa_archive_cutover_store")
 	defer func() { _ = db.Close() }()
 	for _, migration := range []string{
 		"tk_069_create_qa_archive_shards.sql",

--- a/backend/internal/observability/qa/archive/gap_decision_integration_test.go
+++ b/backend/internal/observability/qa/archive/gap_decision_integration_test.go
@@ -4,7 +4,6 @@ package archive
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"testing"
 	"time"
@@ -12,26 +11,11 @@ import (
 	"github.com/Wei-Shaw/sub2api/migrations"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
 )
 
 func TestUS045_GapDecisionPlanJSONApplyIsAtomicAndIdempotentInPostgreSQL(t *testing.T) {
 	ctx := context.Background()
-	container, err := postgres.Run(
-		ctx, "postgres:18.1-alpine3.23",
-		postgres.WithDatabase("qa_archive_gap_decision"),
-		postgres.WithUsername("postgres"), postgres.WithPassword("postgres"),
-		postgres.BasicWaitStrategies(),
-	)
-	if err != nil {
-		t.Skipf("start postgres: %v", err)
-	}
-	defer func() { _ = container.Terminate(ctx) }()
-
-	dsn, err := container.ConnectionString(ctx, "sslmode=disable", "TimeZone=UTC")
-	require.NoError(t, err)
-	db, err := sql.Open("postgres", dsn)
-	require.NoError(t, err)
+	db := openArchiveIntegrationDB(t, "qa_archive_gap_decision")
 	defer func() { _ = db.Close() }()
 	for _, migration := range []string{
 		"tk_004_create_qa_records.sql",
@@ -51,7 +35,7 @@ func TestUS045_GapDecisionPlanJSONApplyIsAtomicAndIdempotentInPostgreSQL(t *test
 	anchor = anchor.UTC()
 	cutoverStart := anchor.Add(-27 * time.Hour)
 	latestNormal := anchor.Add(-time.Hour)
-	_, err = db.ExecContext(ctx, `
+	_, err := db.ExecContext(ctx, `
 INSERT INTO qa_archive_shards (
     window_start, window_end, generation, state, restore_verified_at, forward_cutover
 ) VALUES

--- a/backend/internal/observability/qa/archive/integration_harness_test.go
+++ b/backend/internal/observability/qa/archive/integration_harness_test.go
@@ -1,0 +1,134 @@
+//go:build integration
+
+package archive
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+)
+
+const archiveIntegrationPostgresImage = "postgres:18.1-alpine3.23"
+
+var (
+	archiveIntegrationPostgresDSN      string
+	archiveIntegrationPostgresStartErr error
+	archiveIntegrationDatabaseName     = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+)
+
+func TestMain(m *testing.M) {
+	startedAt := time.Now()
+	ctx := context.Background()
+	container, err := postgres.Run(
+		ctx,
+		archiveIntegrationPostgresImage,
+		postgres.WithDatabase("postgres"),
+		postgres.WithUsername("postgres"),
+		postgres.WithPassword("postgres"),
+		postgres.BasicWaitStrategies(),
+	)
+	if err != nil {
+		archiveIntegrationPostgresStartErr = fmt.Errorf("start shared postgres: %w", err)
+		log.Printf("archive-integration: STAGE postgres-unavailable (%.3fs): %v", time.Since(startedAt).Seconds(), err)
+		os.Exit(m.Run())
+	}
+
+	archiveIntegrationPostgresDSN, err = container.ConnectionString(ctx, "sslmode=disable", "TimeZone=UTC")
+	if err != nil {
+		archiveIntegrationPostgresStartErr = fmt.Errorf("shared postgres connection string: %w", err)
+		_ = container.Terminate(ctx)
+		log.Printf("archive-integration: STAGE postgres-unavailable (%.3fs): %v", time.Since(startedAt).Seconds(), err)
+		os.Exit(m.Run())
+	}
+	log.Printf("archive-integration: STAGE postgres-ready (%.3fs)", time.Since(startedAt).Seconds())
+
+	testsStartedAt := time.Now()
+	code := m.Run()
+	log.Printf("archive-integration: STAGE tests-finished (%.3fs)", time.Since(testsStartedAt).Seconds())
+
+	cleanupStartedAt := time.Now()
+	if err := container.Terminate(ctx); err != nil {
+		log.Printf("archive-integration: shared postgres cleanup failed: %v", err)
+	}
+	log.Printf("archive-integration: STAGE postgres-cleanup (%.3fs)", time.Since(cleanupStartedAt).Seconds())
+	os.Exit(code)
+}
+
+func openArchiveIntegrationDB(t *testing.T, name string) *sql.DB {
+	t.Helper()
+	if archiveIntegrationPostgresStartErr != nil {
+		t.Skipf("shared postgres unavailable: %v", archiveIntegrationPostgresStartErr)
+	}
+	if archiveIntegrationPostgresDSN == "" {
+		t.Fatal("shared postgres DSN is empty")
+	}
+	if !archiveIntegrationDatabaseName.MatchString(name) {
+		t.Fatalf("invalid archive integration database name %q", name)
+	}
+
+	ctx := context.Background()
+	admin, err := sql.Open("postgres", archiveIntegrationPostgresDSN)
+	require.NoError(t, err)
+	quotedName := pq.QuoteIdentifier(name)
+	_, err = admin.ExecContext(ctx, "DROP DATABASE IF EXISTS "+quotedName+" WITH (FORCE)")
+	require.NoError(t, err)
+	_, err = admin.ExecContext(ctx, "CREATE DATABASE "+quotedName)
+	require.NoError(t, err)
+	require.NoError(t, admin.Close())
+
+	dsn, err := archiveIntegrationDatabaseDSN(name)
+	require.NoError(t, err)
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	require.NoError(t, db.PingContext(ctx))
+	t.Cleanup(func() {
+		_ = db.Close()
+		cleanup, cleanupErr := sql.Open("postgres", archiveIntegrationPostgresDSN)
+		require.NoError(t, cleanupErr)
+		defer func() { _ = cleanup.Close() }()
+		_, cleanupErr = cleanup.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+quotedName+" WITH (FORCE)")
+		require.NoError(t, cleanupErr)
+	})
+	return db
+}
+
+func archiveIntegrationDatabaseDSN(name string) (string, error) {
+	parsed, err := url.Parse(archiveIntegrationPostgresDSN)
+	if err != nil {
+		return "", fmt.Errorf("parse shared postgres DSN: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("shared postgres DSN is not a URL")
+	}
+	parsed.Path = "/" + name
+	return parsed.String(), nil
+}
+
+func TestArchiveIntegrationHarnessProvidesIsolatedDatabases(t *testing.T) {
+	ctx := context.Background()
+	first := openArchiveIntegrationDB(t, "qa_archive_harness_first")
+	second := openArchiveIntegrationDB(t, "qa_archive_harness_second")
+
+	_, err := first.ExecContext(ctx, `CREATE TABLE isolation_probe (value text NOT NULL)`)
+	require.NoError(t, err)
+	_, err = first.ExecContext(ctx, `INSERT INTO isolation_probe (value) VALUES ('first')`)
+	require.NoError(t, err)
+
+	var visibleInFirst int
+	require.NoError(t, first.QueryRowContext(ctx, `SELECT count(*) FROM isolation_probe`).Scan(&visibleInFirst))
+	require.Equal(t, 1, visibleInFirst)
+
+	var visibleInSecond bool
+	require.NoError(t, second.QueryRowContext(ctx, `SELECT to_regclass('public.isolation_probe') IS NOT NULL`).Scan(&visibleInSecond))
+	require.False(t, visibleInSecond, "shared PostgreSQL must still isolate each archive test database")
+}

--- a/backend/internal/observability/qa/archive/timeline_selector_integration_test.go
+++ b/backend/internal/observability/qa/archive/timeline_selector_integration_test.go
@@ -11,25 +11,11 @@ import (
 	"github.com/Wei-Shaw/sub2api/migrations"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
 )
 
 func TestUS045_SQLTimelineSelectorPersistsTerminalAndFindsUncoveredIdentity(t *testing.T) {
 	ctx := context.Background()
-	container, err := postgres.Run(
-		ctx, "postgres:18.1-alpine3.23",
-		postgres.WithDatabase("qa_archive_timeline"),
-		postgres.WithUsername("postgres"), postgres.WithPassword("postgres"),
-		postgres.BasicWaitStrategies(),
-	)
-	if err != nil {
-		t.Skipf("start postgres: %v", err)
-	}
-	defer func() { _ = container.Terminate(ctx) }()
-	dsn, err := container.ConnectionString(ctx, "sslmode=disable", "TimeZone=UTC")
-	require.NoError(t, err)
-	db, err := sql.Open("postgres", dsn)
-	require.NoError(t, err)
+	db := openArchiveIntegrationDB(t, "qa_archive_timeline")
 	defer func() { _ = db.Close() }()
 	for _, migration := range []string{
 		"tk_004_create_qa_records.sql",

--- a/backend/internal/repository/integration_harness_test.go
+++ b/backend/internal/repository/integration_harness_test.go
@@ -45,22 +45,27 @@ var (
 
 func TestMain(m *testing.M) {
 	runIntegrationRegistryOnlyIfRequested(m)
+	os.Exit(runRepositoryIntegrationTests(m))
+}
+
+func runRepositoryIntegrationTests(m *testing.M) int {
+	startedAt := time.Now()
 
 	ctx := context.Background()
 
 	if err := timezone.Init("UTC"); err != nil {
 		log.Printf("failed to init timezone: %v", err)
-		os.Exit(1)
+		return 1
 	}
 
 	if !dockerIsAvailable(ctx) {
 		// In CI we expect Docker to be available so integration tests should fail loudly.
 		if os.Getenv("CI") != "" {
 			log.Printf("docker is not available (CI=true); failing integration tests")
-			os.Exit(1)
+			return 1
 		}
 		log.Printf("docker is not available; skipping integration tests (start Docker to enable)")
-		os.Exit(0)
+		return 0
 	}
 
 	postgresImage := selectDockerImage(ctx, postgresImageTag)
@@ -74,50 +79,52 @@ func TestMain(m *testing.M) {
 	)
 	if err != nil {
 		log.Printf("failed to start postgres container: %v", err)
-		os.Exit(1)
+		return 1
 	}
-	defer func() { _ = pgContainer.Terminate(ctx) }()
+	log.Printf("repository-integration: STAGE postgres-ready (%.3fs)", time.Since(startedAt).Seconds())
 
-	redisContainer, err := tcredis.Run(
+	var redisContainer *tcredis.RedisContainer
+	defer func() {
+		cleanupStartedAt := time.Now()
+		if integrationEntClient != nil {
+			_ = integrationEntClient.Close()
+		}
+		if integrationRedis != nil {
+			_ = integrationRedis.Close()
+		}
+		if integrationDB != nil {
+			_ = integrationDB.Close()
+		}
+		if redisContainer != nil {
+			if err := redisContainer.Terminate(ctx); err != nil {
+				log.Printf("repository-integration: redis cleanup failed: %v", err)
+			}
+		}
+		if err := pgContainer.Terminate(ctx); err != nil {
+			log.Printf("repository-integration: postgres cleanup failed: %v", err)
+		}
+		log.Printf("repository-integration: STAGE cleanup (%.3fs)", time.Since(cleanupStartedAt).Seconds())
+	}()
+
+	redisStartedAt := time.Now()
+	redisContainer, err = tcredis.Run(
 		ctx,
 		redisImageTag,
 	)
 	if err != nil {
 		log.Printf("failed to start redis container: %v", err)
-		os.Exit(1)
+		return 1
 	}
-	defer func() { _ = redisContainer.Terminate(ctx) }()
-
-	dsn, err := pgContainer.ConnectionString(ctx, "sslmode=disable", "TimeZone=UTC")
-	if err != nil {
-		log.Printf("failed to get postgres dsn: %v", err)
-		os.Exit(1)
-	}
-	integrationPostgresDSN = dsn
-
-	integrationDB, err = openSQLWithRetry(ctx, dsn, 30*time.Second)
-	if err != nil {
-		log.Printf("failed to open sql db: %v", err)
-		os.Exit(1)
-	}
-	if err := ApplyMigrations(ctx, integrationDB); err != nil {
-		log.Printf("failed to apply db migrations: %v", err)
-		os.Exit(1)
-	}
-
-	// 创建 ent client 用于集成测试
-	drv := entsql.OpenDB(dialect.Postgres, integrationDB)
-	integrationEntClient = dbent.NewClient(dbent.Driver(drv))
 
 	redisHost, err := redisContainer.Host(ctx)
 	if err != nil {
 		log.Printf("failed to get redis host: %v", err)
-		os.Exit(1)
+		return 1
 	}
 	redisPort, err := redisContainer.MappedPort(ctx, "6379/tcp")
 	if err != nil {
 		log.Printf("failed to get redis port: %v", err)
-		os.Exit(1)
+		return 1
 	}
 
 	integrationRedis = redisclient.NewClient(&redisclient.Options{
@@ -126,16 +133,38 @@ func TestMain(m *testing.M) {
 	})
 	if err := integrationRedis.Ping(ctx).Err(); err != nil {
 		log.Printf("failed to ping redis: %v", err)
-		os.Exit(1)
+		return 1
+	}
+	log.Printf("repository-integration: STAGE redis-ready (%.3fs)", time.Since(redisStartedAt).Seconds())
+
+	migrationsStartedAt := time.Now()
+	dsn, err := pgContainer.ConnectionString(ctx, "sslmode=disable", "TimeZone=UTC")
+	if err != nil {
+		log.Printf("failed to get postgres dsn: %v", err)
+		return 1
+	}
+	integrationPostgresDSN = dsn
+
+	integrationDB, err = openSQLWithRetry(ctx, dsn, 30*time.Second)
+	if err != nil {
+		log.Printf("failed to open sql db: %v", err)
+		return 1
+	}
+	if err := ApplyMigrations(ctx, integrationDB); err != nil {
+		log.Printf("failed to apply db migrations: %v", err)
+		return 1
 	}
 
+	// 创建 ent client 用于集成测试
+	drv := entsql.OpenDB(dialect.Postgres, integrationDB)
+	integrationEntClient = dbent.NewClient(dbent.Driver(drv))
+	log.Printf("repository-integration: STAGE migrations-ready (%.3fs)", time.Since(migrationsStartedAt).Seconds())
+
+	testsStartedAt := time.Now()
 	code := m.Run()
+	log.Printf("repository-integration: STAGE tests-finished (%.3fs)", time.Since(testsStartedAt).Seconds())
 
-	_ = integrationEntClient.Close()
-	_ = integrationRedis.Close()
-	_ = integrationDB.Close()
-
-	os.Exit(code)
+	return code
 }
 
 func dockerIsAvailable(ctx context.Context) bool {

--- a/scripts/ci/integration_test_runner.py
+++ b/scripts/ci/integration_test_runner.py
@@ -183,6 +183,7 @@ def run_integration_tests(
                 f"other-{Path(package).name}",
                 (
                     str(binaries[package]),
+                    "-test.v",
                     "-test.timeout=10m",
                     "-test.paniconexit0",
                 ),
@@ -197,6 +198,7 @@ def run_integration_tests(
                     f"repository-shard-{index:0{width}d}",
                     (
                         str(repository_binary),
+                        "-test.v",
                         "-test.run",
                         pattern,
                         "-test.timeout=10m",
@@ -209,6 +211,7 @@ def run_integration_tests(
             commands,
             runner_name="integration-test-runner",
             temporary_prefix="sub2api-integration-",
+            slow_test_limit=5,
         )
 
 

--- a/scripts/ci/test_integration_test_runner.py
+++ b/scripts/ci/test_integration_test_runner.py
@@ -131,6 +131,38 @@ class IntegrationTestRunnerTest(unittest.TestCase):
         )
         self.assertLessEqual(compile_finished, first_binary_started, events)
 
+    def test_reports_stage_lines_and_slowest_top_level_tests(self) -> None:
+        with FakeGoFixture(["TestOne", "TestTwo", "TestThree"]) as fixture:
+            result = fixture.run()
+            events = fixture.read_events()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        run_events = [
+            event
+            for event in events
+            if event["kind"] == "binary" and "-test.list" not in event["args"]
+        ]
+        self.assertTrue(run_events)
+        for event in run_events:
+            self.assertIn("-test.v", event["args"])
+        self.assertIn(
+            "integration-test-runner: DETAIL other-other: "
+            "archive-integration: STAGE postgres-ready (1.234s)",
+            result.stdout,
+        )
+        self.assertIn(
+            "repository-integration: STAGE migrations-ready (2.345s)",
+            result.stdout,
+        )
+        self.assertIn(
+            "integration-test-runner: SLOW other-other (1.230s): TestSlow",
+            result.stdout,
+        )
+        self.assertNotIn(
+            "integration-test-runner: SLOW other-other (0.000s): TestZero",
+            result.stdout,
+        )
+
     @staticmethod
     def _binary_patterns(events: list[dict[str, object]]) -> list[str]:
         patterns = []
@@ -223,6 +255,11 @@ class FakeGoFixture:
                     print(name)
                 raise SystemExit(0)
             if "-test.run" not in args:
+                if "-test.v" in args:
+                    print("archive-integration: STAGE postgres-ready (1.234s)")
+                    print("--- PASS: TestSlow (1.23s)")
+                    print("--- PASS: TestFast (0.01s)")
+                    print("--- PASS: TestZero (0.00s)")
                 print("successful package noise")
                 print("PASS")
                 raise SystemExit(0)
@@ -231,6 +268,10 @@ class FakeGoFixture:
             if fail_test and fail_test in pattern:
                 print(f"intentional {fail_test} failure")
                 raise SystemExit(1)
+            if "-test.v" in args:
+                print("repository-integration: STAGE migrations-ready (2.345s)")
+                print("--- PASS: TestSlow (1.23s)")
+                print("--- PASS: TestFast (0.01s)")
             print("successful shard noise")
             print("PASS")
             """

--- a/scripts/ci/unit_test_runner.py
+++ b/scripts/ci/unit_test_runner.py
@@ -24,6 +24,13 @@ TEST_DISCOVERY_HELPER = Path(__file__).resolve().with_name("list_go_tests.go")
 # Linux limits a single argv entry to 128 KiB. Keep 32 KiB of headroom while
 # avoiding unnecessary shard/link fan-out at the current service test scale.
 DEFAULT_MAX_REGEX_BYTES = 96 * 1024
+GO_TEST_RESULT_RE = re.compile(
+    r"^\s*--- (?:PASS|FAIL|SKIP): (?P<name>\S+) \((?P<seconds>[0-9.]+)s\)\s*$"
+)
+INTEGRATION_STAGE_RE = re.compile(
+    r"^(?:\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} )?"
+    r"(?P<detail>[a-z0-9-]+-integration: STAGE .+)$"
+)
 
 
 class RunnerError(RuntimeError):
@@ -254,6 +261,31 @@ def _last_summary(output: str) -> str:
     return lines[-1] if lines else "no output"
 
 
+def _slow_top_level_tests(output: str, limit: int) -> list[tuple[float, str]]:
+    tests: list[tuple[float, str]] = []
+    for line in output.splitlines():
+        match = GO_TEST_RESULT_RE.match(line)
+        if not match:
+            continue
+        name = match.group("name")
+        if "/" in name:
+            continue
+        seconds = float(match.group("seconds"))
+        if seconds <= 0:
+            continue
+        tests.append((seconds, name))
+    return sorted(tests, reverse=True)[:limit]
+
+
+def _integration_stage_lines(output: str) -> list[str]:
+    details = []
+    for line in output.splitlines():
+        match = INTEGRATION_STAGE_RE.match(line)
+        if match:
+            details.append(match.group("detail"))
+    return details
+
+
 def _terminate_processes(
     running: list[RunningCommand],
 ) -> None:
@@ -287,6 +319,7 @@ def run_commands(
     initial_running: list[RunningCommand] | None = None,
     runner_name: str = "unit-test-runner",
     temporary_prefix: str = "sub2api-unit-",
+    slow_test_limit: int = 0,
 ) -> int:
     with tempfile.TemporaryDirectory(prefix=temporary_prefix) as temporary:
         log_dir = Path(temporary)
@@ -331,6 +364,17 @@ def run_commands(
                     f"{runner_name}: PASS {command.label} "
                     f"({elapsed:.1f}s): {_last_summary(output)}"
                 )
+                if slow_test_limit > 0:
+                    for detail in _integration_stage_lines(output):
+                        print(f"{runner_name}: DETAIL {command.label}: {detail}")
+                    for test_elapsed, test_name in _slow_top_level_tests(
+                        output,
+                        slow_test_limit,
+                    ):
+                        print(
+                            f"{runner_name}: SLOW {command.label} "
+                            f"({test_elapsed:.3f}s): {test_name}"
+                        )
                 continue
             print(
                 f"{runner_name}: FAIL {command.label} ({elapsed:.1f}s)",


### PR DESCRIPTION
## 摘要

- 将 archive 集成测试从 7 次独立 PostgreSQL testcontainer 启动收敛为包级单容器，并为每个测试创建独立数据库保持隔离。
- 为 archive 与 repository TestMain 输出容器启动、迁移、测试和清理阶段耗时；integration runner 仅输出每组非零 Top 5 顶层慢测试，便于继续拆解瓶颈。
- 修复 repository TestMain 中 os.Exit 跳过 defer 的资源清理问题，显式关闭客户端并终止 PostgreSQL/Redis。
- 不增加 GitHub Actions job 或 runner 并发，不增加 credits 消耗面。

## 风险

- 变更仅影响集成测试 harness 和 CI 诊断输出，不影响生产逻辑与 Web 行为。
- archive 测试仍使用独立数据库；测试包当前无 t.Parallel，数据库名经过校验并在前后强制删除。
- repository harness sentinel 影响已核对，无需新增 registry anchor：sentinel-registry-reviewed。

## 验证

- `./scripts/preflight.sh`：PASS（对提交后的 HEAD 重新执行）。
- `python3 -m unittest scripts.ci.test_integration_test_runner scripts.ci.test_unit_test_runner`：19/19 PASS。
- archive 本地真实 Docker 集成测试：PASS；总时长约 2.0s，测试体 0.530s。
- GitHub Actions run `33146254993`：全部 21 项检查通过；integration job 1m45s。
- GitHub runner 上 archive 为 16.9s，相比热缓存基线 29.1s 减少 12.2s（约 42%）；内部为 PostgreSQL 启动 14.710s、测试体 1.618s、清理 0.589s。
- 新诊断确认下一批最大项为 shared compile 33.3s、server 单测 15.78s、repository PostgreSQL 启动约 14.6s、middleware/routes 各约 13s，以及 `TestOpsDailyPartitionMigration_LockContract` 6.04s。
- 独立代码审查：Ready to merge，无 Critical / Important / Minor finding。

## 提交

- `2f4745821 perf(ci): 复用 archive 集成测试 PostgreSQL`

最新提交：`2f4745821`