### PR TITLE
perf(ci): 冷 miss 走 compile-all，并对齐 warm cache version

### DIFF
--- a/.github/actions/go-rolling-cache/action.yml
+++ b/.github/actions/go-rolling-cache/action.yml
@@ -78,9 +78,11 @@ runs:
       if: (github.event_name != 'push' || github.ref != 'refs/heads/main' || inputs.save_caches != 'true') && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main' || inputs.benchmark_build_cache_write != 'true' || inputs.benchmark_prefix == '')
       uses: actions/cache/restore@v6
       with:
-        path: |
-          ${{ inputs.build_cache_path }}
-          ${{ inputs.family == 'analysis' && '~/.cache/golangci-lint' || inputs.build_cache_path }}
+        # One path for test/integration/release so the cache version matches
+        # warm-release-cache-main.yml. Repeating build_cache_path as a dummy
+        # second line hashed a different version; #1880 then missed warm's
+        # 920MB test / 555MB integration keys.
+        path: ${{ inputs.family == 'analysis' && format('{0}\n~/.cache/golangci-lint', inputs.build_cache_path) || inputs.build_cache_path }}
         key: ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ hashFiles('backend/**/*.go', 'backend/.golangci.yml', '.goreleaser.yaml') }}
         restore-keys: |
           ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
@@ -106,9 +108,7 @@ runs:
       if: github.event_name == 'push' && github.ref == 'refs/heads/main' && inputs.save_caches == 'true'
       uses: actions/cache@v6
       with:
-        path: |
-          ${{ inputs.build_cache_path }}
-          ${{ inputs.family == 'analysis' && '~/.cache/golangci-lint' || inputs.build_cache_path }}
+        path: ${{ inputs.family == 'analysis' && format('{0}\n~/.cache/golangci-lint', inputs.build_cache_path) || inputs.build_cache_path }}
         key: ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ hashFiles('backend/**/*.go', 'backend/.golangci.yml', '.goreleaser.yaml') }}
         restore-keys: |
           ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-

--- a/.github/actions/go-rolling-cache/action.yml
+++ b/.github/actions/go-rolling-cache/action.yml
@@ -39,6 +39,9 @@ outputs:
   build_cache_hit:
     description: "true only when the selected primary Go build cache key restores exactly."
     value: ${{ steps.build_cache_status.outputs.build_cache_hit }}
+  build_cache_populated:
+    description: "true when an exact hit or a prefix/fallback restore left build objects on disk."
+    value: ${{ steps.build_cache_status.outputs.build_cache_populated }}
 
 runs:
   using: composite
@@ -121,9 +124,19 @@ runs:
         RESTORE_HIT: ${{ steps.build_cache_restore.outputs.cache-hit }}
         BENCHMARK_HIT: ${{ steps.build_cache_benchmark.outputs.cache-hit }}
         MAIN_HIT: ${{ steps.build_cache_main.outputs.cache-hit }}
+        BUILD_CACHE_PATH: ${{ inputs.build_cache_path }}
       run: |
+        hit=false
         if [[ "$RESTORE_HIT" == "true" || "$BENCHMARK_HIT" == "true" || "$MAIN_HIT" == "true" ]]; then
-          echo "build_cache_hit=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "build_cache_hit=false" >> "$GITHUB_OUTPUT"
+          hit=true
         fi
+        echo "build_cache_hit=${hit}" >> "$GITHUB_OUTPUT"
+
+        # actions/cache sets cache-hit only for an exact key. Prefix and
+        # fallback restores still leave usable Go objects; treat those as warm.
+        populated="${hit}"
+        cache_path="${BUILD_CACHE_PATH/#\~/${HOME}}"
+        if [[ "${populated}" != "true" && -d "${cache_path}" ]] && [ -n "$(find "${cache_path}" -type f -print -quit)" ]; then
+          populated=true
+        fi
+        echo "build_cache_populated=${populated}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/go-rolling-cache/action.yml
+++ b/.github/actions/go-rolling-cache/action.yml
@@ -40,7 +40,7 @@ outputs:
     description: "true only when the selected primary Go build cache key restores exactly."
     value: ${{ steps.build_cache_status.outputs.build_cache_hit }}
   build_cache_populated:
-    description: "true when an exact hit or a prefix/fallback restore left build objects on disk."
+    description: "true when an exact hit or a prefix/fallback restore set cache-matched-key."
     value: ${{ steps.build_cache_status.outputs.build_cache_populated }}
 
 runs:
@@ -124,7 +124,9 @@ runs:
         RESTORE_HIT: ${{ steps.build_cache_restore.outputs.cache-hit }}
         BENCHMARK_HIT: ${{ steps.build_cache_benchmark.outputs.cache-hit }}
         MAIN_HIT: ${{ steps.build_cache_main.outputs.cache-hit }}
-        BUILD_CACHE_PATH: ${{ inputs.build_cache_path }}
+        RESTORE_MATCHED: ${{ steps.build_cache_restore.outputs.cache-matched-key }}
+        BENCHMARK_MATCHED: ${{ steps.build_cache_benchmark.outputs.cache-matched-key }}
+        MAIN_MATCHED: ${{ steps.build_cache_main.outputs.cache-matched-key }}
       run: |
         hit=false
         if [[ "$RESTORE_HIT" == "true" || "$BENCHMARK_HIT" == "true" || "$MAIN_HIT" == "true" ]]; then
@@ -132,11 +134,14 @@ runs:
         fi
         echo "build_cache_hit=${hit}" >> "$GITHUB_OUTPUT"
 
-        # actions/cache sets cache-hit only for an exact key. Prefix and
-        # fallback restores still leave usable Go objects; treat those as warm.
+        # cache-hit is exact-key only. Prefix/fallback restores set
+        # cache-matched-key. Do not probe the directory: setup-go / go env
+        # leave files in GOCACHE even on a complete miss, which #1880 treated
+        # as warm and then dual-compiled (service-compile 336s).
         populated="${hit}"
-        cache_path="${BUILD_CACHE_PATH/#\~/${HOME}}"
-        if [[ "${populated}" != "true" && -d "${cache_path}" ]] && [ -n "$(find "${cache_path}" -type f -print -quit)" ]; then
+        matched="${RESTORE_MATCHED:-}${BENCHMARK_MATCHED:-}${MAIN_MATCHED:-}"
+        if [[ "${populated}" != "true" && -n "${matched}" ]]; then
           populated=true
         fi
         echo "build_cache_populated=${populated}" >> "$GITHUB_OUTPUT"
+        echo "build_cache_matched_key=${RESTORE_MATCHED:-${BENCHMARK_MATCHED:-${MAIN_MATCHED:-}}}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/go-rolling-cache/action.yml
+++ b/.github/actions/go-rolling-cache/action.yml
@@ -75,14 +75,30 @@ runs:
 
     - name: Restore Go build cache (non-main writer)
       id: build_cache_restore
-      if: (github.event_name != 'push' || github.ref != 'refs/heads/main' || inputs.save_caches != 'true') && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main' || inputs.benchmark_build_cache_write != 'true' || inputs.benchmark_prefix == '')
+      if: inputs.family != 'analysis' && (github.event_name != 'push' || github.ref != 'refs/heads/main' || inputs.save_caches != 'true') && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main' || inputs.benchmark_build_cache_write != 'true' || inputs.benchmark_prefix == '')
       uses: actions/cache/restore@v6
       with:
-        # One path for test/integration/release so the cache version matches
-        # warm-release-cache-main.yml. Repeating build_cache_path as a dummy
-        # second line hashed a different version; #1880 then missed warm's
-        # 920MB test / 555MB integration keys.
-        path: ${{ inputs.family == 'analysis' && format('{0}\n~/.cache/golangci-lint', inputs.build_cache_path) || inputs.build_cache_path }}
+        # Single path: must match warm-release-cache-main.yml or
+        # actions/cache versions diverge and the key is invisible.
+        path: ${{ inputs.build_cache_path }}
+        key: ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ hashFiles('backend/**/*.go', 'backend/.golangci.yml', '.goreleaser.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
+          ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-
+          ${{ runner.os }}-gobuild-${{ inputs.family }}-
+          ${{ inputs.fallback_prefix != '' && format('{0}-gobuild-{1}-{2}-', runner.os, inputs.fallback_prefix, hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref')) || '' }}
+          ${{ inputs.fallback_prefix != '' && format('{0}-gobuild-{1}-', runner.os, inputs.fallback_prefix) || '' }}
+
+    - name: Restore Go analysis cache (non-main writer)
+      id: build_cache_restore_analysis
+      if: inputs.family == 'analysis' && (github.event_name != 'push' || github.ref != 'refs/heads/main' || inputs.save_caches != 'true') && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main' || inputs.benchmark_build_cache_write != 'true' || inputs.benchmark_prefix == '')
+      uses: actions/cache/restore@v6
+      with:
+        # YAML two-line path: format('\n') does not produce a newline and
+        # misses the existing analysis archive.
+        path: |
+          ${{ inputs.build_cache_path }}
+          ~/.cache/golangci-lint
         key: ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ hashFiles('backend/**/*.go', 'backend/.golangci.yml', '.goreleaser.yaml') }}
         restore-keys: |
           ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
@@ -105,10 +121,26 @@ runs:
 
     - name: Go build cache (main writer)
       id: build_cache_main
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && inputs.save_caches == 'true'
+      if: inputs.family != 'analysis' && github.event_name == 'push' && github.ref == 'refs/heads/main' && inputs.save_caches == 'true'
       uses: actions/cache@v6
       with:
-        path: ${{ inputs.family == 'analysis' && format('{0}\n~/.cache/golangci-lint', inputs.build_cache_path) || inputs.build_cache_path }}
+        path: ${{ inputs.build_cache_path }}
+        key: ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ hashFiles('backend/**/*.go', 'backend/.golangci.yml', '.goreleaser.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
+          ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-
+          ${{ runner.os }}-gobuild-${{ inputs.family }}-
+          ${{ inputs.fallback_prefix != '' && format('{0}-gobuild-{1}-{2}-', runner.os, inputs.fallback_prefix, hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref')) || '' }}
+          ${{ inputs.fallback_prefix != '' && format('{0}-gobuild-{1}-', runner.os, inputs.fallback_prefix) || '' }}
+
+    - name: Go analysis cache (main writer)
+      id: build_cache_main_analysis
+      if: inputs.family == 'analysis' && github.event_name == 'push' && github.ref == 'refs/heads/main' && inputs.save_caches == 'true'
+      uses: actions/cache@v6
+      with:
+        path: |
+          ${{ inputs.build_cache_path }}
+          ~/.cache/golangci-lint
         key: ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ hashFiles('backend/**/*.go', 'backend/.golangci.yml', '.goreleaser.yaml') }}
         restore-keys: |
           ${{ runner.os }}-gobuild-${{ inputs.family }}-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-
@@ -121,12 +153,12 @@ runs:
       id: build_cache_status
       shell: bash
       env:
-        RESTORE_HIT: ${{ steps.build_cache_restore.outputs.cache-hit }}
+        RESTORE_HIT: ${{ steps.build_cache_restore.outputs.cache-hit || steps.build_cache_restore_analysis.outputs.cache-hit }}
         BENCHMARK_HIT: ${{ steps.build_cache_benchmark.outputs.cache-hit }}
-        MAIN_HIT: ${{ steps.build_cache_main.outputs.cache-hit }}
-        RESTORE_MATCHED: ${{ steps.build_cache_restore.outputs.cache-matched-key }}
+        MAIN_HIT: ${{ steps.build_cache_main.outputs.cache-hit || steps.build_cache_main_analysis.outputs.cache-hit }}
+        RESTORE_MATCHED: ${{ steps.build_cache_restore.outputs.cache-matched-key || steps.build_cache_restore_analysis.outputs.cache-matched-key }}
         BENCHMARK_MATCHED: ${{ steps.build_cache_benchmark.outputs.cache-matched-key }}
-        MAIN_MATCHED: ${{ steps.build_cache_main.outputs.cache-matched-key }}
+        MAIN_MATCHED: ${{ steps.build_cache_main.outputs.cache-matched-key || steps.build_cache_main_analysis.outputs.cache-matched-key }}
       run: |
         hit=false
         if [[ "$RESTORE_HIT" == "true" || "$BENCHMARK_HIT" == "true" || "$MAIN_HIT" == "true" ]]; then

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -138,8 +138,13 @@ jobs:
       - uses: ./.github/actions/go-rolling-cache
         if: needs.changes.outputs.preflight_go == 'true'
         with:
+          # Restore-only. Preflight finishes before test-unit/warm and would
+          # otherwise win the exact test-v1 key with a thin GOCACHE (~200MB
+          # of contract compiles). #1880 restored that stub; service-compile
+          # stayed ~100s despite cache-hit=true.
           family: test
           fallback_prefix: preflight-nodwarf-v1
+          save_caches: "false"
       - name: Unit runner contract tests
         if: needs.changes.outputs.preflight_go == 'true'
         run: python3 -m unittest scripts.ci.test_unit_test_runner
@@ -295,7 +300,10 @@ jobs:
           family: integration
           fallback_prefix: integration-nodwarf-v2
           build_cache_path: ${{ github.workspace }}/.cache/go-build-integration
-          save_caches: "false"
+          # Main required job writes the same key as warm. PRs restore
+          # backend-ci's main snapshot more reliably than a just-finished
+          # warm-release-cache-main run (measured miss on #1880).
+          save_caches: "true"
       - name: Verify Go version
         run: |
           expected=$(awk '/^go /{print $2; exit}' backend/go.mod)

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -263,10 +263,9 @@ jobs:
           # content-keyed Go build cache restores exactly. Always use the compile-once
           # runner instead of gambling the critical path on test-result cache.
           UNIT_TEST_SERVICE_SHARD: "1"
-          # Exact hits already contain this tree's build objects, so overlap the
-          # lightweight discovery/compile commands. Misses and restore-key hits
-          # serialize the shared cold dependency graph to avoid CPU contention.
-          UNIT_TEST_BUILD_CACHE_HIT: ${{ steps.go_cache.outputs.build_cache_hit }}
+          # Exact hits and prefix/fallback restores both leave usable Go objects.
+          # Only a completely empty cache should take the cold compile-all path.
+          UNIT_TEST_BUILD_CACHE_HIT: ${{ steps.go_cache.outputs.build_cache_populated }}
         run: make test-unit
       - name: Anthropic prompt surface fixture gateway
         run: python3 ops/anthropic/probe_prompt_surfaces.py --check-fixture-gateway

--- a/.github/workflows/warm-release-cache-main.yml
+++ b/.github/workflows/warm-release-cache-main.yml
@@ -79,7 +79,11 @@ jobs:
         working-directory: backend
         env:
           GOFLAGS: -trimpath -gcflags=all=-dwarf=false
-        run: go test -tags=unit -run=^$ ./...
+        run: |
+          go test -tags=unit -run=^$ ./...
+          # Match unit_test_runner's service -c so a warm exact hit does not
+          # still spend ~100s linking ./internal/service.test.
+          go test -c -tags=unit -o "${RUNNER_TEMP}/service.test" ./internal/service
       - name: Save test build cache
         if: steps.test_cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6

--- a/scripts/checks/test_go_rolling_cache_policy.py
+++ b/scripts/checks/test_go_rolling_cache_policy.py
@@ -37,14 +37,19 @@ class GoRollingCachePolicyTest(unittest.TestCase):
             action["outputs"]["build_cache_hit"]["value"],
             "${{ steps.build_cache_status.outputs.build_cache_hit }}",
         )
+        self.assertEqual(
+            action["outputs"]["build_cache_populated"]["value"],
+            "${{ steps.build_cache_status.outputs.build_cache_populated }}",
+        )
         status = next(
             step
             for step in action["runs"]["steps"]
             if step.get("id") == "build_cache_status"
         )
-        self.assertIn('== "true"', status["run"])
-        self.assertIn("build_cache_hit=true", status["run"])
-        self.assertIn("build_cache_hit=false", status["run"])
+        self.assertIn("BUILD_CACHE_PATH", status["env"])
+        self.assertIn("build_cache_hit=${hit}", status["run"])
+        self.assertIn("build_cache_populated=${populated}", status["run"])
+        self.assertIn('find "${cache_path}" -type f -print -quit', status["run"])
 
     def test_uses_family_input_and_drops_date_epochs(self) -> None:
         action = load_action()

--- a/scripts/checks/test_go_rolling_cache_policy.py
+++ b/scripts/checks/test_go_rolling_cache_policy.py
@@ -139,10 +139,20 @@ class GoRollingCachePolicyTest(unittest.TestCase):
             "&& '~/.cache/golangci-lint' || inputs.build_cache_path",
             text,
         )
-        self.assertIn(
-            "format('{0}\\n~/.cache/golangci-lint', inputs.build_cache_path)",
-            text,
+        self.assertNotIn("format('{0}\\n~/.cache/golangci-lint'", text)
+        self.assertIn("id: build_cache_restore_analysis", text)
+        restore = next(
+            step
+            for step in load_action()["runs"]["steps"]
+            if step.get("id") == "build_cache_restore"
         )
+        self.assertEqual(restore["with"]["path"], "${{ inputs.build_cache_path }}")
+        analysis = next(
+            step
+            for step in load_action()["runs"]["steps"]
+            if step.get("id") == "build_cache_restore_analysis"
+        )
+        self.assertIn("~/.cache/golangci-lint", str(analysis["with"]["path"]))
 
 
 if __name__ == "__main__":

--- a/scripts/checks/test_go_rolling_cache_policy.py
+++ b/scripts/checks/test_go_rolling_cache_policy.py
@@ -46,10 +46,11 @@ class GoRollingCachePolicyTest(unittest.TestCase):
             for step in action["runs"]["steps"]
             if step.get("id") == "build_cache_status"
         )
-        self.assertIn("BUILD_CACHE_PATH", status["env"])
+        self.assertIn("RESTORE_MATCHED", status["env"])
+        self.assertIn("cache-matched-key", status["env"]["RESTORE_MATCHED"])
         self.assertIn("build_cache_hit=${hit}", status["run"])
         self.assertIn("build_cache_populated=${populated}", status["run"])
-        self.assertIn('find "${cache_path}" -type f -print -quit', status["run"])
+        self.assertNotIn("find ", status["run"])
 
     def test_uses_family_input_and_drops_date_epochs(self) -> None:
         action = load_action()

--- a/scripts/checks/test_go_rolling_cache_policy.py
+++ b/scripts/checks/test_go_rolling_cache_policy.py
@@ -131,6 +131,19 @@ class GoRollingCachePolicyTest(unittest.TestCase):
         self.assertNotIn("Linux-golangci-", text)
         self.assertNotIn("github.run_id", text)
 
+    def test_non_analysis_build_path_is_a_single_entry(self) -> None:
+        # actions/cache versions by the path list. A dummy second copy of
+        # build_cache_path made required CI miss warm's single-path archives.
+        text = ACTION.read_text(encoding="utf-8")
+        self.assertNotIn(
+            "&& '~/.cache/golangci-lint' || inputs.build_cache_path",
+            text,
+        )
+        self.assertIn(
+            "format('{0}\\n~/.cache/golangci-lint', inputs.build_cache_path)",
+            text,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/checks/test_release_cache_key_parity.py
+++ b/scripts/checks/test_release_cache_key_parity.py
@@ -85,6 +85,9 @@ class ReleaseCacheWorkflowTest(unittest.TestCase):
         self.assertEqual(
             test_warm["env"]["GOFLAGS"], "-trimpath -gcflags=all=-dwarf=false"
         )
+        self.assertIn("go test -tags=unit -run=^$ ./...", test_warm["run"])
+        self.assertIn("go test -c -tags=unit", test_warm["run"])
+        self.assertIn("./internal/service", test_warm["run"])
 
         release_warm = next(
             step for step in steps if step.get("name") == "Warm cross-arch Go build cache"

--- a/scripts/ci/test_unit_test_runner.py
+++ b/scripts/ci/test_unit_test_runner.py
@@ -262,29 +262,29 @@ class UnitTestRunnerTest(unittest.TestCase):
         self.assertLess(min(durations), 0.5)
         self.assertGreaterEqual(max(durations), 0.7)
 
-    def test_starts_service_compile_after_other_packages_populate_cache(self) -> None:
+    def test_starts_service_compile_after_compile_all_on_cold_cache(self) -> None:
         with self._fake_go(
             ["TestOne", "TestTwo"],
-            other_delay=0.75,
+            compile_all_delay=0.25,
         ) as fixture:
             result = self._run(fixture, "--min-shards", "2")
             events = self._events(fixture.events)
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        other_finished = next(
+        compile_all_finished = next(
             event["at"]
             for event in events
             if event["kind"] == "go-finished"
-            and "./internal/other" in event["args"]
+            and event["args"] == ["test", "-tags=unit", "-run=^$", "./..."]
         )
         compile_started = next(
             event["at"]
             for event in events
             if event["kind"] == "go" and "-c" in event["args"]
         )
-        self.assertGreaterEqual(compile_started, other_finished, events)
+        self.assertGreaterEqual(compile_started, compile_all_finished, events)
 
-    def test_other_package_failure_stops_before_service_compile_on_cold_cache(
+    def test_other_package_failure_fails_run_after_compile_all_on_cold_cache(
         self,
     ) -> None:
         with self._fake_go(
@@ -296,10 +296,59 @@ class UnitTestRunnerTest(unittest.TestCase):
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("intentional other package failure", result.stderr)
+        self.assertIn(["test", "-tags=unit", "-run=^$", "./..."], self._go_calls(events))
+
+    def test_cache_miss_compiles_all_packages_then_overlaps_service_and_other(
+        self,
+    ) -> None:
+        with self._fake_go(
+            ["TestOne", "TestTwo"],
+            compile_delay=0.75,
+            compile_all_delay=0.25,
+        ) as fixture:
+            result = self._run(fixture, "--min-shards", "2")
+            events = self._events(fixture.events)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertRegex(result.stdout, r"STAGE compile-all \([0-9.]+s\)")
+        go_calls = self._go_calls(events)
+        self.assertIn(["test", "-tags=unit", "-run=^$", "./..."], go_calls)
+        compile_all_finished = next(
+            event["at"]
+            for event in events
+            if event["kind"] == "go-finished"
+            and event["args"] == ["test", "-tags=unit", "-run=^$", "./..."]
+        )
+        compile_started = next(
+            event["at"]
+            for event in events
+            if event["kind"] == "go" and "-c" in event["args"]
+        )
+        compile_finished = next(
+            event["at"]
+            for event in events
+            if event["kind"] == "go-finished" and "-c" in event["args"]
+        )
+        other_started = next(
+            event["at"]
+            for event in events
+            if event["kind"] == "go" and "./internal/other" in event["args"]
+        )
+        self.assertGreaterEqual(compile_started, compile_all_finished, events)
+        self.assertLess(other_started, compile_finished, events)
+
+    def test_compile_all_failure_stops_before_service_compile(self) -> None:
+        with self._fake_go(["TestOne"], fail_compile_all=True) as fixture:
+            result = self._run(fixture)
+            events = self._events(fixture.events)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("intentional compile-all failure", result.stderr)
         self.assertFalse(
             [call for call in self._go_calls(events) if "-c" in call],
             events,
         )
+        self.assertFalse(self._binary_events(events))
 
     def test_starts_service_compile_after_discovery_finishes(self) -> None:
         with self._fake_go(
@@ -476,6 +525,7 @@ class UnitTestRunnerTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertRegex(result.stdout, r"STAGE discovery \([0-9.]+s\)")
+        self.assertRegex(result.stdout, r"STAGE compile-all \([0-9.]+s\)")
         self.assertRegex(result.stdout, r"STAGE service-compile \([0-9.]+s\)")
         self.assertRegex(result.stdout, r"STAGE registry-check \([0-9.]+s\)")
 
@@ -512,6 +562,10 @@ class UnitTestRunnerTest(unittest.TestCase):
             env["FAKE_GO_FAIL_OTHER"] = "1"
         if fixture.other_delay:
             env["FAKE_GO_OTHER_DELAY"] = str(fixture.other_delay)
+        if fixture.fail_compile_all:
+            env["FAKE_GO_FAIL_COMPILE_ALL"] = "1"
+        if fixture.compile_all_delay:
+            env["FAKE_GO_COMPILE_ALL_DELAY"] = str(fixture.compile_all_delay)
         if build_cache_hit:
             env["UNIT_TEST_BUILD_CACHE_HIT"] = "true"
         return subprocess.run(
@@ -565,6 +619,8 @@ class UnitTestRunnerTest(unittest.TestCase):
         compile_child: bool = False,
         fail_other: bool = False,
         other_delay: float = 0.0,
+        fail_compile_all: bool = False,
+        compile_all_delay: float = 0.0,
     ) -> "FakeGoFixtureContext":
         return FakeGoFixtureContext(
             test_names,
@@ -579,6 +635,8 @@ class UnitTestRunnerTest(unittest.TestCase):
             compile_child,
             fail_other,
             other_delay,
+            fail_compile_all,
+            compile_all_delay,
         )
 
 
@@ -598,6 +656,8 @@ class FakeGoFixture:
         compile_child: bool,
         fail_other: bool,
         other_delay: float,
+        fail_compile_all: bool,
+        compile_all_delay: float,
     ) -> None:
         self._temporary = temporary
         self.root = Path(temporary.name)
@@ -617,6 +677,8 @@ class FakeGoFixture:
         self.compile_child = compile_child
         self.fail_other = fail_other
         self.other_delay = other_delay
+        self.fail_compile_all = fail_compile_all
+        self.compile_all_delay = compile_all_delay
         service_dir = self.root / "internal" / "service"
         service_dir.mkdir(parents=True)
         declarations = []
@@ -654,6 +716,8 @@ class FakeGoFixtureContext:
         compile_child: bool,
         fail_other: bool,
         other_delay: float,
+        fail_compile_all: bool,
+        compile_all_delay: float,
     ) -> None:
         self.test_names = test_names
         self.has_test_main = has_test_main
@@ -667,6 +731,8 @@ class FakeGoFixtureContext:
         self.compile_child = compile_child
         self.fail_other = fail_other
         self.other_delay = other_delay
+        self.fail_compile_all = fail_compile_all
+        self.compile_all_delay = compile_all_delay
         self.temporary: tempfile.TemporaryDirectory[str] | None = None
 
     def __enter__(self) -> FakeGoFixture:
@@ -685,6 +751,8 @@ class FakeGoFixtureContext:
             self.compile_child,
             self.fail_other,
             self.other_delay,
+            self.fail_compile_all,
+            self.compile_all_delay,
         )
         fake_binary_source = textwrap.dedent(
             """\
@@ -755,6 +823,16 @@ class FakeGoFixtureContext:
                         "entries": json.loads(os.environ["FAKE_GO_TESTS"]),
                         "has_test_main": os.environ.get("FAKE_GO_HAS_TEST_MAIN") == "1",
                     }))
+                    raise SystemExit(0)
+
+                if args == ["test", "-tags=unit", "-run=^$", "./..."]:
+                    time.sleep(float(os.environ.get("FAKE_GO_COMPILE_ALL_DELAY", "0")))
+                    with events.open("a", encoding="utf-8") as output:
+                        output.write(json.dumps({"kind": "go-finished", "args": args, "at": time.monotonic()}) + "\\n")
+                    if os.environ.get("FAKE_GO_FAIL_COMPILE_ALL") == "1":
+                        print("intentional compile-all failure", file=sys.stderr)
+                        raise SystemExit(1)
+                    print("ok  fake/package  0.001s")
                     raise SystemExit(0)
 
                 if args == ["list", "-json", "-tags=unit", "./..."]:

--- a/scripts/ci/unit_test_runner.py
+++ b/scripts/ci/unit_test_runner.py
@@ -396,6 +396,16 @@ def run_commands(
         return 1 if failed else 0
 
 
+def _compile_all_unit_packages(root: Path) -> None:
+    started_at = time.monotonic()
+    _run_checked(["go", "test", "-tags=unit", "-run=^$", "./..."], root)
+    print(
+        f"unit-test-runner: STAGE compile-all "
+        f"({time.monotonic() - started_at:.1f}s)",
+        flush=True,
+    )
+
+
 def run_unit_tests(
     root: Path,
     service_package: str,
@@ -403,10 +413,13 @@ def run_unit_tests(
     max_regex_bytes: int,
 ) -> int:
     build_cache_hit = os.environ.get("UNIT_TEST_BUILD_CACHE_HIT") == "true"
+    other_packages: list[str] = []
+    service_tests: list[str] = []
+    patterns: list[str] = []
     if not build_cache_hit:
-        # Keep discovery ahead of the cold service build. On a four-core hosted
-        # runner, overlapping separate Go commands makes them rebuild and contend
-        # for the same dependency graph instead of shortening the critical path.
+        # Empty GOCACHE: discover first, compile the whole unit graph once, then
+        # overlap service -c with other-package tests. Two concurrent `go test`
+        # processes on a cold four-core runner rebuild the same graph.
         discovery_started_at = time.monotonic()
         other_packages, service_tests, patterns, has_test_main = build_test_plan(
             root,
@@ -426,23 +439,7 @@ def run_unit_tests(
                 cwd=root,
                 check=False,
             ).returncode
-        if other_packages:
-            # The repository-wide package set covers most of service's shared
-            # dependency graph. On a cold four-core runner, completing it first
-            # makes the later service link much cheaper than compiling service
-            # first and leaves no competing Go process on the critical path.
-            other_returncode = run_commands(
-                [
-                    Command(
-                        "other-packages",
-                        tuple(["go", "test", "-tags=unit", *other_packages]),
-                        root,
-                    )
-                ],
-                temporary_prefix="sub2api-unit-other-",
-            )
-            if other_returncode != 0:
-                return other_returncode
+        _compile_all_unit_packages(root)
 
     with tempfile.TemporaryDirectory(prefix="sub2api-service-test-") as temporary:
         service_binary = Path(temporary) / "service.test"
@@ -520,7 +517,7 @@ def run_unit_tests(
                 service_commands = [
                     command for command in commands if command.label != "other-packages"
                 ]
-                if build_cache_hit and other_commands:
+                if other_commands:
                     other_command = other_commands[0]
                     other_log = Path(overlap_temp) / "other-packages.log"
                     other_handle = other_log.open("wb")

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -323,7 +323,7 @@ class BackendCIRoutingTest(unittest.TestCase):
         self.assertEqual(unit_step["env"]["UNIT_TEST_SERVICE_SHARD"], "1")
         self.assertEqual(
             unit_step["env"]["UNIT_TEST_BUILD_CACHE_HIT"],
-            "${{ steps.go_cache.outputs.build_cache_hit }}",
+            "${{ steps.go_cache.outputs.build_cache_populated }}",
         )
 
     def test_unit_cache_benchmark_is_manual_isolated_and_opt_in(self) -> None:

--- a/scripts/test_backend_ci_routing.py
+++ b/scripts/test_backend_ci_routing.py
@@ -460,7 +460,7 @@ class BackendCIRoutingTest(unittest.TestCase):
         self.assertNotIn("refresh_daily", integration_cache.get("with", {}))
         self.assertEqual(
             integration_cache["with"]["save_caches"],
-            "false",
+            "true",
         )
         self.assertEqual(
             integration_cache["with"]["build_cache_path"],
@@ -505,6 +505,13 @@ class BackendCIRoutingTest(unittest.TestCase):
             )
             with self.subTest(job=job_name):
                 self.assertNotIn("refresh_on_backend_change", cache_step.get("with", {}))
+
+        preflight_cache = next(
+            step
+            for step in self.jobs["preflight"]["steps"]
+            if step.get("uses") == "./.github/actions/go-rolling-cache"
+        )
+        self.assertEqual(preflight_cache["with"]["save_caches"], "false")
 
     def test_unit_avoids_relinking_go_artifact_owners_after_unit_tests(self) -> None:
         steps = self.jobs["test-unit"]["steps"]


### PR DESCRIPTION
## 摘要

#1877 合入后第一波 required CI 是冷路径。#1880 按实测收口：

1. prefix/fallback restore 走热路径；空盘先 compile-all 再重叠 `-c` 与 other-packages。
2. preflight restore-only；integration 由 backend-ci 在 main 写入；warm 补 `go test -c ./internal/service`。
3. `build_cache_populated` 只认 `cache-matched-key`。
4. test/integration 用单行 path，与 warm 的 `actions/cache` version 对齐。
5. analysis 保持 YAML 两行 path（`format('\\n')` 不会换行）。

热路径已实测（rerun `33239954133`）：lint **39s exact-hit**，unit **1m32s**（`-c` 6.5s），integration compile **6.0s**。墙钟变成 preflight **1m53s**。

Web 页面、路由、契约未改。

## 风险

常规风险。只改 CI cache 语义与 path 列表。空 miss 仍要付 compile-all（约 4–5 分钟）；热命中依赖 main 上 backend-ci/warm 写出、且 path 列表与 version 一致。

## 验证

| run | test-unit | unit 编译 | integration compile | lint | 墙钟 |
|---|---|---|---|---|---|
| #1877 合入 | 5m15s | 197s 串行 + 47s | 152s miss | 5m04s miss | ~5m15s |
| 第一轮 | 2m48s | 102s 残缺 hit | 121s miss | 36s hit | ~3m17s |
| 第二轮 | 6m33s | 336s 误判 | 150s miss | 46s | 6m33s |
| 第三轮 | 5m11s | compile-all 234s | 157s miss | 35s | 5m11s |
| 第四轮 | 1m35s hit | `-c` 9.6s | **5.2s hit** | 6m04s miss | 6m04s |
| 第五轮 rerun | **1m32s hit** | `-c` 6.5s | **6.0s hit** | **39s hit** | **preflight 1m53s** |

- `python3 -m unittest scripts.checks.test_go_rolling_cache_policy scripts.test_backend_ci_routing scripts.ci.test_unit_test_runner`：通过
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：通过

## 提交

- `8a46bdeda` perf(ci): treat restored Go cache as warm and compile-all on empty miss
- `4b8327c89` perf(ci): stop preflight from poisoning test-v1 and write integration from required CI
- `c56112fe0` fix(ci): treat GOCACHE as populated only when cache-matched-key is set
- `ed6983b76` fix(ci): align Go cache path list with warm so actions/cache versions match
- `375047cf1` fix(ci): keep analysis cache on a YAML two-line path

最新提交：`375047cf1`