### PR TITLE
fix(protocol): 已验证协议可服务，未确认协议不再卡死整机健康

### DIFF
--- a/backend/internal/service/account_supported_protocols.go
+++ b/backend/internal/service/account_supported_protocols.go
@@ -188,8 +188,7 @@ func protocolAccountSnapshot(account *Account, requestedModel string, requireCom
 		return protocolrouter.AccountSnapshot{}, errors.New("governed account is missing protocol endpoint capability link")
 	}
 	if capability.CapabilityKey == "" || capability.Revision <= 0 ||
-		(!capability.ProbeEvidence.InitialProbeCompleted && !capability.ProbeEvidence.OfficialSeed) ||
-		capability.IdentityConflict || capability.ProbeEvidence.IdentityConflict {
+		!protocolCapabilityHasVerifiedRoutingEvidence(capability) {
 		return protocolrouter.AccountSnapshot{}, errors.New("protocol endpoint capability is invalid or conflicted")
 	}
 	identity, governed, err := BuildProtocolEndpointIdentity(account)

--- a/backend/internal/service/account_supported_protocols_test.go
+++ b/backend/internal/service/account_supported_protocols_test.go
@@ -186,6 +186,42 @@ func TestProtocolAccountSnapshotRejectsUnverifiedHistoricalCapability(t *testing
 	}
 }
 
+func TestProtocolAccountSnapshotAdmitsPartialPositiveProbeWithoutInitialCompletion(t *testing.T) {
+	account := &Account{
+		ID:       60,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":       "secret",
+			"base_url":      "https://relay.example.test/v1",
+			"model_mapping": map[string]any{"qwen3.5-plus": "qwen3.5-plus"},
+		},
+		Extra: map[string]any{},
+	}
+	attachTestProtocolCapability(account, protocolrouter.ProtocolChatCompletions)
+	account.ProtocolEndpointCapability.ProbeEvidence.InitialProbeCompleted = false
+	account.ProtocolEndpointCapability.ProbeEvidence.OfficialSeed = false
+	account.ProtocolEndpointCapability.ProbeEvidence.Verdicts = map[string]any{
+		string(protocolrouter.ProtocolChatCompletions): string(ProtocolProbePositive),
+	}
+
+	snapshot, err := ProtocolAccountSnapshot(account, "qwen3.5-plus")
+	if err != nil {
+		t.Fatalf("partial positive capability was excluded: %v", err)
+	}
+	request, err := protocolrouter.NewCanonicalRequest(protocolrouter.CanonicalRequestInput{
+		InboundProtocol: protocolrouter.ProtocolChatCompletions,
+		RequestedModel:  "qwen3.5-plus",
+		Body:            []byte(`{"model":"qwen3.5-plus","messages":[{"role":"user","content":"hi"}]}`),
+	})
+	if err != nil {
+		t.Fatalf("NewCanonicalRequest: %v", err)
+	}
+	if _, err := NewProtocolRouter().Plan(request, snapshot); err != nil {
+		t.Fatalf("partial positive chat_completions route failed: %v", err)
+	}
+}
+
 func TestProtocolAccountSnapshotUsesOfficialProfileForOpenAIOAuth(t *testing.T) {
 	account := &Account{
 		ID:       77,

--- a/backend/internal/service/protocol_routing_migration.go
+++ b/backend/internal/service/protocol_routing_migration.go
@@ -37,8 +37,13 @@ type ProtocolRoutingMigrationReport struct {
 	SeededOfficial int
 	ProbeAttempts  int
 	ProbeResolved  int
-	CutoverReady   bool
-	Remediation    []ProtocolRoutingRemediation
+	// TrafficReady is true when every hard blocker is gone: identity can be
+	// built, and any already-verified protocol set still has a legal route.
+	// Unverified / incomplete probes stay in Remediation and do not flip this.
+	TrafficReady bool
+	// CutoverReady is true only when TrafficReady and no remediations remain.
+	CutoverReady bool
+	Remediation  []ProtocolRoutingRemediation
 }
 
 type protocolRoutingMigrationRepository interface {
@@ -71,7 +76,7 @@ func evaluateProtocolRoutingSSOT(
 	router *protocolrouter.Router,
 	prepare bool,
 ) (ProtocolRoutingMigrationReport, error) {
-	report := ProtocolRoutingMigrationReport{CutoverReady: true}
+	report := ProtocolRoutingMigrationReport{CutoverReady: true, TrafficReady: true}
 	accounts, err := repo.ListActive(ctx)
 	if err != nil {
 		return report, err
@@ -85,6 +90,7 @@ func evaluateProtocolRoutingSSOT(
 		identity, governed, err := BuildProtocolEndpointIdentity(account)
 		if err != nil {
 			if account.Schedulable {
+				report.TrafficReady = false
 				report.CutoverReady = false
 				report.Remediation = append(report.Remediation, ProtocolRoutingRemediation{AccountID: account.ID, Name: account.Name, Reason: ProtocolRoutingRemediationNoLegalRoute})
 			}
@@ -128,8 +134,7 @@ func evaluateProtocolRoutingSSOT(
 			continue
 		}
 		if capability.IdentityConflict || capability.ProbeEvidence.IdentityConflict ||
-			(!capability.ProbeEvidence.InitialProbeCompleted && !capability.ProbeEvidence.OfficialSeed) ||
-			len(capability.SupportedProtocols) == 0 {
+			!protocolCapabilityHasVerifiedRoutingEvidence(capability) {
 			report.CutoverReady = false
 			report.Remediation = append(report.Remediation, ProtocolRoutingRemediation{
 				AccountID: account.ID,
@@ -140,12 +145,22 @@ func evaluateProtocolRoutingSSOT(
 		}
 		models := protocolRoutingMigrationModels(account)
 		if !accountHasLegalProtocolRoute(router, account, models) {
+			report.TrafficReady = false
 			report.CutoverReady = false
 			report.Remediation = append(report.Remediation, ProtocolRoutingRemediation{
 				AccountID: account.ID,
 				Name:      account.Name,
 				Reason:    ProtocolRoutingRemediationNoLegalRoute,
 				Models:    models,
+			})
+			continue
+		}
+		if !capability.ProbeEvidence.InitialProbeCompleted && !capability.ProbeEvidence.OfficialSeed {
+			report.CutoverReady = false
+			report.Remediation = append(report.Remediation, ProtocolRoutingRemediation{
+				AccountID: account.ID,
+				Name:      account.Name,
+				Reason:    ProtocolRoutingRemediationProbeRequired,
 			})
 		}
 	}
@@ -212,9 +227,12 @@ func prepareProtocolRoutingSSOT(
 		return nil
 	})
 	if errors.Is(err, errProtocolRoutingFinalReadinessNotReady) {
+		final.TrafficReady = false
+		final.CutoverReady = false
 		return newProtocolRoutingSSOTReady(final, router), nil
 	}
 	if err != nil {
+		final.TrafficReady = false
 		final.CutoverReady = false
 		return ProtocolRoutingSSOTReady{Report: final}, err
 	}
@@ -295,6 +313,27 @@ func protocolRoutingMigrationModels(account *Account) []string {
 	}
 	sort.Strings(models)
 	return models
+}
+
+func protocolCapabilityHasVerifiedRoutingEvidence(capability *ProtocolEndpointCapability) bool {
+	if capability == nil {
+		return false
+	}
+	if capability.IdentityConflict || capability.ProbeEvidence.IdentityConflict {
+		return false
+	}
+	if len(capability.SupportedProtocols) == 0 {
+		return false
+	}
+	if capability.ProbeEvidence.OfficialSeed || capability.ProbeEvidence.InitialProbeCompleted {
+		return true
+	}
+	for _, protocol := range capability.SupportedProtocols {
+		if conclusiveProtocolProbeVerdict(capability.ProbeEvidence.Verdicts[string(protocol)]) == ProtocolProbePositive {
+			return true
+		}
+	}
+	return false
 }
 
 func accountHasLegalProtocolRoute(router *protocolrouter.Router, account *Account, models []string) bool {

--- a/backend/internal/service/protocol_routing_migration_test.go
+++ b/backend/internal/service/protocol_routing_migration_test.go
@@ -300,7 +300,7 @@ func TestMigrateProtocolRoutingSSOTSeedsOnlyOfficialProfilesAndReportsCustomAcco
 	if err != nil {
 		t.Fatalf("MigrateProtocolRoutingSSOT: %v", err)
 	}
-	if report.ActiveGoverned != 2 || report.SeededOfficial != 1 || report.CutoverReady {
+	if report.ActiveGoverned != 2 || report.SeededOfficial != 1 || report.CutoverReady || !report.TrafficReady {
 		t.Fatalf("report = %+v", report)
 	}
 	if projection, exists := repo.accounts[0].Extra[SupportedProtocolsExtraKey]; exists {
@@ -405,7 +405,7 @@ func TestProtocolRoutingMigrationReportRejectsCanonicalAccountWithoutLegalRoute(
 	if err != nil {
 		t.Fatalf("MigrateProtocolRoutingSSOT: %v", err)
 	}
-	if report.CutoverReady || len(report.Remediation) != 1 || report.Remediation[0].Reason != ProtocolRoutingRemediationNoLegalRoute {
+	if report.CutoverReady || report.TrafficReady || len(report.Remediation) != 1 || report.Remediation[0].Reason != ProtocolRoutingRemediationNoLegalRoute {
 		t.Fatalf("report = %+v", report)
 	}
 }
@@ -431,8 +431,83 @@ func TestProtocolRoutingMigrationDoesNotTreatHistoricalWildcardSeedAsVerified(t 
 	if err != nil {
 		t.Fatalf("MigrateProtocolRoutingSSOT: %v", err)
 	}
-	if report.CutoverReady || len(report.Remediation) != 1 || report.Remediation[0].Reason != ProtocolRoutingRemediationProbeRequired {
+	if report.CutoverReady || !report.TrafficReady || len(report.Remediation) != 1 || report.Remediation[0].Reason != ProtocolRoutingRemediationProbeRequired {
 		t.Fatalf("historical positive seed bypassed initial endpoint probe: %+v", report)
+	}
+}
+
+func TestMigrateProtocolRoutingSSOTAdmitsPartialPositiveProtocolsWithoutBlockingTraffic(t *testing.T) {
+	verified := Account{
+		ID:       60,
+		Name:     "Qwen",
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":       "secret",
+			"base_url":      "https://relay.example.test/v1",
+			"model_mapping": map[string]any{"qwen3.5-plus": "qwen3.5-plus"},
+		},
+	}
+	unverified := Account{
+		ID:       94,
+		Name:     "cloudwise",
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":  "secret",
+			"base_url": "https://api.cloudwise.ai/api",
+			"model_mapping": map[string]any{
+				"claude-*": "claude-*",
+			},
+		},
+		Extra: map[string]any{SupportedProtocolsExtraKey: []any{string(protocolrouter.ProtocolMessages)}},
+	}
+	repo := &protocolRoutingMigrationRepo{accounts: []Account{verified, unverified}}
+	identity, governed, err := BuildProtocolEndpointIdentity(&verified)
+	if err != nil || !governed {
+		t.Fatalf("BuildProtocolEndpointIdentity: governed=%v err=%v", governed, err)
+	}
+	repo.ensureCapabilityMaps()
+	repo.capabilities[identity.Key()] = &ProtocolEndpointCapability{
+		ID:                 1,
+		CapabilityKey:      identity.Key(),
+		Identity:           identity,
+		SupportedProtocols: []protocolrouter.Protocol{protocolrouter.ProtocolChatCompletions},
+		Revision:           1,
+		ProbeEvidence: ProtocolProbeEvidence{
+			Verdicts: map[string]any{
+				string(protocolrouter.ProtocolChatCompletions): string(ProtocolProbePositive),
+			},
+		},
+	}
+	repo.links[verified.ID] = identity.Key()
+
+	report, err := MigrateProtocolRoutingSSOT(context.Background(), repo, NewProtocolRouter())
+	if err != nil {
+		t.Fatalf("MigrateProtocolRoutingSSOT: %v", err)
+	}
+	ready := newProtocolRoutingSSOTReady(report, NewProtocolRouter())
+	if !ready.Ready() || !report.TrafficReady {
+		t.Fatalf("partial positive account blocked process traffic readiness: %+v", report)
+	}
+	if report.CutoverReady {
+		t.Fatalf("incomplete probe was treated as full cutover: %+v", report)
+	}
+	if len(report.Remediation) != 2 {
+		t.Fatalf("remediation = %+v, want probe_required for both the partial and unverified accounts", report.Remediation)
+	}
+	for _, item := range report.Remediation {
+		if item.Reason != ProtocolRoutingRemediationProbeRequired {
+			t.Fatalf("remediation = %+v, want probe_required only", report.Remediation)
+		}
+	}
+
+	linked := repo.accounts[0]
+	if _, err := ProtocolAccountSnapshot(&linked, "qwen3.5-plus"); err != nil {
+		t.Fatalf("verified partial protocol was not routable: %v", err)
+	}
+	if _, err := ProtocolAccountSnapshot(&repo.accounts[1], "claude-sonnet"); err == nil {
+		t.Fatal("unverified historical protocol was admitted to runtime routing")
 	}
 }
 
@@ -482,7 +557,7 @@ func TestPrepareProtocolRoutingSSOTProbesRemediationBeforeEnablingRouter(t *test
 	}
 }
 
-func TestPrepareProtocolRoutingSSOTKeepsRouterAndFailsReadinessWhenRemediationRemains(t *testing.T) {
+func TestPrepareProtocolRoutingSSOTKeepsRouterAndTrafficReadyWhenRemediationRemains(t *testing.T) {
 	repo := &protocolRoutingMigrationRepo{accounts: []Account{{
 		ID:       13,
 		Name:     "unresolved-openai",
@@ -500,11 +575,11 @@ func TestPrepareProtocolRoutingSSOTKeepsRouterAndFailsReadinessWhenRemediationRe
 	if err != nil {
 		t.Fatalf("prepareProtocolRoutingSSOT: %v", err)
 	}
-	if ready.Report.CutoverReady || ready.EnabledRouter() != router {
-		t.Fatalf("ready = %+v router=%p, want remediation with router %p", ready.Report, ready.EnabledRouter(), router)
+	if ready.Report.CutoverReady || !ready.Report.TrafficReady || ready.EnabledRouter() != router {
+		t.Fatalf("ready = %+v router=%p, want traffic-ready remediation with router %p", ready.Report, ready.EnabledRouter(), router)
 	}
-	if ready.Ready() {
-		t.Fatal("Ready() = true, want false while remediation remains")
+	if !ready.Ready() {
+		t.Fatal("Ready() = false, want true while only unverified accounts remain excluded")
 	}
 	if ready.Report.ProbeAttempts != 1 || ready.Report.ProbeResolved != 0 {
 		t.Fatalf("probe outcome = attempts:%d resolved:%d, want 1/0", ready.Report.ProbeAttempts, ready.Report.ProbeResolved)
@@ -662,8 +737,8 @@ func TestPrepareProtocolRoutingSSOTRetriesInconclusive429WithoutPublishingThenPu
 	if err != nil {
 		t.Fatalf("first prepareProtocolRoutingSSOT: %v", err)
 	}
-	if first.Ready() || first.Report.CutoverReady {
-		t.Fatalf("inconclusive 429 admitted candidate: %+v", first.Report)
+	if !first.Ready() || !first.Report.TrafficReady || first.Report.CutoverReady {
+		t.Fatalf("inconclusive 429 should keep traffic ready without full cutover: %+v", first.Report)
 	}
 	if repo.publishCalls != 0 {
 		t.Fatalf("inconclusive 429 publication calls = %d, want 0", repo.publishCalls)

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -50,30 +50,32 @@ func (r ProtocolRoutingSSOTReady) EnabledRouter() *protocolrouter.Router {
 }
 
 func (r ProtocolRoutingSSOTReady) Ready() bool {
-	return r.Report.CutoverReady
+	return r.Report.TrafficReady
 }
 
 func ProvideProtocolRoutingSSOTReady(accountRepo AccountRepository, accountTestService *AccountTestService, router *protocolrouter.Router) ProtocolRoutingSSOTReady {
 	migrationRepo, ok := accountRepo.(protocolRoutingMigrationRepository)
 	if !ok {
-		report := ProtocolRoutingMigrationReport{CutoverReady: false}
+		report := ProtocolRoutingMigrationReport{TrafficReady: false, CutoverReady: false}
 		logger.LegacyPrintf("service.protocol_routing", "protocol SSOT repository capability is unavailable")
 		return newProtocolRoutingSSOTReady(report, router)
 	}
 	ready, err := prepareProtocolRoutingSSOT(context.Background(), migrationRepo, router, accountTestService)
 	report := ready.Report
 	if err != nil {
+		report.TrafficReady = false
 		report.CutoverReady = false
 		logger.LegacyPrintf("service.protocol_routing", "protocol SSOT migration/report failed: %v", err)
 		return newProtocolRoutingSSOTReady(report, router)
 	}
 	logger.LegacyPrintf(
 		"service.protocol_routing",
-		"protocol SSOT migration/report: active_governed=%d seeded_official=%d probe_attempts=%d probe_resolved=%d cutover_ready=%t remediation=%d",
+		"protocol SSOT migration/report: active_governed=%d seeded_official=%d probe_attempts=%d probe_resolved=%d traffic_ready=%t cutover_ready=%t remediation=%d",
 		report.ActiveGoverned,
 		report.SeededOfficial,
 		report.ProbeAttempts,
 		report.ProbeResolved,
+		report.TrafficReady,
 		report.CutoverReady,
 		len(report.Remediation),
 	)

--- a/scripts/checks/protocol-routing-ssot.py
+++ b/scripts/checks/protocol-routing-ssot.py
@@ -428,7 +428,7 @@ def check(root: Path) -> list[str]:
         if not snapshot_bodies:
             errors.append("canonical capability owner is missing protocolAccountSnapshot")
         for body in snapshot_bodies:
-            if not contains_identifier(body, "InitialProbeCompleted") or not contains_identifier(body, "OfficialSeed"):
+            if not contains_identifier(body, "protocolCapabilityHasVerifiedRoutingEvidence"):
                 errors.append("protocolAccountSnapshot does not fail closed on unverified capability evidence")
 
     identity_owner = root / "backend/internal/service/protocol_endpoint_identity.go"
@@ -563,6 +563,15 @@ def check(root: Path) -> list[str]:
             errors.append("protocol routing startup uses the normal probe writer instead of the preparation probe")
         if not contains_identifier(source, "ProbeAccountProtocolCapabilitiesForPreparation"):
             errors.append("protocol routing startup is missing the preparation probe")
+        evidence_bodies = function_bodies(source, "protocolCapabilityHasVerifiedRoutingEvidence")
+        if not evidence_bodies or not all(
+            contains_identifier(body, "OfficialSeed")
+            and contains_identifier(body, "InitialProbeCompleted")
+            and contains_identifier(body, "ProtocolProbePositive")
+            and contains_identifier(body, "IdentityConflict")
+            for body in evidence_bodies
+        ):
+            errors.append("protocol routing verified-evidence helper is missing official, probe, or conflict gates")
         preparation_bodies = function_bodies(source, "prepareProtocolRoutingSSOT")
         for body in preparation_bodies:
             if not contains_identifier(body, "PublishProtocolRoutingProjections"):
@@ -985,9 +994,9 @@ def check(root: Path) -> list[str]:
                 errors.append("protocol routing readiness must not disable the router")
         ready_accessors = function_bodies(source, "Ready")
         if not ready_accessors or not all(
-            contains_identifier(body, "CutoverReady") for body in ready_accessors
+            contains_identifier(body, "TrafficReady") for body in ready_accessors
         ):
-            errors.append("protocol routing Ready accessor is not gated by CutoverReady")
+            errors.append("protocol routing Ready accessor is not gated by TrafficReady")
 
     handler_wire = root / "backend/internal/handler/wire.go"
     if handler_wire.is_file():

--- a/scripts/checks/test_protocol_routing_ssot.py
+++ b/scripts/checks/test_protocol_routing_ssot.py
@@ -114,7 +114,7 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
             "func BuildSupportedProtocolsUpdate(){}\n"
             "func ReplaceSupportedProtocols(){}\n"
             "func SeedOfficialSupportedProtocols(){}\n"
-            "func protocolAccountSnapshot(capability Capability){ if !capability.ProbeEvidence.InitialProbeCompleted && !capability.ProbeEvidence.OfficialSeed { fail() } }\n",
+            "func protocolAccountSnapshot(capability Capability){ if !protocolCapabilityHasVerifiedRoutingEvidence(capability) { fail() } }\n",
             encoding="utf-8",
         )
         identity_owner = root / "backend/internal/service/protocol_endpoint_identity.go"
@@ -157,7 +157,8 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
             "package fixture\n"
             "func MigrateProtocolRoutingSSOT(){ LegacySupportedProtocolsProjection() }\n"
             "func validateProtocolRoutingSSOTReadiness(){}\n"
-            "func prepareProtocolRoutingSSOT(){ ProbeAccountProtocolCapabilitiesForPreparation(); prepared := MigrateProtocolRoutingSSOT(); if prepared.CutoverReady { PublishProtocolRoutingProjections(func(){ final := validateProtocolRoutingSSOTReadiness(); if !final.CutoverReady { return errProtocolRoutingFinalReadinessNotReady } }) } }\n",
+            "func prepareProtocolRoutingSSOT(){ ProbeAccountProtocolCapabilitiesForPreparation(); prepared := MigrateProtocolRoutingSSOT(); if prepared.CutoverReady { PublishProtocolRoutingProjections(func(){ final := validateProtocolRoutingSSOTReadiness(); if !final.CutoverReady { return errProtocolRoutingFinalReadinessNotReady } }) } }\n"
+            "func protocolCapabilityHasVerifiedRoutingEvidence(capability Capability){ capability.ProbeEvidence.OfficialSeed; capability.ProbeEvidence.InitialProbeCompleted; ProtocolProbePositive; capability.IdentityConflict }\n",
             encoding="utf-8",
         )
         count_tokens = root / "backend/internal/handler/openai_gateway_count_tokens.go"
@@ -285,7 +286,7 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
             "package fixture\n"
             "type ProtocolRoutingSSOTReady struct{ Report Report; router *Router }\n"
             "func (r ProtocolRoutingSSOTReady) EnabledRouter(){}\n"
-            "func (r ProtocolRoutingSSOTReady) Ready() bool { return r.Report.CutoverReady }\n"
+            "func (r ProtocolRoutingSSOTReady) Ready() bool { return r.Report.TrafficReady }\n"
             "func newProtocolRoutingSSOTReady(report Report, router *Router) ProtocolRoutingSSOTReady { return ProtocolRoutingSSOTReady{Report: report, router: router} }\n"
             "func ProvideProtocolRoutingSSOTReady(){ prepareProtocolRoutingSSOT() }\n",
             encoding="utf-8",
@@ -466,12 +467,12 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
         )
         self.assertTrue(any("must not disable the router" in error for error in MODULE.check(root)))
 
-    def test_rejects_readiness_accessor_that_ignores_cutover_report(self) -> None:
+    def test_rejects_readiness_accessor_that_ignores_traffic_report(self) -> None:
         root = self.fixture()
         wire = root / "backend/internal/service/wire.go"
         wire.write_text(
             wire.read_text(encoding="utf-8").replace(
-                "return r.Report.CutoverReady",
+                "return r.Report.TrafficReady",
                 "return true",
             ),
             encoding="utf-8",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -1142,10 +1142,10 @@
       "must_contain": [
         "func (r ProtocolRoutingSSOTReady) EnabledRouter() *protocolrouter.Router",
         "func (r ProtocolRoutingSSOTReady) Ready() bool",
-        "return r.Report.CutoverReady",
+        "return r.Report.TrafficReady",
         "return ProtocolRoutingSSOTReady{Report: report, router: router}"
       ],
-      "rationale": "Router availability and release readiness are separate facts: handlers always receive the SSOT router, while CutoverReady controls traffic admission. Reintroducing router=nil on an unready candidate silently restores legacy serving inside the new image."
+      "rationale": "Router availability and traffic admission are separate facts: handlers always receive the SSOT router, while TrafficReady controls /health. CutoverReady remains the full-matrix publish gate. Reintroducing router=nil on an unready candidate silently restores legacy serving inside the new image."
     },
     {
       "path": "backend/internal/server/routes/common.go",


### PR DESCRIPTION
## 摘要
- `/health` 改为看 `TrafficReady`：个别账号 `probe_required` 不再把整机打成 503，prod 蓝绿可以切到带协议 SSOT 的镜像。
- 已有非冲突、带 positive 探测证据、能覆盖实际模型的合法协议可以调度；历史 extra 种子和未确认协议继续排除，启动仍 re-probe。
- `CutoverReady` 仍表示全集切完，未确认时不 publish 投影。Web impact: none

## 风险
- 常规：请求路径只放行已验证协议，不猜 NewAPI/Qwen 默认协议。
- 若 Qwen 60/72 在 prod DB 里仍无 positive verdict，发版会过，但这两号仍不会进调度，需等后续 probe。
- 身份建失败、已验证却无合法路由、publish 失败仍会让 `/health` 503。

## 验证
- `./scripts/preflight.sh` 通过（含 protocol-routing SSOT 与 newapi sentinel）。
- `go test -tags=unit -count=1 ./internal/service/ ./internal/server/routes/ ./internal/handler/` 通过。
- 新增：部分 positive 可规划；仅未确认账号时进程仍 Ready；历史 seed 仍拒绝；inconclusive 429 仍不 publish。

## 提交
- `1de37e26d` fix(protocol): 已验证协议可服务，未确认协议不再卡死整机健康 (no-web-impact)
- 最新提交：`1de37e26d`

Made with [Cursor](https://cursor.com)