### PR TITLE
fix(protocol): 发送前只比路由事实，不再用 revision 当裁判

### DIFF
--- a/backend/internal/engine/protocolrouter/account.go
+++ b/backend/internal/engine/protocolrouter/account.go
@@ -37,9 +37,7 @@ const TransportHTTP TransportID = "http"
 
 type AccountSnapshotInput struct {
 	AccountID          int64
-	Revision           string
 	CapabilityKey      string
-	CapabilityRevision int64
 	SupportedProtocols []Protocol
 	ResolvedModel      string
 	CustomBaseURL      string
@@ -53,9 +51,7 @@ type AccountSnapshotInput struct {
 
 type AccountSnapshot struct {
 	accountID          int64
-	revision           string
 	capabilityKey      string
-	capabilityRevision int64
 	supportedProtocols map[Protocol]struct{}
 	resolvedModel      string
 	customBaseURL      string
@@ -71,16 +67,9 @@ func NewAccountSnapshot(input AccountSnapshotInput) (AccountSnapshot, error) {
 	if input.AccountID <= 0 {
 		return AccountSnapshot{}, errors.New("account id must be positive")
 	}
-	revision := strings.TrimSpace(input.Revision)
-	if revision == "" {
-		return AccountSnapshot{}, errors.New("account revision is required")
-	}
 	capabilityKey := strings.TrimSpace(input.CapabilityKey)
 	if capabilityKey == "" {
 		return AccountSnapshot{}, errors.New("capability key is required")
-	}
-	if input.CapabilityRevision <= 0 {
-		return AccountSnapshot{}, errors.New("capability revision must be positive")
 	}
 	model := strings.TrimSpace(input.ResolvedModel)
 	if model == "" {
@@ -130,9 +119,7 @@ func NewAccountSnapshot(input AccountSnapshotInput) (AccountSnapshot, error) {
 	}
 	return AccountSnapshot{
 		accountID:          input.AccountID,
-		revision:           revision,
 		capabilityKey:      capabilityKey,
-		capabilityRevision: input.CapabilityRevision,
 		supportedProtocols: supported,
 		resolvedModel:      model,
 		customBaseURL:      strings.TrimSpace(input.CustomBaseURL),
@@ -146,9 +133,7 @@ func NewAccountSnapshot(input AccountSnapshotInput) (AccountSnapshot, error) {
 }
 
 func (a AccountSnapshot) AccountID() int64                     { return a.accountID }
-func (a AccountSnapshot) Revision() string                     { return a.revision }
 func (a AccountSnapshot) CapabilityKey() string                { return a.capabilityKey }
-func (a AccountSnapshot) CapabilityRevision() int64            { return a.capabilityRevision }
 func (a AccountSnapshot) ResolvedModel() string                { return a.resolvedModel }
 func (a AccountSnapshot) GeminiProfile() GeminiEndpointProfile { return a.geminiProfile }
 

--- a/backend/internal/engine/protocolrouter/router.go
+++ b/backend/internal/engine/protocolrouter/router.go
@@ -36,27 +36,23 @@ func New(catalog AdapterCatalog) *Router {
 }
 
 type Plan struct {
-	accountID          int64
-	accountRevision    string
-	capabilityKey      string
-	capabilityRevision int64
-	requestDigest      RequestDigest
-	resolvedModel      string
-	inboundProtocol    Protocol
-	targetProtocol     Protocol
-	responsesPath      ResponsesPathKind
-	endpoint           string
-	adapterID          RouteAdapterID
-	transport          TransportID
-	routeKind          RouteKind
-	geminiProfile      GeminiEndpointProfile
-	reason             string
+	accountID       int64
+	capabilityKey   string
+	requestDigest   RequestDigest
+	resolvedModel   string
+	inboundProtocol Protocol
+	targetProtocol  Protocol
+	responsesPath   ResponsesPathKind
+	endpoint        string
+	adapterID       RouteAdapterID
+	transport       TransportID
+	routeKind       RouteKind
+	geminiProfile   GeminiEndpointProfile
+	reason          string
 }
 
 func (p Plan) AccountID() int64                     { return p.accountID }
-func (p Plan) AccountRevision() string              { return p.accountRevision }
 func (p Plan) CapabilityKey() string                { return p.capabilityKey }
-func (p Plan) CapabilityRevision() int64            { return p.capabilityRevision }
 func (p Plan) RequestDigest() RequestDigest         { return p.requestDigest }
 func (p Plan) ResolvedModel() string                { return p.resolvedModel }
 func (p Plan) InboundProtocol() Protocol            { return p.inboundProtocol }
@@ -111,21 +107,19 @@ func (r *Router) Plan(request CanonicalRequest, account AccountSnapshot) (Plan, 
 			continue
 		}
 		return Plan{
-			accountID:          account.accountID,
-			accountRevision:    account.revision,
-			capabilityKey:      account.capabilityKey,
-			capabilityRevision: account.capabilityRevision,
-			requestDigest:      request.digest,
-			resolvedModel:      account.resolvedModel,
-			inboundProtocol:    request.inboundProtocol,
-			targetProtocol:     route.target,
-			responsesPath:      responsesPath,
-			endpoint:           endpoint,
-			adapterID:          route.adapterID,
-			transport:          route.transport,
-			routeKind:          route.kind,
-			geminiProfile:      account.geminiProfile,
-			reason:             string(route.kind),
+			accountID:       account.accountID,
+			capabilityKey:   account.capabilityKey,
+			requestDigest:   request.digest,
+			resolvedModel:   account.resolvedModel,
+			inboundProtocol: request.inboundProtocol,
+			targetProtocol:  route.target,
+			responsesPath:   responsesPath,
+			endpoint:        endpoint,
+			adapterID:       route.adapterID,
+			transport:       route.transport,
+			routeKind:       route.kind,
+			geminiProfile:   account.geminiProfile,
+			reason:          string(route.kind),
 		}, nil
 	}
 	if supportedTargetSeen && !modelPermittedSeen {
@@ -135,11 +129,9 @@ func (r *Router) Plan(request CanonicalRequest, account AccountSnapshot) (Plan, 
 }
 
 type ExecutionAccountState struct {
-	AccountID          int64
-	Revision           string
-	CapabilityKey      string
-	CapabilityRevision int64
-	CredentialPresent  bool
+	AccountID         int64
+	CapabilityKey     string
+	CredentialPresent bool
 }
 
 type executionAccountStateKey struct{}
@@ -168,8 +160,7 @@ func (r *Router) Execute(ctx context.Context, plan Plan, request CanonicalReques
 		return Result{}, ErrStalePlan
 	}
 	state, ok := ctx.Value(executionAccountStateKey{}).(ExecutionAccountState)
-	if !ok || state.AccountID != plan.accountID || state.Revision != plan.accountRevision ||
-		state.CapabilityKey != plan.capabilityKey || state.CapabilityRevision != plan.capabilityRevision {
+	if !ok || state.AccountID != plan.accountID || state.CapabilityKey != plan.capabilityKey {
 		return Result{}, ErrStalePlan
 	}
 	if !state.CredentialPresent {

--- a/backend/internal/engine/protocolrouter/router_test.go
+++ b/backend/internal/engine/protocolrouter/router_test.go
@@ -52,9 +52,7 @@ func testAccount(t *testing.T, supported ...Protocol) AccountSnapshot {
 	}
 	account, err := NewAccountSnapshot(AccountSnapshotInput{
 		AccountID:          42,
-		Revision:           "rev-1",
 		CapabilityKey:      "capability-test",
-		CapabilityRevision: 1,
 		SupportedProtocols: supported,
 		ResolvedModel:      "upstream-model",
 		CustomBaseURL:      "https://relay.example.test/v1",
@@ -91,9 +89,7 @@ func TestPlanGeminiIdentityRequiresTypedProfileAndExactEndpoint(t *testing.T) {
 	request := testRequest(t, ProtocolGeminiGenerateContent, RequestProfile{ContentKinds: ContentText})
 	input := AccountSnapshotInput{
 		AccountID:          42,
-		Revision:           "rev-1",
 		CapabilityKey:      "capability-test",
-		CapabilityRevision: 1,
 		SupportedProtocols: []Protocol{ProtocolGeminiGenerateContent},
 		ResolvedModel:      "gemini-2.5-pro",
 		ModelAllowed:       map[Protocol]bool{ProtocolGeminiGenerateContent: true},
@@ -132,9 +128,7 @@ func TestPlanGeminiProfilesUseExactEndpoint(t *testing.T) {
 			const endpoint = "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/us-central1/publishers/google/models/gemini-2.5-pro:generateContent"
 			account, err := NewAccountSnapshot(AccountSnapshotInput{
 				AccountID:          42,
-				Revision:           "rev-1",
 				CapabilityKey:      "capability-test",
-				CapabilityRevision: 1,
 				SupportedProtocols: []Protocol{ProtocolGeminiGenerateContent},
 				ResolvedModel:      "gemini-2.5-pro",
 				ExactEndpoints:     map[Protocol]string{ProtocolGeminiGenerateContent: endpoint},
@@ -194,9 +188,7 @@ func TestExecuteRejectsStaleCapabilityBeforeAdapter(t *testing.T) {
 	request := testRequest(t, ProtocolResponses, RequestProfile{})
 	account, err := NewAccountSnapshot(AccountSnapshotInput{
 		AccountID:          42,
-		Revision:           "account-rev-1",
 		CapabilityKey:      "capability-key-a",
-		CapabilityRevision: 7,
 		SupportedProtocols: []Protocol{ProtocolResponses},
 		ResolvedModel:      "upstream-model",
 		CustomBaseURL:      "https://relay.example.test/v1",
@@ -210,15 +202,13 @@ func TestExecuteRejectsStaleCapabilityBeforeAdapter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
-	if plan.CapabilityKey() != "capability-key-a" || plan.CapabilityRevision() != 7 {
-		t.Fatalf("plan capability = %q/%d", plan.CapabilityKey(), plan.CapabilityRevision())
+	if plan.CapabilityKey() != "capability-key-a" {
+		t.Fatalf("plan capability = %q", plan.CapabilityKey())
 	}
 	ctx := WithExecutionAccountState(context.Background(), ExecutionAccountState{
-		AccountID:          42,
-		Revision:           "account-rev-1",
-		CapabilityKey:      "capability-key-a",
-		CapabilityRevision: 8,
-		CredentialPresent:  true,
+		AccountID:         42,
+		CapabilityKey:     "capability-key-b",
+		CredentialPresent: true,
 	})
 	if _, err := router.Execute(ctx, plan, request); !errors.Is(err, ErrStalePlan) {
 		t.Fatalf("Execute error = %v, want ErrStalePlan", err)
@@ -268,9 +258,7 @@ func TestPlanNamesModelPolicyRejection(t *testing.T) {
 func TestPlanFailsClosedWhenCustomEndpointIsMissing(t *testing.T) {
 	account, err := NewAccountSnapshot(AccountSnapshotInput{
 		AccountID:          42,
-		Revision:           "rev-1",
 		CapabilityKey:      "capability-test",
-		CapabilityRevision: 1,
 		SupportedProtocols: []Protocol{ProtocolMessages},
 		ResolvedModel:      "upstream-model",
 		ModelAllowed:       map[Protocol]bool{ProtocolMessages: true},
@@ -289,9 +277,7 @@ func TestPlanFailsClosedWhenCustomEndpointIsMissing(t *testing.T) {
 func TestPlanUsesFixedOpenAICodexEndpointOnlyForResponses(t *testing.T) {
 	account, err := NewAccountSnapshot(AccountSnapshotInput{
 		AccountID:          42,
-		Revision:           "rev-1",
 		CapabilityKey:      "capability-test",
-		CapabilityRevision: 1,
 		SupportedProtocols: []Protocol{ProtocolResponses, ProtocolChatCompletions},
 		ResolvedModel:      "gpt-5.4",
 		OfficialProfile:    OfficialEndpointOpenAICodex,
@@ -485,11 +471,9 @@ func TestExecuteRejectsDifferentRequestBeforeAdapter(t *testing.T) {
 		t.Fatalf("NewCanonicalRequest: %v", err)
 	}
 	ctx := WithExecutionAccountState(context.Background(), ExecutionAccountState{
-		AccountID:          42,
-		Revision:           "rev-1",
-		CapabilityKey:      "capability-test",
-		CapabilityRevision: 1,
-		CredentialPresent:  true,
+		AccountID:         42,
+		CapabilityKey:     "capability-test",
+		CredentialPresent: true,
 	})
 
 	_, err = router.Execute(ctx, plan, different)
@@ -507,8 +491,8 @@ func TestExecuteRejectsStaleAccountOrMissingCredentialBeforeAdapter(t *testing.T
 		state ExecutionAccountState
 		want  error
 	}{
-		{name: "stale revision", state: ExecutionAccountState{AccountID: 42, Revision: "rev-2", CapabilityKey: "capability-test", CapabilityRevision: 1, CredentialPresent: true}, want: ErrStalePlan},
-		{name: "missing credential", state: ExecutionAccountState{AccountID: 42, Revision: "rev-1", CapabilityKey: "capability-test", CapabilityRevision: 1}, want: ErrMissingCredential},
+		{name: "stale capability key", state: ExecutionAccountState{AccountID: 42, CapabilityKey: "capability-other", CredentialPresent: true}, want: ErrStalePlan},
+		{name: "missing credential", state: ExecutionAccountState{AccountID: 42, CapabilityKey: "capability-test"}, want: ErrMissingCredential},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -544,11 +528,9 @@ func TestExecuteInvokesExactlyThePlannedAdapter(t *testing.T) {
 		t.Fatalf("Plan: %v", err)
 	}
 	ctx := WithExecutionAccountState(context.Background(), ExecutionAccountState{
-		AccountID:          42,
-		Revision:           "rev-1",
-		CapabilityKey:      "capability-test",
-		CapabilityRevision: 1,
-		CredentialPresent:  true,
+		AccountID:         42,
+		CapabilityKey:     "capability-test",
+		CredentialPresent: true,
 	})
 
 	result, err := router.Execute(ctx, plan, req)
@@ -589,11 +571,9 @@ func TestRouteRegistryEntriesPlanAndExecuteTheirDeclaredAdapter(t *testing.T) {
 			}
 
 			ctx := WithExecutionAccountState(context.Background(), ExecutionAccountState{
-				AccountID:          account.AccountID(),
-				Revision:           account.Revision(),
-				CapabilityKey:      account.CapabilityKey(),
-				CapabilityRevision: account.CapabilityRevision(),
-				CredentialPresent:  true,
+				AccountID:         account.AccountID(),
+				CapabilityKey:     account.CapabilityKey(),
+				CredentialPresent: true,
 			})
 			result, err := router.Execute(ctx, plan, request)
 			if err != nil {

--- a/backend/internal/service/account_supported_protocols.go
+++ b/backend/internal/service/account_supported_protocols.go
@@ -2,12 +2,8 @@ package service
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 
 	newapiconstant "github.com/QuantumNous/new-api/constant"
@@ -245,15 +241,9 @@ func protocolAccountSnapshot(account *Account, requestedModel string, requireCom
 	if err != nil {
 		return protocolrouter.AccountSnapshot{}, err
 	}
-	revision, err := protocolAccountRevision(account)
-	if err != nil {
-		return protocolrouter.AccountSnapshot{}, err
-	}
 	return protocolrouter.NewAccountSnapshot(protocolrouter.AccountSnapshotInput{
 		AccountID:          account.ID,
-		Revision:           revision,
 		CapabilityKey:      capability.CapabilityKey,
-		CapabilityRevision: capability.Revision,
 		SupportedProtocols: protocols,
 		ResolvedModel:      resolvedModel,
 		CustomBaseURL:      customBaseURL,
@@ -452,96 +442,4 @@ func copyProtocolBaseURL(raw map[string]any, key string, protocol protocolrouter
 	if value = strings.TrimSpace(value); value != "" {
 		out[protocol] = value
 	}
-}
-
-func protocolAccountRevision(account *Account) (string, error) {
-	if account == nil {
-		return "", errors.New("account is required")
-	}
-	baseURL, protocolBaseURLs, officialProfile := protocolAccountEndpoints(account)
-	capabilityKey := ""
-	capabilityRevision := int64(0)
-	identityConflict := false
-	if account.ProtocolEndpointCapability != nil {
-		capabilityKey = account.ProtocolEndpointCapability.CapabilityKey
-		capabilityRevision = account.ProtocolEndpointCapability.Revision
-		identityConflict = account.ProtocolEndpointCapability.IdentityConflict ||
-			account.ProtocolEndpointCapability.ProbeEvidence.IdentityConflict
-	}
-	protocols := routingSupportedProtocols(account)
-	protocolNames := make([]string, 0, len(protocols))
-	for _, protocol := range protocols {
-		protocolNames = append(protocolNames, string(protocol))
-	}
-	protocolURLPairs := make([]string, 0, len(protocolBaseURLs))
-	for _, protocol := range protocolrouter.AllProtocols() {
-		if value := strings.TrimSpace(protocolBaseURLs[protocol]); value != "" {
-			protocolURLPairs = append(protocolURLPairs, string(protocol)+"="+value)
-		}
-	}
-	compactMode := ""
-	if account.Extra != nil {
-		if mode, _ := account.Extra["openai_compact_mode"].(string); strings.TrimSpace(mode) != "" {
-			compactMode = strings.TrimSpace(mode)
-		}
-	}
-	input := struct {
-		ID                 int64    `json:"id"`
-		Platform           string   `json:"platform"`
-		Type               string   `json:"type"`
-		ChannelType        int      `json:"channel_type"`
-		CapabilityKey      string   `json:"capability_key"`
-		CapabilityRevision int64    `json:"capability_revision"`
-		IdentityConflict   bool     `json:"identity_conflict"`
-		SupportedProtocols []string `json:"supported_protocols"`
-		OfficialProfile    string   `json:"official_profile"`
-		GeminiProfile      string   `json:"gemini_profile"`
-		CustomBaseURL      string   `json:"custom_base_url"`
-		ProtocolBaseURLs   []string `json:"protocol_base_urls"`
-		ModelMapping       []string `json:"model_mapping"`
-		CompactMapping     []string `json:"compact_mapping"`
-		Passthrough        bool     `json:"passthrough"`
-		CompactMode        string   `json:"compact_mode"`
-		AuthPresent        bool     `json:"auth_present"`
-	}{
-		ID:                 account.ID,
-		Platform:           account.Platform,
-		Type:               account.Type,
-		ChannelType:        account.ChannelType,
-		CapabilityKey:      capabilityKey,
-		CapabilityRevision: capabilityRevision,
-		IdentityConflict:   identityConflict,
-		SupportedProtocols: protocolNames,
-		OfficialProfile:    string(officialProfile),
-		GeminiProfile:      string(protocolGeminiEndpointProfile(account)),
-		CustomBaseURL:      strings.TrimSpace(baseURL),
-		ProtocolBaseURLs:   protocolURLPairs,
-		ModelMapping:       protocolRevisionMappingPairs(account.GetModelMapping()),
-		CompactMapping:     protocolRevisionMappingPairs(account.GetCompactModelMapping()),
-		Passthrough:        account.IsOpenAIPassthroughEnabled(),
-		CompactMode:        compactMode,
-		AuthPresent:        ProtocolAuthorizationPresent(account),
-	}
-	return protocolRevisionDigest(input)
-}
-
-func protocolRevisionMappingPairs(mapping map[string]string) []string {
-	if len(mapping) == 0 {
-		return nil
-	}
-	pairs := make([]string, 0, len(mapping))
-	for key, value := range mapping {
-		pairs = append(pairs, key+"="+value)
-	}
-	sort.Strings(pairs)
-	return pairs
-}
-
-func protocolRevisionDigest(input any) (string, error) {
-	encoded, err := json.Marshal(input)
-	if err != nil {
-		return "", fmt.Errorf("marshal protocol revision: %w", err)
-	}
-	digest := sha256.Sum256(encoded)
-	return hex.EncodeToString(digest[:]), nil
 }

--- a/backend/internal/service/account_supported_protocols_test.go
+++ b/backend/internal/service/account_supported_protocols_test.go
@@ -123,7 +123,7 @@ func TestBuildSupportedProtocolsUpdateOwnsCanonicalEncoding(t *testing.T) {
 	}
 }
 
-func TestProtocolAccountSnapshotResolvesModelAndRevisionFromAccountFacts(t *testing.T) {
+func TestProtocolAccountSnapshotResolvesModelFromAccountFacts(t *testing.T) {
 	updatedAt := time.Date(2026, 8, 24, 10, 30, 0, 0, time.UTC)
 	account := &Account{
 		ID:        42,
@@ -146,8 +146,8 @@ func TestProtocolAccountSnapshotResolvesModelAndRevisionFromAccountFacts(t *test
 	if snapshot.AccountID() != 42 || snapshot.ResolvedModel() != "upstream-model" {
 		t.Fatalf("snapshot account/model = %d/%q", snapshot.AccountID(), snapshot.ResolvedModel())
 	}
-	if snapshot.Revision() == "" {
-		t.Fatal("snapshot revision is empty")
+	if snapshot.CapabilityKey() == "" {
+		t.Fatal("snapshot capability key is empty")
 	}
 
 	noisy := *account
@@ -161,8 +161,8 @@ func TestProtocolAccountSnapshotResolvesModelAndRevisionFromAccountFacts(t *test
 	if err != nil {
 		t.Fatalf("ProtocolAccountSnapshot noisy: %v", err)
 	}
-	if noisySnapshot.Revision() != snapshot.Revision() {
-		t.Fatal("updated_at or secret rotation must not change protocol revision")
+	if noisySnapshot.CapabilityKey() != snapshot.CapabilityKey() || noisySnapshot.ResolvedModel() != snapshot.ResolvedModel() {
+		t.Fatal("updated_at or secret rotation changed capability key or resolved model")
 	}
 
 	changed := *account
@@ -175,41 +175,8 @@ func TestProtocolAccountSnapshotResolvesModelAndRevisionFromAccountFacts(t *test
 	if err != nil {
 		t.Fatalf("ProtocolAccountSnapshot changed: %v", err)
 	}
-	if changedSnapshot.Revision() == snapshot.Revision() {
-		t.Fatal("model mapping change did not change account revision")
-	}
-}
-
-func TestProtocolAccountRevisionIgnoresUsageExtraWrites(t *testing.T) {
-	account := &Account{
-		ID:        44,
-		Platform:  PlatformOpenAI,
-		Type:      AccountTypeOAuth,
-		UpdatedAt: time.Date(2026, 8, 29, 13, 37, 0, 0, time.UTC),
-		Credentials: map[string]any{
-			"access_token": "secret",
-		},
-		Extra: map[string]any{
-			"codex_usage_updated_at": "2026-08-29T13:37:00Z",
-		},
-	}
-	if !SeedOfficialSupportedProtocols(account) {
-		t.Fatal("official OpenAI OAuth seed must succeed")
-	}
-	before, err := protocolAccountRevision(account)
-	if err != nil {
-		t.Fatalf("protocolAccountRevision: %v", err)
-	}
-
-	account.UpdatedAt = account.UpdatedAt.Add(time.Second)
-	account.Extra["codex_usage_updated_at"] = "2026-08-29T13:38:00Z"
-	account.Extra["quota_used"] = 12.5
-	after, err := protocolAccountRevision(account)
-	if err != nil {
-		t.Fatalf("protocolAccountRevision after extra write: %v", err)
-	}
-	if before != after {
-		t.Fatal("usage/quota extra writes changed protocol revision")
+	if changedSnapshot.ResolvedModel() != "other-upstream" {
+		t.Fatalf("mapping change resolved model = %q, want other-upstream", changedSnapshot.ResolvedModel())
 	}
 }
 

--- a/backend/internal/service/protocol_execution.go
+++ b/backend/internal/service/protocol_execution.go
@@ -417,15 +417,10 @@ func ExecuteSelectedProtocol(
 	}
 	executionCtx := WithProtocolExecutors(ctx, executors)
 	executionCtx = withProtocolExecutionAccount(executionCtx, freshAccount)
-	// Bind the scheduled plan's revision token so Execute can verify the
-	// captured route. Account updated_at / token writes change
-	// snapshot.Revision() without changing the route; those must not 503.
 	executionCtx = protocolrouter.WithExecutionAccountState(executionCtx, protocolrouter.ExecutionAccountState{
-		AccountID:          plan.AccountID(),
-		Revision:           plan.AccountRevision(),
-		CapabilityKey:      plan.CapabilityKey(),
-		CapabilityRevision: plan.CapabilityRevision(),
-		CredentialPresent:  ProtocolAuthorizationPresent(freshAccount),
+		AccountID:         plan.AccountID(),
+		CapabilityKey:     plan.CapabilityKey(),
+		CredentialPresent: ProtocolAuthorizationPresent(freshAccount),
 	})
 	result, err := router.Execute(executionCtx, plan, request)
 	if err != nil {
@@ -441,7 +436,6 @@ func ExecuteSelectedProtocol(
 func protocolPlansRoutingEquivalent(scheduled, fresh protocolrouter.Plan) bool {
 	return scheduled.AccountID() == fresh.AccountID() &&
 		scheduled.CapabilityKey() == fresh.CapabilityKey() &&
-		scheduled.CapabilityRevision() == fresh.CapabilityRevision() &&
 		scheduled.RequestDigest() == fresh.RequestDigest() &&
 		scheduled.ResolvedModel() == fresh.ResolvedModel() &&
 		scheduled.InboundProtocol() == fresh.InboundProtocol() &&

--- a/backend/internal/service/protocol_execution_test.go
+++ b/backend/internal/service/protocol_execution_test.go
@@ -151,7 +151,7 @@ func TestProtocolExecutionRouterInvokesGeminiIdentityExecutor(t *testing.T) {
 	})
 	ctx = withProtocolExecutionAccount(ctx, account)
 	ctx = protocolrouter.WithExecutionAccountState(ctx, protocolrouter.ExecutionAccountState{
-		AccountID: snapshot.AccountID(), Revision: snapshot.Revision(), CapabilityKey: snapshot.CapabilityKey(), CapabilityRevision: snapshot.CapabilityRevision(), CredentialPresent: true,
+		AccountID: snapshot.AccountID(), CapabilityKey: snapshot.CapabilityKey(), CredentialPresent: true,
 	})
 	result, err := router.Execute(ctx, plan, request)
 	if err != nil {
@@ -199,11 +199,9 @@ func TestProtocolExecutionRouterInvokesOnlyPlannedAdapterExecutor(t *testing.T) 
 	})
 	executionCtx = withProtocolExecutionAccount(executionCtx, sourceAccount)
 	executionCtx = protocolrouter.WithExecutionAccountState(executionCtx, protocolrouter.ExecutionAccountState{
-		AccountID:          account.AccountID(),
-		Revision:           account.Revision(),
-		CapabilityKey:      account.CapabilityKey(),
-		CapabilityRevision: account.CapabilityRevision(),
-		CredentialPresent:  true,
+		AccountID:         account.AccountID(),
+		CapabilityKey:     account.CapabilityKey(),
+		CredentialPresent: true,
 	})
 
 	result, err := router.Execute(executionCtx, plan, req)
@@ -227,11 +225,9 @@ func TestProtocolExecutionRouterFailsBeforeNetworkWhenExecutorIsMissing(t *testi
 		t.Fatalf("Plan: %v", err)
 	}
 	ctx := protocolrouter.WithExecutionAccountState(context.Background(), protocolrouter.ExecutionAccountState{
-		AccountID:          account.AccountID(),
-		Revision:           account.Revision(),
-		CapabilityKey:      account.CapabilityKey(),
-		CapabilityRevision: account.CapabilityRevision(),
-		CredentialPresent:  true,
+		AccountID:         account.AccountID(),
+		CapabilityKey:     account.CapabilityKey(),
+		CredentialPresent: true,
 	})
 
 	_, err = router.Execute(ctx, plan, req)
@@ -600,7 +596,47 @@ func TestExecuteSelectedProtocolValidatesExactPlanEndpointBeforeExecutor(t *test
 	}
 }
 
-func TestExecuteSelectedProtocolReloadsAuthoritativeCapabilityBeforeExecutor(t *testing.T) {
+func TestExecuteSelectedProtocolRejectsResolvedModelChangeBeforeExecutor(t *testing.T) {
+	router := NewProtocolRouter()
+	req := protocolRoutingTestRequest(t, protocolrouter.ProtocolMessages)
+	ctx := WithProtocolRouting(context.Background(), router, req)
+	account := protocolRoutingOpenAIAccount(12, "responses")
+	account.Credentials["model_mapping"] = map[string]any{"gpt-5.4": "upstream-a"}
+	plan, _, err := protocolPlanForAccount(ctx, account, "gpt-5.4")
+	if err != nil {
+		t.Fatalf("protocolPlanForAccount: %v", err)
+	}
+	calls := 0
+
+	_, err = ExecuteSelectedProtocol(
+		ctx,
+		router,
+		&AccountSelectionResult{Account: account, ProtocolPlan: &plan},
+		account,
+		func(context.Context, *Account, string) error { return nil },
+		func(context.Context, int64) (*Account, error) {
+			fresh := *account
+			fresh.Credentials = map[string]any{
+				"api_key":       "secret",
+				"base_url":      "https://relay.example.test/v1",
+				"model_mapping": map[string]any{"gpt-5.4": "upstream-b"},
+			}
+			return &fresh, nil
+		},
+		protocolExecutorsForTest(plan, func(context.Context, *Account, protocolrouter.Plan, protocolrouter.CanonicalRequest) (any, error) {
+			calls++
+			return nil, nil
+		}),
+	)
+	if !errors.Is(err, protocolrouter.ErrStalePlan) {
+		t.Fatalf("ExecuteSelectedProtocol error = %v, want ErrStalePlan", err)
+	}
+	if calls != 0 {
+		t.Fatalf("executor calls = %d, want 0", calls)
+	}
+}
+
+func TestExecuteSelectedProtocolKeepsEquivalentRouteAfterCapabilityRevisionBump(t *testing.T) {
 	router := NewProtocolRouter()
 	request := protocolRoutingTestRequest(t, protocolrouter.ProtocolMessages)
 	ctx := WithProtocolRouting(context.Background(), router, request)
@@ -625,14 +661,14 @@ func TestExecuteSelectedProtocolReloadsAuthoritativeCapabilityBeforeExecutor(t *
 		},
 		protocolExecutorsForTest(plan, func(context.Context, *Account, protocolrouter.Plan, protocolrouter.CanonicalRequest) (any, error) {
 			calls++
-			return nil, nil
+			return "sent", nil
 		}),
 	)
-	if !errors.Is(err, protocolrouter.ErrStalePlan) {
-		t.Fatalf("ExecuteSelectedProtocol error = %v, want ErrStalePlan", err)
+	if err != nil {
+		t.Fatalf("ExecuteSelectedProtocol: %v", err)
 	}
-	if calls != 0 {
-		t.Fatalf("executor calls = %d, want 0", calls)
+	if calls != 1 {
+		t.Fatalf("executor calls = %d, want 1 after capability revision-only bump", calls)
 	}
 }
 

--- a/backend/internal/service/protocol_routing_context.go
+++ b/backend/internal/service/protocol_routing_context.go
@@ -19,7 +19,6 @@ type protocolRoutingContextValue struct {
 
 type protocolPlanCacheKey struct {
 	accountID int64
-	revision  string
 }
 
 type protocolPlanCache struct {
@@ -36,9 +35,10 @@ func newProtocolPlanCache() *protocolPlanCache {
 	return &protocolPlanCache{outcomes: make(map[protocolPlanCacheKey]protocolPlanOutcome)}
 }
 
-// getOrPlan is the per-request, per-account-revision planning boundary. It
-// caches both success and failure so scheduler rechecks cannot call Plan twice
-// for the same immutable account snapshot.
+// getOrPlan is the per-request, per-account planning boundary. It caches both
+// success and failure so scheduler rechecks cannot call Plan twice for the
+// same account in one request. Send-time freshness is route-fact equivalence,
+// not a version token.
 func (c *protocolPlanCache) getOrPlan(
 	key protocolPlanCacheKey,
 	compute func() (protocolrouter.Plan, error),
@@ -56,13 +56,13 @@ func (c *protocolPlanCache) getOrPlan(
 	return plan, err
 }
 
-func (c *protocolPlanCache) get(accountID int64, revision string) (protocolrouter.Plan, bool) {
+func (c *protocolPlanCache) get(accountID int64) (protocolrouter.Plan, bool) {
 	if c == nil {
 		return protocolrouter.Plan{}, false
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	outcome, ok := c.outcomes[protocolPlanCacheKey{accountID: accountID, revision: revision}]
+	outcome, ok := c.outcomes[protocolPlanCacheKey{accountID: accountID}]
 	return outcome.plan, ok && outcome.err == nil
 }
 
@@ -167,7 +167,7 @@ func protocolPlanForAccount(
 	if err != nil {
 		return protocolrouter.Plan{}, true, fmt.Errorf("%w: %v", ErrProtocolRouteUnavailable, err)
 	}
-	key := protocolPlanCacheKey{accountID: snapshot.AccountID(), revision: snapshot.Revision()}
+	key := protocolPlanCacheKey{accountID: snapshot.AccountID()}
 	plan, err := routing.plans.getOrPlan(key, func() (protocolrouter.Plan, error) {
 		return routing.router.Plan(routing.request, snapshot)
 	})
@@ -238,7 +238,7 @@ func attachProtocolPlan(
 		}
 		return releaseProtocolSelectionOnPlanError(selection, fmt.Errorf("%w: %v", ErrProtocolRouteUnavailable, err))
 	}
-	plan, planned := routing.plans.get(snapshot.AccountID(), snapshot.Revision())
+	plan, planned := routing.plans.get(snapshot.AccountID())
 	if !planned {
 		if routing.plans.containsAccount(snapshot.AccountID()) {
 			return releaseProtocolSelectionOnPlanError(selection, protocolrouter.ErrStalePlan)

--- a/backend/internal/service/protocol_routing_context.go
+++ b/backend/internal/service/protocol_routing_context.go
@@ -66,20 +66,6 @@ func (c *protocolPlanCache) get(accountID int64) (protocolrouter.Plan, bool) {
 	return outcome.plan, ok && outcome.err == nil
 }
 
-func (c *protocolPlanCache) containsAccount(accountID int64) bool {
-	if c == nil {
-		return false
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	for key, outcome := range c.outcomes {
-		if key.accountID == accountID && outcome.err == nil {
-			return true
-		}
-	}
-	return false
-}
-
 type protocolRoutingContextKey struct{}
 
 func WithProtocolRouting(
@@ -233,16 +219,13 @@ func attachProtocolPlan(
 	}
 	snapshot, err := protocolAccountSnapshotForRequestWithThinking(selection.Account, routing.request, thinkingEnabledFromCtx(ctx))
 	if err != nil {
-		if routing.plans.containsAccount(selection.Account.ID) {
+		if _, planned := routing.plans.get(selection.Account.ID); planned {
 			return releaseProtocolSelectionOnPlanError(selection, protocolrouter.ErrStalePlan)
 		}
 		return releaseProtocolSelectionOnPlanError(selection, fmt.Errorf("%w: %v", ErrProtocolRouteUnavailable, err))
 	}
 	plan, planned := routing.plans.get(snapshot.AccountID())
 	if !planned {
-		if routing.plans.containsAccount(snapshot.AccountID()) {
-			return releaseProtocolSelectionOnPlanError(selection, protocolrouter.ErrStalePlan)
-		}
 		return releaseProtocolSelectionOnPlanError(selection, fmt.Errorf("%w: selected account has no scheduler-created plan", ErrProtocolRouteUnavailable))
 	}
 	if plan.RequestDigest() != routing.request.Digest() {

--- a/backend/internal/service/protocol_routing_context_test.go
+++ b/backend/internal/service/protocol_routing_context_test.go
@@ -567,9 +567,9 @@ func TestFailureDiagnosisDoesNotRenameNoRouteAsUnsupportedModel(t *testing.T) {
 	}
 }
 
-func TestProtocolPlanCacheComputesEachAccountRevisionOnce(t *testing.T) {
+func TestProtocolPlanCacheComputesEachAccountOnce(t *testing.T) {
 	cache := newProtocolPlanCache()
-	key := protocolPlanCacheKey{accountID: 9, revision: "rev-1"}
+	key := protocolPlanCacheKey{accountID: 9}
 	wantErr := errors.New("no route")
 	calls := 0
 	compute := func() (protocolrouter.Plan, error) {
@@ -584,7 +584,7 @@ func TestProtocolPlanCacheComputesEachAccountRevisionOnce(t *testing.T) {
 		t.Fatalf("cached errors = %v / %v, want %v", firstErr, secondErr, wantErr)
 	}
 	if calls != 1 {
-		t.Fatalf("planner calls = %d, want 1 for one account revision", calls)
+		t.Fatalf("planner calls = %d, want 1 for one account", calls)
 	}
 }
 

--- a/docs/approved/pricing-serving-single-source-of-truth.md
+++ b/docs/approved/pricing-serving-single-source-of-truth.md
@@ -5,8 +5,9 @@ approved_by: "xuejiao（2026-08-26 本会话确认）"
 approved_at: "2026-06-17"
 revised_at: "2026-08-29"
 revision_note: >
-  本文只保留组合公式、owner 指针和生命周期分界。generation 细节单向委托
-  protocol-routing-ssot.md；availability 只作 Evidence。
+  generation plan cache 只覆盖 request digest 与 accountID；发送前用当前
+  owner 重规划，路由事实不等价才 stale。不再把 account/capability revision
+  当 Execute 裁判。availability 只作 Evidence。
 authors: [agent]
 created: 2026-06-17
 related_prs: [1821]
@@ -90,7 +91,7 @@ AND 没有 structurally-gone 证据
 
 - 组合公式与 `TaskContinuation` 分界只在本文；协议文档不得复制公式或拥有 `TaskContinuation`。
 - 各 family 的 RequestPlan 测试从 canonical owner 派生样本，不手写模型/协议清单。
-- generation plan cache 覆盖 request digest、account revision、capability key/revision；成败都只规划一次。
+- generation plan cache 覆盖 request digest 与 accountID；成败都只规划一次。发送前用当前 owner 重规划，路由事实不等价才 stale。
 - image/video 续接必须读提交时 task record，禁止重新 scheduler 选号。
 - `_aliases` 校验 owner 存在、单跳、无重叠、无环。
 - catalog / model-list / admin discovery 共用 structurally-gone predicate。

--- a/docs/approved/protocol-routing-ssot.md
+++ b/docs/approved/protocol-routing-ssot.md
@@ -5,6 +5,9 @@ approved_by: "feng (conversation approval, 2026-08-27)"
 authors: [codex]
 created: 2026-08-24
 revised: 2026-08-29
+revision_note: >
+  Plans and Execute no longer compare account or capability revision tokens.
+  Send-time freshness is authoritative reload plus route-fact equivalence.
 related_stories: []
 ---
 
@@ -213,8 +216,8 @@ There is no persisted `unknown`. An empty set is fail-closed. Probe status and
 evidence may be inconclusive, but they cannot act as a third routing state.
 
 `revision` changes whenever the sorted protocol set or conflict state changes.
-Plans store the key and revision so execution can reject stale capability
-input. `probe_generation` increments for every accepted probe request and,
+It is probe compare-and-swap and audit state only. Plans and `Execute` do not
+compare it. `probe_generation` increments for every accepted probe request and,
 together with the lease fields, coordinates probe work; it does not affect
 routing directly.
 
@@ -280,7 +283,7 @@ For one account, a route is legal only when:
 
 ```text
 target protocol is in the linked capability.supported_protocols
-AND the capability key/revision is current
+AND the capability key is current
 AND an ordered registry entry exists
 AND model policy permits the resolved upstream model
 AND the adapter preserves the concrete request features
@@ -313,18 +316,18 @@ Runtime readiness cannot create, replace, or improve a route. Route planning
 cannot treat transient authorization, quota, cooldown, concurrency, or capacity
 as endpoint protocol capability.
 
-The plan stores the request digest, account snapshot revision, capability key
-and revision, resolved model, inbound and target protocols, endpoint, adapter,
-transport, route kind, and reason. Before constructing a network request,
-execution reloads the authoritative account and re-plans it. `Execute` then
-verifies the captured request digest and capability key/revision. A plan is
-stale only when the fresh account no longer produces an equivalent route
-(capability, resolved model, endpoint, adapter, transport) or authorization is
-missing. Account `updated_at`, last-used, token rotation, and other health
-writes do not by themselves invalidate a still-equivalent plan; the reload
-exists to attach current credentials, not to treat every account row write as a
-protocol change. A stale route or missing credential fails closed and enters
-normal account failover.
+The plan stores the request digest, capability key, resolved model, inbound and
+target protocols, endpoint, adapter, transport, route kind, and reason. It does
+not store an account or capability revision token. Before constructing a
+network request, execution reloads the authoritative account and re-plans it.
+A plan is stale only when the fresh account no longer produces an equivalent
+route (capability key, resolved model, endpoint, adapter, transport) or
+authorization is missing. `Execute` verifies the captured request digest and
+capability key. Account `updated_at`, last-used, token rotation, capability
+`revision` bumps, and other health writes do not by themselves invalidate a
+still-equivalent plan; the reload exists to attach current credentials, not to
+treat every account or probe write as a protocol change. A stale route or
+missing credential fails closed and enters normal account failover.
 
 Execution invariants:
 
@@ -644,7 +647,7 @@ Required tests include:
   partial publication;
 - identity-first and fixed conversion order;
 - model, feature, Responses-path, endpoint, adapter, and transport constraints;
-- plan capture and stale capability revision rejection before network I/O;
+- plan capture and inequivalent-route rejection before network I/O;
 - exact outbound host/path/body/credential boundary and response shape;
 - immutable request behavior across account failover;
 - account-level authorization gates remaining independent of shared capability;

--- a/scripts/checks/protocol-routing-ssot.py
+++ b/scripts/checks/protocol-routing-ssot.py
@@ -474,6 +474,8 @@ def check(root: Path) -> list[str]:
             source = strip_go_comments_and_literals(path.read_text(encoding="utf-8"))
             if function_definitions(source, "BuildProtocolEndpointIdentity"):
                 errors.append(f"{path.relative_to(root)}: duplicates the endpoint identity builder")
+            if path.name == "account_supported_protocols.go" and function_definitions(source, "protocolAccountRevision"):
+                errors.append("account snapshot still invents a protocol revision hash")
             if path.name not in {"account_supported_protocols.go", "protocol_routing_migration.go"} and contains_identifier(
                 source, "LegacySupportedProtocolsProjection"
             ):
@@ -487,9 +489,9 @@ def check(root: Path) -> list[str]:
             errors.append("protocol router is missing Execute stale-plan validation")
         for body in execute_bodies:
             if not contains_identifier(body, "CapabilityKey"):
-                errors.append("protocol router Execute is missing capability key stale validation")
-            if not contains_identifier(body, "CapabilityRevision"):
-                errors.append("protocol router Execute is missing capability revision stale validation")
+                errors.append("protocol router Execute is missing capability key identity validation")
+            if contains_identifier(body, "CapabilityRevision") or contains_identifier(body, "accountRevision"):
+                errors.append("protocol router Execute still treats revision tokens as the stale referee")
 
     capability_repo = root / "backend/internal/repository/protocol_endpoint_capability_repo.go"
     if capability_repo.is_file():
@@ -612,6 +614,10 @@ def check(root: Path) -> list[str]:
                 errors.append("selected protocol execution leaves a pre-send stale failure outside account failover")
             if not contains_identifier(body, "ErrMissingCredential"):
                 errors.append("selected protocol execution leaves a missing credential outside account failover")
+        equivalent_bodies = function_bodies(source, "protocolPlansRoutingEquivalent")
+        for body in equivalent_bodies:
+            if contains_identifier(body, "CapabilityRevision") or contains_identifier(body, "AccountRevision"):
+                errors.append("equivalent-route check still compares revision tokens")
         credential_bodies = function_bodies(source, "ProtocolAuthorizationPresent")
         if not credential_bodies or not all(
             contains_identifier(body, "ProtocolAuthorizationSnapshotCredentialKey")
@@ -780,7 +786,7 @@ def check(root: Path) -> list[str]:
             errors.append("protocol routing context is missing protocolPlanForAccount")
         for body in planning_bodies:
             if not contains_identifier(body, "getOrPlan"):
-                errors.append("protocol routing context bypasses the per-revision plan cache")
+                errors.append("protocol routing context bypasses the per-account plan cache")
         bodies = function_bodies(source, "attachProtocolPlan")
         if not bodies:
             errors.append("protocol routing context is missing attachProtocolPlan")

--- a/scripts/checks/test_protocol_routing_ssot.py
+++ b/scripts/checks/test_protocol_routing_ssot.py
@@ -76,6 +76,7 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
             "func ExecuteGeminiProtocolProfile(){}\n"
             "func protocolExecutionPreSendFailure(){ UpstreamFailoverError(); NextAccountRetry() }\n"
             "func ExecuteSelectedProtocol(){ freshAccount := loadAccount(); if freshAccount == nil { protocolExecutionPreSendFailure() }; if !protocolPlansRoutingEquivalent(plan, router.Plan(request, fresh)) { protocolExecutionPreSendFailure() }; withProtocolExecutionAccount(freshAccount); state := ExecutionAccountState{CredentialPresent: ProtocolAuthorizationPresent(freshAccount)}; if router.Execute(state) == ErrStalePlan || router.Execute(state) == ErrMissingCredential { protocolExecutionPreSendFailure() } }\n"
+            "func protocolPlansRoutingEquivalent(scheduled, fresh Plan) bool { return scheduled.CapabilityKey() == fresh.CapabilityKey() && scheduled.Endpoint() == fresh.Endpoint() }\n"
             "func ProtocolAuthorizationPresent(account Account){ ProtocolAuthorizationSnapshotCredentialKey(); if account.IsNewAPIVertexServiceAccount(){ parseVertexServiceAccountKey(account) }; protocolAuthorizationToken(account) }\n"
             "func protocolRuntimeAuthorizationReady(ctx Context, account Account){ ProtocolRoutingRequest(ctx); ProtocolAuthorizationPresent(account) }\n",
             encoding="utf-8",
@@ -103,7 +104,7 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
         router_owner.write_text(
             "package fixture\n"
             "func (r *Router) Execute(plan Plan, state ExecutionAccountState){ "
-            "if state.CapabilityKey != plan.capabilityKey || state.CapabilityRevision != plan.capabilityRevision { ErrStalePlan() } }\n",
+            "if state.CapabilityKey != plan.capabilityKey { ErrStalePlan() } }\n",
             encoding="utf-8",
         )
         canonical_owner = root / "backend/internal/service/account_supported_protocols.go"
@@ -174,7 +175,7 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
             "package fixture\n"
             "type protocolPlanCache struct{}\n"
             "func (c *protocolPlanCache) getOrPlan(key protocolPlanCacheKey, compute func() (Plan, error)) (Plan, error){ return compute() }\n"
-            "func (c *protocolPlanCache) get(id int64, revision string) (Plan, bool){ return Plan{}, true }\n"
+            "func (c *protocolPlanCache) get(id int64) (Plan, bool){ return Plan{}, true }\n"
             "func protocolPlanForAccount(){ plans.getOrPlan() }\n"
             "func attachProtocolPlan(){ plans.get() }\n",
             encoding="utf-8",
@@ -623,17 +624,38 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
         owner.write_text("package fixture\n", encoding="utf-8")
         self.assertTrue(any("query credential identity regression test" in error for error in MODULE.check(root)))
 
-    def test_rejects_removed_capability_revision_stale_guard(self) -> None:
+    def test_rejects_revision_token_stale_guard(self) -> None:
         root = self.fixture()
         owner = root / "backend/internal/engine/protocolrouter/router.go"
         owner.write_text(
             owner.read_text(encoding="utf-8").replace(
-                " || state.CapabilityRevision != plan.capabilityRevision",
-                "",
+                "if state.CapabilityKey != plan.capabilityKey { ErrStalePlan() }",
+                "if state.CapabilityKey != plan.capabilityKey || state.CapabilityRevision != plan.capabilityRevision { ErrStalePlan() }",
             ),
             encoding="utf-8",
         )
-        self.assertTrue(any("capability revision" in error for error in MODULE.check(root)))
+        self.assertTrue(any("revision tokens" in error for error in MODULE.check(root)))
+
+    def test_rejects_equivalent_route_revision_compare(self) -> None:
+        root = self.fixture()
+        owner = root / "backend/internal/service/protocol_execution.go"
+        owner.write_text(
+            owner.read_text(encoding="utf-8").replace(
+                "scheduled.CapabilityKey() == fresh.CapabilityKey()",
+                "scheduled.CapabilityKey() == fresh.CapabilityKey() && scheduled.CapabilityRevision() == fresh.CapabilityRevision()",
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("revision tokens" in error for error in MODULE.check(root)))
+
+    def test_rejects_account_revision_hash(self) -> None:
+        root = self.fixture()
+        owner = root / "backend/internal/service/account_supported_protocols.go"
+        owner.write_text(
+            owner.read_text(encoding="utf-8") + "func protocolAccountRevision(){}\n",
+            encoding="utf-8",
+        )
+        self.assertTrue(any("protocol revision hash" in error for error in MODULE.check(root)))
 
     def test_rejects_capability_repository_without_generation_commit(self) -> None:
         root = self.fixture()

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -1040,9 +1040,10 @@
         "func OpenAIForwardResultFromForward(result *ForwardResult) *OpenAIForwardResult",
         "RouteFacts",
         "ExecuteSelectedProtocol",
+        "protocolPlansRoutingEquivalent",
         "if router == nil && canonical && !routed && !planned {"
       ],
-      "rationale": "Protocol routing is the single execution boundary for governed text channels. Every registered inbound→target pair, including Gemini, has a concrete adapter and immutable route facts; the service execution owner alone dispatches the plan-derived Gemini endpoint profile, while transports bind the selected endpoint and preserve transport-derived query semantics. The nil-router legacy branch remains only as a compatibility boundary for explicitly non-routed callers; production candidate images always inject the router and use readiness for traffic admission. Router-enabled requests without a selected plan remain fail-closed."
+      "rationale": "Protocol routing is the single execution boundary for governed text channels. Every registered inbound→target pair, including Gemini, has a concrete adapter and immutable route facts; send-time freshness is authoritative reload plus protocolPlansRoutingEquivalent, not a revision token. The service execution owner alone dispatches the plan-derived Gemini endpoint profile, while transports bind the selected endpoint and preserve transport-derived query semantics. The nil-router legacy branch remains only as a compatibility boundary for explicitly non-routed callers; production candidate images always inject the router and use readiness for traffic admission. Router-enabled requests without a selected plan remain fail-closed."
     },
     {
       "path": "backend/internal/service/account_supported_protocols.go",
@@ -1301,13 +1302,12 @@
       "path": "backend/internal/engine/protocolrouter/router.go",
       "must_contain": [
         "CapabilityKey",
-        "CapabilityRevision",
         "state.CapabilityKey != plan.capabilityKey",
-        "state.CapabilityRevision != plan.capabilityRevision",
+        "plan.requestDigest != request.digest",
         "ErrStalePlan",
         "ErrModelNotAllowed"
       ],
-      "rationale": "A selected route captures the endpoint capability key and revision. Execute must reject a changed capability before adapter or network execution; otherwise a probe or endpoint relink can make an already-selected route unsafe. Model-policy rejection must stay a distinct Plan error so schedulers do not rename no-route as unsupported, or unsupported as no-route."
+      "rationale": "Execute verifies request digest and capability-key identity only. Capability revision is probe CAS, not a send-time referee; route-fact staleness is owned by ExecuteSelectedProtocol replan plus protocolPlansRoutingEquivalent. Model-policy rejection must stay a distinct Plan error so schedulers do not rename no-route as unsupported, or unsupported as no-route."
     },
     {
       "path": "backend/internal/integration/newapi/discover_filter_tk.go",


### PR DESCRIPTION
## 摘要

#1890 修完后仍用 revision 当裁判：账号哈希 allowlist 漏一个字段就合成 503，路由已经等价还要伪造旧 revision。本 PR 把裁判换成路由事实。

- 删掉 `protocolAccountRevision` 哈希。Plan / Snapshot / Execute 不再比较账号或 capability revision。
- 发送前仍 reload 权威账号并重规划；`protocolPlansRoutingEquivalent` 只比 capability key、model、endpoint、adapter 等路由事实。
- `capability.revision` / `probe_generation` 只留给探测 CAS 和观测。
- plan cache 按 `accountID` 规划一次。
- 审查 R-001：删掉 attach 时 revision 二级 key 残留的 `containsAccount` stale 分支。

Web impact: none
no-web-impact
sentinel-registry-reviewed
high-risk-anchor: docs/approved/protocol-routing-ssot.md

## 风险

高风险：协议规划与执行热路径，以及 approved SSOT 不变量。对外 API 字段不变。回滚即停用本 PR。禁止在本 PR 合并或部署。

## 验证

- `python3 scripts/checks/protocol-routing-ssot.py`：通过
- `python3 scripts/checks/test_protocol_routing_ssot.py`：75 通过
- `go test -tags=unit -count=1 ./internal/engine/protocolrouter/ ./internal/service/`：通过
- `./scripts/preflight.sh`：通过
- 正向：token 旋转 / `updated_at` / 用量 extra / capability revision 空 bump 仍发送（`TestExecuteSelectedProtocolKeepsEquivalentRouteAfterAccountWrite` / `TestExecuteSelectedProtocolKeepsEquivalentRouteAfterCapabilityRevisionBump`）
- 负向：协议集、resolved model、capability key、request digest 变化仍 stale（`TestExecuteSelectedProtocolRejectsInequivalentRouteBeforeExecutor` / `TestExecuteSelectedProtocolRejectsResolvedModelChangeBeforeExecutor` / `TestExecuteRejectsStaleCapabilityBeforeAdapter`）

## 提交

- `6a2c63968` fix(protocol): 发送前只比路由事实，不再用 revision 当裁判 (no-web-impact)
- `a4c48d1b7` fix(protocol): address R-001 — drop leftover attach stale branch (no-web-impact)

最新提交：a4c48d1b7

Made with [Cursor](https://cursor.com)