### PR TITLE
fix(protocol): newapi ExactEndpoints 只解析账号已支持协议

### DIFF
--- a/backend/internal/service/account_supported_protocols.go
+++ b/backend/internal/service/account_supported_protocols.go
@@ -322,14 +322,23 @@ func protocolExactEndpoints(
 	if account == nil || account.Platform != PlatformNewAPI || account.ChannelType <= 0 {
 		return nil, nil
 	}
+	// Only resolve endpoints for protocols this account actually supports.
+	// Channels such as Baidu V2 (channel_type=46) reject Responses relay mode;
+	// forcing that resolution used to poison chat_completions-only snapshots and
+	// falsely mark the account no_legal_route at migration/readiness time.
 	endpoints := make(map[protocolrouter.Protocol]string, 2)
-	for _, protocol := range []protocolrouter.Protocol{
-		protocolrouter.ProtocolChatCompletions,
-		protocolrouter.ProtocolResponses,
-	} {
+	for _, protocol := range routingSupportedProtocols(account) {
+		switch protocol {
+		case protocolrouter.ProtocolChatCompletions, protocolrouter.ProtocolResponses:
+		default:
+			continue
+		}
 		endpoint, err := protocolExactEndpoint(account, protocol, resolvedModel)
 		if err != nil {
 			return nil, err
+		}
+		if strings.TrimSpace(endpoint) == "" {
+			continue
 		}
 		endpoints[protocol] = endpoint
 	}

--- a/backend/internal/service/account_supported_protocols_test.go
+++ b/backend/internal/service/account_supported_protocols_test.go
@@ -504,6 +504,69 @@ func TestProtocolRouterRejectsResolvedModelOutsideOfficialRoutePolicy(t *testing
 	}
 }
 
+func TestProtocolAccountSnapshotBaiduV2ChatOnlyDoesNotRequireResponsesEndpoint(t *testing.T) {
+	// Prod account 90 (百度 / ChannelTypeBaiduV2): capability is chat_completions-only.
+	// Resolving Responses for this channel fails with "unsupported relay mode: 33";
+	// that must not poison chat_completions snapshot/Plan or migration readiness.
+	account := &Account{
+		ID:          90,
+		Name:        "百度",
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeBaiduV2,
+		Credentials: map[string]any{
+			"api_key":  "secret",
+			"base_url": "https://qianfan.baidubce.com",
+			"model_mapping": map[string]any{
+				"glm-5":        "glm-5",
+				"ernie-5.0":    "ernie-5.0",
+				"bge-large-zh": "bge-large-zh",
+			},
+		},
+	}
+	attachTestProtocolCapability(account, protocolrouter.ProtocolChatCompletions)
+	account.ProtocolEndpointCapability.ProbeEvidence = ProtocolProbeEvidence{
+		Verdicts: map[string]any{
+			string(protocolrouter.ProtocolMessages):        string(ProtocolProbeEndpointNegative),
+			string(protocolrouter.ProtocolChatCompletions): string(ProtocolProbePositive),
+		},
+		OfficialSeed:          false,
+		InitialProbeCompleted: false,
+	}
+
+	snapshot, err := ProtocolAccountSnapshot(account, "glm-5")
+	if err != nil {
+		t.Fatalf("ProtocolAccountSnapshot: %v", err)
+	}
+	request, err := protocolrouter.NewCanonicalRequest(protocolrouter.CanonicalRequestInput{
+		InboundProtocol: protocolrouter.ProtocolChatCompletions,
+		RequestedModel:  "glm-5",
+		Profile:         protocolrouter.RequestProfile{ContentKinds: protocolrouter.ContentText},
+		Body:            []byte(`{"model":"glm-5","messages":[{"role":"user","content":"hi"}]}`),
+	})
+	if err != nil {
+		t.Fatalf("NewCanonicalRequest: %v", err)
+	}
+	plan, err := NewProtocolRouter().Plan(request, snapshot)
+	if err != nil {
+		t.Fatalf("Plan chat_completions: %v", err)
+	}
+	if plan.TargetProtocol() != protocolrouter.ProtocolChatCompletions {
+		t.Fatalf("target = %s, want chat_completions", plan.TargetProtocol())
+	}
+
+	models := protocolRoutingMigrationModels(account)
+	if !accountHasLegalProtocolRoute(NewProtocolRouter(), account, models) {
+		t.Fatalf("accountHasLegalProtocolRoute=false for Baidu V2 chat-only account; models=%v", models)
+	}
+
+	// Negative: claiming Responses support still fail-closes when the channel cannot resolve it.
+	attachTestProtocolCapability(account, protocolrouter.ProtocolChatCompletions, protocolrouter.ProtocolResponses)
+	if _, err := ProtocolAccountSnapshot(account, "glm-5"); err == nil {
+		t.Fatal("expected Responses-capable Baidu V2 snapshot to fail closed")
+	}
+}
+
 func TestSeedOfficialSupportedProtocolsIsConservativeAndIdempotent(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## 摘要
- newapi `protocolExactEndpoints` 只为账号已支持的 `chat_completions` / `responses` 解析 endpoint，不再无条件强解 Responses。
- 修复 Baidu V2（prod 账号 90「百度」，channel_type=46）因 `unsupported relay mode: 33` 毒化 snapshot，被误判 `no_legal_route`、阻断 `1.8.183` 蓝绿 `/health` 就绪的问题；chat 能力可继续调度。
- 假称支持 Responses 时仍 fail-closed（负向测试覆盖）。

## 风险
- 常规：协议路由 readiness / newapi ExactEndpoints；无 schema、无公开 API 字段变更。
- 影响面：仅 capability 标明支持的协议才会解析 ExactEndpoints；Baidu V2 chat-only 账号恢复可调度。

## 验证
- `go test -tags=unit ./internal/service/ -run TestProtocolAccountSnapshotBaiduV2ChatOnlyDoesNotRequireResponsesEndpoint`
- `./scripts/preflight.sh` PASS
- `make lint`（backend）0 issues

## 提交
- `05bcdd726` fix(protocol): newapi ExactEndpoints 只解析账号已支持协议
- 最新提交：`05bcdd726`


Made with [Cursor](https://cursor.com)