### PR TITLE
perf(ci): 重叠 preflight 慢门并跳过未改 Ent

### DIFF
--- a/scripts/checks/pricing-serving-docs.py
+++ b/scripts/checks/pricing-serving-docs.py
@@ -98,6 +98,34 @@ SECONDARY_TRUTH_PATTERNS = (
     re.compile(r"account\.go:639"),
 )
 
+# Cheap literal cover of SECONDARY_TRUTH_PATTERNS. A file that cannot contain
+# any of these needles cannot match a secondary-truth regex; skip the 40-pattern
+# scan. Keep this list conservative: every pattern must retain at least one
+# needle in any string it can match.
+SECONDARY_TRUTH_PREFILTER = (
+    "servable",
+    "priced",
+    "serving",
+    "ssot",
+    "四事实",
+    "列出即可调用",
+    "truthful",
+    "unreachable",
+    "unpriced",
+    "四层",
+    "有价",
+    "price 事实",
+    "两个事实",
+    "r-002",
+    "account.go:639",
+    "four facts",
+)
+
+
+def secondary_truth_candidate(text: str) -> bool:
+    lowered = text.lower()
+    return any(needle in lowered for needle in SECONDARY_TRUTH_PREFILTER)
+
 
 def iter_secondary_truth_files(root: Path) -> list[Path]:
     seen: set[Path] = set()
@@ -219,6 +247,8 @@ def check(root: Path) -> list[str]:
     for path in iter_secondary_truth_files(root):
         relative = path.relative_to(root).as_posix()
         text = path.read_text(encoding="utf-8")
+        if not secondary_truth_candidate(text):
+            continue
         for pattern in SECONDARY_TRUTH_PATTERNS:
             match = pattern.search(text)
             if match:

--- a/scripts/checks/test_pricing_serving_docs.py
+++ b/scripts/checks/test_pricing_serving_docs.py
@@ -316,6 +316,34 @@ class PricingServingDocsContractTest(unittest.TestCase):
         self.assertNotIn("TaskContinuation", protocol.read_text(encoding="utf-8"))
         self.assertEqual(MODULE.check(root), [])
 
+    def test_prefilter_keeps_known_forbidden_samples(self) -> None:
+        samples = (
+            "SINGLE client-facing servable truth",
+            "official upstream aliases display when priced+servable",
+            "intersected with public priced+displayable SSOT",
+            "上架一个模型（served + priced）",
+            "per pricing-availability-source-of-truth.md §2.4 / R-002 it is a feed",
+            "家族 floor 是对 PRICE 事实的估计，只**读**两个事实。",
+            "grok defaults must mirror the unified servable SSOT",
+            "Structural SSOT (servable ↔ priced ↔ display intent) stays here.",
+            "truthful callable menus",
+            "unpriced never blocks serving",
+            "¬unreachable accounts stay hidden",
+            "四层洋葱",
+            "有价 + 可服务",
+            "one entry, four facts",
+            "列出即可调用",
+            "account.go:639",
+        )
+        for sample in samples:
+            with self.subTest(sample=sample):
+                self.assertTrue(MODULE.secondary_truth_candidate(sample), sample)
+
+    def test_prefilter_skips_unrelated_go(self) -> None:
+        self.assertFalse(
+            MODULE.secondary_truth_candidate("package service\n\nfunc add(a int, b int) int { return a + b }\n")
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -243,6 +243,23 @@ has_merge_base_with_head() {
     git rev-parse --verify "$ref" >/dev/null 2>&1 && git merge-base "$ref" HEAD >/dev/null 2>&1
 }
 
+# Triple-dot vs PREFLIGHT_BASE is empty on a main push (origin/main == HEAD).
+# Fall back to first-parent so a squash that touched backend/ent/ still
+# generate-and-diffs.
+_ent_surface_touched() {
+    local base="${PREFLIGHT_BASE:-origin/main}"
+    if git diff --name-only "$base"...HEAD -- backend/ent/ 2>/dev/null | grep -q .; then
+        return 0
+    fi
+    if git rev-parse --verify "$base" >/dev/null 2>&1 \
+       && [ "$(git rev-parse "$base")" = "$(git rev-parse HEAD)" ] \
+       && git rev-parse --verify HEAD^1 >/dev/null 2>&1; then
+        git diff --name-only HEAD^1 HEAD -- backend/ent/ 2>/dev/null | grep -q .
+        return $?
+    fi
+    return 1
+}
+
 template_base="${PREFLIGHT_BASE:-}"
 if [ -n "$template_base" ] && ! has_merge_base_with_head "$template_base"; then
     template_base=""
@@ -376,10 +393,6 @@ dev_status=$?
 if [ "$dev_status" -ne 0 ]; then
     exit "$dev_status"
 fi
-
-# Docker-backed archive overlaps the remaining early Python joins. Keep it
-# after the template so it does not compete with the Caddy/template fanout.
-_archive_rehearsal_spawn_if_needed
 
 # ---- sub2api: agent contract drift ------------------------------------------
 # TokenKey-owned inventory (docs/agent_integration.md). The shared template
@@ -1555,6 +1568,11 @@ elif ! python3 -m py_compile ./ops/qa/edge_phase1_baseline.py; then
 else
     echo "  ok: edge_phase1_baseline.py present (Phase 1 soak probe wired)"
 fi
+
+# Start the Docker-backed archive rehearsal here instead of at preflight startup:
+# the following QA baseline and lightweight contracts provide enough overlap,
+# while avoiding extra Docker pressure during the initial Caddy/template fanout.
+_archive_rehearsal_spawn_if_needed
 
 # ---- sub2api: QA Phase 1 closeout + Phase 2 baseline ops -------------------
 echo ""
@@ -3381,7 +3399,7 @@ _ent_surface_changed=0
 _ent_has_base=0
 if has_merge_base_with_head "${PREFLIGHT_BASE:-origin/main}"; then
     _ent_has_base=1
-    if git diff --name-only "${PREFLIGHT_BASE:-origin/main}...HEAD" 2>/dev/null | grep -q '^backend/ent/'; then
+    if _ent_surface_touched; then
         _ent_surface_changed=1
     fi
 fi

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -278,13 +278,50 @@ export PREFLIGHT_BASE="${template_base:-origin/main}"
 
 # ---- TK: spawn the expensive independent gates early --------------------------
 # Spawned BEFORE the dev-rules template so the heavy jobs (QA go test, the
-# unittest-discover suites, the dockerized Caddyfile adapt) overlap with the
-# template's own ~25s of generic + network checks. Joined at their original
+# unittest-discover suites, the dockerized Caddyfile adapt, and the early
+# Python SSOT walkers) overlap with the template. Joined at their original
 # section positions below. Spawn guards mirror each section's prerequisite
 # checks; a missing prerequisite leaves the job unspawned and the section
 # falls back to its serial FAIL/skip path.
 _qa_bundle_gate_run() {
     cd backend && go test -tags=unit -v ./internal/observability/qa/bundle ./internal/observability/qa
+}
+_protocol_routing_gate_run() {
+    python3 ./scripts/checks/test_protocol_routing_ssot.py >/dev/null &&
+        python3 ./scripts/checks/protocol-routing-ssot.py --quiet
+}
+_pricing_serving_gate_run() {
+    python3 ./scripts/checks/test_pricing_serving_docs.py >/dev/null &&
+        python3 ./scripts/checks/pricing-serving-docs.py --quiet
+}
+_merge_conflict_gate_run() {
+    python3 ./scripts/checks/test_merge_conflict_markers.py >/dev/null &&
+        python3 ./scripts/checks/merge-conflict-markers.py --quiet
+}
+_qa_phase2_gate_run() {
+    python3 -m py_compile \
+        ./ops/qa/qa_archive_recovery_gate.py \
+        ./ops/qa/prod_qa_archive_closeout.py \
+        ./ops/qa/prod_phase2_live_health.py \
+        ./ops/qa/verify_raw_archive_iam_contract.py \
+        ./ops/qa/qa_phase2_health.py \
+        ./deploy/aws/cloudformation/test_stage0_qa_raw_archive_contract.py \
+        ./deploy/aws/cloudformation/test_stage0_edge_qa_s3_boundary.py &&
+        python3 -m unittest \
+            deploy.aws.cloudformation.test_stage0_qa_raw_archive_contract \
+            deploy.aws.cloudformation.test_stage0_edge_qa_s3_boundary \
+            ops.qa.test_qa_archive_recovery_gate \
+            ops.qa.test_prod_qa_archive_closeout \
+            ops.qa.test_prod_phase2_live_health
+}
+_qa_phase_ops_gate_run() {
+    python3 -m py_compile ./ops/qa/edge_phase1_closeout.py ./ops/qa/prod_phase2_baseline.py &&
+        python3 ./ops/qa/test_qa_phase_ops.py
+}
+_qa_phase_ops_spawn_if_needed() {
+    if [ "$_preflight_skip_slow_ops" -ne 1 ] && command -v python3 >/dev/null 2>&1; then
+        _bg_spawn qa_phase_ops _qa_phase_ops_gate_run
+    fi
 }
 if [ "$_preflight_skip_go_contracts" -ne 1 ] && [ "$_preflight_skip_slow_ops" -ne 1 ] && command -v python3 >/dev/null 2>&1 && command -v go >/dev/null 2>&1; then
     _bg_spawn qa_bundle _qa_bundle_gate_run
@@ -314,6 +351,11 @@ if command -v python3 >/dev/null 2>&1; then
     _bg_spawn smoke_unittest python3 -m unittest scripts.test_smoke_suite \
         scripts.test_edge_smoke_phase_contract scripts.test_smoke_env \
         scripts.test_smoke_lib scripts.test_load_smoke_github_env -q
+    _bg_spawn protocol_routing _protocol_routing_gate_run
+    _bg_spawn pricing_serving _pricing_serving_gate_run
+    _bg_spawn merge_conflict _merge_conflict_gate_run
+    _bg_spawn qa_phase2 _qa_phase2_gate_run
+    _qa_phase_ops_spawn_if_needed
 fi
 _bg_spawn ssm_parse bash ./scripts/checks/check-stage0-ssm-host-parse.sh
 
@@ -334,6 +376,10 @@ dev_status=$?
 if [ "$dev_status" -ne 0 ]; then
     exit "$dev_status"
 fi
+
+# Docker-backed archive overlaps the remaining early Python joins. Keep it
+# after the template so it does not compete with the Caddy/template fanout.
+_archive_rehearsal_spawn_if_needed
 
 # ---- sub2api: agent contract drift ------------------------------------------
 # TokenKey-owned inventory (docs/agent_integration.md). The shared template
@@ -364,7 +410,18 @@ errors=0
 
 echo ""
 echo "=== sub2api: protocol-routing SSOT ==="
-if ! python3 ./scripts/checks/test_protocol_routing_ssot.py >/dev/null; then
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required by protocol-routing SSOT)"
+    errors=$((errors + 1))
+elif _bg_spawned protocol_routing; then
+    _bg_join protocol_routing replay-on-failure
+    if [ "$_bg_rc" -ne 0 ]; then
+        echo "  FAIL: protocol-routing SSOT checker self-tests or boundary drift"
+        errors=$((errors + 1))
+    else
+        echo "  ok: protocol-routing owner, handler, and selected-plan boundaries"
+    fi
+elif ! python3 ./scripts/checks/test_protocol_routing_ssot.py >/dev/null; then
     echo "  FAIL: protocol-routing SSOT checker self-tests"
     errors=$((errors + 1))
 elif ! python3 ./scripts/checks/protocol-routing-ssot.py --quiet; then
@@ -376,7 +433,18 @@ fi
 
 echo ""
 echo "=== sub2api: pricing/serving approved-doc precedence ==="
-if ! python3 ./scripts/checks/test_pricing_serving_docs.py >/dev/null; then
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required by pricing/serving approved-doc check)"
+    errors=$((errors + 1))
+elif _bg_spawned pricing_serving; then
+    _bg_join pricing_serving replay-on-failure
+    if [ "$_bg_rc" -ne 0 ]; then
+        echo "  FAIL: pricing/serving approved-doc checker self-tests or owner precedence"
+        errors=$((errors + 1))
+    else
+        echo "  ok: pricing, availability, and protocol docs have one reciprocal precedence"
+    fi
+elif ! python3 ./scripts/checks/test_pricing_serving_docs.py >/dev/null; then
     echo "  FAIL: pricing/serving approved-doc checker self-tests"
     errors=$((errors + 1))
 elif ! python3 ./scripts/checks/pricing-serving-docs.py --quiet; then
@@ -388,7 +456,18 @@ fi
 
 echo ""
 echo "=== sub2api: merge conflict markers ==="
-if ! python3 ./scripts/checks/test_merge_conflict_markers.py >/dev/null; then
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required by merge conflict marker check)"
+    errors=$((errors + 1))
+elif _bg_spawned merge_conflict; then
+    _bg_join merge_conflict replay-on-failure
+    if [ "$_bg_rc" -ne 0 ]; then
+        echo "  FAIL: unresolved merge conflict markers"
+        errors=$((errors + 1))
+    else
+        echo "  ok: no unresolved line-level merge conflict markers"
+    fi
+elif ! python3 ./scripts/checks/test_merge_conflict_markers.py >/dev/null; then
     echo "  FAIL: merge conflict marker checker self-tests"
     errors=$((errors + 1))
 elif ! python3 ./scripts/checks/merge-conflict-markers.py --quiet; then
@@ -1435,6 +1514,14 @@ echo "=== sub2api: QA Phase 2 recovery and IAM contracts ==="
 if ! command -v python3 >/dev/null 2>&1; then
     echo "  FAIL: python3 not on PATH (required by QA recovery contract tests)"
     errors=$((errors + 1))
+elif _bg_spawned qa_phase2; then
+    _bg_join qa_phase2 replay-on-failure
+    if [ "$_bg_rc" -ne 0 ]; then
+        echo "  FAIL: QA Phase 2 recovery and IAM contracts"
+        errors=$((errors + 1))
+    else
+        echo "  ok: exact QA IAM sets and approval-bound workstation recovery gate pass"
+    fi
 elif ! python3 -m py_compile \
     ./ops/qa/qa_archive_recovery_gate.py \
     ./ops/qa/prod_qa_archive_closeout.py \
@@ -1469,11 +1556,6 @@ else
     echo "  ok: edge_phase1_baseline.py present (Phase 1 soak probe wired)"
 fi
 
-# Start the Docker-backed archive rehearsal here instead of at preflight startup:
-# the following QA baseline and lightweight contracts provide enough overlap,
-# while avoiding extra Docker pressure during the initial Caddy/template fanout.
-_archive_rehearsal_spawn_if_needed
-
 # ---- sub2api: QA Phase 1 closeout + Phase 2 baseline ops -------------------
 echo ""
 echo "=== sub2api: QA Phase 1 closeout + Phase 2 baseline ==="
@@ -1482,6 +1564,14 @@ if [ "$_preflight_skip_slow_ops" -eq 1 ]; then
 elif ! command -v python3 >/dev/null 2>&1; then
     echo "  FAIL: python3 not on PATH (required by QA phase ops scripts)"
     errors=$((errors + 1))
+elif _bg_spawned qa_phase_ops; then
+    _bg_join qa_phase_ops replay-on-failure
+    if [ "$_bg_rc" -ne 0 ]; then
+        echo "  FAIL: QA phase ops scripts do not compile or regression tests failed"
+        errors=$((errors + 1))
+    else
+        echo "  ok: Phase 1 closeout + Phase 2 baseline artifacts compile and regression tests pass"
+    fi
 elif ! python3 -m py_compile ./ops/qa/edge_phase1_closeout.py ./ops/qa/prod_phase2_baseline.py; then
     echo "  FAIL: QA phase ops scripts do not compile"
     errors=$((errors + 1))
@@ -3287,17 +3377,20 @@ fi
 # and diffs to catch drift. Non-destructive: restores the directory after.
 echo ""
 echo "=== sub2api: Ent generation staleness ==="
-_ent_schema_changed=0
-if has_merge_base_with_head "${PREFLIGHT_BASE:-origin/main}" && \
-   git diff --name-only "${PREFLIGHT_BASE:-origin/main}...HEAD" 2>/dev/null | grep -q '^backend/ent/schema/'; then
-    _ent_schema_changed=1
+_ent_surface_changed=0
+_ent_has_base=0
+if has_merge_base_with_head "${PREFLIGHT_BASE:-origin/main}"; then
+    _ent_has_base=1
+    if git diff --name-only "${PREFLIGHT_BASE:-origin/main}...HEAD" 2>/dev/null | grep -q '^backend/ent/'; then
+        _ent_surface_changed=1
+    fi
 fi
 if [ "$_preflight_skip_go_contracts" -eq 1 ]; then
     echo "  skip: unchanged Go preflight surface"
 elif ! command -v go >/dev/null 2>&1; then
     echo "  skip: go not on PATH"
-elif [ "$_preflight_fast" = "1" ] && [ "$_ent_schema_changed" = "0" ]; then
-    echo "  skip: Ent generation staleness (preflight-fast; no backend/ent/schema changes)"
+elif [ "$_ent_surface_changed" = "0" ] && { [ "$_ent_has_base" = "1" ] || [ "$_preflight_fast" = "1" ]; }; then
+    echo "  skip: Ent generation staleness (no backend/ent changes vs ${PREFLIGHT_BASE:-origin/main})"
 else
     _ent_rc=0
     ( cd backend && GOTOOLCHAIN="$_backend_go_toolchain" go generate ./ent ) >/dev/null 2>&1 || _ent_rc=$?

--- a/scripts/test_preflight_background_output.py
+++ b/scripts/test_preflight_background_output.py
@@ -254,6 +254,53 @@ _qa_phase_ops_spawn_if_needed
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("spawned=qa_phase_ops:_qa_phase_ops_gate_run", result.stdout)
 
+    def test_ent_surface_touched_uses_pr_range_or_main_first_parent(self) -> None:
+        helper = _shell_function("_ent_surface_touched")
+        with tempfile.TemporaryDirectory() as tmp:
+            script = f"""
+set -u
+set -e
+cd {tmp!s}
+git init -q -b main
+mkdir -p backend/ent/schema scripts
+printf 'schema\\n' > backend/ent/schema/user.go
+printf 'other\\n' > scripts/preflight.sh
+git add backend scripts
+git -c user.email=t@t -c user.name=t commit -qm base
+git checkout -q -b feature
+printf 'schema2\\n' > backend/ent/schema/user.go
+git add backend/ent/schema/user.go
+git -c user.email=t@t -c user.name=t commit -qm ent
+PREFLIGHT_BASE=main
+{helper}
+if _ent_surface_touched; then echo pr-ent=yes; else echo pr-ent=no; fi
+printf 'script\\n' > scripts/preflight.sh
+git add scripts/preflight.sh
+git -c user.email=t@t -c user.name=t commit -qm scripts-only
+if _ent_surface_touched; then echo pr-scripts=yes; else echo pr-scripts=no; fi
+git checkout -q main
+printf 'gen\\n' > backend/ent/generated.go
+git add backend/ent/generated.go
+git -c user.email=t@t -c user.name=t commit -qm main-ent
+PREFLIGHT_BASE=main
+if _ent_surface_touched; then echo main-ent=yes; else echo main-ent=no; fi
+printf 'more\\n' > scripts/preflight.sh
+git add scripts/preflight.sh
+git -c user.email=t@t -c user.name=t commit -qm main-scripts
+if _ent_surface_touched; then echo main-scripts=yes; else echo main-scripts=no; fi
+"""
+            result = subprocess.run(
+                ["bash", "-c", script],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("pr-ent=yes", result.stdout)
+        self.assertIn("pr-scripts=yes", result.stdout)
+        self.assertIn("main-ent=yes", result.stdout)
+        self.assertIn("main-scripts=no", result.stdout)
+
     def test_qa_phase_ops_does_not_spawn_when_slow_ops_are_skipped(self) -> None:
         script = f"""
 set -u

--- a/scripts/test_preflight_background_output.py
+++ b/scripts/test_preflight_background_output.py
@@ -236,6 +236,42 @@ class PreflightBackgroundOutputTest(unittest.TestCase):
         )
         self.assertNotIn("serial=", result.stdout)
 
+    def test_qa_phase_ops_spawns_unless_slow_ops_are_skipped(self) -> None:
+        script = f"""
+set -u
+_preflight_skip_slow_ops=0
+_bg_spawn() {{ printf 'spawned=%s:%s\\n' "$1" "$2"; }}
+command() {{ [ "$1" = -v ] && [ "$2" = python3 ]; }}
+{_optional_shell_function("_qa_phase_ops_spawn_if_needed")}
+_qa_phase_ops_spawn_if_needed
+"""
+        result = subprocess.run(
+            ["bash", "-c", script],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("spawned=qa_phase_ops:_qa_phase_ops_gate_run", result.stdout)
+
+    def test_qa_phase_ops_does_not_spawn_when_slow_ops_are_skipped(self) -> None:
+        script = f"""
+set -u
+_preflight_skip_slow_ops=1
+_bg_spawn() {{ printf 'spawned=%s:%s\\n' "$1" "$2"; }}
+command() {{ [ "$1" = -v ] && [ "$2" = python3 ]; }}
+{_optional_shell_function("_qa_phase_ops_spawn_if_needed")}
+_qa_phase_ops_spawn_if_needed
+"""
+        result = subprocess.run(
+            ["bash", "-c", script],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("spawned=", result.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_preflight_ci_handoffs.py
+++ b/scripts/test_preflight_ci_handoffs.py
@@ -76,6 +76,38 @@ class PreflightCIHandoffTest(unittest.TestCase):
             4,
         )
 
+    def test_ent_staleness_skips_when_backend_ent_is_unchanged(self) -> None:
+        script = PREFLIGHT.read_text(encoding="utf-8")
+        ent_section = script.split(
+            'echo "=== sub2api: Ent generation staleness ==="', 1
+        )[1].split('echo "=== sub2api: changed Go file gofmt ==="', 1)[0]
+        self.assertIn("^backend/ent/", ent_section)
+        self.assertIn("_ent_surface_changed", ent_section)
+        self.assertIn("_ent_has_base", ent_section)
+        self.assertNotIn("_ent_schema_changed", ent_section)
+
+    def test_early_python_ssot_gates_spawn_before_template(self) -> None:
+        script = PREFLIGHT.read_text(encoding="utf-8")
+        template_idx = script.index(
+            'PREFLIGHT_BASE="$template_base" PREFLIGHT_REPO_ROOT="$REPO_ROOT"'
+        )
+        for key in (
+            "_bg_spawn protocol_routing",
+            "_bg_spawn pricing_serving",
+            "_bg_spawn merge_conflict",
+            "_bg_spawn qa_phase2",
+            "_qa_phase_ops_spawn_if_needed",
+        ):
+            with self.subTest(key=key):
+                self.assertLess(script.index(key), template_idx)
+
+        after_template = script.split(
+            'if [ "$dev_status" -ne 0 ]; then', 1
+        )[1].split('echo "=== sub2api: agent contract drift ==="', 1)[0]
+        self.assertIn("_archive_rehearsal_spawn_if_needed", after_template)
+        before_template = script[:template_idx]
+        self.assertEqual(before_template.count("_archive_rehearsal_spawn_if_needed"), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_preflight_ci_handoffs.py
+++ b/scripts/test_preflight_ci_handoffs.py
@@ -81,10 +81,12 @@ class PreflightCIHandoffTest(unittest.TestCase):
         ent_section = script.split(
             'echo "=== sub2api: Ent generation staleness ==="', 1
         )[1].split('echo "=== sub2api: changed Go file gofmt ==="', 1)[0]
-        self.assertIn("^backend/ent/", ent_section)
+        self.assertIn("_ent_surface_touched", ent_section)
         self.assertIn("_ent_surface_changed", ent_section)
         self.assertIn("_ent_has_base", ent_section)
         self.assertNotIn("_ent_schema_changed", ent_section)
+        self.assertIn("HEAD^1 HEAD -- backend/ent/", script)
+        self.assertIn('"$base"...HEAD -- backend/ent/', script)
 
     def test_early_python_ssot_gates_spawn_before_template(self) -> None:
         script = PREFLIGHT.read_text(encoding="utf-8")
@@ -104,9 +106,13 @@ class PreflightCIHandoffTest(unittest.TestCase):
         after_template = script.split(
             'if [ "$dev_status" -ne 0 ]; then', 1
         )[1].split('echo "=== sub2api: agent contract drift ==="', 1)[0]
-        self.assertIn("_archive_rehearsal_spawn_if_needed", after_template)
-        before_template = script[:template_idx]
-        self.assertEqual(before_template.count("_archive_rehearsal_spawn_if_needed"), 1)
+        self.assertNotIn("_archive_rehearsal_spawn_if_needed", after_template)
+        phase1 = script.split(
+            'echo "=== sub2api: QA Phase 1 edge baseline probe ==="', 1
+        )[1].split(
+            'echo "=== sub2api: QA Phase 1 closeout + Phase 2 baseline ==="', 1
+        )[0]
+        self.assertIn("_archive_rehearsal_spawn_if_needed", phase1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 摘要
- main 上 preflight 脚本约 67s：pricing/protocol SSOT 与 template 串行，Ent 在 `backend/ent/` 未改时仍 `go generate`。
- 把 protocol / pricing / merge-conflict / QA Phase 2 / QA closeout 提前到 template 之前并行。
- Ent 只在相对 base（PR 用 `base...HEAD`；main push 回退 `HEAD^1`）改了 `backend/ent/` 时再生。
- archive 仍在 QA Phase 1 baseline 之后启动，避免和 Caddy 抢 Docker。
- pricing 扫描先做字面量预过滤。门禁断言不变。

## 风险
常规风险。只改 preflight 编排与文档扫描预过滤，不改对外 API / Web / 鉴权。失败仍在原 section 回放输出。

## 验证
- `python3 -m unittest scripts.test_preflight_background_output scripts.test_preflight_ci_handoffs scripts.checks.test_pricing_serving_docs -q`（52 tests, OK）
- `PREFLIGHT_BASE=origin/main ./scripts/preflight.sh` 通过
- Ent helper 覆盖：PR 含 ent → 跑；main squash 含 ent → 跑；main 只改 scripts → skip
- 本地 pricing check 从 5.9s 降到 1.8s

## 提交
- f48af2010 perf(ci): overlap slow preflight gates and skip unchanged Ent
- 7a8326f63 fix(ci): address R-001..R-002 — keep Ent on main squash and Caddy/archive apart
- 最新提交：7a8326f63