### PR TITLE
fix(ops): 让 Edge infra smoke 解析蓝绿 active 容器

### DIFF
--- a/ops/stage0/edge_infra_smoke.sh
+++ b/ops/stage0/edge_infra_smoke.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Remote Edge infra smoke. Delivered through ops/observability/run-probe.sh,
+# which places the canonical app-container resolver beside this script.
+set -euo pipefail
+
+TOKENKEY_ROOT="${TOKENKEY_ROOT:-/var/lib/tokenkey}"
+TK_DOCKER="${TK_DOCKER:-sudo docker}"
+
+resolver=""
+for candidate in \
+  "${TK_LIB_DIR:-$(dirname "$0")}/resolve-app-container.sh" \
+  "$(dirname "$0")/../lib/resolve-app-container.sh"; do
+  if [ -f "$candidate" ]; then
+    resolver="$candidate"
+    break
+  fi
+done
+if [ -z "$resolver" ]; then
+  echo "tk_edge_post_deploy_smoke: canonical app-container resolver not found" >&2
+  exit 1
+fi
+# shellcheck source=../lib/resolve-app-container.sh
+source "$resolver"
+
+tk_docker() {
+  # shellcheck disable=SC2086  # TK_DOCKER may legitimately be "sudo docker".
+  $TK_DOCKER "$@"
+}
+
+cd "$TOKENKEY_ROOT"
+tk_docker compose version
+tk_docker compose -f docker-compose.yml --env-file .env ps
+
+if ! app_container="$(tk_resolve_app_container auto)"; then
+  echo "tk_edge_post_deploy_smoke: active app container unresolved" >&2
+  exit 1
+fi
+if ! qa_cap="$(tk_docker exec "$app_container" printenv QA_CAPTURE_ENABLED 2>/dev/null)"; then
+  qa_cap="missing"
+fi
+echo "tk_edge_post_deploy_smoke: container=${app_container} QA_CAPTURE_ENABLED=${qa_cap}"
+if [ "$qa_cap" != "false" ]; then
+  echo "tk_edge_post_deploy_smoke: edge QA capture must be disabled (QA_CAPTURE_ENABLED=false)" >&2
+  exit 1
+fi
+
+tk_docker exec "$app_container" wget -qO- http://localhost:8080/health

--- a/ops/stage0/edge_post_deploy_smoke.sh
+++ b/ops/stage0/edge_post_deploy_smoke.sh
@@ -18,6 +18,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+EDGE_RUN_PROBE="${EDGE_RUN_PROBE:-${REPO_ROOT}/ops/observability/run-probe.sh}"
 # shellcheck source=smoke_env.sh
 source "${SCRIPT_DIR}/smoke_env.sh"
 # Shared SSM "resolve managed-instance after tag-targeted send" helper.
@@ -90,91 +92,21 @@ run_infra_smoke() {
     exit 1
   fi
 
-  ssm_commands=(
-    "set -euo pipefail"
-    "cd /var/lib/tokenkey"
-    "sudo docker compose version"
-    "sudo docker compose -f docker-compose.yml --env-file .env ps"
-    'qa_cap=$(sudo docker compose -f docker-compose.yml --env-file .env exec -T tokenkey printenv QA_CAPTURE_ENABLED 2>/dev/null || echo missing)'
-    'echo "tk_edge_post_deploy_smoke: container QA_CAPTURE_ENABLED=${qa_cap}"'
-    'if [ "${qa_cap}" != "false" ]; then echo "tk_edge_post_deploy_smoke: edge QA capture must be disabled (QA_CAPTURE_ENABLED=false)" >&2; exit 1; fi'
-    "sudo docker compose -f docker-compose.yml --env-file .env exec -T tokenkey wget -qO- http://localhost:8080/health"
-  )
-
   if [[ "${EDGE_SELF_SMOKE_MODE}" == "api" ]]; then
     echo "tk_edge_post_deploy_smoke: EDGE_SELF_SMOKE_MODE=api uses edge-native oauth smoke (not post_deploy_smoke)"
   else
     echo "tk_edge_post_deploy_smoke: edge API self-smoke skipped (set EDGE_SELF_SMOKE_MODE=api to enable native oauth probe)"
   fi
 
-  jq -n --argjson commands "$(printf '%s\n' "${ssm_commands[@]}" | jq -R . | jq -s .)" '{commands:$commands}' > "${tmpdir}/edge-ssm.json"
-  eff_instance_id="${EDGE_INSTANCE_ID}"
-  declare -a send_targets_extra=()
-  if [[ "${EDGE_INSTANCE_ID}" == mi-* ]]; then
-    send_targets_extra=(--targets "Key=tag:EdgeId,Values=${EDGE_ID}" "Key=tag:Platform,Values=lightsail")
-  else
-    send_targets_extra=(--instance-ids "${EDGE_INSTANCE_ID}")
-  fi
-  cmd_id="$(aws ssm send-command \
-    --region "${AWS_CLI_REGION}" \
-    "${send_targets_extra[@]}" \
-    --document-name AWS-RunShellScript \
+  bash "${EDGE_RUN_PROBE}" \
+    --target "edge:${EDGE_ID}" \
     --comment "edge-self-smoke edge=${EDGE_ID}" \
-    --parameters "file://${tmpdir}/edge-ssm.json" \
-    --query 'Command.CommandId' --output text)"
-  if [[ "${EDGE_INSTANCE_ID}" == mi-* ]]; then
-    eff_instance_id="$(ssm_resolve_invocation_mi "${AWS_CLI_REGION}" "${cmd_id}")"
-    if [[ "${eff_instance_id}" != "${EDGE_INSTANCE_ID}" ]]; then
-      echo "::warning::live SSM invocation instance ${eff_instance_id} != EDGE_INSTANCE_ID ${EDGE_INSTANCE_ID} (check /ssm_managed_instance_id Parameter Store)"
-    fi
-  fi
-  echo "tk_edge_post_deploy_smoke: edge self-smoke ssm command-id=${cmd_id}"
-
-  deadline=$(( $(date +%s) + 180 ))
-  status="InProgress"
-  while true; do
-    status="$(aws ssm get-command-invocation \
-      --region "${AWS_CLI_REGION}" \
-      --command-id "${cmd_id}" --instance-id "${eff_instance_id}" \
-      --query 'Status' --output text 2>/dev/null || echo InProgress)"
-    case "${status}" in
-      Success|Failed|TimedOut|Cancelled) break ;;
-    esac
-    if [[ $(date +%s) -ge ${deadline} ]]; then
-      status="TimedOut"
-      break
-    fi
-    sleep 5
-  done
-  aws ssm get-command-invocation \
-    --region "${AWS_CLI_REGION}" \
-    --command-id "${cmd_id}" --instance-id "${eff_instance_id}" \
-    --query 'StandardOutputContent' --output text > "${tmpdir}/edge-stdout.txt"
-  aws ssm get-command-invocation \
-    --region "${AWS_CLI_REGION}" \
-    --command-id "${cmd_id}" --instance-id "${eff_instance_id}" \
-    --query 'StandardErrorContent' --output text > "${tmpdir}/edge-stderr.txt"
-  invoke_details="$(aws ssm get-command-invocation \
-    --region "${AWS_CLI_REGION}" \
-    --command-id "${cmd_id}" --instance-id "${eff_instance_id}" \
-    --output json 2>/dev/null || echo '{}')"
-  echo '--- edge self-smoke invocation (Status / ResponseCode / StatusDetails) ---'
-  echo "${invoke_details}" | jq '{Status, ResponseCode, StatusDetails, ExecutionElapsedTime}'
-  echo '--- edge self-smoke stdout (last 4KB) ---'
-  tail -c 4096 "${tmpdir}/edge-stdout.txt"
-  echo
-  echo '--- edge self-smoke stderr (last 4KB) ---'
-  tail -c 4096 "${tmpdir}/edge-stderr.txt"
-  echo
-  if [[ "${status}" != "Success" ]]; then
-    echo "tk_edge_post_deploy_smoke: edge self-smoke SSM status=${status}" >&2
-    exit 1
-  fi
+    --timeout-seconds 180 \
+    --script "${SCRIPT_DIR}/edge_infra_smoke.sh"
 }
 
 run_edge_native_anthropic_smoke() {
   echo "tk_edge_post_deploy_smoke: edge-native anthropic oauth smoke edge=${EDGE_ID} models=${TK_SMOKE_EDGE_LOCAL_CHAT_MODELS}"
-  REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
   bash "${REPO_ROOT}/ops/observability/run-probe.sh" \
     --target "edge:${EDGE_ID}" \
     --comment "edge-native-anthropic-smoke edge=${EDGE_ID}" \

--- a/ops/stage0/test_edge_post_deploy_smoke.py
+++ b/ops/stage0/test_edge_post_deploy_smoke.py
@@ -15,6 +15,117 @@ _SCRIPT = _STAGE0_DIR / "edge_post_deploy_smoke.sh"
 
 
 class EdgePostDeploySmokeTest(unittest.TestCase):
+    def test_infra_smoke_uses_active_bluegreen_container(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="edge-infra-smoke-test-") as td:
+            temp_root = pathlib.Path(td)
+            fake_bin = temp_root / "fake-bin"
+            fake_bin.mkdir()
+            active_color = temp_root / "active-color"
+            active_color.write_text("green\n")
+            docker_calls = temp_root / "docker-calls.txt"
+
+            fake_run_probe = temp_root / "run-probe.sh"
+            fake_run_probe.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    script=""
+                    while [ "$#" -gt 0 ]; do
+                      case "$1" in
+                        --script) script="$2"; shift 2 ;;
+                        --target|--comment|--timeout-seconds|--expected-instance-id|--env|--with|--remote-path) shift 2 ;;
+                        *) echo "unexpected run-probe arg: $1" >&2; exit 1 ;;
+                      esac
+                    done
+                    test -n "$script"
+                    bash "$script"
+                    """
+                )
+            )
+            fake_run_probe.chmod(0o755)
+
+            fake_aws = fake_bin / "aws"
+            fake_aws.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    echo "unexpected direct aws invocation: $*" >&2
+                    exit 99
+                    """
+                )
+            )
+            fake_aws.chmod(0o755)
+
+            fake_curl = fake_bin / "curl"
+            fake_curl.write_text("#!/usr/bin/env bash\nprintf '403'\n")
+            fake_curl.chmod(0o755)
+
+            fake_docker = fake_bin / "docker"
+            fake_docker.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    printf '%s\\n' "$*" >> "${DOCKER_CALLS_LOG}"
+                    case "${1:-}" in
+                      inspect)
+                        name="${!#}"
+                        if [ "$name" = tokenkey-green ]; then
+                          printf 'true\\n'
+                          exit 0
+                        fi
+                        exit 1
+                        ;;
+                      compose)
+                        exit 0
+                        ;;
+                      exec)
+                        container="${2:-}"
+                        [ "$container" = tokenkey-green ] || exit 1
+                        case "${3:-}" in
+                          printenv) printf 'false\\n' ;;
+                          wget) printf '{"status":"ok"}\\n' ;;
+                          *) exit 1 ;;
+                        esac
+                        ;;
+                      *) exit 1 ;;
+                    esac
+                    """
+                )
+            )
+            fake_docker.chmod(0o755)
+
+            env = {
+                **os.environ,
+                "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+                "AWS_REGION": "us-east-1",
+                "EDGE_API_URL": "https://us5.example.test",
+                "EDGE_ID": "us5",
+                "EDGE_INSTANCE_ID": "mi-test",
+                "EDGE_SMOKE_PHASE": "infra",
+                "EDGE_RUN_PROBE": str(fake_run_probe),
+                "SKIP_EXTERNAL_HEALTH": "1",
+                "ACTIVE_COLOR_FILE": str(active_color),
+                "TOKENKEY_ROOT": str(temp_root),
+                "TK_DOCKER": "docker",
+                "DOCKER_CALLS_LOG": str(docker_calls),
+            }
+            proc = subprocess.run(
+                ["bash", str(_SCRIPT)],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+            )
+            calls = docker_calls.read_text().splitlines() if docker_calls.exists() else []
+
+        self.assertEqual(proc.returncode, 0, msg=f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}")
+        self.assertIn("tk_edge_post_deploy_smoke: container=tokenkey-green QA_CAPTURE_ENABLED=false", proc.stdout)
+        self.assertIn("exec tokenkey-green printenv QA_CAPTURE_ENABLED", calls)
+        self.assertIn("exec tokenkey-green wget -qO- http://localhost:8080/health", calls)
+
     def test_native_oauth_smoke_delivers_reserved_resources_companion(self) -> None:
         with tempfile.TemporaryDirectory(prefix="edge-post-deploy-smoke-test-") as td:
             repo_root = pathlib.Path(td) / "repo"


### PR DESCRIPTION
## 摘要

- 将 Edge infra 的远端容器检查拆到 `ops/stage0/edge_infra_smoke.sh`，统一经 `run-probe.sh` 投递。
- 使用 canonical `tk_resolve_app_container auto` 解析当前 active 容器，蓝绿部署后不再固定访问 legacy `tokenkey` service。
- 保留 `QA_CAPTURE_ENABLED=false` 与容器内 `/health` 的 fail-closed 验收；本 PR 不改变运行时镜像内容。

## 风险

- 影响范围仅为 Edge post-deploy infra smoke verifier；不改 prod/Edge 业务运行时、数据、凭证或路由。
- active-color 不合法且无法唯一确定运行容器时会失败关闭，不做位置猜测。
- Web impact: none。
- 合并后复验既有 `v1.8.181` 即可，无需构建新 tag；canary full smoke 绿前不推进 prod。

## 验证

- 修复前回归场景：`active-color=green`、仅 `tokenkey-green` 运行、legacy `tokenkey` 不存在时，旧 infra smoke 超时/失败。
- `python3 -m unittest -v ops.stage0.test_edge_post_deploy_smoke ops.stage0.test_deploy_via_ssm_bluegreen ops.stage0.test_deploy_via_ssm_edge_qa_capture`：25 项通过。
- `python3 scripts/checks/app-container-resolver.py`：通过。
- `bash -n ops/stage0/edge_infra_smoke.sh ops/stage0/edge_post_deploy_smoke.sh`：通过。
- `bash scripts/preflight.sh`：完整通过。

## 提交

- `60ef2da8e fix(ops): resolve active Edge container in infra smoke`
- 最新提交：`60ef2da8e`
