### PR TITLE
fix(protocol): Claude Code messages 走转换，账号写入不再合成预发送 503

### DIFF
--- a/backend/internal/engine/protocolrouter/registry.go
+++ b/backend/internal/engine/protocolrouter/registry.go
@@ -165,8 +165,20 @@ func permitsGeminiModel(account AccountSnapshot) bool {
 func preservesIdentity(CanonicalRequest) bool { return true }
 
 func preservesMessagesToResponses(req CanonicalRequest) bool {
-	return preservesTextOnlyWithoutTools(req) &&
+	// ForwardAsAnthropic already preserves Claude Code tools, images, and
+	// tool_use / tool_result blocks. Text-only-without-tools was fail-closing
+	// those requests onto /v1/messages identity, which TokenKey edge OpenAI
+	// pools cannot serve.
+	return preservesMessagesToResponsesContent(req) &&
 		req.profile.Continuation == ContinuationNone
+}
+
+func preservesMessagesToResponsesContent(req CanonicalRequest) bool {
+	if req.profile.ContentKinds == 0 {
+		return false
+	}
+	allowed := ContentText | ContentImage | ContentUnknown
+	return req.profile.ContentKinds&^allowed == 0
 }
 
 func preservesMessagesToChat(req CanonicalRequest) bool {

--- a/backend/internal/engine/protocolrouter/router_test.go
+++ b/backend/internal/engine/protocolrouter/router_test.go
@@ -381,6 +381,24 @@ func TestPlanRejectsConversionThatCannotPreserveToolsOrUnknownContent(t *testing
 	}
 }
 
+func TestPlanMessagesToResponsesPreservesClaudeCodeTools(t *testing.T) {
+	router := New(allTestAdapters())
+	account := testAccount(t, ProtocolResponses)
+	for _, profile := range []RequestProfile{
+		{Tools: true, ToolChoice: ToolChoiceAuto, ContentKinds: ContentText},
+		{Tools: true, ContentKinds: ContentText | ContentImage},
+		{Tools: true, ContentKinds: ContentText | ContentUnknown},
+	} {
+		plan, err := router.Plan(testRequest(t, ProtocolMessages, profile), account)
+		if err != nil {
+			t.Fatalf("Plan profile=%+v: %v", profile, err)
+		}
+		if plan.TargetProtocol() != ProtocolResponses || plan.AdapterID() != AdapterMessagesToResponses {
+			t.Fatalf("plan target/adapter = %q/%q, want responses/%s", plan.TargetProtocol(), plan.AdapterID(), AdapterMessagesToResponses)
+		}
+	}
+}
+
 func TestRouteRegistryRejectsIncompleteExecutionPolicy(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/backend/internal/service/account_supported_protocols.go
+++ b/backend/internal/service/account_supported_protocols.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	newapiconstant "github.com/QuantumNous/new-api/constant"
@@ -158,6 +159,33 @@ func SeedOfficialSupportedProtocols(account *Account) bool {
 	return true
 }
 
+// routingSupportedProtocols is the Plan() view of capability.supported_protocols.
+// Prod OpenAI edge-mirror stubs (api-*.tokenkey.dev) accept /v1/messages as
+// TokenKey ingress and convert simple probes, but the next hop's OpenAI OAuth
+// pool only speaks responses. Treating probe-positive messages as identity
+// dumps Claude Code bodies onto the edge, which then fail-closes to 503/502.
+func routingSupportedProtocols(account *Account) []protocolrouter.Protocol {
+	protocols := account.SupportedProtocols()
+	if !tkIsOpenAIEdgeMirrorStub(account) {
+		return protocols
+	}
+	filtered := make([]protocolrouter.Protocol, 0, len(protocols))
+	hasOpenAINative := false
+	for _, protocol := range protocols {
+		if protocol == protocolrouter.ProtocolMessages {
+			continue
+		}
+		filtered = append(filtered, protocol)
+		if protocol == protocolrouter.ProtocolResponses || protocol == protocolrouter.ProtocolChatCompletions {
+			hasOpenAINative = true
+		}
+	}
+	if !hasOpenAINative {
+		return protocols
+	}
+	return filtered
+}
+
 func ProtocolAccountSnapshot(account *Account, requestedModel string) (protocolrouter.AccountSnapshot, error) {
 	return protocolAccountSnapshot(account, requestedModel, false, false, nil)
 }
@@ -198,7 +226,7 @@ func protocolAccountSnapshot(account *Account, requestedModel string, requireCom
 	if !governed || identity.Key() != capability.CapabilityKey {
 		return protocolrouter.AccountSnapshot{}, errors.New("account endpoint identity does not match linked capability")
 	}
-	protocols := account.SupportedProtocols()
+	protocols := routingSupportedProtocols(account)
 	resolvedModel := protocolResolvedUpstreamModel(account, requestedModel, requireCompact)
 	customBaseURL, customBaseURLs, officialProfile := protocolAccountEndpoints(account)
 	geminiProfile := protocolGeminiEndpointProfile(account)
@@ -427,14 +455,86 @@ func copyProtocolBaseURL(raw map[string]any, key string, protocol protocolrouter
 }
 
 func protocolAccountRevision(account *Account) (string, error) {
+	if account == nil {
+		return "", errors.New("account is required")
+	}
+	baseURL, protocolBaseURLs, officialProfile := protocolAccountEndpoints(account)
+	capabilityKey := ""
+	capabilityRevision := int64(0)
+	identityConflict := false
+	if account.ProtocolEndpointCapability != nil {
+		capabilityKey = account.ProtocolEndpointCapability.CapabilityKey
+		capabilityRevision = account.ProtocolEndpointCapability.Revision
+		identityConflict = account.ProtocolEndpointCapability.IdentityConflict ||
+			account.ProtocolEndpointCapability.ProbeEvidence.IdentityConflict
+	}
+	protocols := routingSupportedProtocols(account)
+	protocolNames := make([]string, 0, len(protocols))
+	for _, protocol := range protocols {
+		protocolNames = append(protocolNames, string(protocol))
+	}
+	protocolURLPairs := make([]string, 0, len(protocolBaseURLs))
+	for _, protocol := range protocolrouter.AllProtocols() {
+		if value := strings.TrimSpace(protocolBaseURLs[protocol]); value != "" {
+			protocolURLPairs = append(protocolURLPairs, string(protocol)+"="+value)
+		}
+	}
+	compactMode := ""
+	if account.Extra != nil {
+		if mode, _ := account.Extra["openai_compact_mode"].(string); strings.TrimSpace(mode) != "" {
+			compactMode = strings.TrimSpace(mode)
+		}
+	}
 	input := struct {
-		ID        int64 `json:"id"`
-		UpdatedAt int64 `json:"updated_at_unix_nano"`
+		ID                 int64    `json:"id"`
+		Platform           string   `json:"platform"`
+		Type               string   `json:"type"`
+		ChannelType        int      `json:"channel_type"`
+		CapabilityKey      string   `json:"capability_key"`
+		CapabilityRevision int64    `json:"capability_revision"`
+		IdentityConflict   bool     `json:"identity_conflict"`
+		SupportedProtocols []string `json:"supported_protocols"`
+		OfficialProfile    string   `json:"official_profile"`
+		GeminiProfile      string   `json:"gemini_profile"`
+		CustomBaseURL      string   `json:"custom_base_url"`
+		ProtocolBaseURLs   []string `json:"protocol_base_urls"`
+		ModelMapping       []string `json:"model_mapping"`
+		CompactMapping     []string `json:"compact_mapping"`
+		Passthrough        bool     `json:"passthrough"`
+		CompactMode        string   `json:"compact_mode"`
+		AuthPresent        bool     `json:"auth_present"`
 	}{
-		ID:        account.ID,
-		UpdatedAt: account.UpdatedAt.UTC().UnixNano(),
+		ID:                 account.ID,
+		Platform:           account.Platform,
+		Type:               account.Type,
+		ChannelType:        account.ChannelType,
+		CapabilityKey:      capabilityKey,
+		CapabilityRevision: capabilityRevision,
+		IdentityConflict:   identityConflict,
+		SupportedProtocols: protocolNames,
+		OfficialProfile:    string(officialProfile),
+		GeminiProfile:      string(protocolGeminiEndpointProfile(account)),
+		CustomBaseURL:      strings.TrimSpace(baseURL),
+		ProtocolBaseURLs:   protocolURLPairs,
+		ModelMapping:       protocolRevisionMappingPairs(account.GetModelMapping()),
+		CompactMapping:     protocolRevisionMappingPairs(account.GetCompactModelMapping()),
+		Passthrough:        account.IsOpenAIPassthroughEnabled(),
+		CompactMode:        compactMode,
+		AuthPresent:        ProtocolAuthorizationPresent(account),
 	}
 	return protocolRevisionDigest(input)
+}
+
+func protocolRevisionMappingPairs(mapping map[string]string) []string {
+	if len(mapping) == 0 {
+		return nil
+	}
+	pairs := make([]string, 0, len(mapping))
+	for key, value := range mapping {
+		pairs = append(pairs, key+"="+value)
+	}
+	sort.Strings(pairs)
+	return pairs
 }
 
 func protocolRevisionDigest(input any) (string, error) {

--- a/backend/internal/service/account_supported_protocols_test.go
+++ b/backend/internal/service/account_supported_protocols_test.go
@@ -150,19 +150,66 @@ func TestProtocolAccountSnapshotResolvesModelAndRevisionFromAccountFacts(t *test
 		t.Fatal("snapshot revision is empty")
 	}
 
-	changed := *account
-	changed.UpdatedAt = updatedAt.Add(time.Nanosecond)
-	changed.Credentials = map[string]any{
+	noisy := *account
+	noisy.UpdatedAt = updatedAt.Add(time.Nanosecond)
+	noisy.Credentials = map[string]any{
 		"api_key":       "different-secret",
 		"base_url":      "https://relay.example.test/v1",
 		"model_mapping": map[string]any{"client-model": "upstream-model"},
+	}
+	noisySnapshot, err := ProtocolAccountSnapshot(&noisy, "client-model")
+	if err != nil {
+		t.Fatalf("ProtocolAccountSnapshot noisy: %v", err)
+	}
+	if noisySnapshot.Revision() != snapshot.Revision() {
+		t.Fatal("updated_at or secret rotation must not change protocol revision")
+	}
+
+	changed := *account
+	changed.Credentials = map[string]any{
+		"api_key":       "secret",
+		"base_url":      "https://relay.example.test/v1",
+		"model_mapping": map[string]any{"client-model": "other-upstream"},
 	}
 	changedSnapshot, err := ProtocolAccountSnapshot(&changed, "client-model")
 	if err != nil {
 		t.Fatalf("ProtocolAccountSnapshot changed: %v", err)
 	}
 	if changedSnapshot.Revision() == snapshot.Revision() {
-		t.Fatal("persisted account update did not change account revision")
+		t.Fatal("model mapping change did not change account revision")
+	}
+}
+
+func TestProtocolAccountRevisionIgnoresUsageExtraWrites(t *testing.T) {
+	account := &Account{
+		ID:        44,
+		Platform:  PlatformOpenAI,
+		Type:      AccountTypeOAuth,
+		UpdatedAt: time.Date(2026, 8, 29, 13, 37, 0, 0, time.UTC),
+		Credentials: map[string]any{
+			"access_token": "secret",
+		},
+		Extra: map[string]any{
+			"codex_usage_updated_at": "2026-08-29T13:37:00Z",
+		},
+	}
+	if !SeedOfficialSupportedProtocols(account) {
+		t.Fatal("official OpenAI OAuth seed must succeed")
+	}
+	before, err := protocolAccountRevision(account)
+	if err != nil {
+		t.Fatalf("protocolAccountRevision: %v", err)
+	}
+
+	account.UpdatedAt = account.UpdatedAt.Add(time.Second)
+	account.Extra["codex_usage_updated_at"] = "2026-08-29T13:38:00Z"
+	account.Extra["quota_used"] = 12.5
+	after, err := protocolAccountRevision(account)
+	if err != nil {
+		t.Fatalf("protocolAccountRevision after extra write: %v", err)
+	}
+	if before != after {
+		t.Fatal("usage/quota extra writes changed protocol revision")
 	}
 }
 
@@ -610,5 +657,59 @@ func TestAdminUpdateExtraCannotWriteSupportedProtocols(t *testing.T) {
 	}
 	if account.Extra["custom"] != true {
 		t.Fatalf("unmanaged extra update was lost: %#v", account.Extra)
+	}
+}
+
+func TestRoutingSupportedProtocolsStripsMessagesOnOpenAIEdgeMirror(t *testing.T) {
+	stub := &Account{
+		ID:       68,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":  "secret",
+			"base_url": "https://api-us4.tokenkey.dev",
+		},
+	}
+	attachTestProtocolCapability(stub,
+		protocolrouter.ProtocolMessages,
+		protocolrouter.ProtocolChatCompletions,
+		protocolrouter.ProtocolResponses,
+	)
+	got := routingSupportedProtocols(stub)
+	want := []protocolrouter.Protocol{protocolrouter.ProtocolChatCompletions, protocolrouter.ProtocolResponses}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("routingSupportedProtocols(stub) = %v, want %v", got, want)
+	}
+	if !reflect.DeepEqual(stub.SupportedProtocols(), []protocolrouter.Protocol{
+		protocolrouter.ProtocolMessages,
+		protocolrouter.ProtocolChatCompletions,
+		protocolrouter.ProtocolResponses,
+	}) {
+		t.Fatalf("capability owner list was rewritten: %v", stub.SupportedProtocols())
+	}
+
+	external := protocolRoutingOpenAIAccount(70,
+		string(protocolrouter.ProtocolMessages),
+		string(protocolrouter.ProtocolResponses),
+	)
+	if got := routingSupportedProtocols(external); !reflect.DeepEqual(got, []protocolrouter.Protocol{
+		protocolrouter.ProtocolMessages,
+		protocolrouter.ProtocolResponses,
+	}) {
+		t.Fatalf("external OpenAI relay lost native messages: %v", got)
+	}
+
+	messagesOnly := &Account{
+		ID:       71,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":  "secret",
+			"base_url": "https://api-us4.tokenkey.dev",
+		},
+	}
+	attachTestProtocolCapability(messagesOnly, protocolrouter.ProtocolMessages)
+	if got := routingSupportedProtocols(messagesOnly); !reflect.DeepEqual(got, []protocolrouter.Protocol{protocolrouter.ProtocolMessages}) {
+		t.Fatalf("messages-only stub fallback = %v, want messages kept", got)
 	}
 }

--- a/backend/internal/service/protocol_capability_probe.go
+++ b/backend/internal/service/protocol_capability_probe.go
@@ -545,6 +545,9 @@ func ProtocolProbeCandidates(account *Account) []protocolrouter.Protocol {
 		if protocol == protocolrouter.ProtocolGeminiGenerateContent {
 			continue
 		}
+		if protocol == protocolrouter.ProtocolMessages && tkIsOpenAIEdgeMirrorStub(account) {
+			continue
+		}
 		if strings.TrimSpace(protocolProbeBaseURL(account, protocol)) != "" {
 			candidates = append(candidates, protocol)
 		}

--- a/backend/internal/service/protocol_capability_probe_test.go
+++ b/backend/internal/service/protocol_capability_probe_test.go
@@ -716,6 +716,16 @@ func TestProtocolProbeCandidatesCoverGovernedCustomAccountsOnly(t *testing.T) {
 			want: []protocolrouter.Protocol{protocolrouter.ProtocolGeminiGenerateContent},
 		},
 		{
+			name: "openai edge mirror does not probe ingress messages as a native target",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Credentials: map[string]any{
+				"api_key": "secret", "base_url": "https://api-us4.tokenkey.dev",
+			}},
+			want: []protocolrouter.Protocol{
+				protocolrouter.ProtocolChatCompletions,
+				protocolrouter.ProtocolResponses,
+			},
+		},
+		{
 			name: "antigravity edge relay probes its configurable text endpoints",
 			account: &Account{Platform: PlatformAntigravity, Type: AccountTypeAPIKey, Credentials: map[string]any{
 				"api_key": "secret", "base_url": "https://api-us3.tokenkey.dev",

--- a/backend/internal/service/protocol_execution.go
+++ b/backend/internal/service/protocol_execution.go
@@ -405,13 +405,26 @@ func ExecuteSelectedProtocol(
 			GatewayFailureScopeAccount,
 		)
 	}
+	freshPlan, err := router.Plan(request, fresh)
+	if err != nil {
+		return nil, protocolExecutionPreSendFailure(
+			fmt.Errorf("%w: %v", ErrProtocolRouteUnavailable, err),
+			GatewayFailureScopeAccount,
+		)
+	}
+	if !protocolPlansRoutingEquivalent(plan, freshPlan) {
+		return nil, protocolExecutionPreSendFailure(protocolrouter.ErrStalePlan, GatewayFailureScopeAccount)
+	}
 	executionCtx := WithProtocolExecutors(ctx, executors)
 	executionCtx = withProtocolExecutionAccount(executionCtx, freshAccount)
+	// Bind the scheduled plan's revision token so Execute can verify the
+	// captured route. Account updated_at / token writes change
+	// snapshot.Revision() without changing the route; those must not 503.
 	executionCtx = protocolrouter.WithExecutionAccountState(executionCtx, protocolrouter.ExecutionAccountState{
-		AccountID:          fresh.AccountID(),
-		Revision:           fresh.Revision(),
-		CapabilityKey:      fresh.CapabilityKey(),
-		CapabilityRevision: fresh.CapabilityRevision(),
+		AccountID:          plan.AccountID(),
+		Revision:           plan.AccountRevision(),
+		CapabilityKey:      plan.CapabilityKey(),
+		CapabilityRevision: plan.CapabilityRevision(),
 		CredentialPresent:  ProtocolAuthorizationPresent(freshAccount),
 	})
 	result, err := router.Execute(executionCtx, plan, request)
@@ -423,6 +436,22 @@ func ExecuteSelectedProtocol(
 	}
 	stampProtocolRouteFacts(result.Value, routeFactsFromPlan(plan))
 	return result.Value, nil
+}
+
+func protocolPlansRoutingEquivalent(scheduled, fresh protocolrouter.Plan) bool {
+	return scheduled.AccountID() == fresh.AccountID() &&
+		scheduled.CapabilityKey() == fresh.CapabilityKey() &&
+		scheduled.CapabilityRevision() == fresh.CapabilityRevision() &&
+		scheduled.RequestDigest() == fresh.RequestDigest() &&
+		scheduled.ResolvedModel() == fresh.ResolvedModel() &&
+		scheduled.InboundProtocol() == fresh.InboundProtocol() &&
+		scheduled.TargetProtocol() == fresh.TargetProtocol() &&
+		scheduled.ResponsesPath() == fresh.ResponsesPath() &&
+		scheduled.Endpoint() == fresh.Endpoint() &&
+		scheduled.AdapterID() == fresh.AdapterID() &&
+		scheduled.Transport() == fresh.Transport() &&
+		scheduled.RouteKind() == fresh.RouteKind() &&
+		scheduled.GeminiProfile() == fresh.GeminiProfile()
 }
 
 func stampProtocolRouteFacts(value any, facts RouteFacts) {

--- a/backend/internal/service/protocol_execution_test.go
+++ b/backend/internal/service/protocol_execution_test.go
@@ -338,7 +338,7 @@ func TestExecuteSelectedProtocolStampsImmutableRouteFactsOnResult(t *testing.T) 
 	}
 }
 
-func TestExecuteSelectedProtocolRejectsAccountMutationBeforeExecutor(t *testing.T) {
+func TestExecuteSelectedProtocolKeepsEquivalentRouteAfterAccountWrite(t *testing.T) {
 	router := NewProtocolRouter()
 	req := protocolRoutingTestRequest(t, protocolrouter.ProtocolMessages)
 	ctx := WithProtocolRouting(context.Background(), router, req)
@@ -351,18 +351,61 @@ func TestExecuteSelectedProtocolRejectsAccountMutationBeforeExecutor(t *testing.
 	authoritative := *account
 	authoritative.UpdatedAt = account.UpdatedAt.Add(time.Nanosecond)
 	authoritative.Credentials = map[string]any{
-		"api_key":  "changed-secret",
+		"api_key":  "rotated-secret",
 		"base_url": "https://relay.example.test/v1",
 	}
 	calls := 0
 
-	execute := func(context.Context, *Account, protocolrouter.Plan, protocolrouter.CanonicalRequest) (any, error) {
-		calls++
-		return nil, nil
-	}
 	_, err = ExecuteSelectedProtocol(ctx, router, selection, account, func(context.Context, *Account, string) error { return nil }, func(context.Context, int64) (*Account, error) {
 		return &authoritative, nil
-	}, protocolExecutorsForTest(plan, execute))
+	}, protocolExecutorsForTest(plan, func(_ context.Context, executionAccount *Account, _ protocolrouter.Plan, _ protocolrouter.CanonicalRequest) (any, error) {
+		calls++
+		if executionAccount != &authoritative {
+			t.Fatalf("executor account = %p, want authoritative %p", executionAccount, &authoritative)
+		}
+		if executionAccount.GetCredential("api_key") != "rotated-secret" {
+			t.Fatalf("executor credential = %q, want rotated secret", executionAccount.GetCredential("api_key"))
+		}
+		return "sent", nil
+	}))
+	if err != nil {
+		t.Fatalf("ExecuteSelectedProtocol: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("executor calls = %d, want 1 after updated_at/token write", calls)
+	}
+}
+
+func TestExecuteSelectedProtocolRejectsInequivalentRouteBeforeExecutor(t *testing.T) {
+	router := NewProtocolRouter()
+	req := protocolRoutingTestRequest(t, protocolrouter.ProtocolMessages)
+	ctx := WithProtocolRouting(context.Background(), router, req)
+	account := protocolRoutingOpenAIAccount(12, "responses")
+	plan, _, err := protocolPlanForAccount(ctx, account, "gpt-5.4")
+	if err != nil {
+		t.Fatalf("protocolPlanForAccount: %v", err)
+	}
+	calls := 0
+	freshCapability := *account.ProtocolEndpointCapability
+	freshCapability.SupportedProtocols = []protocolrouter.Protocol{protocolrouter.ProtocolChatCompletions}
+
+	_, err = ExecuteSelectedProtocol(
+		ctx,
+		router,
+		&AccountSelectionResult{Account: account, ProtocolPlan: &plan},
+		account,
+		func(context.Context, *Account, string) error { return nil },
+		func(context.Context, int64) (*Account, error) {
+			fresh := *account
+			fresh.UpdatedAt = account.UpdatedAt.Add(time.Nanosecond)
+			fresh.ProtocolEndpointCapability = &freshCapability
+			return &fresh, nil
+		},
+		protocolExecutorsForTest(plan, func(context.Context, *Account, protocolrouter.Plan, protocolrouter.CanonicalRequest) (any, error) {
+			calls++
+			return nil, nil
+		}),
+	)
 	if !errors.Is(err, protocolrouter.ErrStalePlan) {
 		t.Fatalf("ExecuteSelectedProtocol error = %v, want ErrStalePlan", err)
 	}

--- a/backend/internal/service/protocol_routing_context_test.go
+++ b/backend/internal/service/protocol_routing_context_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
@@ -163,6 +162,60 @@ func attachTestProtocolCapability(account *Account, protocols ...protocolrouter.
 		SupportedProtocols: append([]protocolrouter.Protocol(nil), protocols...),
 		Revision:           1,
 		ProbeEvidence:      ProtocolProbeEvidence{InitialProbeCompleted: true},
+	}
+}
+
+func protocolRoutingClaudeCodeMessagesRequest(t *testing.T) protocolrouter.CanonicalRequest {
+	t.Helper()
+	req, err := protocolrouter.NewCanonicalRequest(protocolrouter.CanonicalRequestInput{
+		InboundProtocol: protocolrouter.ProtocolMessages,
+		RequestedModel:  "gpt-5.4",
+		Profile: protocolrouter.RequestProfile{
+			Tools:        true,
+			ToolChoice:   protocolrouter.ToolChoiceAuto,
+			ContentKinds: protocolrouter.ContentText,
+		},
+		Body: []byte(`{"model":"gpt-5.4","tools":[{"name":"lookup"}],"messages":[{"role":"user","content":"hi"}]}`),
+	})
+	if err != nil {
+		t.Fatalf("NewCanonicalRequest: %v", err)
+	}
+	return req
+}
+
+func TestOpenAIEdgeMirrorPlansClaudeCodeMessagesAsResponses(t *testing.T) {
+	account := &Account{
+		ID:          68,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Credentials: map[string]any{
+			"api_key":  "secret",
+			"base_url": "https://api-us4.tokenkey.dev",
+		},
+	}
+	attachTestProtocolCapability(account,
+		protocolrouter.ProtocolMessages,
+		protocolrouter.ProtocolChatCompletions,
+		protocolrouter.ProtocolResponses,
+	)
+	ctx := WithProtocolRouting(
+		context.Background(),
+		protocolRoutingTestRouter(),
+		protocolRoutingClaudeCodeMessagesRequest(t),
+	)
+	if !ProtocolRouteLegal(ctx, account, "gpt-5.4") {
+		t.Fatal("Claude Code messages on openai-us4 edge stub were not route-legal")
+	}
+	plan, governed, err := protocolPlanForAccount(ctx, account, "gpt-5.4")
+	if !governed || err != nil {
+		t.Fatalf("protocolPlanForAccount: governed=%v err=%v", governed, err)
+	}
+	if plan.TargetProtocol() != protocolrouter.ProtocolResponses ||
+		plan.AdapterID() != protocolrouter.AdapterMessagesToResponses {
+		t.Fatalf("plan target/adapter = %q/%q, want responses/%s",
+			plan.TargetProtocol(), plan.AdapterID(), protocolrouter.AdapterMessagesToResponses)
 	}
 }
 
@@ -584,8 +637,7 @@ func TestSelectionRejectsAccountChangedAfterSchedulerPlan(t *testing.T) {
 	if !ProtocolRouteLegal(ctx, account, "gpt-5.4") {
 		t.Fatal("scheduler rejected legal protocol route")
 	}
-	account.Credentials["api_key"] = "rotated-secret"
-	account.UpdatedAt = account.UpdatedAt.Add(time.Nanosecond)
+	account.Credentials["base_url"] = "https://other-relay.example.test/v1"
 
 	_, err := (&OpenAIGatewayService{}).newSelectionResult(ctx, account, false, nil, nil)
 	if !errors.Is(err, protocolrouter.ErrStalePlan) {

--- a/docs/approved/protocol-routing-ssot.md
+++ b/docs/approved/protocol-routing-ssot.md
@@ -316,9 +316,15 @@ as endpoint protocol capability.
 The plan stores the request digest, account snapshot revision, capability key
 and revision, resolved model, inbound and target protocols, endpoint, adapter,
 transport, route kind, and reason. Before constructing a network request,
-`Execute` verifies all captured revisions and digests. A stale account,
-capability, request, endpoint, or credential fails closed and enters normal
-account failover.
+execution reloads the authoritative account and re-plans it. `Execute` then
+verifies the captured request digest and capability key/revision. A plan is
+stale only when the fresh account no longer produces an equivalent route
+(capability, resolved model, endpoint, adapter, transport) or authorization is
+missing. Account `updated_at`, last-used, token rotation, and other health
+writes do not by themselves invalidate a still-equivalent plan; the reload
+exists to attach current credentials, not to treat every account row write as a
+protocol change. A stale route or missing credential fails closed and enters
+normal account failover.
 
 Execution invariants:
 

--- a/scripts/checks/protocol-routing-ssot.py
+++ b/scripts/checks/protocol-routing-ssot.py
@@ -606,7 +606,9 @@ def check(root: Path) -> list[str]:
                 errors.append("selected protocol execution does not bind the authoritative account to executors")
             if not re.search(r"CredentialPresent\s*:\s*ProtocolAuthorizationPresent\s*\(\s*freshAccount\s*\)", body):
                 errors.append("selected protocol execution derives credential readiness from a stale account")
-            if len(call_spans(body, "protocolExecutionPreSendFailure")) < 2:
+            if not contains_identifier(body, "protocolPlansRoutingEquivalent"):
+                errors.append("selected protocol execution skips equivalent-route replan before send")
+            if len(call_spans(body, "protocolExecutionPreSendFailure")) < 3:
                 errors.append("selected protocol execution leaves a pre-send stale failure outside account failover")
             if not contains_identifier(body, "ErrMissingCredential"):
                 errors.append("selected protocol execution leaves a missing credential outside account failover")

--- a/scripts/checks/test_protocol_routing_ssot.py
+++ b/scripts/checks/test_protocol_routing_ssot.py
@@ -75,7 +75,7 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
             "type geminiIdentityAdapter struct{}\n"
             "func ExecuteGeminiProtocolProfile(){}\n"
             "func protocolExecutionPreSendFailure(){ UpstreamFailoverError(); NextAccountRetry() }\n"
-            "func ExecuteSelectedProtocol(){ freshAccount := loadAccount(); if freshAccount == nil { protocolExecutionPreSendFailure() }; withProtocolExecutionAccount(freshAccount); state := ExecutionAccountState{CredentialPresent: ProtocolAuthorizationPresent(freshAccount)}; if router.Execute(state) == ErrStalePlan || router.Execute(state) == ErrMissingCredential { protocolExecutionPreSendFailure() } }\n"
+            "func ExecuteSelectedProtocol(){ freshAccount := loadAccount(); if freshAccount == nil { protocolExecutionPreSendFailure() }; if !protocolPlansRoutingEquivalent(plan, router.Plan(request, fresh)) { protocolExecutionPreSendFailure() }; withProtocolExecutionAccount(freshAccount); state := ExecutionAccountState{CredentialPresent: ProtocolAuthorizationPresent(freshAccount)}; if router.Execute(state) == ErrStalePlan || router.Execute(state) == ErrMissingCredential { protocolExecutionPreSendFailure() } }\n"
             "func ProtocolAuthorizationPresent(account Account){ ProtocolAuthorizationSnapshotCredentialKey(); if account.IsNewAPIVertexServiceAccount(){ parseVertexServiceAccountKey(account) }; protocolAuthorizationToken(account) }\n"
             "func protocolRuntimeAuthorizationReady(ctx Context, account Account){ ProtocolRoutingRequest(ctx); ProtocolAuthorizationPresent(account) }\n",
             encoding="utf-8",


### PR DESCRIPTION
## 摘要

1.8.182 协议 fail-closed 在两条线上把仍可服务的请求合成预发送失败：Claude Code `/v1/messages` 被 OpenAI edge 镜像当成 messages identity，带 tools 时又转不了 Responses；OpenAI OAuth `/v1/responses` 则因账号行 `updated_at`（用量 extra / token 旋转）把仍合法的路由打成 stale plan。两边最终都是 edge 503，再被翻成客户端 502。

本 PR 两层一起留：

1. Messages→Responses 允许 text/image/unknown + tools；OpenAI edge 镜像从 Plan/probe 视角去掉 messages identity（capability owner 清单不改）。
2. `protocolAccountRevision` 只哈希 capability / endpoint / mapping / passthrough，不吃 `updated_at` 和 token 原文；Execute 前仍对权威账号重规划，路由等价则放行。

us3 / us6 保持 1.8.182 作对照，合入后先在这两台验证；us4 / prod 继续留 1.8.177。

Web impact: none
no-web-impact
sentinel-registry-reviewed
high-risk-anchor: docs/approved/protocol-routing-ssot.md

## 风险

高风险：协议规划与执行热路径。不改变对外 API 字段。错误合成 503 会放大成客户侧 502。回滚即停用本 PR，us3/us6 仍可继续对照 us4。

## 验证

- `python3 scripts/checks/protocol-routing-ssot.py`：通过
- `python3 scripts/checks/test_protocol_routing_ssot.py`：73 通过
- `go test -tags=unit -count=1 ./internal/service/ ./internal/engine/protocolrouter/`：通过
- `./scripts/preflight.sh`：通过
- 正向：Claude Code tools 走 `messages→responses`（`TestPlanMessagesToResponsesPreservesClaudeCodeTools` / `TestOpenAIEdgeMirrorPlansClaudeCodeMessagesAsResponses`）；`updated_at` / 用量 extra / token 旋转不换 revision、等价路由仍发送（`TestProtocolAccountRevisionIgnoresUsageExtraWrites` / `TestExecuteSelectedProtocolKeepsEquivalentRouteAfterAccountWrite`）
- 负向：镜像号 capability owner 清单不被改写（`TestRoutingSupportedProtocolsStripsMessagesOnOpenAIEdgeMirror`）；协议集变化仍 stale（`TestExecuteSelectedProtocolRejectsInequivalentRouteBeforeExecutor`）；endpoint 真变仍 stale（`TestSelectionRejectsAccountChangedAfterSchedulerPlan`）

线上验收（合入后，先 us3 / us6，不回滚对照机）：

1. Claude Code `/v1/messages` 打 OpenAI edge 镜像不再因 identity+fail-closed 502
2. 单号 `probe_account_model.sh`：`ENDPOINT=responses` `MODEL=gpt-5.6-sol` 仍 200
3. 有机 `/v1/responses` 不再出现合成 503 海；us4（1.8.177）保持干净

## 提交

- `9611ba989` fix(protocol): 账号写入不再把仍合法的路由打成预发送 503 (no-web-impact)
- `b332897e1` fix(protocol): Claude Code messages 走转换，账号写入不再合成预发送 503 (no-web-impact)

最新提交：b332897e1