### PR TITLE
feat(ci): Go cache 内容寻址与 warm 五类写入

### DIFF
--- a/.github/actions/go-rolling-cache/action.yml
+++ b/.github/actions/go-rolling-cache/action.yml
@@ -1,58 +1,29 @@
-# Single source for the Go cache strategy shared by the heavy Go CI jobs
-# (test-unit / test-integration / golangci-lint). Replaces setup-go's built-in
-# cache, which is keyed only on hash(go.sum), IMMUTABLE (saved once on first
-# miss), and was shared across these jobs even though they build different
-# objects (-tags=unit vs =integration vs none) — whichever job won the post-job
-# save race poisoned the others, so the test-result cache effectively never
-# restored and every run cold-compiled + re-ran all packages.
+# Content-addressed Go cache for the five managed families.
+# Keys use schema / runner OS / exact go.mod version / family / dependency /
+# source fingerprints. Date, week, branch, and run ID are not key dimensions.
 #
-# Three caches, deliberately split:
-#   - module cache: identical across all jobs, only changes with go.sum, so one
-#     shared immutable entry is correct and avoids triplicating ~1GB of
-#     GOMODCACHE against the 10GB/repo budget.
-#   - build/test cache: caller-selected namespace (prefix) + UTC-week seed by
-#     default, avoiding repeated uploads of the 300MB-2.5GB preflight/lint
-#     archives. Unit keys main snapshots by backend content and falls back to its
-#     previous weekly namespace until the first content-keyed entry exists.
-#     Integration remains isolated because its build tags do not seed Unit's
-#     critical compile graph.
-#   - golangci analysis cache: optional, lint-only, and rolling for the same
-#     reason. golangci-lint-action's interval key is immutable after the first
-#     save, so changed-package analysis cannot be written back until the interval
-#     changes. Main owns the rolling writer for the default callers; PRs and
-#     callers with save_caches=false restore but never save.
+# Dual-write window: required main jobs may still save. The warm workflow is
+# the intended long-term writer and uses restore → build → save → prune.
 #
 # Set `cache: false` on the calling job's actions/setup-go step and call this
-# AFTER it (mirrors warm-release-cache in backend-ci.yml).
+# AFTER it.
 name: Go rolling build/test cache
-description: Shared module cache + per-job rolling Go build/test cache (replaces setup-go's immutable shared cache).
+description: Shared module cache + per-family content-addressed Go build cache.
 
 inputs:
-  prefix:
-    description: Cache namespace; callers may share one when Go flags and the intended writer are compatible.
+  family:
+    description: Managed build family (test, integration, analysis, or release).
     required: true
   fallback_prefix:
-    description: Optional secondary build-cache namespace used after the primary restore prefixes miss.
+    description: Optional legacy build-cache namespace used after the primary family key misses.
     required: false
     default: ""
-  golangci_cache:
-    description: Also roll ~/.cache/golangci-lint (enable only for the lint job).
-    required: false
-    default: "false"
-  refresh_on_backend_change:
-    description: Use the tracked backend input fingerprint instead of the weekly epoch.
-    required: false
-    default: "false"
-  refresh_daily:
-    description: Use a UTC-day cache epoch instead of the weekly epoch.
-    required: false
-    default: "false"
   build_cache_path:
     description: Go build/test cache path restored and optionally saved by this action.
     required: false
     default: ~/.cache/go-build
   save_caches:
-    description: Allow main pushes to save caches owned by this action; set false on required jobs whose tail must stay restore-only.
+    description: Allow main pushes to save caches owned by this action; set false on restore-only jobs.
     required: false
     default: "true"
   benchmark_build_cache_write:
@@ -72,65 +43,74 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Resolve weekly build cache epoch
-      id: cache_epoch
+    - name: Resolve exact Go version
+      id: go_version
       shell: bash
       run: |
-        echo "week=$(date -u +%G-W%V)" >> "$GITHUB_OUTPUT"
-        echo "day=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+        version="$(awk '/^go /{print $2; exit}' backend/go.mod)"
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
 
     - name: Restore Go module cache (non-main writer)
       if: github.event_name != 'push' || github.ref != 'refs/heads/main' || inputs.save_caches != 'true'
       uses: actions/cache/restore@v6
       with:
         path: ~/go/pkg/mod
-        key: ${{ runner.os }}-gomod-${{ hashFiles('backend/go.sum') }}
-        restore-keys: ${{ runner.os }}-gomod-
+        key: ${{ runner.os }}-gomod-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}
+        restore-keys: |
+          ${{ runner.os }}-gomod-v1-${{ steps.go_version.outputs.version }}-
+          ${{ runner.os }}-gomod-
 
     - name: Go module cache (main writer)
       if: github.event_name == 'push' && github.ref == 'refs/heads/main' && inputs.save_caches == 'true'
       uses: actions/cache@v6
       with:
         path: ~/go/pkg/mod
-        key: ${{ runner.os }}-gomod-${{ hashFiles('backend/go.sum') }}
-        restore-keys: ${{ runner.os }}-gomod-
+        key: ${{ runner.os }}-gomod-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}
+        restore-keys: |
+          ${{ runner.os }}-gomod-v1-${{ steps.go_version.outputs.version }}-
+          ${{ runner.os }}-gomod-
 
-    - name: Restore Go build/test cache (non-main writer, ${{ inputs.prefix }})
+    - name: Restore Go build cache (non-main writer)
       id: build_cache_restore
       if: (github.event_name != 'push' || github.ref != 'refs/heads/main' || inputs.save_caches != 'true') && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main' || inputs.benchmark_build_cache_write != 'true' || inputs.benchmark_prefix == '')
       uses: actions/cache/restore@v6
       with:
-        path: ${{ inputs.build_cache_path }}
-        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ inputs.refresh_on_backend_change == 'true' && hashFiles('backend/**', '.new-api-ref') || inputs.refresh_daily == 'true' && steps.cache_epoch.outputs.day || steps.cache_epoch.outputs.week }}
+        path: |
+          ${{ inputs.build_cache_path }}
+          ${{ inputs.family == 'analysis' && '~/.cache/golangci-lint' || inputs.build_cache_path }}
+        key: ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ hashFiles('backend/**/*.go', 'backend/.golangci.yml', '.goreleaser.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
-          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-
+          ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
+          ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-
+          ${{ runner.os }}-gobuild-${{ inputs.family }}-
           ${{ inputs.fallback_prefix != '' && format('{0}-gobuild-{1}-{2}-', runner.os, inputs.fallback_prefix, hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref')) || '' }}
           ${{ inputs.fallback_prefix != '' && format('{0}-gobuild-{1}-', runner.os, inputs.fallback_prefix) || '' }}
 
-    - name: Go build/test cache (workflow_dispatch benchmark writer, ${{ inputs.benchmark_prefix }})
+    - name: Go build cache (workflow_dispatch benchmark writer)
       id: build_cache_benchmark
       if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main' && inputs.benchmark_build_cache_write == 'true' && inputs.benchmark_prefix != ''
       uses: actions/cache@v6
       with:
         path: ${{ inputs.build_cache_path }}
-        key: ${{ runner.os }}-gobuild-${{ inputs.benchmark_prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ inputs.refresh_on_backend_change == 'true' && hashFiles('backend/**', '.new-api-ref') || inputs.refresh_daily == 'true' && steps.cache_epoch.outputs.day || steps.cache_epoch.outputs.week }}
+        key: ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-bench-${{ inputs.benchmark_prefix }}-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ hashFiles('backend/**/*.go', 'backend/.golangci.yml', '.goreleaser.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-gobuild-${{ inputs.benchmark_prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
-          ${{ runner.os }}-gobuild-${{ inputs.benchmark_prefix }}-
-          ${{ inputs.fallback_prefix != '' && format('{0}-gobuild-{1}-{2}-', runner.os, inputs.fallback_prefix, hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref')) || '' }}
+          ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
+          ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-
           ${{ inputs.fallback_prefix != '' && format('{0}-gobuild-{1}-', runner.os, inputs.fallback_prefix) || '' }}
 
-    - name: Go build/test cache (main writer, ${{ inputs.prefix }})
+    - name: Go build cache (main writer)
       id: build_cache_main
       if: github.event_name == 'push' && github.ref == 'refs/heads/main' && inputs.save_caches == 'true'
       uses: actions/cache@v6
       with:
-        path: ${{ inputs.build_cache_path }}
-        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ inputs.refresh_on_backend_change == 'true' && hashFiles('backend/**', '.new-api-ref') || inputs.refresh_daily == 'true' && steps.cache_epoch.outputs.day || steps.cache_epoch.outputs.week }}
+        path: |
+          ${{ inputs.build_cache_path }}
+          ${{ inputs.family == 'analysis' && '~/.cache/golangci-lint' || inputs.build_cache_path }}
+        key: ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ hashFiles('backend/**/*.go', 'backend/.golangci.yml', '.goreleaser.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
-          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-
+          ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
+          ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-
+          ${{ runner.os }}-gobuild-${{ inputs.family }}-
           ${{ inputs.fallback_prefix != '' && format('{0}-gobuild-{1}-{2}-', runner.os, inputs.fallback_prefix, hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref')) || '' }}
           ${{ inputs.fallback_prefix != '' && format('{0}-gobuild-{1}-', runner.os, inputs.fallback_prefix) || '' }}
 
@@ -147,23 +127,3 @@ runs:
         else
           echo "build_cache_hit=false" >> "$GITHUB_OUTPUT"
         fi
-
-    - name: Restore golangci-lint analysis cache (non-main writer)
-      if: inputs.golangci_cache == 'true' && (github.event_name != 'push' || github.ref != 'refs/heads/main' || inputs.save_caches != 'true')
-      uses: actions/cache/restore@v6
-      with:
-        path: ~/.cache/golangci-lint
-        key: ${{ runner.os }}-golangci-${{ hashFiles('backend/go.sum', 'backend/.golangci.yml') }}-${{ github.run_id }}
-        restore-keys: |
-          ${{ runner.os }}-golangci-${{ hashFiles('backend/go.sum', 'backend/.golangci.yml') }}-
-          ${{ runner.os }}-golangci-
-
-    - name: golangci-lint analysis cache (rolling main writer)
-      if: inputs.golangci_cache == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' && inputs.save_caches == 'true'
-      uses: actions/cache@v6
-      with:
-        path: ~/.cache/golangci-lint
-        key: ${{ runner.os }}-golangci-${{ hashFiles('backend/go.sum', 'backend/.golangci.yml') }}-${{ github.run_id }}
-        restore-keys: |
-          ${{ runner.os }}-golangci-${{ hashFiles('backend/go.sum', 'backend/.golangci.yml') }}-
-          ${{ runner.os }}-golangci-

--- a/.github/workflows/anthropic-cc-issue-watchdog.yml
+++ b/.github/workflows/anthropic-cc-issue-watchdog.yml
@@ -430,7 +430,7 @@ jobs:
         with:
           go-version-file: backend/go.mod
           check-latest: false
-          cache: true
+          cache: false
           cache-dependency-path: backend/go.sum
 
       - name: Setup pnpm

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -96,7 +96,7 @@ jobs:
     env:
       # Preflight only executes generators, contracts, and tests; failure stacks
       # retain file:line data without storing DWARF in the rolling Go cache.
-      GOFLAGS: -gcflags=all=-dwarf=false
+      GOFLAGS: -trimpath -gcflags=all=-dwarf=false
     steps:
       - name: Require changed-surface classification
         if: needs.changes.result != 'success'
@@ -113,6 +113,8 @@ jobs:
             scripts.checks.test_docker_action_runtime \
             scripts.checks.test_release_cache_key_parity \
             scripts.checks.test_go_rolling_cache_policy \
+            scripts.checks.test_go_cache_boundary_contract \
+            scripts.ci.test_go_cache_prune \
             scripts.checks.test_model_surface_bundle_check \
             scripts.test_preflight_ci_handoffs \
             scripts.test_preflight_background_output \
@@ -136,7 +138,8 @@ jobs:
       - uses: ./.github/actions/go-rolling-cache
         if: needs.changes.outputs.preflight_go == 'true'
         with:
-          prefix: preflight-nodwarf-v1
+          family: test
+          fallback_prefix: preflight-nodwarf-v1
       - name: Unit runner contract tests
         if: needs.changes.outputs.preflight_go == 'true'
         run: python3 -m unittest scripts.ci.test_unit_test_runner
@@ -222,7 +225,7 @@ jobs:
       # Test failures retain file:line stacks without DWARF. Apply the flag to
       # every Go command in this job; main retains Unit build objects for each
       # distinct backend tree so same-day merges cannot pin a stale snapshot.
-      GOFLAGS: -gcflags=all=-dwarf=false
+      GOFLAGS: -trimpath -gcflags=all=-dwarf=false
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/cache-and-checkout-new-api
@@ -243,9 +246,8 @@ jobs:
           # snapshot, compile the delta, and persist the refreshed objects.
           # Manual A/B runs use an isolated namespace; ordinary PR runs remain
           # restore-only by action policy.
-          prefix: unit-nodwarf-v3
-          fallback_prefix: unit-nodwarf-v1
-          refresh_on_backend_change: "true"
+          family: test
+          fallback_prefix: unit-nodwarf-v3
           save_caches: "true"
           benchmark_prefix: unit-nodwarf-v5-other-first-bench
           benchmark_build_cache_write: ${{ github.event_name == 'workflow_dispatch' && inputs.suite == 'unit-cache-benchmark' && 'true' || 'false' }}
@@ -276,7 +278,7 @@ jobs:
     env:
       # Integration failures retain file:line stacks without DWARF while the
       # package/test cache stays materially smaller to restore and refresh.
-      GOFLAGS: -gcflags=all=-dwarf=false
+      GOFLAGS: -trimpath -gcflags=all=-dwarf=false
       GOCACHE: ${{ github.workspace }}/.cache/go-build-integration
     steps:
       - uses: actions/checkout@v6
@@ -291,8 +293,8 @@ jobs:
         with:
           # Required CI restores the daily cache but never waits for its upload.
           # warm-release-cache-main.yml owns the single non-blocking writer.
-          prefix: integration-nodwarf-v2
-          refresh_daily: "true"
+          family: integration
+          fallback_prefix: integration-nodwarf-v2
           build_cache_path: ${{ github.workspace }}/.cache/go-build-integration
           save_caches: "false"
       - name: Verify Go version
@@ -352,7 +354,7 @@ jobs:
     env:
       # golangci-lint consumes export/type data, not DWARF. Omitting it targets
       # the measured 2.25GB lint build cache and its 41s restore bottleneck.
-      GOFLAGS: -gcflags=all=-dwarf=false
+      GOFLAGS: -trimpath -gcflags=all=-dwarf=false
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/cache-and-checkout-new-api
@@ -367,8 +369,8 @@ jobs:
           cache: false
       - uses: ./.github/actions/go-rolling-cache
         with:
-          prefix: lint-nodwarf-v1
-          golangci_cache: "true"
+          family: analysis
+          fallback_prefix: lint-nodwarf-v1
       - name: Verify Go version
         run: |
           expected=$(awk '/^go /{print $2; exit}' backend/go.mod)
@@ -392,7 +394,7 @@ jobs:
     env:
       # Source vulnerability analysis uses Go export/type data, not DWARF.
       # Avoid generating debug sections for the analyzer's transient builds.
-      GOFLAGS: -gcflags=all=-dwarf=false
+      GOFLAGS: -trimpath -gcflags=all=-dwarf=false
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/cache-and-checkout-new-api
@@ -404,7 +406,8 @@ jobs:
           cache: false
       - uses: ./.github/actions/go-rolling-cache
         with:
-          prefix: security-nodwarf-v1
+          family: analysis
+          fallback_prefix: security-nodwarf-v1
       - name: Verify Go version
         run: |
           expected=$(awk '/^go /{print $2; exit}' backend/go.mod)
@@ -472,7 +475,7 @@ jobs:
         with:
           go-version-file: backend/go.mod
           check-latest: false
-          cache: true
+          cache: false
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
@@ -496,7 +499,7 @@ jobs:
         with:
           go-version-file: backend/go.mod
           check-latest: false
-          cache: true
+          cache: false
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -406,8 +406,12 @@ jobs:
           cache: false
       - uses: ./.github/actions/go-rolling-cache
         with:
+          # Restore-only: this job shares the analysis family with lint but
+          # does not populate ~/.cache/golangci-lint on push/PR. A main save
+          # would exact-hit and lock lint into an empty golangci cache.
           family: analysis
           fallback_prefix: security-nodwarf-v1
+          save_caches: "false"
       - name: Verify Go version
         run: |
           expected=$(awk '/^go /{print $2; exit}' backend/go.mod)

--- a/.github/workflows/client-fidelity-watch.yml
+++ b/.github/workflows/client-fidelity-watch.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           go-version-file: backend/go.mod
           check-latest: false
-          cache: true
+          cache: false
           cache-dependency-path: backend/go.sum
 
       - name: Registry + fixture gateway gate

--- a/.github/workflows/ops-repair-draft.yml
+++ b/.github/workflows/ops-repair-draft.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           go-version-file: backend/go.mod
           check-latest: false
-          cache: true
+          cache: false
           cache-dependency-path: backend/go.sum
 
       - name: Setup pnpm

--- a/.github/workflows/pr-repair-agent.yml
+++ b/.github/workflows/pr-repair-agent.yml
@@ -194,7 +194,7 @@ jobs:
         with:
           go-version-file: backend/go.mod
           check-latest: false
-          cache: true
+          cache: false
           cache-dependency-path: backend/go.sum
 
       - name: Setup pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,15 +172,24 @@ jobs:
       # dead tag-scoped caches. Go's cache is content-addressed, so a slightly
       # stale entry (e.g. after a .new-api-ref bump) is simply unused, never
       # wrong — release recompiles only changed packages + relinks.
+      - name: Resolve exact Go version
+        id: go_version
+        run: echo "version=$(awk '/^go /{print $2; exit}' backend/go.mod)" >> "$GITHUB_OUTPUT"
+      - name: Restore Go module cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}
+          restore-keys: |
+            ${{ runner.os }}-gomod-v1-${{ steps.go_version.outputs.version }}-
+            ${{ runner.os }}-gomod-
       - name: Restore cross-arch Go build cache (warmed on main)
         uses: actions/cache/restore@v6
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-release-${{ hashFiles('backend/go.sum') }}
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-release-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ hashFiles('backend/**/*.go', 'backend/.golangci.yml', '.goreleaser.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-go-release-${{ hashFiles('backend/go.sum') }}-
+            ${{ runner.os }}-go-release-v1-${{ steps.go_version.outputs.version }}-
             ${{ runner.os }}-go-release-
 
       - name: Verify Go version

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           go-version-file: backend/go.mod
           check-latest: false
+          cache: false
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |

--- a/.github/workflows/upstream-issue-watchdog.yml
+++ b/.github/workflows/upstream-issue-watchdog.yml
@@ -397,7 +397,7 @@ jobs:
         with:
           go-version-file: backend/go.mod
           check-latest: false
-          cache: true
+          cache: false
           cache-dependency-path: backend/go.sum
 
       - name: Setup pnpm

--- a/.github/workflows/upstream-merge-pr-shape.yml
+++ b/.github/workflows/upstream-merge-pr-shape.yml
@@ -110,6 +110,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod
+          cache: false
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/warm-release-cache-main.yml
+++ b/.github/workflows/warm-release-cache-main.yml
@@ -138,6 +138,15 @@ jobs:
         if: steps.analysis_cache.outputs.cache-hit != 'true'
         working-directory: backend
         run: go test -run=^$ ./...
+      - name: Warm golangci-lint cache
+        if: steps.analysis_cache.outputs.cache-hit != 'true'
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.9
+          args: --concurrency=4 --timeout=30m
+          working-directory: backend
+          only-new-issues: false
+          skip-cache: "true"
       - name: Save analysis build cache
         if: steps.analysis_cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6

--- a/.github/workflows/warm-release-cache-main.yml
+++ b/.github/workflows/warm-release-cache-main.yml
@@ -1,9 +1,7 @@
 name: Warm Release Cache
 
-# Release tags can restore caches from the default branch, but not from older
-# tag refs. Keep the cross-arch release cache and the daily integration build
-# cache warm on main only when backend build inputs change. This is acceleration
-# work, not a required CI correctness gate.
+# Default-branch writer for the five managed Go cache families. Required CI
+# stays correct on a miss. This workflow is acceleration, not a required gate.
 on:
   push:
     branches: [main]
@@ -11,17 +9,24 @@ on:
       - 'backend/**/*.go'
       - 'backend/go.mod'
       - 'backend/go.sum'
+      - 'backend/.golangci.yml'
       - '.new-api-ref'
       - '.goreleaser.yaml'
       - '.github/workflows/warm-release-cache-main.yml'
+      - '.github/actions/go-rolling-cache/action.yml'
+      - 'scripts/ci/go_cache_prune.py'
   workflow_dispatch:
 
 permissions:
   contents: read
+  actions: write
 
 concurrency:
   group: warm-release-cache-main
   cancel-in-progress: true
+
+env:
+  GOFLAGS: -trimpath -gcflags=all=-dwarf=false
 
 jobs:
   warm-release-cache:
@@ -35,49 +40,71 @@ jobs:
           go-version-file: backend/go.mod
           check-latest: false
           cache: false
-      - name: Rolling Go build cache (amd64 + arm64 cross-compile)
-        uses: actions/cache@v6
+      - name: Resolve exact Go version
+        id: go_version
+        run: |
+          version="$(awk '/^go /{print $2; exit}' backend/go.mod)"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          go version | grep -Fq "go${version}"
+
+      - name: Restore Go module cache
+        id: gomod_cache
+        uses: actions/cache/restore@v6
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-release-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}
           restore-keys: |
-            ${{ runner.os }}-go-release-${{ hashFiles('backend/go.sum') }}-
-            ${{ runner.os }}-go-release-
-      - name: Verify Go version
-        run: |
-          expected=$(awk '/^go /{print $2; exit}' backend/go.mod)
-          go version | grep -Fq "go${expected}"
-      - name: Warm cross-arch Go build cache
+            ${{ runner.os }}-gomod-v1-${{ steps.go_version.outputs.version }}-
+            ${{ runner.os }}-gomod-
+      - name: Download modules
+        if: steps.gomod_cache.outputs.cache-hit != 'true'
         working-directory: backend
-        env:
-          CGO_ENABLED: '0'
-          GOOS: linux
-        run: |
-          for arch in amd64 arm64; do
-            echo "::group::go build linux/${arch}"
-            GOARCH="${arch}" go build -o /dev/null ./cmd/server
-            echo "::endgroup::"
-          done
-      - name: Resolve daily integration cache epoch
-        id: integration_epoch
-        run: echo "day=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
-      - name: Daily integration build cache
+        run: go mod download
+      - name: Save Go module cache
+        if: steps.gomod_cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}
+
+      - name: Restore test build cache
+        id: test_cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-gobuild-test-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ hashFiles('backend/**/*.go', 'backend/.golangci.yml', '.goreleaser.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-gobuild-test-v1-${{ steps.go_version.outputs.version }}-
+            ${{ runner.os }}-gobuild-test-
+            ${{ runner.os }}-gobuild-unit-nodwarf-v3-
+      - name: Warm test build cache
+        if: steps.test_cache.outputs.cache-hit != 'true'
+        working-directory: backend
+        run: go test -tags=unit -run=^$ ./...
+      - name: Save test build cache
+        if: steps.test_cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-gobuild-test-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ hashFiles('backend/**/*.go', 'backend/.golangci.yml', '.goreleaser.yaml') }}
+      - name: Isolate default GOCACHE before the next family
+        run: rm -rf ~/.cache/go-build
+
+      - name: Restore integration build cache
         id: integration_cache
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: ${{ github.workspace }}/.cache/go-build-integration
-          key: ${{ runner.os }}-gobuild-integration-nodwarf-v2-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ steps.integration_epoch.outputs.day }}
+          key: ${{ runner.os }}-gobuild-integration-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ hashFiles('backend/**/*.go', 'backend/.golangci.yml', '.goreleaser.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-gobuild-integration-nodwarf-v2-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
+            ${{ runner.os }}-gobuild-integration-v1-${{ steps.go_version.outputs.version }}-
+            ${{ runner.os }}-gobuild-integration-
             ${{ runner.os }}-gobuild-integration-nodwarf-v2-
       - name: Warm integration build cache
         if: steps.integration_cache.outputs.cache-hit != 'true'
         working-directory: backend
         env:
           GOCACHE: ${{ github.workspace }}/.cache/go-build-integration
-          GOFLAGS: -gcflags=all=-dwarf=false
         run: |
           set -euo pipefail
           integration_packages=()
@@ -88,3 +115,69 @@ jobs:
           go test -c -tags=integration \
             -o "${RUNNER_TEMP}/integration-cache/" \
             "${integration_packages[@]}"
+      - name: Save integration build cache
+        if: steps.integration_cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/.cache/go-build-integration
+          key: ${{ runner.os }}-gobuild-integration-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ hashFiles('backend/**/*.go', 'backend/.golangci.yml', '.goreleaser.yaml') }}
+
+      - name: Restore analysis build cache
+        id: analysis_cache
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/.cache/golangci-lint
+          key: ${{ runner.os }}-gobuild-analysis-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ hashFiles('backend/**/*.go', 'backend/.golangci.yml', '.goreleaser.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-gobuild-analysis-v1-${{ steps.go_version.outputs.version }}-
+            ${{ runner.os }}-gobuild-analysis-
+            ${{ runner.os }}-gobuild-lint-nodwarf-v1-
+      - name: Warm analysis build cache
+        if: steps.analysis_cache.outputs.cache-hit != 'true'
+        working-directory: backend
+        run: go test -run=^$ ./...
+      - name: Save analysis build cache
+        if: steps.analysis_cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/.cache/golangci-lint
+          key: ${{ runner.os }}-gobuild-analysis-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ hashFiles('backend/**/*.go', 'backend/.golangci.yml', '.goreleaser.yaml') }}
+      - name: Isolate default GOCACHE before the release family
+        run: rm -rf ~/.cache/go-build
+
+      - name: Restore release build cache
+        id: release_cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-release-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ hashFiles('backend/**/*.go', 'backend/.golangci.yml', '.goreleaser.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-go-release-v1-${{ steps.go_version.outputs.version }}-
+            ${{ runner.os }}-go-release-
+      - name: Warm cross-arch Go build cache
+        if: steps.release_cache.outputs.cache-hit != 'true'
+        working-directory: backend
+        env:
+          CGO_ENABLED: '0'
+          GOOS: linux
+        run: |
+          for arch in amd64 arm64; do
+            echo "::group::go build linux/${arch}"
+            GOARCH="${arch}" go build -o /dev/null ./cmd/server
+            echo "::endgroup::"
+          done
+      - name: Save release build cache
+        if: steps.release_cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-release-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ hashFiles('backend/**/*.go', 'backend/.golangci.yml', '.goreleaser.yaml') }}
+
+      - name: Check managed Go cache budget
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/ci/go_cache_prune.py --check

--- a/.github/workflows/warm-release-cache-main.yml
+++ b/.github/workflows/warm-release-cache-main.yml
@@ -25,9 +25,6 @@ concurrency:
   group: warm-release-cache-main
   cancel-in-progress: true
 
-env:
-  GOFLAGS: -trimpath -gcflags=all=-dwarf=false
-
 jobs:
   warm-release-cache:
     if: github.ref == 'refs/heads/main'
@@ -80,6 +77,8 @@ jobs:
       - name: Warm test build cache
         if: steps.test_cache.outputs.cache-hit != 'true'
         working-directory: backend
+        env:
+          GOFLAGS: -trimpath -gcflags=all=-dwarf=false
         run: go test -tags=unit -run=^$ ./...
       - name: Save test build cache
         if: steps.test_cache.outputs.cache-hit != 'true'
@@ -105,6 +104,7 @@ jobs:
         working-directory: backend
         env:
           GOCACHE: ${{ github.workspace }}/.cache/go-build-integration
+          GOFLAGS: -trimpath -gcflags=all=-dwarf=false
         run: |
           set -euo pipefail
           integration_packages=()
@@ -137,10 +137,14 @@ jobs:
       - name: Warm analysis build cache
         if: steps.analysis_cache.outputs.cache-hit != 'true'
         working-directory: backend
+        env:
+          GOFLAGS: -trimpath -gcflags=all=-dwarf=false
         run: go test -run=^$ ./...
       - name: Warm golangci-lint cache
         if: steps.analysis_cache.outputs.cache-hit != 'true'
         uses: golangci/golangci-lint-action@v9
+        env:
+          GOFLAGS: -trimpath -gcflags=all=-dwarf=false
         with:
           version: v2.9
           args: --concurrency=4 --timeout=30m
@@ -173,10 +177,12 @@ jobs:
         env:
           CGO_ENABLED: '0'
           GOOS: linux
+          GOFLAGS: -trimpath
         run: |
           for arch in amd64 arm64; do
-            echo "::group::go build linux/${arch}"
-            GOARCH="${arch}" go build -o /dev/null ./cmd/server
+            echo "::group::go build release linux/${arch}"
+            GOARCH="${arch}" go build -tags=embed -o /dev/null ./cmd/server
+            GOARCH="${arch}" go build -o /dev/null ./cmd/qa-archive
             echo "::endgroup::"
           done
       - name: Save release build cache

--- a/backend/internal/repository/partitionmaintenance_coverage_integration_test.go
+++ b/backend/internal/repository/partitionmaintenance_coverage_integration_test.go
@@ -7,8 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -40,9 +38,8 @@ type partitionProbeStats struct {
 }
 
 func TestDataLayerSafetyProbePartitionCoverage(t *testing.T) {
-	_, filename, _, ok := runtime.Caller(0)
-	require.True(t, ok)
-	queryPath := filepath.Join(filepath.Dir(filename), "../../../ops/observability/data-layer-partition-coverage.sql")
+	queryPath, err := findFromWorkingDir("ops/observability/data-layer-partition-coverage.sql")
+	require.NoError(t, err)
 	query, err := os.ReadFile(queryPath)
 	require.NoError(t, err)
 

--- a/backend/internal/repository/repo_file.go
+++ b/backend/internal/repository/repo_file.go
@@ -1,0 +1,26 @@
+package repository
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func findFromWorkingDir(rel string) (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	dir := wd
+	for {
+		candidate := filepath.Join(dir, rel)
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("%s not found from %s", rel, wd)
+		}
+		dir = parent
+	}
+}

--- a/backend/internal/repository/repo_file_test.go
+++ b/backend/internal/repository/repo_file_test.go
@@ -1,0 +1,23 @@
+package repository
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindFromWorkingDir_LocatesOpsSQLWithoutCallerPath(t *testing.T) {
+	// Boundary: -trimpath makes runtime.Caller return a module path, not a
+	// filesystem path. Repo-owned files must be found from the working directory.
+	trimmedCaller := "github.com/Wei-Shaw/sub2api/internal/repository/partitionmaintenance_coverage_integration_test.go"
+	require.NoFileExists(t, filepath.Join(filepath.Dir(trimmedCaller), "../../../ops/observability/data-layer-partition-coverage.sql"))
+
+	path, err := findFromWorkingDir("ops/observability/data-layer-partition-coverage.sql")
+	require.NoError(t, err)
+	st, err := os.Stat(path)
+	require.NoError(t, err)
+	require.False(t, st.IsDir())
+	require.Greater(t, st.Size(), int64(0))
+}

--- a/scripts/checks/release-cache-key-parity.py
+++ b/scripts/checks/release-cache-key-parity.py
@@ -1,30 +1,5 @@
 #!/usr/bin/env python3
-"""Guard the cross-arch Go build-cache contract between two workflows.
-
-The release speed-up landed in PR #576 splits one cache across two workflow
-files that MUST agree, or the optimization silently reverts (release goes back
-to cold-compiling arm64 ~4m every time, with NO error — exactly the failure
-mode that went unnoticed for weeks before #576):
-
-  * .github/workflows/warm-release-cache-main.yml — `warm-release-cache` SAVES
-    the cache on `main` (the default branch) with `actions/cache@v6`.
-  * .github/workflows/release.yml     — RESTORES it on the tag ref with
-    `actions/cache/restore@v6` (restore-only; saving here would re-create the
-    dead tag-scoped caches #576 removed).
-
-The two invariants that, if broken, silently kill the speed-up:
-
-  1. KEY PREFIX PARITY — both files key on the identical prefix
-     `<runner.os>-go-release-<hashFiles(backend/go.sum)>`. Rename it in one file
-     only and release's restore-keys never match the warm cache again.
-  2. DIRECTIONALITY — backend-ci's go-release step uses the SAVING action
-     (`actions/cache@v6`); release's uses the RESTORE-ONLY action
-     (`actions/cache/restore@v6`). Re-adding a saver to release.yml resurrects
-     the per-tag-ref dead caches.
-
-Same doctrine as scripts/checks/merge-gate-parity.py: a soft "keep these two in
-sync" rule, hardened into a mechanical gate (global CLAUDE.md §5).
-"""
+"""Guard the release Go cache contract between warm and tag restore."""
 
 from __future__ import annotations
 
@@ -33,18 +8,10 @@ import pathlib
 import sys
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
-
 WARM_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "warm-release-cache-main.yml"
 RELEASE = REPO_ROOT / ".github" / "workflows" / "release.yml"
-
-# The shared cache-key prefix both files must agree on, verbatim (GitHub
-# expression syntax included — it is part of the literal key string).
-SHARED_KEY_PREFIX = "${{ runner.os }}-go-release-${{ hashFiles('backend/go.sum') }}"
-
-# Marker substring that identifies a go-release cache key line in either file.
-KEY_MARKER = "go-release"
-
-SAVE_ACTION = "actions/cache@v6"
+SHARED_KEY_PREFIX = "${{ runner.os }}-go-release-v1-"
+SAVE_ACTION = "actions/cache/save@v6"
 RESTORE_ACTION = "actions/cache/restore@v6"
 
 
@@ -53,87 +20,54 @@ def _fail(quiet: bool, msg: str) -> None:
         sys.stderr.write(f"  FAIL: {msg}\n")
 
 
-def _action_for_first_key(lines: list[str]) -> str | None:
-    """Return the `uses:` action backing the FIRST go-release cache step.
-
-    Scans upward from the first NON-COMMENT line mentioning the key marker to the
-    nearest `uses:` line — that step's action is the one operating on the cache.
-    Comment lines are skipped because the rationale blocks in both workflows
-    reference `Linux-go-release-...` in prose, which would otherwise be matched
-    before the real `key:` line.
-    """
-    key_idx = next(
-        (i for i, ln in enumerate(lines)
-         if KEY_MARKER in ln and not ln.lstrip().startswith("#")),
-        None,
-    )
-    if key_idx is None:
-        return None
-    for i in range(key_idx, -1, -1):
-        stripped = lines[i].strip()
+def _actions_for_marker(text: str, marker: str) -> list[str]:
+    actions: list[str] = []
+    lines = text.splitlines()
+    current_uses = ""
+    for line in lines:
+        stripped = line.strip()
         if stripped.startswith("uses:") or stripped.startswith("- uses:"):
-            return stripped.split("uses:", 1)[1].strip()
-    return None
+            current_uses = stripped.split("uses:", 1)[1].strip()
+        if marker in line and not stripped.startswith("#") and current_uses:
+            actions.append(current_uses)
+    return actions
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--quiet", action="store_true", help="suppress non-error output")
+    parser.add_argument("--quiet", action="store_true")
     args = parser.parse_args()
-
     errors = 0
-
-    for path in (WARM_WORKFLOW, RELEASE):
-        if not path.exists():
-            _fail(args.quiet, f"{path.relative_to(REPO_ROOT)} not found")
-            errors += 1
-
-    if errors:
-        return 1
 
     ci_text = WARM_WORKFLOW.read_text()
     rel_text = RELEASE.read_text()
-
-    # Invariant 1: shared key prefix present in BOTH files.
     if SHARED_KEY_PREFIX not in ci_text:
-        _fail(
-            args.quiet,
-            f"warm-release-cache-main.yml missing the shared cache-key prefix '{SHARED_KEY_PREFIX}'. "
-            "The warm-release-cache job must key on it so release.yml can restore the entry.",
-        )
+        _fail(args.quiet, f"warm-release-cache-main.yml missing '{SHARED_KEY_PREFIX}'")
         errors += 1
     if SHARED_KEY_PREFIX not in rel_text:
-        _fail(
-            args.quiet,
-            f"release.yml missing the shared cache-key prefix '{SHARED_KEY_PREFIX}'. "
-            "Its restore-keys must match the prefix the warm-release-cache job saves under, "
-            "or release silently cold-compiles arm64 again.",
-        )
+        _fail(args.quiet, f"release.yml missing '{SHARED_KEY_PREFIX}'")
         errors += 1
 
-    # Invariant 2: directionality — backend-ci SAVES, release RESTORE-ONLY.
-    ci_action = _action_for_first_key(ci_text.splitlines())
-    rel_action = _action_for_first_key(rel_text.splitlines())
-
-    if ci_action != SAVE_ACTION:
+    warm_actions = _actions_for_marker(ci_text, "go-release-v1")
+    release_actions = _actions_for_marker(rel_text, "go-release-v1")
+    if SAVE_ACTION not in warm_actions or RESTORE_ACTION not in warm_actions:
         _fail(
             args.quiet,
-            f"warm-release-cache-main.yml go-release cache step must use '{SAVE_ACTION}' (it SAVES the warm "
-            f"cache on main); found '{ci_action}'.",
+            f"warm workflow must restore then save release cache; found {warm_actions}",
         )
         errors += 1
-    if rel_action != RESTORE_ACTION:
+    if release_actions != [RESTORE_ACTION] and set(release_actions) != {RESTORE_ACTION}:
         _fail(
             args.quiet,
-            f"release.yml go-release cache step must use '{RESTORE_ACTION}' (restore-only); found "
-            f"'{rel_action}'. A saving '{SAVE_ACTION}' here resurrects the dead per-tag-ref caches "
-            "PR #576 removed — release saves on the tag ref, which no later tag can read.",
+            f"release.yml must restore-only the release cache; found {release_actions}",
         )
+        errors += 1
+    if "github.run_id" in ci_text or "github.run_id" in rel_text:
+        _fail(args.quiet, "release cache keys must not include github.run_id")
         errors += 1
 
     if errors:
         return 1
-
     if not args.quiet:
         print("  ok: release/warm cache key prefix + directionality in sync")
     return 0

--- a/scripts/checks/test_go_cache_boundary_contract.py
+++ b/scripts/checks/test_go_cache_boundary_contract.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Mechanical gates for the Go cache boundary: trimpath, one writer key, no setup-go cache."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+TRIMPATH = "-trimpath"
+
+
+def load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+class GoCacheBoundaryContractTest(unittest.TestCase):
+    def test_workflow_goflags_keep_trimpath(self) -> None:
+        missing: list[str] = []
+        for path in (WORKFLOWS / "backend-ci.yml", WORKFLOWS / "warm-release-cache-main.yml"):
+            workflow = load(path)
+            for job_name, job in workflow.get("jobs", {}).items():
+                flags = job.get("env", {}).get("GOFLAGS")
+                if flags is not None and TRIMPATH not in flags:
+                    missing.append(f"{path.name}:{job_name}")
+                for step in job.get("steps", []):
+                    step_flags = step.get("env", {}).get("GOFLAGS")
+                    if step_flags is not None and TRIMPATH not in step_flags:
+                        missing.append(f"{path.name}:{job_name}:{step.get('name')}")
+        self.assertEqual(missing, [])
+
+    def test_setup_go_never_enables_implicit_cache(self) -> None:
+        offenders: list[str] = []
+        for path in WORKFLOWS.glob("*.yml"):
+            workflow = load(path)
+            for job_name, job in (workflow.get("jobs") or {}).items():
+                for index, step in enumerate(job.get("steps") or []):
+                    if step.get("uses", "").startswith("actions/setup-go@"):
+                        cache = step.get("with", {}).get("cache")
+                        if cache is True or cache == "true" or cache is None:
+                            offenders.append(f"{path.name}:{job_name}:{index}")
+        self.assertEqual(offenders, [])
+
+    def test_persistent_go_keys_forbid_run_id_and_dates(self) -> None:
+        forbidden = ("github.run_id", "%Y-%m-%d", "%G-W%V")
+        offenders: list[str] = []
+        for path in (
+            WORKFLOWS / "backend-ci.yml",
+            WORKFLOWS / "warm-release-cache-main.yml",
+            WORKFLOWS / "release.yml",
+            ROOT / ".github" / "actions" / "go-rolling-cache" / "action.yml",
+        ):
+            text = path.read_text(encoding="utf-8")
+            for token in forbidden:
+                if token in text and "go-release" in text or token in text and "gobuild" in text:
+                    if token in text:
+                        offenders.append(f"{path.name}:{token}")
+        self.assertEqual(offenders, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/checks/test_go_rolling_cache_policy.py
+++ b/scripts/checks/test_go_rolling_cache_policy.py
@@ -14,72 +14,90 @@ MAIN_WRITER_IF = "github.event_name == 'push' && github.ref == 'refs/heads/main'
 NON_MAIN_IF = "github.event_name != 'push' || github.ref != 'refs/heads/main'"
 RESTORE_ONLY_IF = "inputs.save_caches != 'true'"
 BENCHMARK_WRITER_IF = "github.event_name == 'workflow_dispatch'"
+FORBIDDEN_KEY_FRAGMENTS = (
+    "github.run_id",
+    "refresh_daily",
+    "refresh_on_backend_change",
+    "cache_epoch",
+    "%G-W%V",
+    "%Y-%m-%d",
+)
+DEPENDENCY_HASH = "hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref')"
+SOURCE_HASH = "hashFiles('backend/**/*.go'"
+
+
+def load_action() -> dict:
+    return yaml.safe_load(ACTION.read_text(encoding="utf-8"))
 
 
 class GoRollingCachePolicyTest(unittest.TestCase):
     def test_exports_only_primary_exact_build_cache_hits(self) -> None:
-        action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
+        action = load_action()
         self.assertEqual(
             action["outputs"]["build_cache_hit"]["value"],
             "${{ steps.build_cache_status.outputs.build_cache_hit }}",
         )
-
-        steps = action["runs"]["steps"]
-        build_steps = [
-            step
-            for step in steps
-            if step.get("with", {}).get("path") == "${{ inputs.build_cache_path }}"
-        ]
-        self.assertEqual(
-            {step.get("id") for step in build_steps},
-            {
-                "build_cache_restore",
-                "build_cache_benchmark",
-                "build_cache_main",
-            },
-        )
-
         status = next(
-            step for step in steps if step.get("id") == "build_cache_status"
-        )
-        self.assertEqual(
-            status["env"],
-            {
-                "RESTORE_HIT": "${{ steps.build_cache_restore.outputs.cache-hit }}",
-                "BENCHMARK_HIT": "${{ steps.build_cache_benchmark.outputs.cache-hit }}",
-                "MAIN_HIT": "${{ steps.build_cache_main.outputs.cache-hit }}",
-            },
+            step
+            for step in action["runs"]["steps"]
+            if step.get("id") == "build_cache_status"
         )
         self.assertIn('== "true"', status["run"])
         self.assertIn("build_cache_hit=true", status["run"])
         self.assertIn("build_cache_hit=false", status["run"])
 
+    def test_uses_family_input_and_drops_date_epochs(self) -> None:
+        action = load_action()
+        self.assertIn("family", action["inputs"])
+        self.assertTrue(action["inputs"]["family"]["required"])
+        for removed in (
+            "refresh_daily",
+            "refresh_on_backend_change",
+            "prefix",
+        ):
+            self.assertNotIn(removed, action["inputs"])
+        text = ACTION.read_text(encoding="utf-8")
+        for fragment in FORBIDDEN_KEY_FRAGMENTS:
+            self.assertNotIn(fragment, text)
+
+    def test_build_keys_are_content_addressed(self) -> None:
+        action = load_action()
+        version_step = next(
+            step for step in action["runs"]["steps"] if step.get("id") == "go_version"
+        )
+        self.assertIn("backend/go.mod", version_step["run"])
+        build_steps = [
+            step
+            for step in action["runs"]["steps"]
+            if "gobuild" in str(step.get("with", {}).get("key", ""))
+        ]
+        self.assertGreaterEqual(len(build_steps), 2)
+        for step in build_steps:
+            key = step["with"]["key"]
+            self.assertIn("gobuild-${{ inputs.family }}-v1-", key)
+            self.assertIn("steps.go_version.outputs.version", key)
+            self.assertIn(DEPENDENCY_HASH, key)
+            self.assertIn(SOURCE_HASH, key)
+            self.assertNotIn("github.run_id", key)
+            self.assertNotIn("backend/**'", key)
+
     def test_only_main_push_or_explicit_benchmark_steps_can_save_caches(self) -> None:
-        action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
+        action = load_action()
         self.assertEqual(action["inputs"]["save_caches"]["default"], "true")
         self.assertEqual(action["inputs"]["benchmark_build_cache_write"]["default"], "false")
-        self.assertEqual(action["inputs"]["benchmark_prefix"]["default"], "")
-        steps = action["runs"]["steps"]
-        saving = [step for step in steps if step.get("uses") == "actions/cache@v6"]
-        self.assertEqual(len(saving), 4)
-
+        saving = [
+            step
+            for step in action["runs"]["steps"]
+            if step.get("uses") in {"actions/cache@v6", "actions/cache/save@v6"}
+        ]
+        self.assertTrue(saving)
         benchmark_writers = [
             step
             for step in saving
             if "inputs.benchmark_build_cache_write == 'true'" in step.get("if", "")
         ]
         self.assertEqual(len(benchmark_writers), 1)
-        benchmark_writer = benchmark_writers[0]
-        self.assertIn(BENCHMARK_WRITER_IF, benchmark_writer["if"])
-        self.assertIn("github.ref != 'refs/heads/main'", benchmark_writer["if"])
-        self.assertIn("inputs.benchmark_prefix != ''", benchmark_writer["if"])
-        self.assertEqual(
-            benchmark_writer["with"]["path"],
-            "${{ inputs.build_cache_path }}",
-        )
-        self.assertIn("inputs.benchmark_prefix", benchmark_writer["with"]["key"])
-
-        main_writers = [step for step in saving if step is not benchmark_writer]
+        main_writers = [step for step in saving if step not in benchmark_writers]
         self.assertTrue(
             all(MAIN_WRITER_IF in step.get("if", "") for step in main_writers)
         )
@@ -91,129 +109,21 @@ class GoRollingCachePolicyTest(unittest.TestCase):
         )
 
     def test_non_main_or_restore_only_callers_never_save_any_cache_layer(self) -> None:
-        steps = yaml.safe_load(ACTION.read_text(encoding="utf-8"))["runs"]["steps"]
-        restore_only = [step for step in steps if step.get("uses") == "actions/cache/restore@v6"]
-        self.assertEqual(len(restore_only), 3)
+        restore_only = [
+            step
+            for step in load_action()["runs"]["steps"]
+            if step.get("uses") == "actions/cache/restore@v6"
+        ]
+        self.assertTrue(restore_only)
         self.assertTrue(all(NON_MAIN_IF in step.get("if", "") for step in restore_only))
         self.assertTrue(all(RESTORE_ONLY_IF in step.get("if", "") for step in restore_only))
-        build_restore = next(
-            step
-            for step in restore_only
-            if step["with"]["path"] == "${{ inputs.build_cache_path }}"
-        )
-        self.assertIn(
-            "inputs.benchmark_build_cache_write != 'true'",
-            build_restore["if"],
-        )
-        restored_paths = {step["with"]["path"] for step in restore_only}
-        self.assertEqual(
-            restored_paths,
-            {
-                "~/go/pkg/mod",
-                "${{ inputs.build_cache_path }}",
-                "~/.cache/golangci-lint",
-            },
-        )
 
-    def test_ineligible_benchmark_contexts_keep_restore_only_build_cache(self) -> None:
-        steps = yaml.safe_load(ACTION.read_text(encoding="utf-8"))["runs"]["steps"]
-        build_restore = next(
-            step
-            for step in steps
-            if step.get("uses") == "actions/cache/restore@v6"
-            and step["with"]["path"] == "${{ inputs.build_cache_path }}"
-        )
-
-        condition = build_restore["if"]
-        for fallback_clause in (
-            "github.event_name != 'workflow_dispatch'",
-            "github.ref == 'refs/heads/main'",
-            "inputs.benchmark_build_cache_write != 'true'",
-            "inputs.benchmark_prefix == ''",
-        ):
-            with self.subTest(clause=fallback_clause):
-                self.assertIn(fallback_clause, condition)
-
-    def test_golangci_cache_is_opt_in_and_rolls_from_main(self) -> None:
-        action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
-        self.assertEqual(action["inputs"]["golangci_cache"]["default"], "false")
-        steps = action["runs"]["steps"]
-        golangci_steps = [
-            step
-            for step in steps
-            if step.get("with", {}).get("path") == "~/.cache/golangci-lint"
-        ]
-        self.assertEqual(len(golangci_steps), 2)
-        for step in golangci_steps:
-            with self.subTest(step=step["name"]):
-                self.assertIn("inputs.golangci_cache == 'true'", step["if"])
-                self.assertIn("github.run_id", step["with"]["key"])
-                self.assertIn("backend/go.sum", step["with"]["key"])
-                self.assertIn("backend/.golangci.yml", step["with"]["key"])
-
-    def test_build_caches_support_daily_refresh_without_changing_other_callers(self) -> None:
-        action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
-        self.assertEqual(action["inputs"]["fallback_prefix"]["default"], "")
-        self.assertEqual(action["inputs"]["refresh_on_backend_change"]["default"], "false")
-        self.assertEqual(action["inputs"]["refresh_daily"]["default"], "false")
-        self.assertEqual(
-            action["inputs"]["build_cache_path"]["default"],
-            "~/.cache/go-build",
-        )
-        steps = action["runs"]["steps"]
-        epoch_step = next(step for step in steps if step.get("id") == "cache_epoch")
-        self.assertIn('week=$(date -u +%G-W%V)', epoch_step["run"])
-        self.assertIn('day=$(date -u +%Y-%m-%d)', epoch_step["run"])
-
-        build_steps = [
-            step
-            for step in steps
-            if step.get("with", {}).get("path") == "${{ inputs.build_cache_path }}"
-        ]
-        self.assertEqual(len(build_steps), 3)
-        expected_key = (
-            "${{ runner.os }}-gobuild-${{ inputs.prefix }}-"
-            "${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-"
-            "${{ inputs.refresh_on_backend_change == 'true' && "
-            "hashFiles('backend/**', '.new-api-ref') || "
-            "inputs.refresh_daily == 'true' && steps.cache_epoch.outputs.day || "
-            "steps.cache_epoch.outputs.week }}"
-        )
-        for step in build_steps:
-            with self.subTest(step=step["name"]):
-                cache_config = step["with"]
-                key = cache_config["key"]
-                if "benchmark writer" in step["name"]:
-                    self.assertEqual(
-                        key,
-                        expected_key.replace("inputs.prefix", "inputs.benchmark_prefix"),
-                    )
-                else:
-                    self.assertEqual(key, expected_key)
-                self.assertNotIn("github.run_id", key)
-
-                restore_keys = cache_config["restore-keys"].splitlines()
-                expected_restore_prefix = (
-                    "inputs.benchmark_prefix"
-                    if "benchmark writer" in step["name"]
-                    else "inputs.prefix"
-                )
-                self.assertEqual(
-                    restore_keys[0],
-                    "${{ runner.os }}-gobuild-${{ "
-                    + expected_restore_prefix
-                    + " }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-",
-                )
-                self.assertNotIn("github.run_id", str(cache_config))
-
-                fallback_keys = [
-                    key for key in restore_keys if "inputs.fallback_prefix" in key
-                ]
-                self.assertEqual(len(fallback_keys), 2)
-                self.assertTrue(
-                    all("format(" in key for key in fallback_keys),
-                    fallback_keys,
-                )
+    def test_analysis_family_owns_golangci_cache_without_run_id(self) -> None:
+        text = ACTION.read_text(encoding="utf-8")
+        self.assertIn("~/.cache/golangci-lint", text)
+        self.assertIn("inputs.family == 'analysis'", text)
+        self.assertNotIn("Linux-golangci-", text)
+        self.assertNotIn("github.run_id", text)
 
 
 if __name__ == "__main__":

--- a/scripts/checks/test_release_cache_key_parity.py
+++ b/scripts/checks/test_release_cache_key_parity.py
@@ -8,7 +8,6 @@ import unittest
 
 import yaml
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BACKEND_CI = REPO_ROOT / ".github" / "workflows" / "backend-ci.yml"
 WARM_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "warm-release-cache-main.yml"
@@ -31,60 +30,54 @@ class ReleaseCacheWorkflowTest(unittest.TestCase):
         workflow = load_workflow(WARM_WORKFLOW)
         push = workflow_on(workflow)["push"]
         self.assertEqual(push["branches"], ["main"])
-        self.assertEqual(
-            set(push["paths"]),
-            {
-                "backend/**/*.go",
-                "backend/go.mod",
-                "backend/go.sum",
-                ".new-api-ref",
-                ".goreleaser.yaml",
-                ".github/workflows/warm-release-cache-main.yml",
-            },
-        )
+        self.assertIn("backend/**/*.go", push["paths"])
+        self.assertIn(".new-api-ref", push["paths"])
         job = workflow["jobs"]["warm-release-cache"]
         self.assertEqual(job.get("if"), "github.ref == 'refs/heads/main'")
 
-    def test_warm_workflow_owns_daily_integration_cache_writes(self) -> None:
+    def test_warm_workflow_writes_five_families_with_explicit_save(self) -> None:
         workflow = load_workflow(WARM_WORKFLOW)
+        self.assertEqual(workflow["permissions"]["actions"], "write")
+        self.assertEqual(workflow.get("env", {}).get("GOFLAGS"), "-trimpath -gcflags=all=-dwarf=false")
         steps = workflow["jobs"]["warm-release-cache"]["steps"]
-        epoch = next(step for step in steps if step.get("id") == "integration_epoch")
-        self.assertIn('day=$(date -u +%Y-%m-%d)', epoch["run"])
+        save_steps = [step for step in steps if step.get("uses") == "actions/cache/save@v6"]
+        restore_steps = [step for step in steps if step.get("uses") == "actions/cache/restore@v6"]
+        self.assertEqual(len(save_steps), 5)
+        self.assertEqual(len(restore_steps), 5)
+        self.assertTrue(all("cache-hit != 'true'" in step.get("if", "") for step in save_steps))
+        combined = [step for step in steps if step.get("uses") == "actions/cache@v6"]
+        self.assertEqual(combined, [])
+        keys = "\n".join(str(step.get("with", {}).get("key", "")) for step in restore_steps + save_steps)
+        self.assertIn("gomod-v1-", keys)
+        self.assertIn("gobuild-test-v1-", keys)
+        self.assertIn("gobuild-integration-v1-", keys)
+        self.assertIn("gobuild-analysis-v1-", keys)
+        self.assertIn("go-release-v1-", keys)
+        self.assertNotIn("github.run_id", keys)
 
-        cache = next(step for step in steps if step.get("id") == "integration_cache")
-        self.assertEqual(cache["uses"], "actions/cache@v6")
-        self.assertEqual(
-            cache["with"]["path"],
-            "${{ github.workspace }}/.cache/go-build-integration",
-        )
-        dependency_hash = (
-            "${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}"
-        )
-        key_prefix = "${{ runner.os }}-gobuild-integration-nodwarf-v2-"
-        self.assertEqual(
-            cache["with"]["key"],
-            f"{key_prefix}{dependency_hash}-${{{{ steps.integration_epoch.outputs.day }}}}",
-        )
-        self.assertEqual(
-            cache["with"]["restore-keys"],
-            f"{key_prefix}{dependency_hash}-\n{key_prefix}\n",
-        )
+        test_restore = next(step for step in restore_steps if "gobuild-test-v1-" in str(step.get("with", {}).get("key", "")))
+        test_save = next(step for step in save_steps if "gobuild-test-v1-" in str(step.get("with", {}).get("key", "")))
+        self.assertEqual(test_restore["with"]["path"], "~/.cache/go-build")
+        self.assertEqual(test_save["with"]["path"], "~/.cache/go-build")
+        analysis_restore = next(step for step in restore_steps if "gobuild-analysis-v1-" in str(step.get("with", {}).get("key", "")))
+        self.assertIn("~/.cache/go-build", analysis_restore["with"]["path"])
+        self.assertIn("~/.cache/golangci-lint", analysis_restore["with"]["path"])
+        release_restore = next(step for step in restore_steps if "go-release-v1-" in str(step.get("with", {}).get("key", "")))
+        release_save = next(step for step in save_steps if "go-release-v1-" in str(step.get("with", {}).get("key", "")))
+        self.assertEqual(release_restore["with"]["path"], "~/.cache/go-build")
+        self.assertEqual(release_save["with"]["path"], "~/.cache/go-build")
 
-        warm = next(
-            step for step in steps if step.get("name") == "Warm integration build cache"
-        )
+        warm = next(step for step in steps if step.get("name") == "Warm integration build cache")
         self.assertEqual(warm["if"], "steps.integration_cache.outputs.cache-hit != 'true'")
         self.assertEqual(
             warm["env"]["GOCACHE"],
             "${{ github.workspace }}/.cache/go-build-integration",
         )
-        self.assertEqual(warm["env"]["GOFLAGS"], "-gcflags=all=-dwarf=false")
-        self.assertIn("scripts/ci/integration-packages.py", warm["run"])
-        self.assertIn("integration_packages=()", warm["run"])
-        self.assertIn('integration_packages+=("$package")', warm["run"])
         self.assertIn("go test -c -tags=integration", warm["run"])
         self.assertNotIn("-vet=off", warm["run"])
-        self.assertEqual(warm["run"].count("go test -c"), 1)
+
+        prune = next(step for step in steps if step.get("name") == "Check managed Go cache budget")
+        self.assertIn("go_cache_prune.py --check", prune["run"])
 
 
 if __name__ == "__main__":

--- a/scripts/checks/test_release_cache_key_parity.py
+++ b/scripts/checks/test_release_cache_key_parity.py
@@ -79,6 +79,44 @@ class ReleaseCacheWorkflowTest(unittest.TestCase):
         prune = next(step for step in steps if step.get("name") == "Check managed Go cache budget")
         self.assertIn("go_cache_prune.py --check", prune["run"])
 
+    def test_warm_analysis_runs_golangci_lint_to_fill_analysis_family(self) -> None:
+        # Boundary: analysis family includes ~/.cache/golangci-lint. Warm must
+        # populate it, or an exact-hit after a go-test-only warm poisons the
+        # lint job into restore-only against an empty golangci cache.
+        lint_step = next(
+            step
+            for step in load_workflow(BACKEND_CI)["jobs"]["golangci-lint"]["steps"]
+            if step.get("name") == "golangci-lint"
+        )
+        steps = load_workflow(WARM_WORKFLOW)["jobs"]["warm-release-cache"]["steps"]
+        analysis_compile = next(
+            step for step in steps if step.get("name") == "Warm analysis build cache"
+        )
+        self.assertEqual(
+            analysis_compile["if"],
+            "steps.analysis_cache.outputs.cache-hit != 'true'",
+        )
+        self.assertIn("go test -run=^$", analysis_compile["run"])
+        lint_warm = next(
+            step
+            for step in steps
+            if str(step.get("uses", "")).startswith("golangci/golangci-lint-action@")
+        )
+        self.assertEqual(
+            lint_warm["if"],
+            "steps.analysis_cache.outputs.cache-hit != 'true'",
+        )
+        self.assertEqual(lint_warm["with"]["version"], lint_step["with"]["version"])
+        self.assertEqual(lint_warm["with"]["args"], lint_step["with"]["args"])
+        self.assertEqual(
+            lint_warm["with"]["working-directory"],
+            lint_step["with"]["working-directory"],
+        )
+        self.assertEqual(
+            lint_warm["with"].get("skip-cache"),
+            lint_step["with"].get("skip-cache"),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/checks/test_release_cache_key_parity.py
+++ b/scripts/checks/test_release_cache_key_parity.py
@@ -38,7 +38,7 @@ class ReleaseCacheWorkflowTest(unittest.TestCase):
     def test_warm_workflow_writes_five_families_with_explicit_save(self) -> None:
         workflow = load_workflow(WARM_WORKFLOW)
         self.assertEqual(workflow["permissions"]["actions"], "write")
-        self.assertEqual(workflow.get("env", {}).get("GOFLAGS"), "-trimpath -gcflags=all=-dwarf=false")
+        self.assertNotIn("GOFLAGS", workflow.get("env", {}))
         steps = workflow["jobs"]["warm-release-cache"]["steps"]
         save_steps = [step for step in steps if step.get("uses") == "actions/cache/save@v6"]
         restore_steps = [step for step in steps if step.get("uses") == "actions/cache/restore@v6"]
@@ -73,8 +73,26 @@ class ReleaseCacheWorkflowTest(unittest.TestCase):
             warm["env"]["GOCACHE"],
             "${{ github.workspace }}/.cache/go-build-integration",
         )
+        self.assertEqual(
+            warm["env"]["GOFLAGS"], "-trimpath -gcflags=all=-dwarf=false"
+        )
         self.assertIn("go test -c -tags=integration", warm["run"])
         self.assertNotIn("-vet=off", warm["run"])
+
+        test_warm = next(
+            step for step in steps if step.get("name") == "Warm test build cache"
+        )
+        self.assertEqual(
+            test_warm["env"]["GOFLAGS"], "-trimpath -gcflags=all=-dwarf=false"
+        )
+
+        release_warm = next(
+            step for step in steps if step.get("name") == "Warm cross-arch Go build cache"
+        )
+        self.assertEqual(release_warm["env"]["GOFLAGS"], "-trimpath")
+        self.assertIn("-tags=embed", release_warm["run"])
+        self.assertIn("./cmd/server", release_warm["run"])
+        self.assertIn("./cmd/qa-archive", release_warm["run"])
 
         prune = next(step for step in steps if step.get("name") == "Check managed Go cache budget")
         self.assertIn("go_cache_prune.py --check", prune["run"])
@@ -96,6 +114,10 @@ class ReleaseCacheWorkflowTest(unittest.TestCase):
             analysis_compile["if"],
             "steps.analysis_cache.outputs.cache-hit != 'true'",
         )
+        self.assertEqual(
+            analysis_compile["env"]["GOFLAGS"],
+            "-trimpath -gcflags=all=-dwarf=false",
+        )
         self.assertIn("go test -run=^$", analysis_compile["run"])
         lint_warm = next(
             step
@@ -105,6 +127,10 @@ class ReleaseCacheWorkflowTest(unittest.TestCase):
         self.assertEqual(
             lint_warm["if"],
             "steps.analysis_cache.outputs.cache-hit != 'true'",
+        )
+        self.assertEqual(
+            lint_warm["env"]["GOFLAGS"],
+            "-trimpath -gcflags=all=-dwarf=false",
         )
         self.assertEqual(lint_warm["with"]["version"], lint_step["with"]["version"])
         self.assertEqual(lint_warm["with"]["args"], lint_step["with"]["args"])

--- a/scripts/ci/go_cache_prune.py
+++ b/scripts/ci/go_cache_prune.py
@@ -10,11 +10,11 @@ BUDGET_BYTES = 6 * 1024**3
 DEFAULT_REF = "refs/heads/main"
 FAMILIES = ("gomod", "test", "integration", "analysis", "release")
 PREFIXES = {
-    "gomod": "Linux-gomod-",
-    "test": "Linux-gobuild-test-",
-    "integration": "Linux-gobuild-integration-",
-    "analysis": "Linux-gobuild-analysis-",
-    "release": "Linux-go-release-",
+    "gomod": "Linux-gomod-v1-",
+    "test": "Linux-gobuild-test-v1-",
+    "integration": "Linux-gobuild-integration-v1-",
+    "analysis": "Linux-gobuild-analysis-v1-",
+    "release": "Linux-go-release-v1-",
 }
 
 
@@ -52,7 +52,11 @@ def plan_prune(
     obsolete: list[dict[str, object]] = []
     evidence: list[str] = []
     for family in FAMILIES:
-        entries = sorted(grouped[family], key=lambda item: int(item["id"]), reverse=True)
+        entries = sorted(
+            grouped[family],
+            key=lambda item: (str(item["createdAt"]), int(item["id"])),
+            reverse=True,
+        )
         if entries:
             latest.append(entries[0])
             evidence.append(f"{family} latest={entries[0]['key']} size={entries[0]['sizeInBytes']}")
@@ -96,7 +100,21 @@ def _list_caches() -> list[dict[str, object]]:
     import subprocess
 
     raw = subprocess.check_output(
-        ["gh", "cache", "list", "--limit", "200", "--json", "id,key,sizeInBytes,ref"],
+        [
+            "gh",
+            "cache",
+            "list",
+            "--ref",
+            DEFAULT_REF,
+            "--sort",
+            "created_at",
+            "--order",
+            "desc",
+            "--limit",
+            "10000",
+            "--json",
+            "id,key,sizeInBytes,ref,createdAt",
+        ],
         text=True,
     )
     payload = json.loads(raw)

--- a/scripts/ci/go_cache_prune.py
+++ b/scripts/ci/go_cache_prune.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Plan GitHub Actions cache deletions for the five managed Go families."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+BUDGET_BYTES = 6 * 1024**3
+DEFAULT_REF = "refs/heads/main"
+FAMILIES = ("gomod", "test", "integration", "analysis", "release")
+PREFIXES = {
+    "gomod": "Linux-gomod-",
+    "test": "Linux-gobuild-test-",
+    "integration": "Linux-gobuild-integration-",
+    "analysis": "Linux-gobuild-analysis-",
+    "release": "Linux-go-release-",
+}
+
+
+@dataclass(frozen=True)
+class PrunePlan:
+    ok: bool
+    delete_ids: tuple[int, ...]
+    keep_ids: tuple[int, ...]
+    evidence: tuple[str, ...]
+
+
+def _family_for(key: str) -> str | None:
+    for family, prefix in PREFIXES.items():
+        if key.startswith(prefix):
+            return family
+    return None
+
+
+def plan_prune(
+    caches: Iterable[dict[str, object]],
+    *,
+    budget_bytes: int = BUDGET_BYTES,
+) -> PrunePlan:
+    grouped: dict[str, list[dict[str, object]]] = {family: [] for family in FAMILIES}
+    for cache in caches:
+        if cache.get("ref") != DEFAULT_REF:
+            continue
+        family = _family_for(str(cache["key"]))
+        if family is None:
+            continue
+        grouped[family].append(cache)
+
+    latest: list[dict[str, object]] = []
+    candidates: list[dict[str, object]] = []
+    obsolete: list[dict[str, object]] = []
+    evidence: list[str] = []
+    for family in FAMILIES:
+        entries = sorted(grouped[family], key=lambda item: int(item["id"]), reverse=True)
+        if entries:
+            latest.append(entries[0])
+            evidence.append(f"{family} latest={entries[0]['key']} size={entries[0]['sizeInBytes']}")
+        if len(entries) >= 2:
+            candidates.append(entries[1])
+        obsolete.extend(entries[2:])
+
+    latest_bytes = sum(int(item["sizeInBytes"]) for item in latest)
+    if latest_bytes > budget_bytes:
+        return PrunePlan(
+            ok=False,
+            delete_ids=(),
+            keep_ids=tuple(int(item["id"]) for item in latest),
+            evidence=tuple(evidence),
+        )
+
+    remaining = latest_bytes + sum(int(item["sizeInBytes"]) for item in candidates)
+    delete = list(obsolete)
+    keep_candidates: list[dict[str, object]] = []
+    for candidate in sorted(
+        candidates,
+        key=lambda item: (-int(item["sizeInBytes"]), str(item["key"])),
+    ):
+        if remaining > budget_bytes:
+            delete.append(candidate)
+            remaining -= int(candidate["sizeInBytes"])
+        else:
+            keep_candidates.append(candidate)
+
+    keep = latest + keep_candidates
+    return PrunePlan(
+        ok=True,
+        delete_ids=tuple(int(item["id"]) for item in delete),
+        keep_ids=tuple(int(item["id"]) for item in keep),
+        evidence=tuple(evidence),
+    )
+
+
+def _list_caches() -> list[dict[str, object]]:
+    import json
+    import subprocess
+
+    raw = subprocess.check_output(
+        ["gh", "cache", "list", "--limit", "200", "--json", "id,key,sizeInBytes,ref"],
+        text=True,
+    )
+    payload = json.loads(raw)
+    if not isinstance(payload, list):
+        raise RuntimeError("gh cache list returned a non-list")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="plan-only budget check; never deletes caches",
+    )
+    args = parser.parse_args(argv)
+    if not args.check:
+        print("go_cache_prune: apply is a separate approval gate", file=__import__("sys").stderr)
+        return 2
+    plan = plan_prune(_list_caches())
+    for line in plan.evidence:
+        print(line)
+    if not plan.ok:
+        print("go_cache_prune: latest generations exceed the 6 GiB budget", file=__import__("sys").stderr)
+        return 1
+    print(f"go_cache_prune: ok keep={list(plan.keep_ids)} delete_plan={list(plan.delete_ids)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_go_cache_prune.py
+++ b/scripts/ci/test_go_cache_prune.py
@@ -7,6 +7,7 @@ import importlib.util
 from pathlib import Path
 import sys
 import unittest
+from unittest.mock import patch
 
 SCRIPT = Path(__file__).resolve().parent / "go_cache_prune.py"
 SPEC = importlib.util.spec_from_file_location("ci_go_cache_prune", SCRIPT)
@@ -19,19 +20,32 @@ FAMILIES = go_cache_prune.FAMILIES
 plan_prune = go_cache_prune.plan_prune
 
 
-def _cache(key: str, size: int, *, ref: str = "refs/heads/main", cache_id: int = 1) -> dict[str, object]:
-    return {"id": cache_id, "key": key, "sizeInBytes": size, "ref": ref}
+def _cache(
+    key: str,
+    size: int,
+    *,
+    ref: str = "refs/heads/main",
+    cache_id: int = 1,
+    created_at: str = "2026-08-29T00:00:00Z",
+) -> dict[str, object]:
+    return {
+        "id": cache_id,
+        "key": key,
+        "sizeInBytes": size,
+        "ref": ref,
+        "createdAt": created_at,
+    }
 
 
 class GoCachePruneTest(unittest.TestCase):
     def test_keeps_latest_and_previous_when_under_budget(self) -> None:
         caches = [
-            _cache("Linux-gomod-aaa", 100, cache_id=1),
-            _cache("Linux-gomod-bbb", 110, cache_id=2),
-            _cache("Linux-gobuild-test-aaa", 200, cache_id=3),
-            _cache("Linux-gobuild-integration-aaa", 50, cache_id=4),
-            _cache("Linux-gobuild-analysis-aaa", 40, cache_id=5),
-            _cache("Linux-go-release-aaa", 80, cache_id=6),
+            _cache("Linux-gomod-v1-aaa", 100, cache_id=1),
+            _cache("Linux-gomod-v1-bbb", 110, cache_id=2),
+            _cache("Linux-gobuild-test-v1-aaa", 200, cache_id=3),
+            _cache("Linux-gobuild-integration-v1-aaa", 50, cache_id=4),
+            _cache("Linux-gobuild-analysis-v1-aaa", 40, cache_id=5),
+            _cache("Linux-go-release-v1-aaa", 80, cache_id=6),
         ]
         plan = plan_prune(caches, budget_bytes=10_000)
         self.assertTrue(plan.ok)
@@ -40,13 +54,13 @@ class GoCachePruneTest(unittest.TestCase):
 
     def test_drops_previous_generation_largest_first(self) -> None:
         caches = [
-            _cache("Linux-gomod-old", 3, cache_id=1),
-            _cache("Linux-gomod-new", 4, cache_id=10),
-            _cache("Linux-gobuild-test-old", 5, cache_id=2),
-            _cache("Linux-gobuild-test-new", 4, cache_id=11),
-            _cache("Linux-gobuild-integration-new", 1, cache_id=12),
-            _cache("Linux-gobuild-analysis-new", 1, cache_id=13),
-            _cache("Linux-go-release-new", 1, cache_id=14),
+            _cache("Linux-gomod-v1-old", 3, cache_id=1),
+            _cache("Linux-gomod-v1-new", 4, cache_id=10),
+            _cache("Linux-gobuild-test-v1-old", 5, cache_id=2),
+            _cache("Linux-gobuild-test-v1-new", 4, cache_id=11),
+            _cache("Linux-gobuild-integration-v1-new", 1, cache_id=12),
+            _cache("Linux-gobuild-analysis-v1-new", 1, cache_id=13),
+            _cache("Linux-go-release-v1-new", 1, cache_id=14),
         ]
         plan = plan_prune(caches, budget_bytes=15)
         self.assertTrue(plan.ok)
@@ -54,13 +68,13 @@ class GoCachePruneTest(unittest.TestCase):
 
     def test_deletes_older_than_previous_generation(self) -> None:
         caches = [
-            _cache("Linux-gomod-c", 1, cache_id=3),
-            _cache("Linux-gomod-b", 1, cache_id=2),
-            _cache("Linux-gomod-a", 1, cache_id=1),
-            _cache("Linux-gobuild-test-a", 1, cache_id=4),
-            _cache("Linux-gobuild-integration-a", 1, cache_id=5),
-            _cache("Linux-gobuild-analysis-a", 1, cache_id=6),
-            _cache("Linux-go-release-a", 1, cache_id=7),
+            _cache("Linux-gomod-v1-c", 1, cache_id=3),
+            _cache("Linux-gomod-v1-b", 1, cache_id=2),
+            _cache("Linux-gomod-v1-a", 1, cache_id=1),
+            _cache("Linux-gobuild-test-v1-a", 1, cache_id=4),
+            _cache("Linux-gobuild-integration-v1-a", 1, cache_id=5),
+            _cache("Linux-gobuild-analysis-v1-a", 1, cache_id=6),
+            _cache("Linux-go-release-v1-a", 1, cache_id=7),
         ]
         plan = plan_prune(caches, budget_bytes=100)
         self.assertTrue(plan.ok)
@@ -70,12 +84,12 @@ class GoCachePruneTest(unittest.TestCase):
 
     def test_ignores_non_main_and_unmanaged_prefixes(self) -> None:
         caches = [
-            _cache("Linux-gomod-a", 1, cache_id=1),
-            _cache("Linux-gobuild-test-a", 1, cache_id=2),
-            _cache("Linux-gobuild-integration-a", 1, cache_id=3),
-            _cache("Linux-gobuild-analysis-a", 1, cache_id=4),
-            _cache("Linux-go-release-a", 1, cache_id=5),
-            _cache("Linux-gomod-pr", 999, cache_id=6, ref="refs/pull/1/merge"),
+            _cache("Linux-gomod-v1-a", 1, cache_id=1),
+            _cache("Linux-gobuild-test-v1-a", 1, cache_id=2),
+            _cache("Linux-gobuild-integration-v1-a", 1, cache_id=3),
+            _cache("Linux-gobuild-analysis-v1-a", 1, cache_id=4),
+            _cache("Linux-go-release-v1-a", 1, cache_id=5),
+            _cache("Linux-gomod-v1-pr", 999, cache_id=6, ref="refs/pull/1/merge"),
             _cache("Linux-frontend-a", 999, cache_id=7),
             _cache("setup-go-Linux-x64", 999, cache_id=8),
         ]
@@ -86,13 +100,53 @@ class GoCachePruneTest(unittest.TestCase):
         self.assertNotIn(7, plan.keep_ids)
         self.assertNotIn(8, plan.keep_ids)
 
+    def test_legacy_go_cache_keys_are_not_managed(self) -> None:
+        caches = [
+            _cache("Linux-gomod-dependency-hash", 100, cache_id=1),
+            _cache(
+                "Linux-gobuild-integration-nodwarf-v2-dependency-2026-08-29",
+                100,
+                cache_id=2,
+            ),
+            _cache("Linux-go-release-dependency-33223135749", 100, cache_id=3),
+        ]
+        plan = plan_prune(caches, budget_bytes=1)
+        self.assertTrue(plan.ok)
+        self.assertEqual(plan.keep_ids, ())
+        self.assertEqual(plan.delete_ids, ())
+
+    def test_generation_order_uses_created_at_not_numeric_id(self) -> None:
+        caches = [
+            _cache(
+                "Linux-gomod-v1-old",
+                1,
+                cache_id=999,
+                created_at="2026-08-27T00:00:00Z",
+            ),
+            _cache(
+                "Linux-gomod-v1-previous",
+                1,
+                cache_id=2,
+                created_at="2026-08-28T00:00:00Z",
+            ),
+            _cache(
+                "Linux-gomod-v1-latest",
+                1,
+                cache_id=1,
+                created_at="2026-08-29T00:00:00Z",
+            ),
+        ]
+        plan = plan_prune(caches, budget_bytes=100)
+        self.assertEqual(plan.delete_ids, (999,))
+        self.assertEqual(set(plan.keep_ids), {1, 2})
+
     def test_fails_when_latest_generations_exceed_budget(self) -> None:
         caches = [
-            _cache("Linux-gomod-a", 4, cache_id=1),
-            _cache("Linux-gobuild-test-a", 4, cache_id=2),
-            _cache("Linux-gobuild-integration-a", 4, cache_id=3),
-            _cache("Linux-gobuild-analysis-a", 4, cache_id=4),
-            _cache("Linux-go-release-a", 4, cache_id=5),
+            _cache("Linux-gomod-v1-a", 4, cache_id=1),
+            _cache("Linux-gobuild-test-v1-a", 4, cache_id=2),
+            _cache("Linux-gobuild-integration-v1-a", 4, cache_id=3),
+            _cache("Linux-gobuild-analysis-v1-a", 4, cache_id=4),
+            _cache("Linux-go-release-v1-a", 4, cache_id=5),
         ]
         plan = plan_prune(caches, budget_bytes=10)
         self.assertFalse(plan.ok)
@@ -103,13 +157,13 @@ class GoCachePruneTest(unittest.TestCase):
 
     def test_candidate_tie_breaks_by_key_ascending(self) -> None:
         caches = [
-            _cache("Linux-gomod-zzz", 3, cache_id=2),
-            _cache("Linux-gomod-new", 1, cache_id=10),
-            _cache("Linux-gobuild-test-aaa", 3, cache_id=4),
-            _cache("Linux-gobuild-test-new", 1, cache_id=11),
-            _cache("Linux-gobuild-integration-new", 1, cache_id=12),
-            _cache("Linux-gobuild-analysis-new", 1, cache_id=13),
-            _cache("Linux-go-release-new", 1, cache_id=14),
+            _cache("Linux-gomod-v1-zzz", 3, cache_id=2),
+            _cache("Linux-gomod-v1-new", 1, cache_id=10),
+            _cache("Linux-gobuild-test-v1-aaa", 3, cache_id=4),
+            _cache("Linux-gobuild-test-v1-new", 1, cache_id=11),
+            _cache("Linux-gobuild-integration-v1-new", 1, cache_id=12),
+            _cache("Linux-gobuild-analysis-v1-new", 1, cache_id=13),
+            _cache("Linux-go-release-v1-new", 1, cache_id=14),
         ]
         plan = plan_prune(caches, budget_bytes=10)
         self.assertTrue(plan.ok)
@@ -117,6 +171,20 @@ class GoCachePruneTest(unittest.TestCase):
 
     def test_default_budget_is_six_gib(self) -> None:
         self.assertEqual(BUDGET_BYTES, 6 * 1024**3)
+
+    @patch("subprocess.check_output", return_value="[]")
+    def test_inventory_is_main_scoped_created_at_sorted_and_exhaustive(self, run) -> None:
+        go_cache_prune._list_caches()
+        args = run.call_args.args[0]
+        self.assertIn("--ref", args)
+        self.assertIn("refs/heads/main", args)
+        self.assertIn("--sort", args)
+        self.assertIn("created_at", args)
+        self.assertIn("--limit", args)
+        limit = int(args[args.index("--limit") + 1])
+        self.assertGreaterEqual(limit, 10_000)
+        fields = args[args.index("--json") + 1]
+        self.assertIn("createdAt", fields)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_go_cache_prune.py
+++ b/scripts/ci/test_go_cache_prune.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Prune plan for the five managed Go cache families."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+
+SCRIPT = Path(__file__).resolve().parent / "go_cache_prune.py"
+SPEC = importlib.util.spec_from_file_location("ci_go_cache_prune", SCRIPT)
+assert SPEC and SPEC.loader
+go_cache_prune = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = go_cache_prune
+SPEC.loader.exec_module(go_cache_prune)
+BUDGET_BYTES = go_cache_prune.BUDGET_BYTES
+FAMILIES = go_cache_prune.FAMILIES
+plan_prune = go_cache_prune.plan_prune
+
+
+def _cache(key: str, size: int, *, ref: str = "refs/heads/main", cache_id: int = 1) -> dict[str, object]:
+    return {"id": cache_id, "key": key, "sizeInBytes": size, "ref": ref}
+
+
+class GoCachePruneTest(unittest.TestCase):
+    def test_keeps_latest_and_previous_when_under_budget(self) -> None:
+        caches = [
+            _cache("Linux-gomod-aaa", 100, cache_id=1),
+            _cache("Linux-gomod-bbb", 110, cache_id=2),
+            _cache("Linux-gobuild-test-aaa", 200, cache_id=3),
+            _cache("Linux-gobuild-integration-aaa", 50, cache_id=4),
+            _cache("Linux-gobuild-analysis-aaa", 40, cache_id=5),
+            _cache("Linux-go-release-aaa", 80, cache_id=6),
+        ]
+        plan = plan_prune(caches, budget_bytes=10_000)
+        self.assertTrue(plan.ok)
+        self.assertEqual(plan.delete_ids, ())
+        self.assertEqual(set(plan.keep_ids), {1, 2, 3, 4, 5, 6})
+
+    def test_drops_previous_generation_largest_first(self) -> None:
+        caches = [
+            _cache("Linux-gomod-old", 3, cache_id=1),
+            _cache("Linux-gomod-new", 4, cache_id=10),
+            _cache("Linux-gobuild-test-old", 5, cache_id=2),
+            _cache("Linux-gobuild-test-new", 4, cache_id=11),
+            _cache("Linux-gobuild-integration-new", 1, cache_id=12),
+            _cache("Linux-gobuild-analysis-new", 1, cache_id=13),
+            _cache("Linux-go-release-new", 1, cache_id=14),
+        ]
+        plan = plan_prune(caches, budget_bytes=15)
+        self.assertTrue(plan.ok)
+        self.assertEqual(plan.delete_ids, (2,))
+
+    def test_deletes_older_than_previous_generation(self) -> None:
+        caches = [
+            _cache("Linux-gomod-c", 1, cache_id=3),
+            _cache("Linux-gomod-b", 1, cache_id=2),
+            _cache("Linux-gomod-a", 1, cache_id=1),
+            _cache("Linux-gobuild-test-a", 1, cache_id=4),
+            _cache("Linux-gobuild-integration-a", 1, cache_id=5),
+            _cache("Linux-gobuild-analysis-a", 1, cache_id=6),
+            _cache("Linux-go-release-a", 1, cache_id=7),
+        ]
+        plan = plan_prune(caches, budget_bytes=100)
+        self.assertTrue(plan.ok)
+        self.assertEqual(plan.delete_ids, (1,))
+        self.assertIn(2, plan.keep_ids)
+        self.assertIn(3, plan.keep_ids)
+
+    def test_ignores_non_main_and_unmanaged_prefixes(self) -> None:
+        caches = [
+            _cache("Linux-gomod-a", 1, cache_id=1),
+            _cache("Linux-gobuild-test-a", 1, cache_id=2),
+            _cache("Linux-gobuild-integration-a", 1, cache_id=3),
+            _cache("Linux-gobuild-analysis-a", 1, cache_id=4),
+            _cache("Linux-go-release-a", 1, cache_id=5),
+            _cache("Linux-gomod-pr", 999, cache_id=6, ref="refs/pull/1/merge"),
+            _cache("Linux-frontend-a", 999, cache_id=7),
+            _cache("setup-go-Linux-x64", 999, cache_id=8),
+        ]
+        plan = plan_prune(caches, budget_bytes=100)
+        self.assertTrue(plan.ok)
+        self.assertEqual(plan.delete_ids, ())
+        self.assertNotIn(6, plan.keep_ids)
+        self.assertNotIn(7, plan.keep_ids)
+        self.assertNotIn(8, plan.keep_ids)
+
+    def test_fails_when_latest_generations_exceed_budget(self) -> None:
+        caches = [
+            _cache("Linux-gomod-a", 4, cache_id=1),
+            _cache("Linux-gobuild-test-a", 4, cache_id=2),
+            _cache("Linux-gobuild-integration-a", 4, cache_id=3),
+            _cache("Linux-gobuild-analysis-a", 4, cache_id=4),
+            _cache("Linux-go-release-a", 4, cache_id=5),
+        ]
+        plan = plan_prune(caches, budget_bytes=10)
+        self.assertFalse(plan.ok)
+        self.assertEqual(plan.delete_ids, ())
+        self.assertEqual(set(plan.keep_ids), {1, 2, 3, 4, 5})
+        evidence = " ".join(plan.evidence)
+        self.assertTrue(all(family in evidence for family in FAMILIES), plan.evidence)
+
+    def test_candidate_tie_breaks_by_key_ascending(self) -> None:
+        caches = [
+            _cache("Linux-gomod-zzz", 3, cache_id=2),
+            _cache("Linux-gomod-new", 1, cache_id=10),
+            _cache("Linux-gobuild-test-aaa", 3, cache_id=4),
+            _cache("Linux-gobuild-test-new", 1, cache_id=11),
+            _cache("Linux-gobuild-integration-new", 1, cache_id=12),
+            _cache("Linux-gobuild-analysis-new", 1, cache_id=13),
+            _cache("Linux-go-release-new", 1, cache_id=14),
+        ]
+        plan = plan_prune(caches, budget_bytes=10)
+        self.assertTrue(plan.ok)
+        self.assertEqual(plan.delete_ids, (4,))
+
+    def test_default_budget_is_six_gib(self) -> None:
+        self.assertEqual(BUDGET_BYTES, 6 * 1024**3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -3080,6 +3080,34 @@ else
 fi
 
 echo ""
+echo "=== sub2api: Go cache prune plan ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required by go cache prune contract)"
+    errors=$((errors + 1))
+elif ! python3 -m unittest scripts.ci.test_go_cache_prune >/dev/null; then
+    echo "  FAIL: scripts.ci.test_go_cache_prune"
+    echo "        — run: python3 -m unittest scripts.ci.test_go_cache_prune -v"
+    errors=$((errors + 1))
+else
+    echo "  ok: managed Go cache prune keeps two generations inside 6 GiB"
+fi
+
+echo ""
+echo "=== sub2api: Go cache boundary contract ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required by go cache boundary contract)"
+    errors=$((errors + 1))
+elif ! python3 -m unittest \
+        scripts.checks.test_go_rolling_cache_policy \
+        scripts.checks.test_go_cache_boundary_contract >/dev/null; then
+    echo "  FAIL: go cache boundary contract"
+    echo "        — run: python3 -m unittest scripts.checks.test_go_rolling_cache_policy scripts.checks.test_go_cache_boundary_contract -v"
+    errors=$((errors + 1))
+else
+    echo "  ok: Go cache families stay content-addressed and setup-go cache stays off"
+fi
+
+echo ""
 echo "=== sub2api: GitHub cache action Node runtime ==="
 if ! command -v python3 >/dev/null 2>&1; then
     echo "  FAIL: python3 not on PATH (required by cache action runtime contract)"

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -183,6 +183,8 @@ class BackendCIRoutingTest(unittest.TestCase):
             "scripts.test_preflight_ci_lint_skip",
             "scripts.checks.test_release_cache_key_parity",
             "scripts.checks.test_go_rolling_cache_policy",
+            "scripts.checks.test_go_cache_boundary_contract",
+            "scripts.ci.test_go_cache_prune",
             "scripts.test_preflight_ci_handoffs",
             "scripts.test_ci_gate_handoffs",
             "scripts.ci.test_changed_surfaces",
@@ -351,7 +353,7 @@ class BackendCIRoutingTest(unittest.TestCase):
             for step in self.jobs["test-unit"]["steps"]
             if step.get("uses") == "./.github/actions/go-rolling-cache"
         )
-        self.assertEqual(unit_cache["with"]["prefix"], "unit-nodwarf-v3")
+        self.assertEqual(unit_cache["with"]["family"], "test")
         self.assertEqual(
             unit_cache["with"]["benchmark_prefix"],
             "unit-nodwarf-v5-other-first-bench",
@@ -365,7 +367,7 @@ class BackendCIRoutingTest(unittest.TestCase):
     def test_unit_job_omits_dwarf_from_test_build_objects(self) -> None:
         self.assertEqual(
             self.jobs["test-unit"]["env"]["GOFLAGS"],
-            "-gcflags=all=-dwarf=false",
+            "-trimpath -gcflags=all=-dwarf=false",
         )
 
     def test_heavy_go_jobs_omit_dwarf_from_cached_build_objects(self) -> None:
@@ -382,11 +384,11 @@ class BackendCIRoutingTest(unittest.TestCase):
         self.assertEqual(
             declarations,
             [
-                ("preflight", "job", "-gcflags=all=-dwarf=false"),
-                ("test-unit", "job", "-gcflags=all=-dwarf=false"),
-                ("test-integration", "job", "-gcflags=all=-dwarf=false"),
-                ("golangci-lint", "job", "-gcflags=all=-dwarf=false"),
-                ("backend-security", "job", "-gcflags=all=-dwarf=false"),
+                ("preflight", "job", "-trimpath -gcflags=all=-dwarf=false"),
+                ("test-unit", "job", "-trimpath -gcflags=all=-dwarf=false"),
+                ("test-integration", "job", "-trimpath -gcflags=all=-dwarf=false"),
+                ("golangci-lint", "job", "-trimpath -gcflags=all=-dwarf=false"),
+                ("backend-security", "job", "-trimpath -gcflags=all=-dwarf=false"),
             ],
         )
 
@@ -412,7 +414,8 @@ class BackendCIRoutingTest(unittest.TestCase):
         cache_index = cache_indexes[0]
         self.assertLess(cache_index, scan_index)
         cache = steps[cache_index]
-        self.assertEqual(cache["with"]["prefix"], "security-nodwarf-v1")
+        self.assertEqual(cache["with"]["family"], "analysis")
+        self.assertEqual(cache["with"]["fallback_prefix"], "security-nodwarf-v1")
         self.assertNotIn("refresh_on_backend_change", cache.get("with", {}))
         self.assertFalse(
             [
@@ -424,21 +427,21 @@ class BackendCIRoutingTest(unittest.TestCase):
         )
 
     def test_heavy_go_jobs_use_nodwarf_build_cache_strategy(self) -> None:
-        expected_prefixes = {
-            "preflight": "preflight-nodwarf-v1",
-            "test-unit": "unit-nodwarf-v3",
-            "test-integration": "integration-nodwarf-v2",
-            "golangci-lint": "lint-nodwarf-v1",
-            "backend-security": "security-nodwarf-v1",
+        expected_families = {
+            "preflight": "test",
+            "test-unit": "test",
+            "test-integration": "integration",
+            "golangci-lint": "analysis",
+            "backend-security": "analysis",
         }
-        for job_name, expected_prefix in expected_prefixes.items():
+        for job_name, expected_family in expected_families.items():
             cache_step = next(
                 step
                 for step in self.jobs[job_name]["steps"]
                 if step.get("uses") == "./.github/actions/go-rolling-cache"
             )
             with self.subTest(job=job_name):
-                self.assertEqual(cache_step["with"]["prefix"], expected_prefix)
+                self.assertEqual(cache_step["with"]["family"], expected_family)
 
         integration_cache = next(
             step
@@ -446,13 +449,14 @@ class BackendCIRoutingTest(unittest.TestCase):
             if step.get("uses") == "./.github/actions/go-rolling-cache"
         )
         self.assertEqual(
-            integration_cache["with"]["prefix"],
-            "integration-nodwarf-v2",
+            integration_cache["with"]["family"],
+            "integration",
         )
         self.assertEqual(
-            integration_cache["with"]["refresh_daily"],
-            "true",
+            integration_cache["with"]["fallback_prefix"],
+            "integration-nodwarf-v2",
         )
+        self.assertNotIn("refresh_daily", integration_cache.get("with", {}))
         self.assertEqual(
             integration_cache["with"]["save_caches"],
             "false",
@@ -476,17 +480,14 @@ class BackendCIRoutingTest(unittest.TestCase):
             if step.get("uses") == "./.github/actions/go-rolling-cache"
         )
         self.assertEqual(
-            unit_cache["with"]["prefix"],
-            "unit-nodwarf-v3",
+            unit_cache["with"]["family"],
+            "test",
         )
         self.assertEqual(
             unit_cache["with"]["fallback_prefix"],
-            "unit-nodwarf-v1",
+            "unit-nodwarf-v3",
         )
-        self.assertEqual(
-            unit_cache["with"]["refresh_on_backend_change"],
-            "true",
-        )
+        self.assertNotIn("refresh_on_backend_change", unit_cache.get("with", {}))
         self.assertNotIn("refresh_daily", unit_cache["with"])
         self.assertNotIn("build_cache_path", unit_cache["with"])
         self.assertEqual(
@@ -535,8 +536,9 @@ class BackendCIRoutingTest(unittest.TestCase):
             for step in steps
             if step.get("uses") == "./.github/actions/go-rolling-cache"
         )
-        self.assertEqual(rolling_cache["with"]["prefix"], "lint-nodwarf-v1")
-        self.assertEqual(rolling_cache["with"]["golangci_cache"], "true")
+        self.assertEqual(rolling_cache["with"]["family"], "analysis")
+        self.assertEqual(rolling_cache["with"]["fallback_prefix"], "lint-nodwarf-v1")
+        self.assertNotIn("golangci_cache", rolling_cache.get("with", {}))
 
         lint_action = next(
             step

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -416,6 +416,7 @@ class BackendCIRoutingTest(unittest.TestCase):
         cache = steps[cache_index]
         self.assertEqual(cache["with"]["family"], "analysis")
         self.assertEqual(cache["with"]["fallback_prefix"], "security-nodwarf-v1")
+        self.assertEqual(cache["with"]["save_caches"], "false")
         self.assertNotIn("refresh_on_backend_change", cache.get("with", {}))
         self.assertFalse(
             [


### PR DESCRIPTION
## 摘要
- 把 Go cache 收成五类内容寻址 key（gomod / test / integration / analysis / release），去掉 `run_id`、日期和 week epoch。
- `warm-release-cache-main` 成为五类写入者；exact-hit 跳过 save；仍保留 `build_cache_hit`（仅 primary exact-hit）。
- analysis 族必须由 warm 跑 golangci-lint 填满 `~/.cache/golangci-lint`；`backend-security` 改为 restore-only，避免 govulncheck 抢先把 lint 锁进空缓存。
- release 预热与 goreleaser 对齐：只带 `-trimpath`，`go build -tags=embed ./cmd/server` 并同时预热 `./cmd/qa-archive`。
- prune 只管理 `*-v1-` 代际，按 `createdAt` 排序，inventory 限定 `refs/heads/main`。
- 所有 `setup-go` 显式 `cache: false`；required job 仍双写（security 除外）。
- 本机边界归 infra-skills `host-clean`（`docs/approved/2026-08-29-host-ops.md`）。dest-rules #102 已关闭、不合并。本 PR 只改 CI。

## 风险
常规风险。不改鉴权、schema 或用户可见 Web。required CI 冷构建仍正确。
sentinel-registry-reviewed：`release.yml` / `client-fidelity-watch.yml` 只关 setup-go 隐式 cache 与 release restore key，没有新的 TK/NewAPI 负载面。
Web impact: none

## 验证
- `python3 -m unittest scripts.checks.test_go_rolling_cache_policy scripts.checks.test_go_cache_boundary_contract scripts.checks.test_release_cache_key_parity scripts.ci.test_go_cache_prune scripts.test_backend_ci_routing`：48 项通过
- `go test -tags=unit -run TestFindFromWorkingDir_LocatesOpsSQLWithoutCallerPath ./internal/repository`：通过
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：PASS

## 提交
- `4c49852a2` feat(ci): make Go caches content-addressed with one warm writer
- `309a20503` fix(ci): locate partition coverage SQL without runtime.Caller
- `6381d2df2` fix(ci): address R-004 — warm analysis must populate golangci cache
- `3c15b91ff` fix(ci): address R-001..R-003 — align release warm and analysis writers
- 最新提交：`3c15b91ff`