### PR TITLE
fix(protocol): 双栈 relay 非 Claude messages 改走 chat，并补 header-wait ping

### DIFF
--- a/backend/internal/engine/protocolrouter/registry.go
+++ b/backend/internal/engine/protocolrouter/registry.go
@@ -182,10 +182,12 @@ func preservesMessagesToResponsesContent(req CanonicalRequest) bool {
 }
 
 func preservesMessagesToChat(req CanonicalRequest) bool {
-	return preservesTextOnlyWithoutTools(req) &&
-		req.profile.Continuation == ContinuationNone &&
-		req.profile.Reasoning == ReasoningNone &&
-		req.profile.PromptCache == PromptCacheNone
+	// forwardAnthropicViaRawChatCompletions already converts Claude Code
+	// function tools and images (AnthropicToChatCompletionsRequest). The old
+	// text-only-without-tools gate fail-closed those requests onto messages
+	// identity, which dual-stack OpenAI relays cannot serve for non-Claude models.
+	return preservesMessagesToResponsesContent(req) &&
+		req.profile.Continuation == ContinuationNone
 }
 
 func preservesChatToResponses(req CanonicalRequest) bool {

--- a/backend/internal/engine/protocolrouter/router_test.go
+++ b/backend/internal/engine/protocolrouter/router_test.go
@@ -352,17 +352,21 @@ func TestPlanRejectsConversionThatCannotPreserveContinuation(t *testing.T) {
 	}
 }
 
-func TestPlanRejectsConversionThatCannotPreserveToolsOrUnknownContent(t *testing.T) {
+func TestPlanMessagesToChatPreservesClaudeCodeTools(t *testing.T) {
 	router := New(allTestAdapters())
 	account := testAccount(t, ProtocolChatCompletions)
 	for _, profile := range []RequestProfile{
-		{Tools: true, ContentKinds: ContentText},
-		{ToolChoice: ToolChoiceRequired, ContentKinds: ContentText},
-		{ContentKinds: ContentText | ContentUnknown},
+		{Tools: true, ToolChoice: ToolChoiceAuto, ContentKinds: ContentText},
+		{Tools: true, ContentKinds: ContentText | ContentImage},
+		{Tools: true, ContentKinds: ContentText | ContentUnknown},
 	} {
-		_, err := router.Plan(testRequest(t, ProtocolMessages, profile), account)
-		if !errors.Is(err, ErrNoLegalRoute) {
-			t.Fatalf("Plan profile=%+v error = %v, want ErrNoLegalRoute", profile, err)
+		plan, err := router.Plan(testRequest(t, ProtocolMessages, profile), account)
+		if err != nil {
+			t.Fatalf("Plan profile=%+v: %v", profile, err)
+		}
+		if plan.TargetProtocol() != ProtocolChatCompletions || plan.AdapterID() != AdapterMessagesToChat {
+			t.Fatalf("plan target/adapter = %q/%q, want chat_completions/%s",
+				plan.TargetProtocol(), plan.AdapterID(), AdapterMessagesToChat)
 		}
 	}
 }

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1466,6 +1466,9 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 					// 断开排水期间上游已计量的 usage 必须入账（此前直接 return 丢弃，
 					// payg 上游照常计费而平台漏记）。
 					submitMessagesUsage(result)
+					// Client already gone; if nothing was written, still emit an
+					// Anthropic error so access logs are 502 instead of empty 200.
+					h.ensureAnthropicErrorResponse(c, streamStarted)
 					return
 				}
 				h.gatewayService.ReportOpenAIAccountScheduleResult(account, openAIAccountScheduleModel(c, account, currentRoutingModel, false, result), false, nil, err)

--- a/backend/internal/service/account_supported_protocols.go
+++ b/backend/internal/service/account_supported_protocols.go
@@ -277,6 +277,22 @@ func protocolResolvedModelAllowedForTarget(
 	case protocolrouter.OfficialEndpointAnthropic:
 		return target == protocolrouter.ProtocolMessages
 	}
+	// Native Anthropic /v1/messages only accepts Claude-family names. Dual-stack
+	// OpenAI relays (tokensea, cloudwise) advertise messages plus chat/responses;
+	// without this gate, inbound Claude Code + gpt-* / MiniMax / GLM plans
+	// identity messages and execute fail-closes with
+	// "native anthropic messages requires a Claude model".
+	if target == protocolrouter.ProtocolMessages && !tkIsForwardableAnthropicModelName(resolvedModel) {
+		return false
+	}
+	// Those same relays advertise /v1/responses because the probe treats HTTP 400
+	// as "endpoint exists". Execute already forces raw chat
+	// (shouldForwardOpenAIResponsesViaRawChatCompletions). Plan must not pick
+	// responses or Claude Code + non-Claude would convert onto a dead wire.
+	if target == protocolrouter.ProtocolResponses &&
+		(account.IsOpenAICloudwiseRelay() || account.IsOpenAITokenseaRelay()) {
+		return false
+	}
 	if target == protocolrouter.ProtocolGeminiGenerateContent {
 		return protocolGeminiEndpointProfile(account).Valid()
 	}

--- a/backend/internal/service/account_supported_protocols_test.go
+++ b/backend/internal/service/account_supported_protocols_test.go
@@ -123,6 +123,35 @@ func TestBuildSupportedProtocolsUpdateOwnsCanonicalEncoding(t *testing.T) {
 	}
 }
 
+func TestProtocolResolvedModelAllowedForTarget_DualStackMessagesRequiresClaude(t *testing.T) {
+	account := protocolRoutingOpenAIAccount(92, "messages", "chat_completions")
+	if !protocolResolvedModelAllowedForTarget(account, "", protocolrouter.ProtocolMessages, "claude-sonnet-4-6", "claude-sonnet-4-6", nil) {
+		t.Fatal("claude model must remain legal for native messages")
+	}
+	if protocolResolvedModelAllowedForTarget(account, "", protocolrouter.ProtocolMessages, "gpt-5.4", "gpt-5.4", nil) {
+		t.Fatal("gpt-5.4 must not be legal for native messages on a dual-stack OpenAI relay")
+	}
+	if !protocolResolvedModelAllowedForTarget(account, "", protocolrouter.ProtocolChatCompletions, "gpt-5.4", "gpt-5.4", nil) {
+		t.Fatal("gpt-5.4 must remain legal for chat_completions")
+	}
+
+	tokensea := protocolRoutingRelinkedOpenAIAccount(92, "https://agent.tokensea.ai/v1", "messages", "chat_completions", "responses")
+	if protocolResolvedModelAllowedForTarget(tokensea, "", protocolrouter.ProtocolResponses, "gpt-5.4", "gpt-5.4", nil) {
+		t.Fatal("tokensea must not plan native responses")
+	}
+
+	cloudwise := protocolRoutingRelinkedOpenAIAccount(95, "https://api.cloudwise.ai/api", "messages", "chat_completions", "responses")
+	if protocolResolvedModelAllowedForTarget(cloudwise, "", protocolrouter.ProtocolMessages, "MiniMax-M3", "MiniMax-M3", nil) {
+		t.Fatal("cloudwise MiniMax must not plan native messages")
+	}
+	if protocolResolvedModelAllowedForTarget(cloudwise, "", protocolrouter.ProtocolResponses, "MiniMax-M3", "MiniMax-M3", nil) {
+		t.Fatal("cloudwise must not plan native responses")
+	}
+	if !protocolResolvedModelAllowedForTarget(cloudwise, "", protocolrouter.ProtocolChatCompletions, "MiniMax-M3", "MiniMax-M3", nil) {
+		t.Fatal("cloudwise MiniMax must remain legal for chat_completions")
+	}
+}
+
 func TestProtocolAccountSnapshotResolvesModelFromAccountFacts(t *testing.T) {
 	updatedAt := time.Date(2026, 8, 24, 10, 30, 0, 0, time.UTC)
 	account := &Account{

--- a/backend/internal/service/gateway_service_tk_header_wait_keepalive.go
+++ b/backend/internal/service/gateway_service_tk_header_wait_keepalive.go
@@ -92,6 +92,17 @@ func (s *OpenAIGatewayService) beginHeaderWaitKeepalive(c *gin.Context, reqStrea
 	return beginConfiguredHeaderWaitKeepalive(c, reqStream, s.cfg.Gateway.StreamKeepaliveInterval, openaiSSECommentFrame)
 }
 
+// beginAnthropicClientHeaderWaitKeepalive emits Anthropic ping frames while a
+// /v1/messages client waits on upstream response headers. Do not reuse
+// beginHeaderWaitKeepalive here: that helper emits OpenAI SSE comments, which
+// Claude Code treats as idle and will still drop the connection.
+func (s *OpenAIGatewayService) beginAnthropicClientHeaderWaitKeepalive(c *gin.Context, reqStream bool) *headerWaitKeepalive {
+	if s == nil || s.cfg == nil {
+		return nil
+	}
+	return beginConfiguredHeaderWaitKeepalive(c, reqStream, s.cfg.Gateway.StreamKeepaliveInterval, anthropicSSEPingFrame)
+}
+
 // beginConfiguredHeaderWaitKeepalive is the shared constructor used by every
 // streaming platform Forward/Do path (Anthropic, OpenAI, Kiro, Bedrock,
 // Antigravity, Gemini). intervalSec comes from gateway.stream_keepalive_interval.

--- a/backend/internal/service/gateway_service_tk_header_wait_keepalive_test.go
+++ b/backend/internal/service/gateway_service_tk_header_wait_keepalive_test.go
@@ -82,6 +82,25 @@ func TestStartHeaderWaitKeepalive_DisabledReturnsNil(t *testing.T) {
 	nilHandle.stop()
 }
 
+func TestOpenAIGatewayService_BeginAnthropicClientHeaderWaitKeepaliveUsesPingFrame(t *testing.T) {
+	c, rec := newKeepaliveTestContext(t)
+	svc := &OpenAIGatewayService{cfg: &config.Config{Gateway: config.GatewayConfig{StreamKeepaliveInterval: 1}}}
+	k := svc.beginAnthropicClientHeaderWaitKeepalive(c, true)
+	if k == nil {
+		t.Fatal("expected non-nil Anthropic client keepalive handle")
+	}
+	time.Sleep(1100 * time.Millisecond)
+	k.stop()
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "event: ping") {
+		t.Fatalf("messages client keepalive must emit Anthropic ping, got %q", body)
+	}
+	if strings.Contains(body, ":\n\n") && !strings.Contains(body, "event: ping") {
+		t.Fatalf("messages client keepalive must not be an OpenAI comment, got %q", body)
+	}
+}
+
 func TestBeginHeaderWaitKeepalive_NonStreamReturnsNil(t *testing.T) {
 	c, _ := newKeepaliveTestContext(t)
 	// reqStream=false short-circuits before any config lookup, so a zero-value

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -363,7 +363,9 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 				return nil, fmt.Errorf("build grok retry request: %w", err)
 			}
 		}
+		hwka := s.beginAnthropicClientHeaderWaitKeepalive(c, isStream)
 		resp, err = s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
+		hwka.stop()
 		if err != nil {
 			return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, false)
 		}
@@ -1440,7 +1442,9 @@ func (s *OpenAIGatewayService) fallbackAnthropicToGrokChatCompletions(
 	if account.Proxy != nil {
 		proxyURL = account.Proxy.URL()
 	}
+	hwka := s.beginAnthropicClientHeaderWaitKeepalive(c, clientStream)
 	resp, err := s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
+	hwka.stop()
 	if err != nil {
 		return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, false)
 	}

--- a/backend/internal/service/openai_gateway_messages_anthropic_native_tk.go
+++ b/backend/internal/service/openai_gateway_messages_anthropic_native_tk.go
@@ -97,7 +97,9 @@ func (s *OpenAIGatewayService) forwardAnthropicViaNativeAnthropicEndpoint(
 		return nil, err
 	}
 
+	hwka := s.beginAnthropicClientHeaderWaitKeepalive(c, clientStream)
 	resp, err := s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
+	hwka.stop()
 	if err != nil {
 		return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, true)
 	}

--- a/backend/internal/service/openai_gateway_messages_chat_fallback.go
+++ b/backend/internal/service/openai_gateway_messages_chat_fallback.go
@@ -106,7 +106,9 @@ func (s *OpenAIGatewayService) forwardAnthropicViaRawChatCompletions(
 	if err != nil {
 		return nil, err
 	}
+	hwka := s.beginAnthropicClientHeaderWaitKeepalive(c, clientStream)
 	resp, err := s.sendCCUpstreamRequest(ctx, c, account, targetURL, chatBody, clientStream, apiKey, account.GetOpenAIUserAgent(), "")
+	hwka.stop()
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/service/openai_gateway_messages_native.go
+++ b/backend/internal/service/openai_gateway_messages_native.go
@@ -152,7 +152,9 @@ func (s *OpenAIGatewayService) sendNativeAnthropicMessagesRequest(
 	if account.Proxy != nil {
 		proxyURL = account.Proxy.URL()
 	}
+	hwka := s.beginAnthropicClientHeaderWaitKeepalive(c, stream)
 	resp, err := s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
+	hwka.stop()
 	if err != nil {
 		return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, false)
 	}

--- a/backend/internal/service/openai_gateway_messages_native_test.go
+++ b/backend/internal/service/openai_gateway_messages_native_test.go
@@ -10,8 +10,10 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -159,4 +161,55 @@ func TestForwardAsAnthropic_TokenseaGPTKeepsResponsesWhenFlagTrue(t *testing.T) 
 	require.NotNil(t, result)
 	require.True(t, strings.HasSuffix(upstream.lastReq.URL.Path, "/responses"),
 		"92 GPT /v1/messages must stay on Responses when extra.responses=true, got %s", upstream.lastReq.URL.String())
+}
+
+type delayingHTTPUpstream struct {
+	delay time.Duration
+	inner HTTPUpstream
+}
+
+func (u *delayingHTTPUpstream) Do(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error) {
+	time.Sleep(u.delay)
+	return u.inner.Do(req, proxyURL, accountID, accountConcurrency)
+}
+
+func (u *delayingHTTPUpstream) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile) (*http.Response, error) {
+	return u.Do(req, proxyURL, accountID, accountConcurrency)
+}
+
+func TestForwardAsAnthropic_HeaderWaitKeepaliveEmitsAnthropicPing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+
+	upstreamBody := strings.Join([]string{
+		`data: {"type":"response.created","response":{"id":"resp_ka","object":"response","model":"gpt-5.4","status":"in_progress"}}`,
+		"",
+		`data: {"type":"response.output_text.delta","delta":"ok"}`,
+		"",
+		`data: {"type":"response.completed","response":{"id":"resp_ka","object":"response","model":"gpt-5.4","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":5,"output_tokens":2,"total_tokens":7}}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	inner := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	cfg := rawChatCompletionsTestConfig()
+	cfg.Gateway.StreamKeepaliveInterval = 1
+	svc := &OpenAIGatewayService{
+		cfg:          cfg,
+		httpUpstream: &delayingHTTPUpstream{delay: 1100 * time.Millisecond, inner: inner},
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, rawChatCompletionsTestAccount(), body, "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Contains(t, rec.Body.String(), "event: ping",
+		"Claude /v1/messages clients must receive Anthropic ping while waiting on upstream headers")
 }

--- a/backend/internal/service/protocol_execution_test.go
+++ b/backend/internal/service/protocol_execution_test.go
@@ -570,7 +570,7 @@ func TestExecuteSelectedProtocolUsesLegacyExecutorWhenCutoverRouterDisabled(t *t
 
 func TestExecuteSelectedProtocolValidatesExactPlanEndpointBeforeExecutor(t *testing.T) {
 	router := NewProtocolRouter()
-	req := protocolRoutingTestRequest(t, protocolrouter.ProtocolMessages)
+	req := protocolRoutingClaudeMessagesRequest(t, "claude-sonnet-4-6")
 	ctx := WithProtocolRouting(context.Background(), router, req)
 	account := protocolRoutingOpenAIAccount(12, "messages")
 	plan, _, err := protocolPlanForAccount(ctx, account, req.RequestedModel())

--- a/backend/internal/service/protocol_routing_context_test.go
+++ b/backend/internal/service/protocol_routing_context_test.go
@@ -219,6 +219,89 @@ func TestOpenAIEdgeMirrorPlansClaudeCodeMessagesAsResponses(t *testing.T) {
 	}
 }
 
+func protocolRoutingClaudeMessagesRequest(t *testing.T, model string) protocolrouter.CanonicalRequest {
+	t.Helper()
+	req, err := protocolrouter.NewCanonicalRequest(protocolrouter.CanonicalRequestInput{
+		InboundProtocol: protocolrouter.ProtocolMessages,
+		RequestedModel:  model,
+		Profile: protocolrouter.RequestProfile{
+			Tools:        true,
+			ToolChoice:   protocolrouter.ToolChoiceAuto,
+			ContentKinds: protocolrouter.ContentText,
+		},
+		Body: []byte(`{"model":"` + model + `","tools":[{"name":"lookup"}],"messages":[{"role":"user","content":"hi"}]}`),
+	})
+	if err != nil {
+		t.Fatalf("NewCanonicalRequest: %v", err)
+	}
+	return req
+}
+
+func protocolRoutingRelinkedOpenAIAccount(id int64, baseURL string, protocols ...string) *Account {
+	account := protocolRoutingOpenAIAccount(id, protocols...)
+	account.Credentials["base_url"] = baseURL
+	supported := make([]protocolrouter.Protocol, len(protocols))
+	for i, protocol := range protocols {
+		supported[i] = protocolrouter.Protocol(protocol)
+	}
+	attachTestProtocolCapability(account, supported...)
+	return account
+}
+
+func TestDualStackOpenAIRelayPlansNonClaudeMessagesAwayFromNativeIdentity(t *testing.T) {
+	tokenseaLike := protocolRoutingRelinkedOpenAIAccount(92, "https://agent.tokensea.ai/v1", "messages", "chat_completions")
+	cloudwiseLike := protocolRoutingRelinkedOpenAIAccount(95, "https://api.cloudwise.ai/api", "messages", "chat_completions", "responses")
+
+	t.Run("tokensea gpt-5.4 uses chat_completions", func(t *testing.T) {
+		ctx := WithProtocolRouting(context.Background(), protocolRoutingTestRouter(), protocolRoutingClaudeCodeMessagesRequest(t))
+		if !ProtocolRouteLegal(ctx, tokenseaLike, "gpt-5.4") {
+			t.Fatal("tokensea dual-stack must still route Claude Code gpt-5.4")
+		}
+		plan, governed, err := protocolPlanForAccount(ctx, tokenseaLike, "gpt-5.4")
+		if !governed || err != nil {
+			t.Fatalf("protocolPlanForAccount: governed=%v err=%v", governed, err)
+		}
+		if plan.TargetProtocol() != protocolrouter.ProtocolChatCompletions ||
+			plan.AdapterID() != protocolrouter.AdapterMessagesToChat {
+			t.Fatalf("plan target/adapter = %q/%q, want chat_completions/%s",
+				plan.TargetProtocol(), plan.AdapterID(), protocolrouter.AdapterMessagesToChat)
+		}
+	})
+
+	t.Run("cloudwise MiniMax uses chat_completions not responses", func(t *testing.T) {
+		req := protocolRoutingClaudeMessagesRequest(t, "MiniMax-M3")
+		ctx := WithProtocolRouting(context.Background(), protocolRoutingTestRouter(), req)
+		if !ProtocolRouteLegal(ctx, cloudwiseLike, "MiniMax-M3") {
+			t.Fatal("cloudwise dual-stack must still route Claude Code MiniMax")
+		}
+		plan, governed, err := protocolPlanForAccount(ctx, cloudwiseLike, "MiniMax-M3")
+		if !governed || err != nil {
+			t.Fatalf("protocolPlanForAccount: governed=%v err=%v", governed, err)
+		}
+		if plan.TargetProtocol() != protocolrouter.ProtocolChatCompletions ||
+			plan.AdapterID() != protocolrouter.AdapterMessagesToChat {
+			t.Fatalf("plan target/adapter = %q/%q, want chat_completions/%s",
+				plan.TargetProtocol(), plan.AdapterID(), protocolrouter.AdapterMessagesToChat)
+		}
+	})
+
+	t.Run("claude model stays on native messages", func(t *testing.T) {
+		req := protocolRoutingClaudeMessagesRequest(t, "claude-sonnet-4-6")
+		for _, account := range []*Account{tokenseaLike, cloudwiseLike} {
+			ctx := WithProtocolRouting(context.Background(), protocolRoutingTestRouter(), req)
+			plan, governed, err := protocolPlanForAccount(ctx, account, "claude-sonnet-4-6")
+			if !governed || err != nil {
+				t.Fatalf("account %d: governed=%v err=%v", account.ID, governed, err)
+			}
+			if plan.TargetProtocol() != protocolrouter.ProtocolMessages ||
+				plan.AdapterID() != protocolrouter.AdapterMessagesIdentity {
+				t.Fatalf("account %d plan target/adapter = %q/%q, want messages/%s",
+					account.ID, plan.TargetProtocol(), plan.AdapterID(), protocolrouter.AdapterMessagesIdentity)
+			}
+		}
+	})
+}
+
 func TestProtocolRoutingHardGateRejectsGovernedAccountWithoutLegalPath(t *testing.T) {
 	ctx := WithProtocolRouting(
 		context.Background(),

--- a/docs/approved/protocol-routing-ssot.md
+++ b/docs/approved/protocol-routing-ssot.md
@@ -12,6 +12,9 @@ revision_note: >
   NewAPI exact-endpoint resolution is per declared protocol: undeclared
   protocols are not resolved, and a missing Responses URL omits that route
   from both exact endpoints and the Plan-facing supported set.
+  On a non-OfficialEndpointAnthropic identity, native messages is legal only
+  for a Claude-family resolved model; dual-stack OpenAI relays convert
+  inbound /v1/messages for GPT and other non-Claude models.
 related_stories: []
 ---
 
@@ -294,6 +297,18 @@ AND the adapter preserves the concrete request features
 AND the endpoint resolves explicitly from the same identity/account snapshot
 AND the required adapter and transport exist
 ```
+
+On a non-`OfficialEndpointAnthropic` identity, native `messages` is legal only
+when the resolved upstream model is in the Claude family (`claude-*`). Dual-stack
+OpenAI relays that advertise `messages` plus `chat_completions` and/or
+`responses` therefore convert inbound Claude Code `/v1/messages` for GPT and
+other non-Claude models instead of identity-forwarding onto a Claude-only
+native path. TokenSea and CloudWise also omit native `responses` from Plan
+because their advertised Responses support is a probe false-positive; the
+legal conversion for those identities is `chat_completions`. The
+`messages → chat_completions` conversion preserves Claude Code function tools
+and images, matching the already-proven `messages → responses` surface, so a
+tools-bearing Claude Code body does not fail closed back onto identity.
 
 Endpoint resolution must reproduce the identity used to obtain the capability
 key. A configurable endpoint with an empty or mismatched URL never falls back


### PR DESCRIPTION
## 摘要

线上 Claude Code `POST /v1/messages` + `gpt-5.4` 出现两类故障，一并修在规划层和流式等待路径：

- tokensea（账号 92）被规划成 native `messages`，执行层只认 `claude-*`，返回 502 `native anthropic messages requires a Claude model`。cloudwise（账号 95）对 MiniMax/GLM 等非 Claude 模型有同一类问题；它的 `/v1/responses` 还是探针假阳性。
- 流量落到 us4/us6 后，prod 等 edge 首包时没有给 Claude 客户端发 Anthropic ping，客户端空等后掐连接：prod 记 200 + 0 token，edge 其实已经出字。

规划现在对非 `OfficialEndpointAnthropic` 的 native `messages` 只允许 `claude-*`；tokensea/cloudwise 不再把假阳性 `responses` 当作合法目标。Claude Code 的 tools/images 可由 `messages → chat_completions` 转换。`/v1/messages` 在等上游 header 时发 Anthropic `event: ping`；若客户端已断开且未写出任何字节，补 Anthropic 502。

无 Web 页面改动。`docs/approved/protocol-routing-ssot.md` 已同步这条模型策略。

upstream-conflict-surface-accepted：只在已有 companion `openai_gateway_messages_anthropic_native_tk.go` 的 `Do()` 外包了一层 Anthropic header-wait ping，没有改上游主文件。

## 风险

高风险：协议规划 SSOT 与核心 `/v1/messages` 流式契约。绑定审批锚点 `docs/approved/protocol-routing-ssot.md`。回滚可 `git revert`。发版后再打开 tokensea 调度。

## 验证

- `PREFLIGHT_BASE=origin/main ./scripts/preflight.sh` 通过
- `go test -tags=unit` 覆盖规划（tokensea gpt-5.4 → chat、cloudwise MiniMax → chat、claude 仍走 native messages）、`messages → chat` 保留 tools、Anthropic header-wait ping

## 提交

- `1a36c8bc0` fix(protocol): 双栈 relay 的非 Claude messages 改走 chat，并在等上游时发 ping
- `e41ddeef8` merge: 同步 origin/main，让 PR 基线成为祖先
- 最新提交：`e41ddeef8`