### PR TITLE
chore(ops): 对齐 Lightsail edge 出口 IP 与污染名单

### DIFF
--- a/.cursor/skills/tokenkey-stage0-edge-lightsail-ip-rotation/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-lightsail-ip-rotation/SKILL.md
@@ -81,7 +81,7 @@ bash ops/lightsail/rotate-static-ip.sh <edge_id> --apply --reason 'upstream-api-
 4. `aws lightsail get-static-ip` 读出 NEW ip
 5. `aws ssm put-parameter` 写 `${ssm_prefix}/public_ip = <new_ip>`
 6. `aws lightsail release-static-ip` 旧名字（**该 IP 进入 AWS pool**）
-7. `record-polluted-ip.py append` 把旧 IP 写入 exclusion registry（**记得 commit JSON + 跑 `scripts/edge-ip-status.sh --check`**）
+7. `record-polluted-ip.py append` 把旧 IP 写入 exclusion registry（**记得更新 matrix `static_ip_name` / `porkbun_a_ipv4`、commit JSON + 跑 `scripts/edge-ip-status.sh --check`**）
 
 输出最后会打印 NEW ip 和 DNS / smoke 提示。
 
@@ -91,7 +91,7 @@ bash ops/lightsail/rotate-static-ip.sh <edge_id> --apply --reason 'upstream-api-
 
 ## 3) DNS 与 Caddy
 
-去 Porkbun 把 `api-<edge_id>.tokenkey.dev` 的 A 记录改成 NEW ip。等 `dig +short @1.1.1.1` 指向 NEW ip（常见约 1 分钟）。
+去 Porkbun 把 `api-<edge_id>.tokenkey.dev` 的 A 记录改成 NEW ip。等 `dig +short @1.1.1.1` 指向 NEW ip（常见约 1 分钟）。Prod 走 AWS VPC DNS（`10.0.0.2`），可能在 Porkbun TTL 内仍解析旧 IP，表现为 `/api/v1/edge/accounts` `context deadline exceeded`；公网 `/health` 绿不能单独当作 prod 已切过去。
 
 IP 变更后重启 Caddy 以刷新 ACME / 绑定：
 

--- a/deploy/aws/lightsail/edge-targets-lightsail.json
+++ b/deploy/aws/lightsail/edge-targets-lightsail.json
@@ -99,14 +99,14 @@
       "ec2_equivalent_region": "us-east-2",
       "availability_zone": "us-east-2a",
       "domain": "api-us3.tokenkey.dev",
-      "porkbun_a_ipv4": "18.220.195.44",
+      "porkbun_a_ipv4": "18.216.113.132",
       "instance_name": "tokenkey-edge-us-oh1-ls",
-      "static_ip_name": "vless-oh-fresh-1",
+      "static_ip_name": "vless-oh-fresh-1-rot-20260828T122454Z",
       "bundle_id": "micro_3_0",
       "blueprint_id": "amazon_linux_2023",
       "monthly_budget_usd": 12,
       "ssm_prefix": "/tokenkey/lightsail/us3",
-      "purpose": "us-east-2-ohio-egress (rotated 2026-06-16: swapped to vless-oh-fresh-1 / 18.220.195.44 after Static-oh-1 / 3.128.102.134 upstream API risk-block; old Static-oh-1 detached, recorded in edge-polluted-ips.json)"
+      "purpose": "us-east-2-ohio-egress (rotated 2026-08-28: swapped to vless-oh-fresh-1-rot-20260828T122454Z / 18.216.113.132 after vless-oh-fresh-1 / 18.220.195.44 upstream API risk-block; prior 2026-06-16 rotation was vless-oh-fresh-1 after Static-oh-1 / 3.128.102.134)"
     },
     "us4": {
       "deployable": true,
@@ -116,14 +116,14 @@
       "ec2_equivalent_region": "us-west-2",
       "availability_zone": "us-west-2a",
       "domain": "api-us4.tokenkey.dev",
-      "porkbun_a_ipv4": "35.81.204.18",
+      "porkbun_a_ipv4": "32.188.80.151",
       "instance_name": "tokenkey-edge-us-or1-ls",
-      "static_ip_name": "Static-or-1",
+      "static_ip_name": "Static-or-1-rot-20260828T122052Z",
       "bundle_id": "micro_3_0",
       "blueprint_id": "amazon_linux_2023",
       "monthly_budget_usd": 12,
       "ssm_prefix": "/tokenkey/lightsail/us4",
-      "purpose": "us-west-2-oregon-egress (pre-provisioned Static-or-1 / tokenkey-edge-us-or1-ls)"
+      "purpose": "us-west-2-oregon-egress (rotated 2026-08-28: swapped to Static-or-1-rot-20260828T122052Z / 32.188.80.151 after Static-or-1 / 35.81.204.18 upstream API risk-block)"
     },
     "us5": {
       "deployable": true,
@@ -133,14 +133,14 @@
       "ec2_equivalent_region": "us-west-2",
       "availability_zone": "us-west-2a",
       "domain": "api-us5.tokenkey.dev",
-      "porkbun_a_ipv4": "32.185.163.163",
+      "porkbun_a_ipv4": "16.144.175.131",
       "instance_name": "tokenkey-edge-us-or2-ls",
-      "static_ip_name": "vless-or-fresh-1",
+      "static_ip_name": "vless-or-fresh-1-rot-20260828T115642Z",
       "bundle_id": "micro_3_0",
       "blueprint_id": "amazon_linux_2023",
       "monthly_budget_usd": 12,
       "ssm_prefix": "/tokenkey/lightsail/us5",
-      "purpose": "us-west-2-oregon-egress-2 (rotated 2026-06-16: swapped to vless-or-fresh-1 / 32.185.163.163 after StaticIp-or-2 / 44.224.133.40 upstream API risk-block; old StaticIp-or-2 detached, recorded in edge-polluted-ips.json)"
+      "purpose": "us-west-2-oregon-egress-2 (rotated 2026-08-28: swapped to vless-or-fresh-1-rot-20260828T115642Z / 16.144.175.131 after vless-or-fresh-1 / 32.185.163.163 upstream API risk-block; prior 2026-06-16 rotation was vless-or-fresh-1 after StaticIp-or-2 / 44.224.133.40)"
     },
     "us6": {
       "deployable": true,
@@ -150,14 +150,14 @@
       "ec2_equivalent_region": "us-east-2",
       "availability_zone": "us-east-2a",
       "domain": "api-us6.tokenkey.dev",
-      "porkbun_a_ipv4": "3.148.79.145",
+      "porkbun_a_ipv4": "3.147.98.112",
       "instance_name": "edge-ls-us-oh-3",
-      "static_ip_name": "StaticIp-oh-3",
+      "static_ip_name": "StaticIp-oh-3-rot-20260828T121745Z",
       "bundle_id": "micro_3_0",
       "blueprint_id": "amazon_linux_2023",
       "monthly_budget_usd": 12,
       "ssm_prefix": "/tokenkey/lightsail/us6",
-      "purpose": "us-east-2-ohio-egress (rehomed 2026-06-05 to adopted console-created edge-ls-us-oh-3 / StaticIp-oh-3; corrected 2026-06-08: A record was stale at ephemeral 52.15.35.197 which AWS re-adopted to *.coverahealth.com — StaticIp-oh-3 truth is 3.148.79.145)"
+      "purpose": "us-east-2-ohio-egress (rotated 2026-08-28: swapped to StaticIp-oh-3-rot-20260828T121745Z / 3.147.98.112 after StaticIp-oh-3 / 3.148.79.145 upstream API risk-block)"
     },
     "us7": {
       "deployable": false,

--- a/deploy/aws/stage0/edge-polluted-ips.json
+++ b/deploy/aws/stage0/edge-polluted-ips.json
@@ -71,6 +71,34 @@
       "notes": "Lightsail edge-uk1 tokenkey-edge-uk1-ls-ip upstream API risk-block (2026-06-16); swapped to vless-uk-fresh-1 / 18.175.27.120; old static IP released, exclude from re-allocation",
       "edge_id": "uk1",
       "platform": "lightsail"
+    },
+    {
+      "ip": "32.185.163.163",
+      "region": "us-west-2",
+      "notes": "upstream-api-risk-block-2026-08-28; static_ip_name=vless-or-fresh-1; released via ops/lightsail/rotate-static-ip.sh",
+      "edge_id": "us5",
+      "platform": "lightsail"
+    },
+    {
+      "ip": "3.148.79.145",
+      "region": "us-east-2",
+      "notes": "upstream-api-risk-block-2026-08-28; static_ip_name=StaticIp-oh-3; released via ops/lightsail/rotate-static-ip.sh",
+      "edge_id": "us6",
+      "platform": "lightsail"
+    },
+    {
+      "ip": "35.81.204.18",
+      "region": "us-west-2",
+      "notes": "upstream-api-risk-block-2026-08-28; static_ip_name=Static-or-1; released via ops/lightsail/rotate-static-ip.sh",
+      "edge_id": "us4",
+      "platform": "lightsail"
+    },
+    {
+      "ip": "18.220.195.44",
+      "region": "us-east-2",
+      "notes": "upstream-api-risk-block-2026-08-28; static_ip_name=vless-oh-fresh-1; released via ops/lightsail/rotate-static-ip.sh",
+      "edge_id": "us3",
+      "platform": "lightsail"
     }
   ]
 }

--- a/deploy/aws/stage0/record-polluted-ip.py
+++ b/deploy/aws/stage0/record-polluted-ip.py
@@ -142,16 +142,20 @@ def main() -> int:
     append.add_argument("--edge-id", default="")
     append.add_argument("--platform", choices=("ec2", "lightsail"), default="")
     append.add_argument("--dry-run", action="store_true")
+    # Same flag after the subcommand must not clobber the parent dest.
+    append.add_argument("--registry", type=Path, dest="registry_after", default=None)
 
     check = sub.add_parser("is-excluded", help="Exit 0 when ip+region is already excluded")
     check.add_argument("--ip", required=True)
     check.add_argument("--region", required=True)
+    check.add_argument("--registry", type=Path, dest="registry_after", default=None)
 
     args = parser.parse_args()
+    registry = args.registry_after if args.registry_after is not None else args.registry
 
     if args.command == "is-excluded":
         validate_ip(args.ip)
-        data = load_registry(args.registry)
+        data = load_registry(registry)
         if args.ip in excluded_ips_for_region(data, args.region):
             return 0
         return 1
@@ -162,7 +166,7 @@ def main() -> int:
         notes=args.notes,
         edge_id=args.edge_id,
         platform=args.platform,
-        registry_path=args.registry,
+        registry_path=registry,
         dry_run=args.dry_run,
     )
     return 0

--- a/deploy/aws/stage0/test_edge_ip_status.py
+++ b/deploy/aws/stage0/test_edge_ip_status.py
@@ -1,0 +1,125 @@
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "edge-ip-status.sh"
+
+
+def _run(env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
+    merged = os.environ.copy()
+    merged.update(env)
+    return subprocess.run(
+        [str(SCRIPT), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=merged,
+    )
+
+
+def _write_fixtures(tmp: Path) -> dict[str, str]:
+    matrix = tmp / "edge-targets-lightsail.json"
+    polluted = tmp / "edge-polluted-ips.json"
+    doc = tmp / "tokenkey-edge-ip-history.md"
+    matrix.write_text(
+        json.dumps(
+            {
+                "targets": {
+                    "us9": {
+                        "deployable": False,
+                        "lightsail_region": "us-east-2",
+                        "domain": "api-us9.tokenkey.dev",
+                        "static_ip_name": "retired",
+                        "porkbun_a_ipv4": "1.1.1.1",
+                    },
+                    "us8": {
+                        "deployable": True,
+                        "lightsail_region": "us-west-2",
+                        "domain": "api-us8.tokenkey.dev",
+                        "static_ip_name": "live-static",
+                        "porkbun_a_ipv4": "9.9.9.9",
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    polluted.write_text(
+        json.dumps(
+            {
+                "polluted": [
+                    {
+                        "ip": "8.8.8.8",
+                        "region": "us-west-2",
+                        "notes": "fixture-old",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    env = {
+        "EDGE_IP_STATUS_MATRIX": str(matrix),
+        "EDGE_IP_STATUS_POLLUTED": str(polluted),
+        "EDGE_IP_STATUS_DOC": str(doc),
+    }
+    rendered = _run(env)
+    if rendered.returncode != 0:
+        raise AssertionError(rendered.stderr)
+    doc.write_text(rendered.stdout, encoding="utf-8")
+    return env
+
+
+class EdgeIPStatusTests(unittest.TestCase):
+    def test_markdown_and_json_include_current_and_skip_retired(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _write_fixtures(Path(tmp))
+            md = _run(env)
+            self.assertEqual(md.returncode, 0)
+            self.assertIn("BEGIN edge-ip-status:current", md.stdout)
+            self.assertIn("BEGIN edge-ip-status:polluted", md.stdout)
+            self.assertIn("`us8`", md.stdout)
+            self.assertIn("`9.9.9.9`", md.stdout)
+            self.assertNotIn("`us9`", md.stdout)
+            self.assertIn("`8.8.8.8`", md.stdout)
+
+            payload = _run(env, "--json")
+            self.assertEqual(payload.returncode, 0)
+            data = json.loads(payload.stdout)
+            self.assertEqual(
+                data["current"],
+                [
+                    {
+                        "edge": "us8",
+                        "region": "us-west-2",
+                        "domain": "api-us8.tokenkey.dev",
+                        "static_ip_name": "live-static",
+                        "ipv4": "9.9.9.9",
+                    }
+                ],
+            )
+            self.assertEqual(data["polluted"][0]["ip"], "8.8.8.8")
+
+    def test_check_passes_when_doc_matches_and_fails_on_current_drift(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env = _write_fixtures(Path(tmp))
+            ok = _run(env, "--check")
+            self.assertEqual(ok.returncode, 0, ok.stderr)
+            self.assertIn("current table in sync", ok.stdout)
+            self.assertIn("polluted table in sync", ok.stdout)
+
+            doc = Path(env["EDGE_IP_STATUS_DOC"])
+            drifted = doc.read_text(encoding="utf-8").replace("9.9.9.9", "1.2.3.4")
+            doc.write_text(drifted, encoding="utf-8")
+            failed = _run(env, "--check")
+            self.assertEqual(failed.returncode, 1)
+            self.assertIn("current block in", failed.stderr)
+            self.assertIn("polluted table in sync", failed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/aws/stage0/test_record_polluted_ip.py
+++ b/deploy/aws/stage0/test_record_polluted_ip.py
@@ -1,4 +1,6 @@
 import json
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -79,6 +81,65 @@ class RecordPollutedIPTests(unittest.TestCase):
             excluded = self.mod.excluded_ips_for_region(data, "eu-west-2")
             self.assertIn("3.9.160.161", excluded)
             self.assertNotIn("3.9.160.161", self.mod.excluded_ips_for_region(data, "us-east-1"))
+
+    def test_is_excluded_cli_accepts_registry_before_or_after_command(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "edge-polluted-ips.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "polluted": [
+                            {"ip": "32.185.163.163", "region": "us-west-2", "notes": "x"}
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            before = subprocess.run(
+                [
+                    sys.executable,
+                    str(RECORD),
+                    "--registry",
+                    str(path),
+                    "is-excluded",
+                    "--ip",
+                    "32.185.163.163",
+                    "--region",
+                    "us-west-2",
+                ],
+                check=False,
+            )
+            after = subprocess.run(
+                [
+                    sys.executable,
+                    str(RECORD),
+                    "is-excluded",
+                    "--ip",
+                    "32.185.163.163",
+                    "--region",
+                    "us-west-2",
+                    "--registry",
+                    str(path),
+                ],
+                check=False,
+            )
+            miss = subprocess.run(
+                [
+                    sys.executable,
+                    str(RECORD),
+                    "is-excluded",
+                    "--ip",
+                    "1.2.3.4",
+                    "--region",
+                    "us-west-2",
+                    "--registry",
+                    str(path),
+                ],
+                check=False,
+            )
+            self.assertEqual(before.returncode, 0)
+            self.assertEqual(after.returncode, 0)
+            self.assertEqual(miss.returncode, 1)
 
 
 if __name__ == "__main__":

--- a/docs/deploy/tokenkey-edge-ip-history.md
+++ b/docs/deploy/tokenkey-edge-ip-history.md
@@ -6,7 +6,7 @@ retired egress addresses. Do not bind excluded addresses to any edge again.
 - **Live IPs:** [`deploy/aws/lightsail/edge-targets-lightsail.json`](../../deploy/aws/lightsail/edge-targets-lightsail.json) (`porkbun_a_ipv4` / `static_ip_name`)
 - **Exclusion registry:** [`deploy/aws/stage0/edge-polluted-ips.json`](../../deploy/aws/stage0/edge-polluted-ips.json)
 - **Enforcement:** [`deploy/aws/stage0/record-polluted-ip.py`](../../deploy/aws/stage0/record-polluted-ip.py) + [`ops/lightsail/rotate-static-ip.sh`](../../ops/lightsail/rotate-static-ip.sh)
-- **Regenerate tables:** `scripts/edge-ip-status.sh --markdown` (polluted) and `--check` (polluted + current)
+- **Regenerate tables:** `scripts/edge-ip-status.sh --markdown` (current + polluted); `--check` fails if either block drifted
 
 Rotation runbook: [`.cursor/skills/tokenkey-stage0-edge-lightsail-ip-rotation/SKILL.md`](../../.cursor/skills/tokenkey-stage0-edge-lightsail-ip-rotation/SKILL.md).
 
@@ -24,15 +24,6 @@ Prod talks to edges by hostname (`api-<id>.tokenkey.dev`). After an A-record cha
 | `us5` | us-west-2 | `api-us5.tokenkey.dev` | `vless-or-fresh-1-rot-20260828T115642Z` | `16.144.175.131` |
 | `us6` | us-east-2 | `api-us6.tokenkey.dev` | `StaticIp-oh-3-rot-20260828T121745Z` | `3.147.98.112` |
 <!-- END edge-ip-status:current -->
-
-Rotated 2026-08-28 (instances unchanged; old IPs released into the polluted table):
-
-| Edge | Previous IPv4 |
-| --- | --- |
-| us3 | `18.220.195.44` |
-| us4 | `35.81.204.18` |
-| us5 | `32.185.163.163` |
-| us6 | `3.148.79.145` |
 
 ## Polluted IPs (do not re-use)
 

--- a/docs/deploy/tokenkey-edge-ip-history.md
+++ b/docs/deploy/tokenkey-edge-ip-history.md
@@ -1,12 +1,38 @@
-# Edge egress IP exclusion registry
+# Edge egress IP registry
 
-Permanent list of **excluded** edge egress IPs (EC2 EIP and Lightsail Static IP). Do not bind these addresses to any edge again.
+Live Lightsail Static IPs and the permanent exclusion list of polluted /
+retired egress addresses. Do not bind excluded addresses to any edge again.
 
-- **Source of truth:** [`deploy/aws/stage0/edge-polluted-ips.json`](../../deploy/aws/stage0/edge-polluted-ips.json)
-- **Enforcement:** [`deploy/aws/stage0/record-polluted-ip.py`](../../deploy/aws/stage0/record-polluted-ip.py) + [`ops/lightsail/rotate-static-ip.sh`](../../ops/lightsail/rotate-static-ip.sh) (Lightsail Static IP rotation). The EC2 `rotate_egress_ip` path (`allocate-clean-egress-eip.py`) was removed 2026-06-07 when edges went Lightsail-only; legacy EC2 EIP rows are retained below as history.
-- **Regenerate table:** `scripts/edge-ip-status.sh --markdown` (paste polluted block below if it drifted)
+- **Live IPs:** [`deploy/aws/lightsail/edge-targets-lightsail.json`](../../deploy/aws/lightsail/edge-targets-lightsail.json) (`porkbun_a_ipv4` / `static_ip_name`)
+- **Exclusion registry:** [`deploy/aws/stage0/edge-polluted-ips.json`](../../deploy/aws/stage0/edge-polluted-ips.json)
+- **Enforcement:** [`deploy/aws/stage0/record-polluted-ip.py`](../../deploy/aws/stage0/record-polluted-ip.py) + [`ops/lightsail/rotate-static-ip.sh`](../../ops/lightsail/rotate-static-ip.sh)
+- **Regenerate tables:** `scripts/edge-ip-status.sh --markdown` (polluted) and `--check` (polluted + current)
 
-Active edge EIP rotation runbook: [`.cursor/skills/tokenkey-stage0-edge-ip-rotation/SKILL.md`](../../.cursor/skills/tokenkey-stage0-edge-ip-rotation/SKILL.md).
+Rotation runbook: [`.cursor/skills/tokenkey-stage0-edge-lightsail-ip-rotation/SKILL.md`](../../.cursor/skills/tokenkey-stage0-edge-lightsail-ip-rotation/SKILL.md).
+
+The EC2 `rotate_egress_ip` path was removed 2026-06-07 when edges went Lightsail-only; legacy EC2 EIP rows stay in the polluted table as history.
+
+Prod talks to edges by hostname (`api-<id>.tokenkey.dev`). After an A-record change, AWS VPC DNS (`10.0.0.2`) can keep the old IP until the Porkbun TTL expires; `/health` from a public resolver can be green while prod still times out.
+
+## Current live Static IPs
+
+<!-- BEGIN edge-ip-status:current (generated from deploy/aws/lightsail/edge-targets-lightsail.json) -->
+| Edge | Region | Domain | Static IP name | IPv4 |
+| --- | --- | --- | --- | --- |
+| `us3` | us-east-2 | `api-us3.tokenkey.dev` | `vless-oh-fresh-1-rot-20260828T122454Z` | `18.216.113.132` |
+| `us4` | us-west-2 | `api-us4.tokenkey.dev` | `Static-or-1-rot-20260828T122052Z` | `32.188.80.151` |
+| `us5` | us-west-2 | `api-us5.tokenkey.dev` | `vless-or-fresh-1-rot-20260828T115642Z` | `16.144.175.131` |
+| `us6` | us-east-2 | `api-us6.tokenkey.dev` | `StaticIp-oh-3-rot-20260828T121745Z` | `3.147.98.112` |
+<!-- END edge-ip-status:current -->
+
+Rotated 2026-08-28 (instances unchanged; old IPs released into the polluted table):
+
+| Edge | Previous IPv4 |
+| --- | --- |
+| us3 | `18.220.195.44` |
+| us4 | `35.81.204.18` |
+| us5 | `32.185.163.163` |
+| us6 | `3.148.79.145` |
 
 ## Polluted IPs (do not re-use)
 
@@ -23,4 +49,8 @@ Active edge EIP rotation runbook: [`.cursor/skills/tokenkey-stage0-edge-ip-rotat
 | `3.128.102.134` | us-east-2 | Lightsail edge-us3 Static-oh-1 upstream API risk-block (2026-06-16); swapped to vless-oh-fresh-1 / 18.220.195.44; old Static-oh-1 detached, exclude from re-allocation |
 | `44.224.133.40` | us-west-2 | Lightsail edge-us5 StaticIp-or-2 upstream API risk-block (2026-06-16); swapped to vless-or-fresh-1 / 32.185.163.163; old StaticIp-or-2 detached, exclude from re-allocation |
 | `13.134.80.182` | eu-west-2 | Lightsail edge-uk1 tokenkey-edge-uk1-ls-ip upstream API risk-block (2026-06-16); swapped to vless-uk-fresh-1 / 18.175.27.120; old static IP released, exclude from re-allocation |
+| `32.185.163.163` | us-west-2 | upstream-api-risk-block-2026-08-28; static_ip_name=vless-or-fresh-1; released via ops/lightsail/rotate-static-ip.sh |
+| `3.148.79.145` | us-east-2 | upstream-api-risk-block-2026-08-28; static_ip_name=StaticIp-oh-3; released via ops/lightsail/rotate-static-ip.sh |
+| `35.81.204.18` | us-west-2 | upstream-api-risk-block-2026-08-28; static_ip_name=Static-or-1; released via ops/lightsail/rotate-static-ip.sh |
+| `18.220.195.44` | us-east-2 | upstream-api-risk-block-2026-08-28; static_ip_name=vless-oh-fresh-1; released via ops/lightsail/rotate-static-ip.sh |
 <!-- END edge-ip-status:polluted -->

--- a/ops/anthropic/capture_cc_fingerprint.py
+++ b/ops/anthropic/capture_cc_fingerprint.py
@@ -1096,9 +1096,9 @@ def run_check_env(
     # Fallback only — the operator's ~/.config/cc0/env CC0_EXPECT_EGRESS_IP wins.
     # Current canonical cc0 SOCKS-chain egress (see docs/spec-delta/cc-2.1.16x.md).
     # 16.147.170.3 (retired EC2 us1 EIP) was decommissioned 2026-06-07; egress moved to
-    # edge-ls-us-oh-3 (StaticIp-oh-3). Its public IP rotated 52.15.35.197 → 3.148.79.145
-    # on 2026-06-08 (old IP was an ephemeral AWS re-adopted to *.coverahealth.com).
-    expect_ip = os.environ.get("CC0_EXPECT_EGRESS_IP", "3.148.79.145")
+    # edge-ls-us-oh-3. Public IP rotated 52.15.35.197 → 3.148.79.145 (2026-06-08) →
+    # 3.147.98.112 (2026-08-28, StaticIp-oh-3-rot-20260828T121745Z).
+    expect_ip = os.environ.get("CC0_EXPECT_EGRESS_IP", "3.147.98.112")
     try:
         socks_host, socks_port = _parse_host_port(socks, default_host="127.0.0.1")
     except ValueError as exc:

--- a/ops/lightsail/rotate-static-ip.sh
+++ b/ops/lightsail/rotate-static-ip.sh
@@ -92,7 +92,7 @@ fi
 
 is_excluded_ip() {
   local ip="$1" rc
-  python3 "$RECORD_PY" is-excluded --ip "$ip" --region "$region" --registry "$REGISTRY"
+  python3 "$RECORD_PY" --registry "$REGISTRY" is-excluded --ip "$ip" --region "$region"
   rc=$?
   case "$rc" in
     0) return 0 ;;
@@ -225,7 +225,7 @@ domain  : ${domain}
 registry: ${REGISTRY} (commit this file + run scripts/edge-ip-status.sh --check)
 
 NEXT (human):
-  - commit deploy/aws/stage0/edge-polluted-ips.json and sync docs/deploy/tokenkey-edge-ip-history.md
+  - update matrix static_ip_name + porkbun_a_ipv4; commit polluted-ips.json; run scripts/edge-ip-status.sh --check
   - Porkbun A record ${domain} -> ${new_ip}
   - external probe from a clean-egress host:
       curl -sS --resolve ${domain}:443:${new_ip} https://${domain}/health

--- a/scripts/edge-ip-status.sh
+++ b/scripts/edge-ip-status.sh
@@ -1,18 +1,21 @@
 #!/usr/bin/env bash
-# scripts/edge-ip-status.sh — Render polluted EIP exclusion table for docs.
+# scripts/edge-ip-status.sh — Render edge IP tables for docs.
 #
-# Source: deploy/aws/stage0/edge-polluted-ips.json
-# Target: docs/deploy/tokenkey-edge-ip-history.md (polluted block only)
+# Sources:
+#   deploy/aws/stage0/edge-polluted-ips.json
+#   deploy/aws/lightsail/edge-targets-lightsail.json (deployable current IPs)
+# Target: docs/deploy/tokenkey-edge-ip-history.md
 #
 # Usage:
 #   scripts/edge-ip-status.sh             # print polluted markdown block
 #   scripts/edge-ip-status.sh --json      # raw JSON
-#   scripts/edge-ip-status.sh --check     # exit non-zero if doc polluted block drifted
+#   scripts/edge-ip-status.sh --check     # exit non-zero if doc blocks drifted
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 POLLUTED="${REPO_ROOT}/deploy/aws/stage0/edge-polluted-ips.json"
+MATRIX="${REPO_ROOT}/deploy/aws/lightsail/edge-targets-lightsail.json"
 DOC="${REPO_ROOT}/docs/deploy/tokenkey-edge-ip-history.md"
 MODE="${1:---markdown}"
 
@@ -36,12 +39,48 @@ emit_polluted_block() {
   echo "<!-- END edge-ip-status:polluted -->"
 }
 
+emit_current_block() {
+  if [ ! -f "$MATRIX" ]; then
+    echo "missing $MATRIX" >&2
+    exit 1
+  fi
+  echo "<!-- BEGIN edge-ip-status:current (generated from deploy/aws/lightsail/edge-targets-lightsail.json) -->"
+  echo "| Edge | Region | Domain | Static IP name | IPv4 |"
+  echo "| --- | --- | --- | --- | --- |"
+  jq -r '
+    .targets
+    | to_entries
+    | sort_by(.key)[]
+    | select(.value.deployable == true)
+    | "| `\(.key)` | \(.value.lightsail_region) | `\(.value.domain)` | `\(.value.static_ip_name)` | `\(.value.porkbun_a_ipv4 // "")` |"
+  ' "$MATRIX"
+  echo "<!-- END edge-ip-status:current -->"
+}
+
 extract_block() {
-  awk '
-    index($0, "<!-- BEGIN edge-ip-status:polluted ") == 1 { inside = 1 }
+  local begin_prefix="$1"
+  local end_line="$2"
+  awk -v begin="$begin_prefix" -v end="$end_line" '
+    index($0, begin) == 1 { inside = 1 }
     inside { print }
-    index($0, "<!-- END edge-ip-status:polluted -->") == 1 { inside = 0 }
+    $0 == end { inside = 0 }
   ' "$DOC"
+}
+
+check_block() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ -z "$actual" ]; then
+    echo "edge-ip-status: ${name} block missing from $DOC" >&2
+    return 1
+  fi
+  if [ "$expected" != "$actual" ]; then
+    echo "edge-ip-status: ${name} block in $DOC drifted" >&2
+    diff <(printf '%s\n' "$expected") <(printf '%s\n' "$actual") >&2 || true
+    return 1
+  fi
+  echo "edge-ip-status: ${name} table in sync"
 }
 
 case "$MODE" in
@@ -56,19 +95,10 @@ case "$MODE" in
       echo "missing $DOC" >&2
       exit 1
     fi
-    expected=$(emit_polluted_block)
-    actual=$(extract_block)
-    if [ -z "$actual" ]; then
-      echo "edge-ip-status: polluted block missing from $DOC" >&2
-      exit 1
-    fi
-    if [ "$expected" = "$actual" ]; then
-      echo "edge-ip-status: polluted table in sync"
-      exit 0
-    fi
-    echo "edge-ip-status: polluted block in $DOC drifted" >&2
-    diff <(printf '%s\n' "$expected") <(printf '%s\n' "$actual") >&2 || true
-    exit 1
+    failed=0
+    check_block "polluted" "$(emit_polluted_block)" "$(extract_block '<!-- BEGIN edge-ip-status:polluted ' '<!-- END edge-ip-status:polluted -->')" || failed=1
+    check_block "current" "$(emit_current_block)" "$(extract_block '<!-- BEGIN edge-ip-status:current ' '<!-- END edge-ip-status:current -->')" || failed=1
+    exit "$failed"
     ;;
   *)
     echo "usage: $0 [--markdown|--json|--check]" >&2

--- a/scripts/edge-ip-status.sh
+++ b/scripts/edge-ip-status.sh
@@ -7,20 +7,24 @@
 # Target: docs/deploy/tokenkey-edge-ip-history.md
 #
 # Usage:
-#   scripts/edge-ip-status.sh             # print polluted markdown block
-#   scripts/edge-ip-status.sh --json      # raw JSON
+#   scripts/edge-ip-status.sh             # print current + polluted markdown blocks
+#   scripts/edge-ip-status.sh --json      # raw JSON (current + polluted)
 #   scripts/edge-ip-status.sh --check     # exit non-zero if doc blocks drifted
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-POLLUTED="${REPO_ROOT}/deploy/aws/stage0/edge-polluted-ips.json"
-MATRIX="${REPO_ROOT}/deploy/aws/lightsail/edge-targets-lightsail.json"
-DOC="${REPO_ROOT}/docs/deploy/tokenkey-edge-ip-history.md"
+POLLUTED="${EDGE_IP_STATUS_POLLUTED:-${REPO_ROOT}/deploy/aws/stage0/edge-polluted-ips.json}"
+MATRIX="${EDGE_IP_STATUS_MATRIX:-${REPO_ROOT}/deploy/aws/lightsail/edge-targets-lightsail.json}"
+DOC="${EDGE_IP_STATUS_DOC:-${REPO_ROOT}/docs/deploy/tokenkey-edge-ip-history.md}"
 MODE="${1:---markdown}"
 
 if [ ! -f "$POLLUTED" ]; then
   echo "missing $POLLUTED" >&2
+  exit 1
+fi
+if [ ! -f "$MATRIX" ]; then
+  echo "missing $MATRIX" >&2
   exit 1
 fi
 
@@ -40,10 +44,6 @@ emit_polluted_block() {
 }
 
 emit_current_block() {
-  if [ ! -f "$MATRIX" ]; then
-    echo "missing $MATRIX" >&2
-    exit 1
-  fi
   echo "<!-- BEGIN edge-ip-status:current (generated from deploy/aws/lightsail/edge-targets-lightsail.json) -->"
   echo "| Edge | Region | Domain | Static IP name | IPv4 |"
   echo "| --- | --- | --- | --- | --- |"
@@ -85,10 +85,14 @@ check_block() {
 
 case "$MODE" in
   --markdown)
+    emit_current_block
+    echo
     emit_polluted_block
     ;;
   --json)
-    jq -nc --argjson polluted "$polluted_json" '{polluted:$polluted}'
+    jq -nc --argjson polluted "$polluted_json" --argjson current "$(
+      jq '[.targets | to_entries | sort_by(.key)[] | select(.value.deployable == true) | {edge:.key, region:.value.lightsail_region, domain:.value.domain, static_ip_name:.value.static_ip_name, ipv4:(.value.porkbun_a_ipv4 // "")}]' "$MATRIX"
+    )" '{current:$current, polluted:$polluted}'
     ;;
   --check)
     if [ ! -f "$DOC" ]; then

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -2154,8 +2154,8 @@ else
 fi
 
 # ---- sub2api: edge-ip-status doc / live AWS drift ---------------------------
-# Source of truth: deploy/aws/stage0/edge-polluted-ips.json. The script's --check
-# mode reconciles docs/deploy/tokenkey-edge-ip-history.md polluted table only.
+# Source of truth: edge-polluted-ips.json + lightsail matrix porkbun_a_ipv4.
+# --check reconciles polluted and current tables in tokenkey-edge-ip-history.md.
 echo ""
 echo "=== sub2api: edge-ip-status doc / live AWS drift ==="
 if [ ! -x ./scripts/edge-ip-status.sh ]; then


### PR DESCRIPTION
## 摘要

2026-08-28 四台在线 Lightsail edge 已完成 Static IP 轮换（实例/库/账号/镜像未动）。本 PR 把仓库里的 matrix、污染 exclusion registry、历史文档、rotate 脚本和 cc0 默认出口校验对齐到现行线上真值。

现行出口：

- us3 / api-us3.tokenkey.dev → `18.216.113.132`（`vless-oh-fresh-1-rot-20260828T122454Z`）
- us4 / api-us4.tokenkey.dev → `32.188.80.151`（`Static-or-1-rot-20260828T122052Z`）
- us5 / api-us5.tokenkey.dev → `16.144.175.131`（`vless-or-fresh-1-rot-20260828T115642Z`）
- us6 / api-us6.tokenkey.dev → `3.147.98.112`（`StaticIp-oh-3-rot-20260828T121745Z`）

已释放且写入污染名单、禁止再分配：`18.220.195.44`、`35.81.204.18`、`32.185.163.163`、`3.148.79.145`。

顺带修了 `record-polluted-ip.py` 的 `--registry` 只能写在子命令前、rotate 中途会失败的问题。审查闭环里补了 `--markdown`/`--json` 同时产出 current 表、删掉不受检的手写旧 IP 表，以及 current 漂移负向测试。

## 风险

常规风险。无公共 API / Web 契约变化（`no-web-impact`）。错写现行 IP 或漏记污染名单会让后续轮换再次分到已被上游封的地址；`scripts/edge-ip-status.sh --check` 同时核 current 与 polluted。退役 uk1/us2/us7 未改。

轮换窗口内 prod 走 VPC DNS 时，Porkbun TTL 未掉会短暂解析旧 IP，表现为 `edge/accounts` `context deadline exceeded`；公网 DNS 已切、`/health` 绿不等于 prod 已切。文档和 skill 已写明这一点。

## 验证

- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh` → PASS
- `python3 -m unittest discover -s deploy/aws/stage0 -p 'test_*.py' -t deploy/aws/stage0` → OK（含 `test_edge_ip_status` / `test_record_polluted_ip`）
- `scripts/edge-ip-status.sh --check` → PASS
- 线上 smoke：
  - us5 https://github.com/youxuanxue/sub2api/actions/runs/33169762119
  - us6 https://github.com/youxuanxue/sub2api/actions/runs/33170589729
  - us4 https://github.com/youxuanxue/sub2api/actions/runs/33170787400
  - us3 https://github.com/youxuanxue/sub2api/actions/runs/33171604034
- prod 复核：四台 VPC DNS 均为新 IP，`/health` 200，accounts 无 key 返回 401（路径通）

## 提交

- `d77020ae5` chore(ops): 对齐 Lightsail edge 出口 IP 与污染名单
- `d46c7aebe` fix(ops): address R-001..R-003 — current 表可生成且有负向校验
- 最新提交：`d46c7aebe`