### PR TITLE
fix(protocol): 单个账号无合法路由不再 503 整机，千帆可规划 chat

### DIFF
--- a/backend/internal/service/account_supported_protocols.go
+++ b/backend/internal/service/account_supported_protocols.go
@@ -323,15 +323,25 @@ func protocolExactEndpoints(
 		return nil, nil
 	}
 	endpoints := make(map[protocolrouter.Protocol]string, 2)
+	var firstErr error
 	for _, protocol := range []protocolrouter.Protocol{
 		protocolrouter.ProtocolChatCompletions,
 		protocolrouter.ProtocolResponses,
 	} {
 		endpoint, err := protocolExactEndpoint(account, protocol, resolvedModel)
 		if err != nil {
-			return nil, err
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if strings.TrimSpace(endpoint) == "" {
+			continue
 		}
 		endpoints[protocol] = endpoint
+	}
+	if len(endpoints) == 0 && firstErr != nil {
+		return nil, firstErr
 	}
 	return endpoints, nil
 }

--- a/backend/internal/service/account_supported_protocols.go
+++ b/backend/internal/service/account_supported_protocols.go
@@ -241,6 +241,7 @@ func protocolAccountSnapshot(account *Account, requestedModel string, requireCom
 	if err != nil {
 		return protocolrouter.AccountSnapshot{}, err
 	}
+	protocols = retainResolvedNewAPIExactProtocols(account, protocols, exactEndpoints)
 	return protocolrouter.NewAccountSnapshot(protocolrouter.AccountSnapshotInput{
 		AccountID:          account.ID,
 		CapabilityKey:      capability.CapabilityKey,
@@ -350,6 +351,30 @@ func protocolExactEndpoints(
 		return nil, firstErr
 	}
 	return endpoints, nil
+}
+
+// retainResolvedNewAPIExactProtocols drops Chat/Responses that the channel
+// adaptor could not resolve. Leaving them in the Plan-facing set lets
+// resolveEndpoint invent /v1/responses from customBaseURL.
+func retainResolvedNewAPIExactProtocols(
+	account *Account,
+	protocols []protocolrouter.Protocol,
+	exactEndpoints map[protocolrouter.Protocol]string,
+) []protocolrouter.Protocol {
+	if account == nil || account.Platform != PlatformNewAPI || account.ChannelType <= 0 {
+		return protocols
+	}
+	kept := make([]protocolrouter.Protocol, 0, len(protocols))
+	for _, protocol := range protocols {
+		switch protocol {
+		case protocolrouter.ProtocolChatCompletions, protocolrouter.ProtocolResponses:
+			if strings.TrimSpace(exactEndpoints[protocol]) == "" {
+				continue
+			}
+		}
+		kept = append(kept, protocol)
+	}
+	return kept
 }
 
 func protocolGeminiEndpointProfile(account *Account) protocolrouter.GeminiEndpointProfile {

--- a/backend/internal/service/account_supported_protocols.go
+++ b/backend/internal/service/account_supported_protocols.go
@@ -322,12 +322,18 @@ func protocolExactEndpoints(
 	if account == nil || account.Platform != PlatformNewAPI || account.ChannelType <= 0 {
 		return nil, nil
 	}
+	// Only resolve protocols the linked capability already claims. Qianfan
+	// (channel 46) rejects Responses; forcing that URL used to poison
+	// chat-only snapshots. A claimed protocol that cannot resolve is omitted
+	// so a remaining legal Chat route still plans.
 	endpoints := make(map[protocolrouter.Protocol]string, 2)
 	var firstErr error
-	for _, protocol := range []protocolrouter.Protocol{
-		protocolrouter.ProtocolChatCompletions,
-		protocolrouter.ProtocolResponses,
-	} {
+	for _, protocol := range routingSupportedProtocols(account) {
+		switch protocol {
+		case protocolrouter.ProtocolChatCompletions, protocolrouter.ProtocolResponses:
+		default:
+			continue
+		}
 		endpoint, err := protocolExactEndpoint(account, protocol, resolvedModel)
 		if err != nil {
 			if firstErr == nil {

--- a/backend/internal/service/account_supported_protocols_test.go
+++ b/backend/internal/service/account_supported_protocols_test.go
@@ -466,6 +466,29 @@ func TestProtocolAccountSnapshotOmitsUnresolvableClaimedResponses(t *testing.T) 
 	if got, want := plan.Endpoint(), newapiintegration.QianfanBaseURL+"/v2/chat/completions"; got != want {
 		t.Fatalf("endpoint = %q, want %q", got, want)
 	}
+
+	responsesReq, err := protocolrouter.NewCanonicalRequest(protocolrouter.CanonicalRequestInput{
+		InboundProtocol: protocolrouter.ProtocolResponses,
+		RequestedModel:  "ernie-5.0",
+		ResponsesPath:   protocolrouter.ResponsesPathRoot,
+		Profile: protocolrouter.RequestProfile{
+			ContentKinds: protocolrouter.ContentText,
+		},
+		Body: []byte(`{"model":"ernie-5.0","input":"hi"}`),
+	})
+	if err != nil {
+		t.Fatalf("NewCanonicalRequest responses: %v", err)
+	}
+	converted, err := NewProtocolRouter().Plan(responsesReq, snapshot)
+	if err != nil {
+		t.Fatalf("inbound Responses should convert to chat, not invent /v1/responses: %v", err)
+	}
+	if got, want := converted.TargetProtocol(), protocolrouter.ProtocolChatCompletions; got != want {
+		t.Fatalf("converted target = %q, want %q", got, want)
+	}
+	if got, want := converted.Endpoint(), newapiintegration.QianfanBaseURL+"/v2/chat/completions"; got != want {
+		t.Fatalf("converted endpoint = %q, want invented Responses URL %q", got, want)
+	}
 }
 
 func qianfanChatTestAccount(id int64) *Account {

--- a/backend/internal/service/account_supported_protocols_test.go
+++ b/backend/internal/service/account_supported_protocols_test.go
@@ -340,6 +340,7 @@ func TestProtocolAccountSnapshotUsesCanonicalAgentPlanEndpoints(t *testing.T) {
 
 func TestProtocolExactEndpointsOmitsUnsupportedNewAPIProtocol(t *testing.T) {
 	account := qianfanChatTestAccount(90)
+	attachTestProtocolCapability(account, protocolrouter.ProtocolChatCompletions)
 	endpoints, err := protocolExactEndpoints(account, "ernie-5.0", protocolrouter.GeminiEndpointNone, false)
 	if err != nil {
 		t.Fatalf("protocolExactEndpoints: %v", err)
@@ -349,6 +350,31 @@ func TestProtocolExactEndpointsOmitsUnsupportedNewAPIProtocol(t *testing.T) {
 	}
 	if _, ok := endpoints[protocolrouter.ProtocolResponses]; ok {
 		t.Fatalf("unsupported Responses exact endpoint was attached: %#v", endpoints)
+	}
+}
+
+func TestProtocolExactEndpointsOmitsUnresolvableClaimedResponses(t *testing.T) {
+	// #1893 fail-closed when capability falsely claimed Responses. Keep Chat
+	// and omit the unresolvable protocol instead of poisoning the snapshot.
+	account := qianfanChatTestAccount(90)
+	attachTestProtocolCapability(account, protocolrouter.ProtocolChatCompletions, protocolrouter.ProtocolResponses)
+	endpoints, err := protocolExactEndpoints(account, "ernie-5.0", protocolrouter.GeminiEndpointNone, false)
+	if err != nil {
+		t.Fatalf("claimed Responses must not fail Chat exact endpoints: %v", err)
+	}
+	if got := endpoints[protocolrouter.ProtocolChatCompletions]; got != newapiintegration.QianfanBaseURL+"/v2/chat/completions" {
+		t.Fatalf("chat exact endpoint = %q", got)
+	}
+	if _, ok := endpoints[protocolrouter.ProtocolResponses]; ok {
+		t.Fatalf("unresolvable claimed Responses was attached: %#v", endpoints)
+	}
+}
+
+func TestProtocolExactEndpointsFailsWhenEveryDeclaredProtocolIsUnresolvable(t *testing.T) {
+	account := qianfanChatTestAccount(90)
+	attachTestProtocolCapability(account, protocolrouter.ProtocolResponses)
+	if _, err := protocolExactEndpoints(account, "ernie-5.0", protocolrouter.GeminiEndpointNone, false); err == nil {
+		t.Fatal("expected Responses-only Qianfan exact endpoints to fail closed")
 	}
 }
 
@@ -409,6 +435,36 @@ func TestProtocolAccountSnapshotPlansQianfanChatWithoutResponses(t *testing.T) {
 	}
 	if got, want := converted.Endpoint(), newapiintegration.QianfanBaseURL+"/v2/chat/completions"; got != want {
 		t.Fatalf("converted endpoint = %q, want invented Responses URL %q", got, want)
+	}
+}
+
+func TestProtocolAccountSnapshotOmitsUnresolvableClaimedResponses(t *testing.T) {
+	account := qianfanChatTestAccount(90)
+	attachTestProtocolCapability(account, protocolrouter.ProtocolChatCompletions, protocolrouter.ProtocolResponses)
+	snapshot, err := ProtocolAccountSnapshot(account, "ernie-5.0")
+	if err != nil {
+		t.Fatalf("claimed Responses must not fail Chat snapshot: %v", err)
+	}
+	request, err := protocolrouter.NewCanonicalRequest(protocolrouter.CanonicalRequestInput{
+		InboundProtocol: protocolrouter.ProtocolChatCompletions,
+		RequestedModel:  "ernie-5.0",
+		Profile: protocolrouter.RequestProfile{
+			ContentKinds: protocolrouter.ContentText,
+		},
+		Body: []byte(`{"model":"ernie-5.0","messages":[{"role":"user","content":"hi"}]}`),
+	})
+	if err != nil {
+		t.Fatalf("NewCanonicalRequest: %v", err)
+	}
+	plan, err := NewProtocolRouter().Plan(request, snapshot)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if got, want := plan.TargetProtocol(), protocolrouter.ProtocolChatCompletions; got != want {
+		t.Fatalf("target = %q, want %q", got, want)
+	}
+	if got, want := plan.Endpoint(), newapiintegration.QianfanBaseURL+"/v2/chat/completions"; got != want {
+		t.Fatalf("endpoint = %q, want %q", got, want)
 	}
 }
 

--- a/backend/internal/service/account_supported_protocols_test.go
+++ b/backend/internal/service/account_supported_protocols_test.go
@@ -338,6 +338,100 @@ func TestProtocolAccountSnapshotUsesCanonicalAgentPlanEndpoints(t *testing.T) {
 	}
 }
 
+func TestProtocolExactEndpointsOmitsUnsupportedNewAPIProtocol(t *testing.T) {
+	account := qianfanChatTestAccount(90)
+	endpoints, err := protocolExactEndpoints(account, "ernie-5.0", protocolrouter.GeminiEndpointNone, false)
+	if err != nil {
+		t.Fatalf("protocolExactEndpoints: %v", err)
+	}
+	if got := endpoints[protocolrouter.ProtocolChatCompletions]; got != newapiintegration.QianfanBaseURL+"/v2/chat/completions" {
+		t.Fatalf("chat exact endpoint = %q", got)
+	}
+	if _, ok := endpoints[protocolrouter.ProtocolResponses]; ok {
+		t.Fatalf("unsupported Responses exact endpoint was attached: %#v", endpoints)
+	}
+}
+
+func TestProtocolAccountSnapshotPlansQianfanChatWithoutResponses(t *testing.T) {
+	account := qianfanChatTestAccount(90)
+	attachTestProtocolCapability(account, protocolrouter.ProtocolChatCompletions)
+	account.ProtocolEndpointCapability.ProbeEvidence.InitialProbeCompleted = false
+	account.ProtocolEndpointCapability.ProbeEvidence.OfficialSeed = false
+	account.ProtocolEndpointCapability.ProbeEvidence.Verdicts = map[string]any{
+		string(protocolrouter.ProtocolChatCompletions): string(ProtocolProbePositive),
+		string(protocolrouter.ProtocolMessages):        string(ProtocolProbeEndpointNegative),
+	}
+
+	snapshot, err := ProtocolAccountSnapshot(account, "ernie-5.0")
+	if err != nil {
+		t.Fatalf("chat-only Qianfan snapshot failed: %v", err)
+	}
+	request, err := protocolrouter.NewCanonicalRequest(protocolrouter.CanonicalRequestInput{
+		InboundProtocol: protocolrouter.ProtocolChatCompletions,
+		RequestedModel:  "ernie-5.0",
+		Profile: protocolrouter.RequestProfile{
+			ContentKinds: protocolrouter.ContentText,
+		},
+		Body: []byte(`{"model":"ernie-5.0","messages":[{"role":"user","content":"hi"}]}`),
+	})
+	if err != nil {
+		t.Fatalf("NewCanonicalRequest: %v", err)
+	}
+	plan, err := NewProtocolRouter().Plan(request, snapshot)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if got, want := plan.TargetProtocol(), protocolrouter.ProtocolChatCompletions; got != want {
+		t.Fatalf("target = %q, want %q", got, want)
+	}
+	if got, want := plan.Endpoint(), newapiintegration.QianfanBaseURL+"/v2/chat/completions"; got != want {
+		t.Fatalf("endpoint = %q, want %q", got, want)
+	}
+
+	responsesReq, err := protocolrouter.NewCanonicalRequest(protocolrouter.CanonicalRequestInput{
+		InboundProtocol: protocolrouter.ProtocolResponses,
+		RequestedModel:  "ernie-5.0",
+		ResponsesPath:   protocolrouter.ResponsesPathRoot,
+		Profile: protocolrouter.RequestProfile{
+			ContentKinds: protocolrouter.ContentText,
+		},
+		Body: []byte(`{"model":"ernie-5.0","input":"hi"}`),
+	})
+	if err != nil {
+		t.Fatalf("NewCanonicalRequest responses: %v", err)
+	}
+	converted, err := NewProtocolRouter().Plan(responsesReq, snapshot)
+	if err != nil {
+		t.Fatalf("inbound Responses should convert to chat: %v", err)
+	}
+	if got, want := converted.TargetProtocol(), protocolrouter.ProtocolChatCompletions; got != want {
+		t.Fatalf("converted target = %q, want %q", got, want)
+	}
+	if got, want := converted.Endpoint(), newapiintegration.QianfanBaseURL+"/v2/chat/completions"; got != want {
+		t.Fatalf("converted endpoint = %q, want invented Responses URL %q", got, want)
+	}
+}
+
+func qianfanChatTestAccount(id int64) *Account {
+	return &Account{
+		ID:          id,
+		Name:        "百度",
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeBaiduV2,
+		Credentials: map[string]any{
+			"api_key":  "secret",
+			"base_url": newapiintegration.QianfanBaseURL,
+			"model_mapping": map[string]any{
+				"ernie-5.0":     "ernie-5.0",
+				"bge-large-zh":  "bge-large-zh",
+				"deepseek-ocr":  "deepseek-ocr",
+				"deepseek-v3.2": "deepseek-v3.2",
+			},
+		},
+	}
+}
+
 func TestProtocolRoutingGovernsStableGeminiAccountShapes(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/backend/internal/service/protocol_routing_migration.go
+++ b/backend/internal/service/protocol_routing_migration.go
@@ -225,7 +225,6 @@ func prepareProtocolRoutingSSOT(
 		return nil
 	})
 	if errors.Is(err, errProtocolRoutingFinalReadinessNotReady) {
-		final.TrafficReady = false
 		final.CutoverReady = false
 		return newProtocolRoutingSSOTReady(final, router), nil
 	}

--- a/backend/internal/service/protocol_routing_migration.go
+++ b/backend/internal/service/protocol_routing_migration.go
@@ -37,9 +37,9 @@ type ProtocolRoutingMigrationReport struct {
 	SeededOfficial int
 	ProbeAttempts  int
 	ProbeResolved  int
-	// TrafficReady is true when every hard blocker is gone: identity can be
-	// built, and any already-verified protocol set still has a legal route.
-	// Unverified / incomplete probes stay in Remediation and do not flip this.
+	// TrafficReady is true when the process can serve: the router exists and
+	// startup evaluation did not abort. Account remediations stay in
+	// Remediation and only clear CutoverReady.
 	TrafficReady bool
 	// CutoverReady is true only when TrafficReady and no remediations remain.
 	CutoverReady bool
@@ -76,7 +76,7 @@ func evaluateProtocolRoutingSSOT(
 	router *protocolrouter.Router,
 	prepare bool,
 ) (ProtocolRoutingMigrationReport, error) {
-	report := ProtocolRoutingMigrationReport{CutoverReady: true, TrafficReady: true}
+	report := ProtocolRoutingMigrationReport{CutoverReady: router != nil, TrafficReady: router != nil}
 	accounts, err := repo.ListActive(ctx)
 	if err != nil {
 		return report, err
@@ -90,7 +90,6 @@ func evaluateProtocolRoutingSSOT(
 		identity, governed, err := BuildProtocolEndpointIdentity(account)
 		if err != nil {
 			if account.Schedulable {
-				report.TrafficReady = false
 				report.CutoverReady = false
 				report.Remediation = append(report.Remediation, ProtocolRoutingRemediation{AccountID: account.ID, Name: account.Name, Reason: ProtocolRoutingRemediationNoLegalRoute})
 			}
@@ -145,7 +144,6 @@ func evaluateProtocolRoutingSSOT(
 		}
 		models := protocolRoutingMigrationModels(account)
 		if !accountHasLegalProtocolRoute(router, account, models) {
-			report.TrafficReady = false
 			report.CutoverReady = false
 			report.Remediation = append(report.Remediation, ProtocolRoutingRemediation{
 				AccountID: account.ID,

--- a/backend/internal/service/protocol_routing_migration_test.go
+++ b/backend/internal/service/protocol_routing_migration_test.go
@@ -409,6 +409,48 @@ func TestProtocolRoutingMigrationReportFailsTrafficReadyWhenRouterMissing(t *tes
 	}
 }
 
+func TestMigrateProtocolRoutingSSOTDoesNotMarkQianfanChatOnlyAsNoLegalRoute(t *testing.T) {
+	account := qianfanChatTestAccount(90)
+	repo := &protocolRoutingMigrationRepo{accounts: []Account{*account}}
+	identity, governed, err := BuildProtocolEndpointIdentity(account)
+	if err != nil || !governed {
+		t.Fatalf("BuildProtocolEndpointIdentity: governed=%v err=%v", governed, err)
+	}
+	repo.ensureCapabilityMaps()
+	repo.capabilities[identity.Key()] = &ProtocolEndpointCapability{
+		ID:                 1,
+		CapabilityKey:      identity.Key(),
+		Identity:           identity,
+		SupportedProtocols: []protocolrouter.Protocol{protocolrouter.ProtocolChatCompletions},
+		Revision:           1,
+		ProbeEvidence: ProtocolProbeEvidence{
+			Verdicts: map[string]any{
+				string(protocolrouter.ProtocolChatCompletions): string(ProtocolProbePositive),
+				string(protocolrouter.ProtocolMessages):        string(ProtocolProbeEndpointNegative),
+			},
+		},
+	}
+	repo.links[account.ID] = identity.Key()
+
+	report, err := MigrateProtocolRoutingSSOT(context.Background(), repo, NewProtocolRouter())
+	if err != nil {
+		t.Fatalf("MigrateProtocolRoutingSSOT: %v", err)
+	}
+	ready := newProtocolRoutingSSOTReady(report, NewProtocolRouter())
+	if !ready.Ready() || !report.TrafficReady {
+		t.Fatalf("Qianfan chat-only account blocked process traffic: %+v", report)
+	}
+	for _, item := range report.Remediation {
+		if item.Reason == ProtocolRoutingRemediationNoLegalRoute {
+			t.Fatalf("verified Qianfan chat evidence was treated as no_legal_route: %+v", report.Remediation)
+		}
+	}
+	linked := repo.accounts[0]
+	if !accountHasLegalProtocolRoute(NewProtocolRouter(), &linked, []string{"ernie-5.0"}) {
+		t.Fatal("verified Qianfan chat account has no legal text route")
+	}
+}
+
 func TestProtocolRoutingMigrationReportKeepsTrafficReadyWhenAccountHasNoLegalRoute(t *testing.T) {
 	repo := &protocolRoutingMigrationRepo{accounts: []Account{{
 		ID:       9,

--- a/backend/internal/service/protocol_routing_migration_test.go
+++ b/backend/internal/service/protocol_routing_migration_test.go
@@ -387,7 +387,29 @@ func TestProtocolRoutingMediaOnlyClassificationExcludesKnownImageAliases(t *test
 	}
 }
 
-func TestProtocolRoutingMigrationReportRejectsCanonicalAccountWithoutLegalRoute(t *testing.T) {
+func TestProtocolRoutingMigrationReportFailsTrafficReadyWhenRouterMissing(t *testing.T) {
+	repo := &protocolRoutingMigrationRepo{accounts: []Account{{
+		ID:       9,
+		Name:     "custom-openai",
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":  "secret",
+			"base_url": "https://relay.example.test/v1",
+		},
+	}}}
+
+	report, err := MigrateProtocolRoutingSSOT(context.Background(), repo, nil)
+	if err != nil {
+		t.Fatalf("MigrateProtocolRoutingSSOT: %v", err)
+	}
+	ready := newProtocolRoutingSSOTReady(report, nil)
+	if ready.Ready() || report.TrafficReady || report.CutoverReady {
+		t.Fatalf("missing router admitted traffic: %+v", report)
+	}
+}
+
+func TestProtocolRoutingMigrationReportKeepsTrafficReadyWhenAccountHasNoLegalRoute(t *testing.T) {
 	repo := &protocolRoutingMigrationRepo{accounts: []Account{{
 		ID:       9,
 		Name:     "bad-route",
@@ -405,8 +427,12 @@ func TestProtocolRoutingMigrationReportRejectsCanonicalAccountWithoutLegalRoute(
 	if err != nil {
 		t.Fatalf("MigrateProtocolRoutingSSOT: %v", err)
 	}
-	if report.CutoverReady || report.TrafficReady || len(report.Remediation) != 1 || report.Remediation[0].Reason != ProtocolRoutingRemediationNoLegalRoute {
-		t.Fatalf("report = %+v", report)
+	ready := newProtocolRoutingSSOTReady(report, NewProtocolRouter())
+	if !ready.Ready() || !report.TrafficReady {
+		t.Fatalf("account without a legal route blocked process traffic readiness: %+v", report)
+	}
+	if report.CutoverReady || len(report.Remediation) != 1 || report.Remediation[0].Reason != ProtocolRoutingRemediationNoLegalRoute {
+		t.Fatalf("report = %+v, want no_legal_route remediation without cutover", report)
 	}
 }
 

--- a/backend/internal/service/protocol_routing_migration_test.go
+++ b/backend/internal/service/protocol_routing_migration_test.go
@@ -729,8 +729,8 @@ func TestPrepareProtocolRoutingSSOTRollsBackPublicationWhenFinalReadinessFails(t
 	if err != nil {
 		t.Fatalf("prepareProtocolRoutingSSOT: %v", err)
 	}
-	if ready.Ready() || ready.Report.CutoverReady {
-		t.Fatalf("final readiness failure admitted candidate: %+v", ready.Report)
+	if !ready.Ready() || ready.Report.CutoverReady {
+		t.Fatalf("final readiness failure should keep process traffic ready without cutover: %+v", ready.Report)
 	}
 	if got := LegacySupportedProtocolsProjection(&repo.accounts[0]); !reflect.DeepEqual(got, []protocolrouter.Protocol{protocolrouter.ProtocolMessages}) {
 		t.Fatalf("failed final readiness left projection=%v, want pre-candidate messages", got)

--- a/docs/approved/protocol-routing-ssot.md
+++ b/docs/approved/protocol-routing-ssot.md
@@ -574,8 +574,8 @@ in the same generation remains inconclusive.
 
 New application code always reads the capability table. It has no fallback to
 `accounts.extra.supported_protocols`, even during migration. Preparation,
-probing, and hard routing cutover may ship in one image because readiness is the
-traffic-admission boundary.
+probing, and hard routing cutover may ship in one image. TrafficReady admits
+process traffic; CutoverReady is the publication-completeness signal.
 
 The image reports `/health` as `503 not_ready` only for a process-wide
 blocker: drain, missing router, or startup evaluation abort. An individual

--- a/docs/approved/protocol-routing-ssot.md
+++ b/docs/approved/protocol-routing-ssot.md
@@ -9,6 +9,8 @@ revision_note: >
   Plans and Execute no longer compare account or capability revision tokens.
   Send-time freshness is authoritative reload plus route-fact equivalence.
   /health follows process TrafficReady, not one account's missing route.
+  NewAPI exact-endpoint resolution is per protocol: a missing Responses URL
+  omits that route instead of failing the whole account snapshot.
 related_stories: []
 ---
 
@@ -294,7 +296,9 @@ AND the required adapter and transport exist
 
 Endpoint resolution must reproduce the identity used to obtain the capability
 key. A configurable endpoint with an empty or mismatched URL never falls back
-to an official host.
+to an official host. For NewAPI channel adaptors, exact URLs are attached per
+protocol. A channel that cannot resolve Responses omits that protocol; it does
+not fail Chat snapshot construction or the account's remaining legal routes.
 
 ## 6. Scheduling and execution
 

--- a/docs/approved/protocol-routing-ssot.md
+++ b/docs/approved/protocol-routing-ssot.md
@@ -11,7 +11,7 @@ revision_note: >
   /health follows process TrafficReady, not one account's missing route.
   NewAPI exact-endpoint resolution is per declared protocol: undeclared
   protocols are not resolved, and a missing Responses URL omits that route
-  instead of failing the whole account snapshot.
+  from both exact endpoints and the Plan-facing supported set.
 related_stories: []
 ---
 
@@ -299,9 +299,11 @@ Endpoint resolution must reproduce the identity used to obtain the capability
 key. A configurable endpoint with an empty or mismatched URL never falls back
 to an official host. For NewAPI channel adaptors, exact URLs are attached only
 for Chat/Responses protocols already in the linked capability. A declared
-protocol that cannot resolve is omitted; undeclared protocols are not resolved.
+protocol that cannot resolve is omitted from both the exact-endpoint map and
+the Plan-facing supported set; undeclared protocols are not resolved.
 A channel that cannot resolve Responses does not fail Chat snapshot
-construction or the account's remaining legal routes.
+construction or the account's remaining legal routes, and must not invent a
+Responses URL from the channel base.
 
 ## 6. Scheduling and execution
 
@@ -614,8 +616,10 @@ projections commit in one database transaction. During candidate startup,
 capability preparation is intentionally durable but unpublished; the complete
 projection, account revision advances, and scheduler invalidations are instead
 published together only after preliminary readiness succeeds. A publication
-failure rolls back every legacy-visible effect and blocks readiness because an
-image rollback must not restore divergent account facts.
+callback that fails CutoverReady rolls back every legacy-visible effect and
+keeps process TrafficReady so `/health` does not 503 the candidate. A
+publication transaction error still flips TrafficReady, because an image
+rollback must not restore divergent account facts.
 
 After the rollback window, deleting the legacy field, projection writer, and
 compatibility code is a separate reviewed change. The shared capability table

--- a/docs/approved/protocol-routing-ssot.md
+++ b/docs/approved/protocol-routing-ssot.md
@@ -4,10 +4,11 @@ status: approved
 approved_by: "feng (conversation approval, 2026-08-27)"
 authors: [codex]
 created: 2026-08-24
-revised: 2026-08-29
+revised: 2026-08-30
 revision_note: >
   Plans and Execute no longer compare account or capability revision tokens.
   Send-time freshness is authoritative reload plus route-fact equivalence.
+  /health follows process TrafficReady, not one account's missing route.
 related_stories: []
 ---
 
@@ -553,9 +554,10 @@ release boundary:
 Final readiness runs inside the publication transaction and sees its
 uncommitted projection/outbox writes. It is read-only with respect to
 capability/link facts: a concurrently introduced missing or mismatched link
-fails readiness instead of being repaired after publication. Only that final
-successful evaluation may commit the transaction and make `/health` return
-`200`. Repeating publication with already-matching projections is a no-op: it
+fails CutoverReady instead of being repaired after publication. Only that
+final successful evaluation may commit the transaction. `/health` follows
+process TrafficReady independently and does not wait for publication.
+Repeating publication with already-matching projections is a no-op: it
 does not advance account revisions or enqueue duplicate scheduler events.
 
 Historical union is a migration seed, not permanent evidence ownership. Once
@@ -571,19 +573,22 @@ New application code always reads the capability table. It has no fallback to
 probing, and hard routing cutover may ship in one image because readiness is the
 traffic-admission boundary.
 
-The image reports `/health` as `503 not_ready` when any active, schedulable,
-governed account:
+The image reports `/health` as `503 not_ready` only for a process-wide
+blocker: drain, missing router, or startup evaluation abort. An individual
+active, schedulable, governed account that:
 
 - lacks a valid capability link;
 - has neither completed initial probing nor an allowed official seed;
 - is linked to an identity conflict relevant to its served routes;
 - has no legal native or convertible route for its served models;
 - fails its independent authorization/schedulability gate;
-- cannot receive the atomically published rollback projection and scheduler
-  invalidation required for this release boundary.
+
+is recorded as remediation, stays fail-closed at schedule and execute, and
+does not 503 the process. CutoverReady remains the publication-completeness
+signal; it is not the traffic-admission boundary.
 
 Disabled or deliberately unschedulable accounts do not block release
-readiness. They remain fail-closed if re-enabled before their identity,
+publication. They remain fail-closed if re-enabled before their identity,
 capability, and account gates are valid.
 
 The candidate image never serves customer traffic through legacy routing. A
@@ -724,13 +729,12 @@ or capability state.
   change the legacy projection, account revision, or scheduler outbox before
   preliminary readiness succeeds.
 - A successful candidate publishes rollback projections, account revisions,
-  and scheduler invalidations in one transaction, then passes a final readiness
-  evaluation before `/health` becomes `200`.
+  and scheduler invalidations in one transaction after CutoverReady.
 - A failed candidate can be retried from persisted preparation facts while the
   previous image continues to observe its pre-candidate routing state.
-- The new image reads only the capability table. Readiness prevents traffic
-  until every active/schedulable governed account has a linked, conflict-free,
-  usable capability and valid account gates.
+- The new image reads only the capability table. `/health` admits traffic when
+  the process can serve. An account without a legal route fails closed at
+  selection or execute and does not 503 the machine.
 - The account legacy field exists only as a one-window rollback projection and
   is never a new-version routing input.
 - CI uses mock upstreams and mechanically rejects competing protocol owners.

--- a/docs/approved/protocol-routing-ssot.md
+++ b/docs/approved/protocol-routing-ssot.md
@@ -9,8 +9,9 @@ revision_note: >
   Plans and Execute no longer compare account or capability revision tokens.
   Send-time freshness is authoritative reload plus route-fact equivalence.
   /health follows process TrafficReady, not one account's missing route.
-  NewAPI exact-endpoint resolution is per protocol: a missing Responses URL
-  omits that route instead of failing the whole account snapshot.
+  NewAPI exact-endpoint resolution is per declared protocol: undeclared
+  protocols are not resolved, and a missing Responses URL omits that route
+  instead of failing the whole account snapshot.
 related_stories: []
 ---
 
@@ -296,9 +297,11 @@ AND the required adapter and transport exist
 
 Endpoint resolution must reproduce the identity used to obtain the capability
 key. A configurable endpoint with an empty or mismatched URL never falls back
-to an official host. For NewAPI channel adaptors, exact URLs are attached per
-protocol. A channel that cannot resolve Responses omits that protocol; it does
-not fail Chat snapshot construction or the account's remaining legal routes.
+to an official host. For NewAPI channel adaptors, exact URLs are attached only
+for Chat/Responses protocols already in the linked capability. A declared
+protocol that cannot resolve is omitted; undeclared protocols are not resolved.
+A channel that cannot resolve Responses does not fail Chat snapshot
+construction or the account's remaining legal routes.
 
 ## 6. Scheduling and execution
 

--- a/scripts/checks/protocol-routing-ssot.py
+++ b/scripts/checks/protocol-routing-ssot.py
@@ -436,6 +436,10 @@ def check(root: Path) -> list[str]:
         for body in exact_bodies:
             if not contains_identifier(body, "protocolExactEndpoint"):
                 errors.append("protocolExactEndpoints does not resolve NewAPI protocol URLs")
+            if not contains_identifier(body, "routingSupportedProtocols"):
+                errors.append(
+                    "protocolExactEndpoints does not limit NewAPI exact URLs to declared protocols"
+                )
             if re.search(
                 r"protocolExactEndpoint\s*\([\s\S]*?if\s+err\s*!=\s*nil\s*\{\s*return\s+nil,\s*err",
                 body,

--- a/scripts/checks/protocol-routing-ssot.py
+++ b/scripts/checks/protocol-routing-ssot.py
@@ -584,6 +584,22 @@ def check(root: Path) -> list[str]:
         for body in evaluate_bodies:
             if re.search(r"TrafficReady\s*=\s*false", body):
                 errors.append("account evaluation still treats one account remediation as process TrafficReady")
+        prepare_bodies = function_bodies(source, "prepareProtocolRoutingSSOT")
+        for body in prepare_bodies:
+            match = re.search(
+                r"if\s+errors\s*\.\s*Is\s*\(\s*err\s*,\s*errProtocolRoutingFinalReadinessNotReady\s*\)\s*\{",
+                body,
+            )
+            if match is None:
+                continue
+            open_brace = body.find("{", match.start(), match.end())
+            close_brace = matching_brace(body, open_brace)
+            if close_brace is None:
+                continue
+            if re.search(r"TrafficReady\s*=\s*false", body[open_brace + 1 : close_brace]):
+                errors.append(
+                    "publication-time CutoverReady failure still treats one account as process TrafficReady"
+                )
         evidence_bodies = function_bodies(source, "protocolCapabilityHasVerifiedRoutingEvidence")
         if not evidence_bodies or not all(
             contains_identifier(body, "OfficialSeed")

--- a/scripts/checks/protocol-routing-ssot.py
+++ b/scripts/checks/protocol-routing-ssot.py
@@ -430,6 +430,19 @@ def check(root: Path) -> list[str]:
         for body in snapshot_bodies:
             if not contains_identifier(body, "protocolCapabilityHasVerifiedRoutingEvidence"):
                 errors.append("protocolAccountSnapshot does not fail closed on unverified capability evidence")
+        exact_bodies = function_bodies(source, "protocolExactEndpoints")
+        if not exact_bodies:
+            errors.append("canonical capability owner is missing protocolExactEndpoints")
+        for body in exact_bodies:
+            if not contains_identifier(body, "protocolExactEndpoint"):
+                errors.append("protocolExactEndpoints does not resolve NewAPI protocol URLs")
+            if re.search(
+                r"protocolExactEndpoint\s*\([\s\S]*?if\s+err\s*!=\s*nil\s*\{\s*return\s+nil,\s*err",
+                body,
+            ):
+                errors.append(
+                    "NewAPI exact-endpoint resolution still fail-closes the snapshot on one unsupported protocol"
+                )
 
     identity_owner = root / "backend/internal/service/protocol_endpoint_identity.go"
     if identity_owner.is_file():

--- a/scripts/checks/protocol-routing-ssot.py
+++ b/scripts/checks/protocol-routing-ssot.py
@@ -430,6 +430,10 @@ def check(root: Path) -> list[str]:
         for body in snapshot_bodies:
             if not contains_identifier(body, "protocolCapabilityHasVerifiedRoutingEvidence"):
                 errors.append("protocolAccountSnapshot does not fail closed on unverified capability evidence")
+            if not contains_identifier(body, "retainResolvedNewAPIExactProtocols"):
+                errors.append(
+                    "protocolAccountSnapshot still plans NewAPI protocols that have no exact endpoint"
+                )
         exact_bodies = function_bodies(source, "protocolExactEndpoints")
         if not exact_bodies:
             errors.append("canonical capability owner is missing protocolExactEndpoints")

--- a/scripts/checks/protocol-routing-ssot.py
+++ b/scripts/checks/protocol-routing-ssot.py
@@ -565,6 +565,12 @@ def check(root: Path) -> list[str]:
             errors.append("protocol routing startup uses the normal probe writer instead of the preparation probe")
         if not contains_identifier(source, "ProbeAccountProtocolCapabilitiesForPreparation"):
             errors.append("protocol routing startup is missing the preparation probe")
+        evaluate_bodies = function_bodies(source, "evaluateProtocolRoutingSSOT")
+        if not evaluate_bodies:
+            errors.append("protocol routing startup is missing account evaluation")
+        for body in evaluate_bodies:
+            if re.search(r"TrafficReady\s*=\s*false", body):
+                errors.append("account evaluation still treats one account remediation as process TrafficReady")
         evidence_bodies = function_bodies(source, "protocolCapabilityHasVerifiedRoutingEvidence")
         if not evidence_bodies or not all(
             contains_identifier(body, "OfficialSeed")

--- a/scripts/checks/test_protocol_routing_ssot.py
+++ b/scripts/checks/test_protocol_routing_ssot.py
@@ -158,6 +158,7 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
             "package fixture\n"
             "func MigrateProtocolRoutingSSOT(){ LegacySupportedProtocolsProjection() }\n"
             "func validateProtocolRoutingSSOTReadiness(){}\n"
+            "func evaluateProtocolRoutingSSOT(){ report.CutoverReady = false }\n"
             "func prepareProtocolRoutingSSOT(){ ProbeAccountProtocolCapabilitiesForPreparation(); prepared := MigrateProtocolRoutingSSOT(); if prepared.CutoverReady { PublishProtocolRoutingProjections(func(){ final := validateProtocolRoutingSSOTReadiness(); if !final.CutoverReady { return errProtocolRoutingFinalReadinessNotReady } }) } }\n"
             "func protocolCapabilityHasVerifiedRoutingEvidence(capability Capability){ capability.ProbeEvidence.OfficialSeed; capability.ProbeEvidence.InitialProbeCompleted; ProtocolProbePositive; capability.IdentityConflict }\n",
             encoding="utf-8",
@@ -750,6 +751,18 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
             encoding="utf-8",
         )
         self.assertTrue(any("publication transaction callback" in error for error in MODULE.check(root)))
+
+    def test_rejects_account_evaluation_that_flips_process_traffic_ready(self) -> None:
+        root = self.fixture()
+        owner = root / "backend/internal/service/protocol_routing_migration.go"
+        owner.write_text(
+            owner.read_text(encoding="utf-8").replace(
+                "func evaluateProtocolRoutingSSOT(){ report.CutoverReady = false }",
+                "func evaluateProtocolRoutingSSOT(){ report.TrafficReady = false }",
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("process TrafficReady" in error for error in MODULE.check(root)))
 
     def test_rejects_startup_migration_that_uses_normal_probe_writer(self) -> None:
         root = self.fixture()

--- a/scripts/checks/test_protocol_routing_ssot.py
+++ b/scripts/checks/test_protocol_routing_ssot.py
@@ -116,7 +116,7 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
             "func ReplaceSupportedProtocols(){}\n"
             "func SeedOfficialSupportedProtocols(){}\n"
             "func protocolAccountSnapshot(capability Capability){ if !protocolCapabilityHasVerifiedRoutingEvidence(capability) { fail() } }\n"
-            "func protocolExactEndpoints(){ endpoint, err := protocolExactEndpoint(); if err != nil { continue }; endpoints[protocol] = endpoint }\n",
+            "func protocolExactEndpoints(){ for _, protocol := range routingSupportedProtocols(account) { endpoint, err := protocolExactEndpoint(); if err != nil { continue }; endpoints[protocol] = endpoint } }\n",
             encoding="utf-8",
         )
         identity_owner = root / "backend/internal/service/protocol_endpoint_identity.go"
@@ -758,13 +758,27 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
         owner = root / "backend/internal/service/account_supported_protocols.go"
         owner.write_text(
             owner.read_text(encoding="utf-8").replace(
-                "func protocolExactEndpoints(){ endpoint, err := protocolExactEndpoint(); if err != nil { continue }; endpoints[protocol] = endpoint }",
-                "func protocolExactEndpoints(){ endpoint, err := protocolExactEndpoint(); if err != nil { return nil, err }; endpoints[protocol] = endpoint }",
+                "func protocolExactEndpoints(){ for _, protocol := range routingSupportedProtocols(account) { endpoint, err := protocolExactEndpoint(); if err != nil { continue }; endpoints[protocol] = endpoint } }",
+                "func protocolExactEndpoints(){ for _, protocol := range routingSupportedProtocols(account) { endpoint, err := protocolExactEndpoint(); if err != nil { return nil, err }; endpoints[protocol] = endpoint } }",
             ),
             encoding="utf-8",
         )
         self.assertTrue(
             any("one unsupported protocol" in error for error in MODULE.check(root))
+        )
+
+    def test_rejects_newapi_exact_endpoints_that_ignore_declared_protocols(self) -> None:
+        root = self.fixture()
+        owner = root / "backend/internal/service/account_supported_protocols.go"
+        owner.write_text(
+            owner.read_text(encoding="utf-8").replace(
+                "for _, protocol := range routingSupportedProtocols(account) {",
+                "for _, protocol := range []Protocol{ChatCompletions, Responses} {",
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(
+            any("declared protocols" in error for error in MODULE.check(root))
         )
 
     def test_rejects_publication_cutover_failure_that_flips_process_traffic_ready(self) -> None:

--- a/scripts/checks/test_protocol_routing_ssot.py
+++ b/scripts/checks/test_protocol_routing_ssot.py
@@ -115,7 +115,7 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
             "func BuildSupportedProtocolsUpdate(){}\n"
             "func ReplaceSupportedProtocols(){}\n"
             "func SeedOfficialSupportedProtocols(){}\n"
-            "func protocolAccountSnapshot(capability Capability){ if !protocolCapabilityHasVerifiedRoutingEvidence(capability) { fail() } }\n"
+            "func protocolAccountSnapshot(capability Capability){ if !protocolCapabilityHasVerifiedRoutingEvidence(capability) { fail() }; retainResolvedNewAPIExactProtocols() }\n"
             "func protocolExactEndpoints(){ for _, protocol := range routingSupportedProtocols(account) { endpoint, err := protocolExactEndpoint(); if err != nil { continue }; endpoints[protocol] = endpoint } }\n",
             encoding="utf-8",
         )
@@ -779,6 +779,20 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
         )
         self.assertTrue(
             any("declared protocols" in error for error in MODULE.check(root))
+        )
+
+    def test_rejects_snapshot_that_plans_unresolved_newapi_protocols(self) -> None:
+        root = self.fixture()
+        owner = root / "backend/internal/service/account_supported_protocols.go"
+        owner.write_text(
+            owner.read_text(encoding="utf-8").replace(
+                "retainResolvedNewAPIExactProtocols()",
+                "keepDeclaredProtocols()",
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(
+            any("no exact endpoint" in error for error in MODULE.check(root))
         )
 
     def test_rejects_publication_cutover_failure_that_flips_process_traffic_ready(self) -> None:

--- a/scripts/checks/test_protocol_routing_ssot.py
+++ b/scripts/checks/test_protocol_routing_ssot.py
@@ -115,7 +115,8 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
             "func BuildSupportedProtocolsUpdate(){}\n"
             "func ReplaceSupportedProtocols(){}\n"
             "func SeedOfficialSupportedProtocols(){}\n"
-            "func protocolAccountSnapshot(capability Capability){ if !protocolCapabilityHasVerifiedRoutingEvidence(capability) { fail() } }\n",
+            "func protocolAccountSnapshot(capability Capability){ if !protocolCapabilityHasVerifiedRoutingEvidence(capability) { fail() } }\n"
+            "func protocolExactEndpoints(){ endpoint, err := protocolExactEndpoint(); if err != nil { continue }; endpoints[protocol] = endpoint }\n",
             encoding="utf-8",
         )
         identity_owner = root / "backend/internal/service/protocol_endpoint_identity.go"
@@ -751,6 +752,20 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
             encoding="utf-8",
         )
         self.assertTrue(any("publication transaction callback" in error for error in MODULE.check(root)))
+
+    def test_rejects_newapi_exact_endpoints_that_fail_closed_on_one_protocol(self) -> None:
+        root = self.fixture()
+        owner = root / "backend/internal/service/account_supported_protocols.go"
+        owner.write_text(
+            owner.read_text(encoding="utf-8").replace(
+                "func protocolExactEndpoints(){ endpoint, err := protocolExactEndpoint(); if err != nil { continue }; endpoints[protocol] = endpoint }",
+                "func protocolExactEndpoints(){ endpoint, err := protocolExactEndpoint(); if err != nil { return nil, err }; endpoints[protocol] = endpoint }",
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(
+            any("one unsupported protocol" in error for error in MODULE.check(root))
+        )
 
     def test_rejects_account_evaluation_that_flips_process_traffic_ready(self) -> None:
         root = self.fixture()

--- a/scripts/checks/test_protocol_routing_ssot.py
+++ b/scripts/checks/test_protocol_routing_ssot.py
@@ -160,7 +160,7 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
             "func MigrateProtocolRoutingSSOT(){ LegacySupportedProtocolsProjection() }\n"
             "func validateProtocolRoutingSSOTReadiness(){}\n"
             "func evaluateProtocolRoutingSSOT(){ report.CutoverReady = false }\n"
-            "func prepareProtocolRoutingSSOT(){ ProbeAccountProtocolCapabilitiesForPreparation(); prepared := MigrateProtocolRoutingSSOT(); if prepared.CutoverReady { PublishProtocolRoutingProjections(func(){ final := validateProtocolRoutingSSOTReadiness(); if !final.CutoverReady { return errProtocolRoutingFinalReadinessNotReady } }) } }\n"
+            "func prepareProtocolRoutingSSOT(){ ProbeAccountProtocolCapabilitiesForPreparation(); prepared := MigrateProtocolRoutingSSOT(); if prepared.CutoverReady { PublishProtocolRoutingProjections(func(){ final := validateProtocolRoutingSSOTReadiness(); if !final.CutoverReady { return errProtocolRoutingFinalReadinessNotReady } }) }; if errors.Is(err, errProtocolRoutingFinalReadinessNotReady) { final.CutoverReady = false } }\n"
             "func protocolCapabilityHasVerifiedRoutingEvidence(capability Capability){ capability.ProbeEvidence.OfficialSeed; capability.ProbeEvidence.InitialProbeCompleted; ProtocolProbePositive; capability.IdentityConflict }\n",
             encoding="utf-8",
         )
@@ -765,6 +765,20 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
         )
         self.assertTrue(
             any("one unsupported protocol" in error for error in MODULE.check(root))
+        )
+
+    def test_rejects_publication_cutover_failure_that_flips_process_traffic_ready(self) -> None:
+        root = self.fixture()
+        owner = root / "backend/internal/service/protocol_routing_migration.go"
+        owner.write_text(
+            owner.read_text(encoding="utf-8").replace(
+                "if errors.Is(err, errProtocolRoutingFinalReadinessNotReady) { final.CutoverReady = false }",
+                "if errors.Is(err, errProtocolRoutingFinalReadinessNotReady) { final.TrafficReady = false; final.CutoverReady = false }",
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(
+            any("publication-time CutoverReady" in error for error in MODULE.check(root))
         )
 
     def test_rejects_account_evaluation_that_flips_process_traffic_ready(self) -> None:


### PR DESCRIPTION
## 摘要

1.8.183 prod 蓝绿失败：`/health` 等整机 `TrafficReady`，百度账号 `no_legal_route` 把候选容器卡在 `not_ready`。根因有两层。

- 账号级 remediation（`no_legal_route`、单账号 identity 失败）只清 `CutoverReady`，不再翻 `TrafficReady`。`/health` 只在进程级失败时 503。publication 里 CutoverReady 失败同样不 503 整机。
- NewAPI snapshot 只解析账号已声明的 Chat/Responses。未声明协议不解析；已声明但 URL 解析失败则从 exact map 和 Plan 协议集同时拿掉，不发明 `/v1/responses`，也不整账号规划失败。千帆（ch46）只有 chat；缺 Responses 只省略该协议。该账号仍在调度/发送时 fail-closed。

Web impact: none
no-web-impact
sentinel-registry-reviewed
high-risk-anchor: docs/approved/protocol-routing-ssot.md

## 风险

高风险：协议就绪、`/health` 流量准入、NewAPI 精确 endpoint 解析。对外 API 字段不变。回滚即停用本 PR。本 PR 不部署。

## 验证

- `python3 scripts/checks/protocol-routing-ssot.py`：通过
- `python3 -m unittest scripts.checks.test_protocol_routing_ssot -q`：80 通过
- `go test -tags=unit -count=1 -run 'TestPrepareProtocol|TestMigrateProtocol|TestProtocolExact|TestProtocolAccountSnapshotPlansQianfan|TestProtocolAccountSnapshotOmitsUnresolvable|TestProtocolRoutingMigration' ./internal/service/`：通过
- `./scripts/preflight.sh`：通过
- 正向：千帆 chat snapshot/Plan 成功；publication CutoverReady 失败仍 TrafficReady
- 负向：未声明/不可解析 Responses 不附着、不发明 URL；Responses-only 仍 fail-closed；缺少 router / 发布事务 abort 仍 503

## 提交

- `56788d956` fix(protocol): 单个账号无合法路由不再 503 整机健康 (no-web-impact)
- `28290001c` fix(protocol): NewAPI 缺 Responses URL 不再整账号规划失败 (no-web-impact)
- `dda6108bb` fix(protocol): address R-001 R-002 — publication 失败不再 503 整机 (no-web-impact)
- `17f90290d` fix(protocol): NewAPI exact URL 只解析账号已声明协议 (no-web-impact)
- `d86e0c6c6` fix(protocol): address R-001 R-002 — 不可解析协议不再发明 URL (no-web-impact)

最新提交：d86e0c6c6