### PR TITLE
fix(protocol): /health 只认 drain，发版探测不再绕公网

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -367,7 +367,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	stepUpAuthMiddleware := middleware.NewStepUpAuthMiddleware(totpService, userService, settingService)
 	terminalOutcomeRepository := repository.NewTerminalOutcomeRepository(db)
 	terminalOutcomeRecorder := service.ProvideTerminalOutcomeRecorder(terminalOutcomeRepository)
-	engine := server.ProvideRouter(configConfig, handlers, jwtAuthMiddleware, optionalJWTAuthMiddleware, adminAuthMiddleware, apiKeyAuthMiddleware, eitherAuthMiddleware, auditLogMiddleware, stepUpAuthMiddleware, apiKeyService, userService, subscriptionService, opsService, settingService, compositeRouteResolver, terminalOutcomeRecorder, protocolRoutingSSOTReady, redisClient)
+	engine := server.ProvideRouter(configConfig, handlers, jwtAuthMiddleware, optionalJWTAuthMiddleware, adminAuthMiddleware, apiKeyAuthMiddleware, eitherAuthMiddleware, auditLogMiddleware, stepUpAuthMiddleware, apiKeyService, userService, subscriptionService, opsService, settingService, compositeRouteResolver, terminalOutcomeRecorder, redisClient)
 	httpServer := server.ProvideHTTPServer(configConfig, engine)
 	opsMetricsCollector := service.ProvideOpsMetricsCollector(opsRepository, settingRepository, accountRepository, concurrencyService, db, redisClient, configConfig, qaService)
 	opsAggregationService := service.ProvideOpsAggregationService(opsRepository, settingRepository, db, redisClient, configConfig)

--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -44,7 +44,6 @@ func ProvideRouter(
 	settingService *service.SettingService,
 	compositeResolver *service.CompositeRouteResolver,
 	terminalOutcomeRecorder *service.TerminalOutcomeRecorder,
-	protocolRoutingReady service.ProtocolRoutingSSOTReady,
 	redisClient *redis.Client,
 ) *gin.Engine {
 	if cfg.Server.Mode == "release" {
@@ -106,7 +105,7 @@ func ProvideRouter(
 		service.SetWebSearchManager(websearch.NewManager(configs, redisClient))
 	})
 
-	return SetupRouter(r, handlers, jwtAuth, optionalJWTAuth, adminAuth, apiKeyAuth, eitherAuth, auditLog, stepUpAuth, apiKeyService, userService, subscriptionService, opsService, settingService, compositeResolver, terminalOutcomeRecorder, protocolRoutingReady, cfg, redisClient)
+	return SetupRouter(r, handlers, jwtAuth, optionalJWTAuth, adminAuth, apiKeyAuth, eitherAuth, auditLog, stepUpAuth, apiKeyService, userService, subscriptionService, opsService, settingService, compositeResolver, terminalOutcomeRecorder, cfg, redisClient)
 }
 
 func configureTrustedProxies(r *gin.Engine, cfg config.ServerConfig) {

--- a/backend/internal/server/router.go
+++ b/backend/internal/server/router.go
@@ -124,8 +124,9 @@ func registerRoutes(
 	cfg *config.Config,
 	redisClient *redis.Client,
 ) {
-	// 通用路由（健康检查、状态等）
-	routes.RegisterCommonRoutes(r, protocolRoutingReady.Ready())
+	// 通用路由（健康检查、状态等）。协议就绪只写日志/CutoverReady，不进 /health。
+	_ = protocolRoutingReady
+	routes.RegisterCommonRoutes(r)
 
 	// API v1
 	v1 := r.Group("/api/v1")

--- a/backend/internal/server/router.go
+++ b/backend/internal/server/router.go
@@ -37,7 +37,6 @@ func SetupRouter(
 	settingService *service.SettingService,
 	compositeResolver *service.CompositeRouteResolver,
 	terminalOutcomeRecorder *service.TerminalOutcomeRecorder,
-	protocolRoutingReady service.ProtocolRoutingSSOTReady,
 	cfg *config.Config,
 	redisClient *redis.Client,
 ) *gin.Engine {
@@ -97,7 +96,7 @@ func SetupRouter(
 	}
 
 	// 注册路由
-	registerRoutes(r, handlers, jwtAuth, optionalJWTAuth, adminAuth, apiKeyAuth, eitherAuth, auditLog, stepUpAuth, apiKeyService, userService, subscriptionService, opsService, settingService, compositeResolver, terminalOutcomeRecorder, protocolRoutingReady, cfg, redisClient)
+	registerRoutes(r, handlers, jwtAuth, optionalJWTAuth, adminAuth, apiKeyAuth, eitherAuth, auditLog, stepUpAuth, apiKeyService, userService, subscriptionService, opsService, settingService, compositeResolver, terminalOutcomeRecorder, cfg, redisClient)
 
 	return r
 }
@@ -120,12 +119,10 @@ func registerRoutes(
 	settingService *service.SettingService,
 	compositeResolver *service.CompositeRouteResolver,
 	terminalOutcomeRecorder *service.TerminalOutcomeRecorder,
-	protocolRoutingReady service.ProtocolRoutingSSOTReady,
 	cfg *config.Config,
 	redisClient *redis.Client,
 ) {
-	// 通用路由（健康检查、状态等）。协议就绪只写日志/CutoverReady，不进 /health。
-	_ = protocolRoutingReady
+	// 通用路由（健康检查、状态等）。协议 remediation 不进 /health。
 	routes.RegisterCommonRoutes(r)
 
 	// API v1

--- a/backend/internal/server/routes/common.go
+++ b/backend/internal/server/routes/common.go
@@ -10,22 +10,14 @@ import (
 )
 
 // RegisterCommonRoutes 注册通用路由（健康检查、状态等）
-func RegisterCommonRoutes(r *gin.Engine, protocolReady ...bool) {
-	protocolRoutingReady := true
-	if len(protocolReady) > 0 {
-		protocolRoutingReady = protocolReady[0]
-	}
+func RegisterCommonRoutes(r *gin.Engine) {
 	// /health: 就绪探针（readiness）。
-	// drain 模式下 503，Caddy 的 passive 检查据此立刻摘除 upstream。
-	// 注意：body 不带 in_flight 数；那是内部状态，由 /health/inflight 提供，
-	// /health 是公开端点，只反映 ready/draining 二态。
+	// drain 模式下 503，Caddy 的 active 检查据此立刻摘除 upstream。
+	// 协议账号 remediation 不进这个端点；那是调度/发送 fail-closed。
+	// body 不带 in_flight 数；那是内部状态，由 /health/inflight 提供。
 	r.GET("/health", func(c *gin.Context) {
 		if middleware.IsDraining() {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "draining"})
-			return
-		}
-		if !protocolRoutingReady {
-			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "not_ready"})
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})

--- a/backend/internal/server/routes/common_health_test.go
+++ b/backend/internal/server/routes/common_health_test.go
@@ -17,29 +17,31 @@ func init() {
 	gin.SetMode(gin.TestMode)
 }
 
-func newCommonRouter(t *testing.T, protocolReady ...bool) *gin.Engine {
+func newCommonRouter(t *testing.T) *gin.Engine {
 	t.Helper()
 	r := gin.New()
 	// 复刻 router.go 的中间件顺序，确保 /health/inflight 能读到 InFlightTracker 的计数。
 	r.Use(middleware.InFlightTracker())
-	RegisterCommonRoutes(r, protocolReady...)
+	RegisterCommonRoutes(r)
 	return r
 }
 
-func TestHealthEndpoint_503_WhenProtocolRoutingNotReady(t *testing.T) {
+func TestHealthEndpoint_OK_WithoutProtocolReadiness(t *testing.T) {
+	// /health stays 200 even when protocol remediations remain. 1.8.183/184
+	// used this endpoint as a process gate and failed blue/green cutover.
 	resetDrainForTest(t)
-	r := newCommonRouter(t, false)
+	r := newCommonRouter(t)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	r.ServeHTTP(w, req)
 
-	if w.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503 got %d body=%s", w.Code, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d body=%s", w.Code, w.Body.String())
 	}
 	got := decodeJSON(t, w.Body.Bytes())
-	if got["status"] != "not_ready" {
-		t.Fatalf("expected status=not_ready got %v", got["status"])
+	if got["status"] != "ok" {
+		t.Fatalf("expected status=ok got %v", got["status"])
 	}
 }
 

--- a/backend/internal/server/routes/common_health_test.go
+++ b/backend/internal/server/routes/common_health_test.go
@@ -26,25 +26,6 @@ func newCommonRouter(t *testing.T) *gin.Engine {
 	return r
 }
 
-func TestHealthEndpoint_OK_WithoutProtocolReadiness(t *testing.T) {
-	// /health stays 200 even when protocol remediations remain. 1.8.183/184
-	// used this endpoint as a process gate and failed blue/green cutover.
-	resetDrainForTest(t)
-	r := newCommonRouter(t)
-
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/health", nil)
-	r.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200 got %d body=%s", w.Code, w.Body.String())
-	}
-	got := decodeJSON(t, w.Body.Bytes())
-	if got["status"] != "ok" {
-		t.Fatalf("expected status=ok got %v", got["status"])
-	}
-}
-
 func resetDrainForTest(t *testing.T) {
 	t.Helper()
 	middleware.SetDrain(false)
@@ -61,6 +42,8 @@ func decodeJSON(t *testing.T, body []byte) map[string]any {
 }
 
 func TestHealthEndpoint_OK_WhenNotDraining(t *testing.T) {
+	// Drain is the only /health 503. Protocol remediations stay fail-closed
+	// at schedule/execute; 1.8.183/184 used this endpoint as a process gate.
 	resetDrainForTest(t)
 	r := newCommonRouter(t)
 

--- a/backend/internal/service/protocol_routing_migration.go
+++ b/backend/internal/service/protocol_routing_migration.go
@@ -37,11 +37,7 @@ type ProtocolRoutingMigrationReport struct {
 	SeededOfficial int
 	ProbeAttempts  int
 	ProbeResolved  int
-	// TrafficReady is true when the process can serve: the router exists and
-	// startup evaluation did not abort. Account remediations stay in
-	// Remediation and only clear CutoverReady.
-	TrafficReady bool
-	// CutoverReady is true only when TrafficReady and no remediations remain.
+	// CutoverReady is true only when the router exists and no remediations remain.
 	CutoverReady bool
 	Remediation  []ProtocolRoutingRemediation
 }
@@ -76,7 +72,7 @@ func evaluateProtocolRoutingSSOT(
 	router *protocolrouter.Router,
 	prepare bool,
 ) (ProtocolRoutingMigrationReport, error) {
-	report := ProtocolRoutingMigrationReport{CutoverReady: router != nil, TrafficReady: router != nil}
+	report := ProtocolRoutingMigrationReport{CutoverReady: router != nil}
 	accounts, err := repo.ListActive(ctx)
 	if err != nil {
 		return report, err
@@ -229,7 +225,6 @@ func prepareProtocolRoutingSSOT(
 		return newProtocolRoutingSSOTReady(final, router), nil
 	}
 	if err != nil {
-		final.TrafficReady = false
 		final.CutoverReady = false
 		return ProtocolRoutingSSOTReady{Report: final}, err
 	}

--- a/backend/internal/service/protocol_routing_migration_test.go
+++ b/backend/internal/service/protocol_routing_migration_test.go
@@ -300,7 +300,7 @@ func TestMigrateProtocolRoutingSSOTSeedsOnlyOfficialProfilesAndReportsCustomAcco
 	if err != nil {
 		t.Fatalf("MigrateProtocolRoutingSSOT: %v", err)
 	}
-	if report.ActiveGoverned != 2 || report.SeededOfficial != 1 || report.CutoverReady || !report.TrafficReady {
+	if report.ActiveGoverned != 2 || report.SeededOfficial != 1 || report.CutoverReady {
 		t.Fatalf("report = %+v", report)
 	}
 	if projection, exists := repo.accounts[0].Extra[SupportedProtocolsExtraKey]; exists {
@@ -387,7 +387,7 @@ func TestProtocolRoutingMediaOnlyClassificationExcludesKnownImageAliases(t *test
 	}
 }
 
-func TestProtocolRoutingMigrationReportFailsTrafficReadyWhenRouterMissing(t *testing.T) {
+func TestProtocolRoutingMigrationReportFailsCutoverWhenRouterMissing(t *testing.T) {
 	repo := &protocolRoutingMigrationRepo{accounts: []Account{{
 		ID:       9,
 		Name:     "custom-openai",
@@ -404,8 +404,8 @@ func TestProtocolRoutingMigrationReportFailsTrafficReadyWhenRouterMissing(t *tes
 		t.Fatalf("MigrateProtocolRoutingSSOT: %v", err)
 	}
 	ready := newProtocolRoutingSSOTReady(report, nil)
-	if ready.Ready() || report.TrafficReady || report.CutoverReady {
-		t.Fatalf("missing router admitted traffic: %+v", report)
+	if ready.EnabledRouter() != nil || report.CutoverReady {
+		t.Fatalf("missing router admitted cutover: %+v", report)
 	}
 }
 
@@ -437,8 +437,8 @@ func TestMigrateProtocolRoutingSSOTDoesNotMarkQianfanChatOnlyAsNoLegalRoute(t *t
 		t.Fatalf("MigrateProtocolRoutingSSOT: %v", err)
 	}
 	ready := newProtocolRoutingSSOTReady(report, NewProtocolRouter())
-	if !ready.Ready() || !report.TrafficReady {
-		t.Fatalf("Qianfan chat-only account blocked process traffic: %+v", report)
+	if ready.EnabledRouter() == nil {
+		t.Fatalf("Qianfan chat-only account dropped the router: %+v", report)
 	}
 	for _, item := range report.Remediation {
 		if item.Reason == ProtocolRoutingRemediationNoLegalRoute {
@@ -451,7 +451,7 @@ func TestMigrateProtocolRoutingSSOTDoesNotMarkQianfanChatOnlyAsNoLegalRoute(t *t
 	}
 }
 
-func TestProtocolRoutingMigrationReportKeepsTrafficReadyWhenAccountHasNoLegalRoute(t *testing.T) {
+func TestProtocolRoutingMigrationReportKeepsRouterWhenAccountHasNoLegalRoute(t *testing.T) {
 	repo := &protocolRoutingMigrationRepo{accounts: []Account{{
 		ID:       9,
 		Name:     "bad-route",
@@ -470,8 +470,8 @@ func TestProtocolRoutingMigrationReportKeepsTrafficReadyWhenAccountHasNoLegalRou
 		t.Fatalf("MigrateProtocolRoutingSSOT: %v", err)
 	}
 	ready := newProtocolRoutingSSOTReady(report, NewProtocolRouter())
-	if !ready.Ready() || !report.TrafficReady {
-		t.Fatalf("account without a legal route blocked process traffic readiness: %+v", report)
+	if ready.EnabledRouter() == nil {
+		t.Fatalf("account without a legal route dropped the router: %+v", report)
 	}
 	if report.CutoverReady || len(report.Remediation) != 1 || report.Remediation[0].Reason != ProtocolRoutingRemediationNoLegalRoute {
 		t.Fatalf("report = %+v, want no_legal_route remediation without cutover", report)
@@ -499,7 +499,7 @@ func TestProtocolRoutingMigrationDoesNotTreatHistoricalWildcardSeedAsVerified(t 
 	if err != nil {
 		t.Fatalf("MigrateProtocolRoutingSSOT: %v", err)
 	}
-	if report.CutoverReady || !report.TrafficReady || len(report.Remediation) != 1 || report.Remediation[0].Reason != ProtocolRoutingRemediationProbeRequired {
+	if report.CutoverReady || len(report.Remediation) != 1 || report.Remediation[0].Reason != ProtocolRoutingRemediationProbeRequired {
 		t.Fatalf("historical positive seed bypassed initial endpoint probe: %+v", report)
 	}
 }
@@ -555,8 +555,8 @@ func TestMigrateProtocolRoutingSSOTAdmitsPartialPositiveProtocolsWithoutBlocking
 		t.Fatalf("MigrateProtocolRoutingSSOT: %v", err)
 	}
 	ready := newProtocolRoutingSSOTReady(report, NewProtocolRouter())
-	if !ready.Ready() || !report.TrafficReady {
-		t.Fatalf("partial positive account blocked process traffic readiness: %+v", report)
+	if ready.EnabledRouter() == nil {
+		t.Fatalf("partial positive account dropped the router: %+v", report)
 	}
 	if report.CutoverReady {
 		t.Fatalf("incomplete probe was treated as full cutover: %+v", report)
@@ -625,7 +625,7 @@ func TestPrepareProtocolRoutingSSOTProbesRemediationBeforeEnablingRouter(t *test
 	}
 }
 
-func TestPrepareProtocolRoutingSSOTKeepsRouterAndTrafficReadyWhenRemediationRemains(t *testing.T) {
+func TestPrepareProtocolRoutingSSOTKeepsRouterWhenRemediationRemains(t *testing.T) {
 	repo := &protocolRoutingMigrationRepo{accounts: []Account{{
 		ID:       13,
 		Name:     "unresolved-openai",
@@ -643,11 +643,8 @@ func TestPrepareProtocolRoutingSSOTKeepsRouterAndTrafficReadyWhenRemediationRema
 	if err != nil {
 		t.Fatalf("prepareProtocolRoutingSSOT: %v", err)
 	}
-	if ready.Report.CutoverReady || !ready.Report.TrafficReady || ready.EnabledRouter() != router {
-		t.Fatalf("ready = %+v router=%p, want traffic-ready remediation with router %p", ready.Report, ready.EnabledRouter(), router)
-	}
-	if !ready.Ready() {
-		t.Fatal("Ready() = false, want true while only unverified accounts remain excluded")
+	if ready.Report.CutoverReady || ready.EnabledRouter() != router {
+		t.Fatalf("ready = %+v router=%p, want remediation with router %p", ready.Report, ready.EnabledRouter(), router)
 	}
 	if ready.Report.ProbeAttempts != 1 || ready.Report.ProbeResolved != 0 {
 		t.Fatalf("probe outcome = attempts:%d resolved:%d, want 1/0", ready.Report.ProbeAttempts, ready.Report.ProbeResolved)
@@ -679,7 +676,7 @@ func TestPrepareProtocolRoutingSSOTFailsClosedWhenPublicationFails(t *testing.T)
 	if err == nil || err.Error() != "publish failed" {
 		t.Fatalf("prepareProtocolRoutingSSOT error = %v, want publish failed", err)
 	}
-	if ready.Ready() || ready.Report.CutoverReady {
+	if ready.EnabledRouter() != nil || ready.Report.CutoverReady {
 		t.Fatalf("publication failure admitted candidate: %+v", ready.Report)
 	}
 	if repo.publishCalls != 1 || repo.listCalls != 1 {
@@ -699,7 +696,7 @@ func TestPrepareProtocolRoutingSSOTFinalReadinessDoesNotMutateCapabilityLinks(t 
 	}}}
 
 	ready, err := prepareProtocolRoutingSSOT(context.Background(), repo, NewProtocolRouter(), nil)
-	if err != nil || !ready.Ready() {
+	if err != nil || ready.EnabledRouter() == nil {
 		t.Fatalf("prepareProtocolRoutingSSOT = %+v err=%v", ready.Report, err)
 	}
 	if repo.ensureCalls != 1 {
@@ -729,8 +726,8 @@ func TestPrepareProtocolRoutingSSOTRollsBackPublicationWhenFinalReadinessFails(t
 	if err != nil {
 		t.Fatalf("prepareProtocolRoutingSSOT: %v", err)
 	}
-	if !ready.Ready() || ready.Report.CutoverReady {
-		t.Fatalf("final readiness failure should keep process traffic ready without cutover: %+v", ready.Report)
+	if ready.EnabledRouter() != router || ready.Report.CutoverReady {
+		t.Fatalf("final readiness failure should keep router without cutover: %+v", ready.Report)
 	}
 	if got := LegacySupportedProtocolsProjection(&repo.accounts[0]); !reflect.DeepEqual(got, []protocolrouter.Protocol{protocolrouter.ProtocolMessages}) {
 		t.Fatalf("failed final readiness left projection=%v, want pre-candidate messages", got)
@@ -757,11 +754,11 @@ func TestPrepareProtocolRoutingSSOTReusesCompletedProbeOnRestart(t *testing.T) {
 	router := NewProtocolRouter()
 
 	first, err := prepareProtocolRoutingSSOT(context.Background(), repo, router, prober)
-	if err != nil || !first.Ready() {
+	if err != nil || first.EnabledRouter() == nil {
 		t.Fatalf("first preparation = %+v err=%v", first.Report, err)
 	}
 	second, err := prepareProtocolRoutingSSOT(context.Background(), repo, router, prober)
-	if err != nil || !second.Ready() {
+	if err != nil || second.EnabledRouter() == nil {
 		t.Fatalf("second preparation = %+v err=%v", second.Report, err)
 	}
 	if !reflect.DeepEqual(prober.calls, []int64{15}) {
@@ -805,8 +802,8 @@ func TestPrepareProtocolRoutingSSOTRetriesInconclusive429WithoutPublishingThenPu
 	if err != nil {
 		t.Fatalf("first prepareProtocolRoutingSSOT: %v", err)
 	}
-	if !first.Ready() || !first.Report.TrafficReady || first.Report.CutoverReady {
-		t.Fatalf("inconclusive 429 should keep traffic ready without full cutover: %+v", first.Report)
+	if first.EnabledRouter() != router || first.Report.CutoverReady {
+		t.Fatalf("inconclusive 429 should keep router without full cutover: %+v", first.Report)
 	}
 	if repo.publishCalls != 0 {
 		t.Fatalf("inconclusive 429 publication calls = %d, want 0", repo.publishCalls)
@@ -823,8 +820,8 @@ func TestPrepareProtocolRoutingSSOTRetriesInconclusive429WithoutPublishingThenPu
 	if err != nil {
 		t.Fatalf("second prepareProtocolRoutingSSOT: %v", err)
 	}
-	if !second.Ready() || !second.Report.CutoverReady {
-		t.Fatalf("recovered endpoint remained not ready: %+v", second.Report)
+	if second.EnabledRouter() != router || !second.Report.CutoverReady {
+		t.Fatalf("recovered endpoint remained not cutover-ready: %+v", second.Report)
 	}
 	if !reflect.DeepEqual(prober.calls, []int64{17, 17}) {
 		t.Fatalf("probe calls = %v, want one retry against the same linked capability", prober.calls)

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -49,33 +49,27 @@ func (r ProtocolRoutingSSOTReady) EnabledRouter() *protocolrouter.Router {
 	return r.router
 }
 
-func (r ProtocolRoutingSSOTReady) Ready() bool {
-	return r.Report.TrafficReady
-}
-
 func ProvideProtocolRoutingSSOTReady(accountRepo AccountRepository, accountTestService *AccountTestService, router *protocolrouter.Router) ProtocolRoutingSSOTReady {
 	migrationRepo, ok := accountRepo.(protocolRoutingMigrationRepository)
 	if !ok {
-		report := ProtocolRoutingMigrationReport{TrafficReady: false, CutoverReady: false}
+		report := ProtocolRoutingMigrationReport{CutoverReady: false}
 		logger.LegacyPrintf("service.protocol_routing", "protocol SSOT repository capability is unavailable")
 		return newProtocolRoutingSSOTReady(report, router)
 	}
 	ready, err := prepareProtocolRoutingSSOT(context.Background(), migrationRepo, router, accountTestService)
 	report := ready.Report
 	if err != nil {
-		report.TrafficReady = false
 		report.CutoverReady = false
 		logger.LegacyPrintf("service.protocol_routing", "protocol SSOT migration/report failed: %v", err)
 		return newProtocolRoutingSSOTReady(report, router)
 	}
 	logger.LegacyPrintf(
 		"service.protocol_routing",
-		"protocol SSOT migration/report: active_governed=%d seeded_official=%d probe_attempts=%d probe_resolved=%d traffic_ready=%t cutover_ready=%t remediation=%d",
+		"protocol SSOT migration/report: active_governed=%d seeded_official=%d probe_attempts=%d probe_resolved=%d cutover_ready=%t remediation=%d",
 		report.ActiveGoverned,
 		report.SeededOfficial,
 		report.ProbeAttempts,
 		report.ProbeResolved,
-		report.TrafficReady,
 		report.CutoverReady,
 		len(report.Remediation),
 	)

--- a/docs/approved/protocol-routing-ssot.md
+++ b/docs/approved/protocol-routing-ssot.md
@@ -8,7 +8,7 @@ revised: 2026-08-30
 revision_note: >
   Plans and Execute no longer compare account or capability revision tokens.
   Send-time freshness is authoritative reload plus route-fact equivalence.
-  /health follows process TrafficReady, not one account's missing route.
+  /health is drain-only. Protocol remediations never 503 the process.
   NewAPI exact-endpoint resolution is per declared protocol: undeclared
   protocols are not resolved, and a missing Responses URL omits that route
   from both exact endpoints and the Plan-facing supported set.
@@ -564,8 +564,8 @@ Final readiness runs inside the publication transaction and sees its
 uncommitted projection/outbox writes. It is read-only with respect to
 capability/link facts: a concurrently introduced missing or mismatched link
 fails CutoverReady instead of being repaired after publication. Only that
-final successful evaluation may commit the transaction. `/health` follows
-process TrafficReady independently and does not wait for publication.
+final successful evaluation may commit the transaction. `/health` does not
+wait for publication.
 Repeating publication with already-matching projections is a no-op: it
 does not advance account revisions or enqueue duplicate scheduler events.
 
@@ -579,11 +579,10 @@ in the same generation remains inconclusive.
 
 New application code always reads the capability table. It has no fallback to
 `accounts.extra.supported_protocols`, even during migration. Preparation,
-probing, and hard routing cutover may ship in one image. TrafficReady admits
-process traffic; CutoverReady is the publication-completeness signal.
+probing, and hard routing cutover may ship in one image. CutoverReady is the
+publication-completeness signal. `/health` does not read it.
 
-The image reports `/health` as `503 not_ready` only for a process-wide
-blocker: drain, missing router, or startup evaluation abort. An individual
+The image reports `/health` as `503` only while draining. An individual
 active, schedulable, governed account that:
 
 - lacks a valid capability link;
@@ -616,10 +615,10 @@ projections commit in one database transaction. During candidate startup,
 capability preparation is intentionally durable but unpublished; the complete
 projection, account revision advances, and scheduler invalidations are instead
 published together only after preliminary readiness succeeds. A publication
-callback that fails CutoverReady rolls back every legacy-visible effect and
-keeps process TrafficReady so `/health` does not 503 the candidate. A
-publication transaction error still flips TrafficReady, because an image
-rollback must not restore divergent account facts.
+callback that fails CutoverReady rolls back every legacy-visible effect.
+`/health` stays drain-only. A publication transaction error still flips
+TrafficReady in the report, because an image rollback must not restore
+divergent account facts.
 
 After the rollback window, deleting the legacy field, projection writer, and
 compatibility code is a separate reviewed change. The shared capability table
@@ -743,9 +742,8 @@ or capability state.
   and scheduler invalidations in one transaction after CutoverReady.
 - A failed candidate can be retried from persisted preparation facts while the
   previous image continues to observe its pre-candidate routing state.
-- The new image reads only the capability table. `/health` admits traffic when
-  the process can serve. An account without a legal route fails closed at
-  selection or execute and does not 503 the machine.
+- The new image reads only the capability table. `/health` is drain-only.
+  An account without a legal route fails closed at selection or execute.
 - The account legacy field exists only as a one-window rollback projection and
   is never a new-version routing input.
 - CI uses mock upstreams and mechanically rejects competing protocol owners.

--- a/docs/approved/protocol-routing-ssot.md
+++ b/docs/approved/protocol-routing-ssot.md
@@ -9,6 +9,7 @@ revision_note: >
   Plans and Execute no longer compare account or capability revision tokens.
   Send-time freshness is authoritative reload plus route-fact equivalence.
   /health is drain-only. Protocol remediations never 503 the process.
+  TrafficReady and Ready() are gone; CutoverReady is the only report gate.
   NewAPI exact-endpoint resolution is per declared protocol: undeclared
   protocols are not resolved, and a missing Responses URL omits that route
   from both exact endpoints and the Plan-facing supported set.
@@ -616,9 +617,9 @@ capability preparation is intentionally durable but unpublished; the complete
 projection, account revision advances, and scheduler invalidations are instead
 published together only after preliminary readiness succeeds. A publication
 callback that fails CutoverReady rolls back every legacy-visible effect.
-`/health` stays drain-only. A publication transaction error still flips
-TrafficReady in the report, because an image rollback must not restore
-divergent account facts.
+`/health` stays drain-only. A publication transaction error fails
+preparation and keeps CutoverReady false; it does not invent a second
+process-admission boolean.
 
 After the rollback window, deleting the legacy field, projection writer, and
 compatibility code is a separate reviewed change. The shared capability table

--- a/ops/stage0/deploy_via_ssm_bluegreen.sh
+++ b/ops/stage0/deploy_via_ssm_bluegreen.sh
@@ -815,15 +815,17 @@ write_active_color() {
 }
 
 observe_routed_health() {
-  local color="$1" seconds="${TOKENKEY_BLUEGREEN_OBSERVE_SECONDS:-30}" domain i body
-  domain="$(env_get API_DOMAIN)"
-  [[ -n "${domain}" ]] || die "API_DOMAIN is required for routed health observation"
+  local color="$1" seconds="${TOKENKEY_BLUEGREEN_OBSERVE_SECONDS:-30}" upstream i body
+  # Observe the color Caddy now routes to on the docker network.
+  # Do not hairpin wget through https://$API_DOMAIN (Cloudflare): 1.8.184
+  # first poll was ok, second failed, workflow red, traffic already on green.
+  upstream="$(color_container "${color}"):8080"
   for i in $(seq 1 "${seconds}"); do
-    if ! body="$(sudo docker exec tokenkey-caddy wget -q -T 5 -O - "https://${domain}/health" 2>/dev/null)"; then
-      echo "::error::routed /health failed after committed cutover color=${color} second=${i}/${seconds}"
+    if ! body="$(sudo docker exec tokenkey-caddy wget -q -T 5 -O - "http://${upstream}/health" 2>/dev/null)"; then
+      echo "::error::routed /health failed after committed cutover color=${color} upstream=${upstream} second=${i}/${seconds}"
       return 1
     fi
-    log "routed /health color=${color} second=${i}/${seconds}: ${body}"
+    log "routed /health color=${color} upstream=${upstream} second=${i}/${seconds}: ${body}"
     sleep 1
   done
 }

--- a/ops/stage0/deploy_via_ssm_bluegreen.sh
+++ b/ops/stage0/deploy_via_ssm_bluegreen.sh
@@ -815,17 +815,18 @@ write_active_color() {
 }
 
 observe_routed_health() {
-  local color="$1" seconds="${TOKENKEY_BLUEGREEN_OBSERVE_SECONDS:-30}" upstream i body
-  # Observe the color Caddy now routes to on the docker network.
-  # Do not hairpin wget through https://$API_DOMAIN (Cloudflare): 1.8.184
-  # first poll was ok, second failed, workflow red, traffic already on green.
-  upstream="$(color_container "${color}"):8080"
+  local color="$1" seconds="${TOKENKEY_BLUEGREEN_OBSERVE_SECONDS:-30}" domain i body
+  # Hit local Caddy with the real Host/SNI. Do not hairpin through Cloudflare
+  # (1.8.184: first public poll ok, second wget failed, workflow red) and do
+  # not skip Caddy by probing tokenkey-{color}:8080 directly.
+  domain="$(env_get API_DOMAIN)"
+  [[ -n "${domain}" ]] || die "API_DOMAIN is required for routed health observation"
   for i in $(seq 1 "${seconds}"); do
-    if ! body="$(sudo docker exec tokenkey-caddy wget -q -T 5 -O - "http://${upstream}/health" 2>/dev/null)"; then
-      echo "::error::routed /health failed after committed cutover color=${color} upstream=${upstream} second=${i}/${seconds}"
+    if ! body="$(curl -fsS --max-time 5 --resolve "${domain}:443:127.0.0.1" "https://${domain}/health")"; then
+      echo "::error::routed /health failed after committed cutover color=${color} second=${i}/${seconds}"
       return 1
     fi
-    log "routed /health color=${color} upstream=${upstream} second=${i}/${seconds}: ${body}"
+    log "routed /health color=${color} second=${i}/${seconds}: ${body}"
     sleep 1
   done
 }

--- a/ops/stage0/test_deploy_via_ssm_bluegreen.py
+++ b/ops/stage0/test_deploy_via_ssm_bluegreen.py
@@ -565,9 +565,9 @@ class BlueGreenRenderTest(unittest.TestCase):
         self.assertNotIn('trap on_err ERR', remote)
         self.assertIn('observe_routed_health', remote)
         self.assertIn('TOKENKEY_BLUEGREEN_OBSERVE_SECONDS:-30', remote)
-        self.assertIn('docker exec tokenkey-caddy wget', remote)
-        self.assertIn('"http://${upstream}/health"', remote)
-        self.assertNotIn('"https://${domain}/health"', remote)
+        self.assertIn('curl -fsS --max-time 5 --resolve "${domain}:443:127.0.0.1"', remote)
+        self.assertIn('"https://${domain}/health"', remote)
+        self.assertNotIn('"http://${upstream}/health"', remote)
         self.assertNotIn("--no-check-certificate", remote)
         self.assertIn("last-cutover-at", remote)
 

--- a/ops/stage0/test_deploy_via_ssm_bluegreen.py
+++ b/ops/stage0/test_deploy_via_ssm_bluegreen.py
@@ -566,7 +566,8 @@ class BlueGreenRenderTest(unittest.TestCase):
         self.assertIn('observe_routed_health', remote)
         self.assertIn('TOKENKEY_BLUEGREEN_OBSERVE_SECONDS:-30', remote)
         self.assertIn('docker exec tokenkey-caddy wget', remote)
-        self.assertIn('"https://${domain}/health"', remote)
+        self.assertIn('"http://${upstream}/health"', remote)
+        self.assertNotIn('"https://${domain}/health"', remote)
         self.assertNotIn("--no-check-certificate", remote)
         self.assertIn("last-cutover-at", remote)
 

--- a/scripts/checks/protocol-routing-ssot.py
+++ b/scripts/checks/protocol-routing-ssot.py
@@ -1082,22 +1082,24 @@ def check(root: Path) -> list[str]:
         source = strip_go_comments_and_literals(server_router.read_text(encoding="utf-8"))
         route_bodies = function_bodies(source, "registerRoutes")
         if not route_bodies or not all(
-            contains_identifier(body, "RegisterCommonRoutes")
-            and contains_identifier(body, "Ready")
-            for body in route_bodies
+            contains_identifier(body, "RegisterCommonRoutes") for body in route_bodies
         ):
-            errors.append("server router does not pass protocol readiness to common health routes")
+            errors.append("server router does not register common health routes")
+        for body in route_bodies:
+            if contains_identifier(body, "Ready"):
+                errors.append("server router still gates /health on protocol readiness")
 
     common_routes = root / "backend/internal/server/routes/common.go"
     if common_routes.is_file():
         source = strip_go_comments_and_literals(common_routes.read_text(encoding="utf-8"))
         route_bodies = function_bodies(source, "RegisterCommonRoutes")
-        if not route_bodies or not all(
-            re.search(r"!\s*protocol(?:Routing)?Ready\b", body)
-            and contains_identifier(body, "StatusServiceUnavailable")
-            for body in route_bodies
-        ):
-            errors.append("common health readiness gate is missing protocol readiness enforcement")
+        if not route_bodies:
+            errors.append("common health routes are missing RegisterCommonRoutes")
+        for body in route_bodies:
+            if re.search(r"protocol(?:Routing)?Ready", body):
+                errors.append("common /health still consults protocol readiness")
+            if not contains_identifier(body, "IsDraining"):
+                errors.append("common /health is missing the drain gate")
 
     count_tokens = root / "backend/internal/handler/openai_gateway_count_tokens.go"
     if count_tokens.is_file():

--- a/scripts/checks/protocol-routing-ssot.py
+++ b/scripts/checks/protocol-routing-ssot.py
@@ -582,6 +582,8 @@ def check(root: Path) -> list[str]:
     migration_owner = root / "backend/internal/service/protocol_routing_migration.go"
     if migration_owner.is_file():
         source = strip_go_comments_and_literals(migration_owner.read_text(encoding="utf-8"))
+        if contains_identifier(source, "TrafficReady"):
+            errors.append("protocol routing report still carries process TrafficReady")
         if contains_identifier(source, "ProbeAccountProtocolCapabilities"):
             errors.append("protocol routing startup uses the normal probe writer instead of the preparation probe")
         if not contains_identifier(source, "ProbeAccountProtocolCapabilitiesForPreparation"):
@@ -1043,11 +1045,8 @@ def check(root: Path) -> list[str]:
         for body in ready_builders:
             if re.search(r"\brouter\s*=\s*nil\b", body) or re.search(r"\brouter\s*:\s*nil\b", body):
                 errors.append("protocol routing readiness must not disable the router")
-        ready_accessors = function_bodies(source, "Ready")
-        if not ready_accessors or not all(
-            contains_identifier(body, "TrafficReady") for body in ready_accessors
-        ):
-            errors.append("protocol routing Ready accessor is not gated by TrafficReady")
+        if function_bodies(source, "Ready") or contains_identifier(source, "TrafficReady"):
+            errors.append("protocol routing still exposes a Ready/TrafficReady process gate")
 
     handler_wire = root / "backend/internal/handler/wire.go"
     if handler_wire.is_file():

--- a/scripts/checks/test_protocol_routing_ssot.py
+++ b/scripts/checks/test_protocol_routing_ssot.py
@@ -289,7 +289,6 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
             "package fixture\n"
             "type ProtocolRoutingSSOTReady struct{ Report Report; router *Router }\n"
             "func (r ProtocolRoutingSSOTReady) EnabledRouter(){}\n"
-            "func (r ProtocolRoutingSSOTReady) Ready() bool { return r.Report.TrafficReady }\n"
             "func newProtocolRoutingSSOTReady(report Report, router *Router) ProtocolRoutingSSOTReady { return ProtocolRoutingSSOTReady{Report: report, router: router} }\n"
             "func ProvideProtocolRoutingSSOTReady(){ prepareProtocolRoutingSSOT() }\n",
             encoding="utf-8",
@@ -470,17 +469,17 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
         )
         self.assertTrue(any("must not disable the router" in error for error in MODULE.check(root)))
 
-    def test_rejects_readiness_accessor_that_ignores_traffic_report(self) -> None:
+    def test_rejects_ready_accessor(self) -> None:
         root = self.fixture()
         wire = root / "backend/internal/service/wire.go"
         wire.write_text(
             wire.read_text(encoding="utf-8").replace(
-                "return r.Report.TrafficReady",
-                "return true",
+                "func (r ProtocolRoutingSSOTReady) EnabledRouter(){}",
+                "func (r ProtocolRoutingSSOTReady) EnabledRouter(){}\nfunc (r ProtocolRoutingSSOTReady) Ready() bool { return true }",
             ),
             encoding="utf-8",
         )
-        self.assertTrue(any("Ready accessor" in error for error in MODULE.check(root)))
+        self.assertTrue(any("Ready/TrafficReady process gate" in error for error in MODULE.check(root)))
 
     def test_rejects_health_route_that_gates_on_protocol_readiness(self) -> None:
         root = self.fixture()

--- a/scripts/checks/test_protocol_routing_ssot.py
+++ b/scripts/checks/test_protocol_routing_ssot.py
@@ -313,14 +313,14 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
         server_router.parent.mkdir(parents=True, exist_ok=True)
         server_router.write_text(
             "package fixture\n"
-            "func registerRoutes(ready ProtocolRoutingSSOTReady){ RegisterCommonRoutes(ready.Ready()) }\n",
+            "func registerRoutes(){ RegisterCommonRoutes() }\n",
             encoding="utf-8",
         )
         common_routes = root / "backend/internal/server/routes/common.go"
         common_routes.parent.mkdir(parents=True, exist_ok=True)
         common_routes.write_text(
             "package fixture\n"
-            "func RegisterCommonRoutes(protocolReady bool){ if !protocolReady { http.StatusServiceUnavailable; not_ready() } }\n",
+            "func RegisterCommonRoutes(){ if IsDraining() { http.StatusServiceUnavailable; draining() } }\n",
             encoding="utf-8",
         )
         return root
@@ -482,17 +482,29 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
         )
         self.assertTrue(any("Ready accessor" in error for error in MODULE.check(root)))
 
-    def test_rejects_health_route_without_protocol_readiness_gate(self) -> None:
+    def test_rejects_health_route_that_gates_on_protocol_readiness(self) -> None:
         root = self.fixture()
         common = root / "backend/internal/server/routes/common.go"
         common.write_text(
             common.read_text(encoding="utf-8").replace(
+                "if IsDraining() { http.StatusServiceUnavailable; draining() }",
                 "if !protocolReady { http.StatusServiceUnavailable; not_ready() }",
-                "ok()",
             ),
             encoding="utf-8",
         )
-        self.assertTrue(any("health readiness gate" in error for error in MODULE.check(root)))
+        self.assertTrue(any("consults protocol readiness" in error for error in MODULE.check(root)))
+
+    def test_rejects_router_that_passes_protocol_ready_to_health(self) -> None:
+        root = self.fixture()
+        router = root / "backend/internal/server/router.go"
+        router.write_text(
+            router.read_text(encoding="utf-8").replace(
+                "RegisterCommonRoutes()",
+                "RegisterCommonRoutes(ready.Ready())",
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("gates /health on protocol readiness" in error for error in MODULE.check(root)))
 
     def test_rejects_handler_target_protocol_switch(self) -> None:
         root = self.fixture()

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -1146,16 +1146,16 @@
         "return r.Report.TrafficReady",
         "return ProtocolRoutingSSOTReady{Report: report, router: router}"
       ],
-      "rationale": "Router availability and traffic admission are separate facts: handlers always receive the SSOT router, while TrafficReady controls /health. CutoverReady remains the full-matrix publish gate. Reintroducing router=nil on an unready candidate silently restores legacy serving inside the new image."
+      "rationale": "Router availability stays independent of publication completeness. TrafficReady is a report field; /health does not read it. CutoverReady remains the full-matrix publish gate. Reintroducing router=nil on an unready candidate silently restores legacy serving inside the new image."
     },
     {
       "path": "backend/internal/server/routes/common.go",
       "must_contain": [
-        "if !protocolRoutingReady {",
-        "gin.H{\"status\": \"not_ready\"}",
+        "if middleware.IsDraining() {",
+        "gin.H{\"status\": \"draining\"}",
         "http.StatusServiceUnavailable"
       ],
-      "rationale": "The public readiness endpoint returns 503 for a protocol-SSOT candidate that has not completed probe/revalidation, while liveness remains independent. This is the deployment hard gate that replaces runtime legacy fallback."
+      "rationale": "/health is drain-only. Protocol remediations stay fail-closed at schedule and execute and must not 503 the public readiness endpoint or block blue/green cutover."
     },
     {
       "path": "backend/internal/handler/gemini_v1beta_handler.go",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -1142,11 +1142,9 @@
       "path": "backend/internal/service/wire.go",
       "must_contain": [
         "func (r ProtocolRoutingSSOTReady) EnabledRouter() *protocolrouter.Router",
-        "func (r ProtocolRoutingSSOTReady) Ready() bool",
-        "return r.Report.TrafficReady",
         "return ProtocolRoutingSSOTReady{Report: report, router: router}"
       ],
-      "rationale": "Router availability stays independent of publication completeness. TrafficReady is a report field; /health does not read it. CutoverReady remains the full-matrix publish gate. Reintroducing router=nil on an unready candidate silently restores legacy serving inside the new image."
+      "rationale": "Router availability stays independent of publication completeness. /health is drain-only and must not read a process TrafficReady/Ready gate. CutoverReady remains the full-matrix publish gate. Reintroducing router=nil on an unready candidate silently restores legacy serving inside the new image."
     },
     {
       "path": "backend/internal/server/routes/common.go",


### PR DESCRIPTION
## 摘要

- `/health` 只认 drain：协议账号 remediation 不再让进程 503。
- 发版切流后的探测改为宿主机 `curl --resolve ${API_DOMAIN}:443:127.0.0.1` 打本机 Caddy，不经 Cloudflare，也不直打上游容器。
- 删除无生产读者的 `TrafficReady` / `Ready()`；发布完整性只留 `CutoverReady`。
- 同步改掉逼 `/health` 绑协议就绪的 SSOT 门禁和 newapi sentinel；server 层不再注入未使用的 `protocolRoutingReady`。

1.8.184 切流已经成功；workflow 红在第二次公网 wget。线上 green 已在服务。

## 风险

- 高风险：改 `/health` 公共契约与审批基线。`high-risk-anchor: docs/approved/protocol-routing-ssot.md`
- 协议 remediation 仍只在调度/发送 fail-closed，不再抬进程健康。
- 无 Web 产品面：`no-web-impact`
- 已更新 sentinel：`sentinel-registry-reviewed`

## 验证

- `./scripts/preflight.sh`：PASS（`24576462e` vs `origin/main@6aba0cff7`）
- `python3 -m unittest scripts.checks.test_protocol_routing_ssot -q`
- `go test -tags=unit ./internal/service/`
- `python3 scripts/sentinels/check-newapi.py`：PASS
- 未部署、未回滚 1.8.184

## 提交

- `27bdf890d` fix(protocol): /health 只认 drain，发版探测不再绕公网 (no-web-impact)
- `132756ebc` fix(protocol): address R-001..R-003 — 切流探测走本机 Caddy (no-web-impact)
- `24576462e` fix(protocol): address R-001 — 删掉无读者的 TrafficReady/Ready (no-web-impact)

最新提交：`24576462e`