### PR TITLE
fix(protocol): Claude messages 经 GPT 专线时回写 Codex 正文

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -762,14 +762,15 @@ func TestResponsesEventToAnthropicEvents_ResponseDone(t *testing.T) {
 			Usage:  &ResponsesUsage{InputTokens: 12, OutputTokens: 4},
 		},
 	}, state)
-	require.Len(t, events, 4)
-	assert.Equal(t, "content_block_start", events[0].Type)
-	assert.Equal(t, "content_block_stop", events[1].Type)
-	assert.Equal(t, "message_delta", events[2].Type)
-	assert.Equal(t, "end_turn", events[2].Delta.StopReason)
-	assert.Equal(t, 12, events[2].Usage.InputTokens)
-	assert.Equal(t, 4, events[2].Usage.OutputTokens)
-	assert.Equal(t, "message_stop", events[3].Type)
+	require.Len(t, events, 5)
+	assert.Equal(t, "message_start", events[0].Type)
+	assert.Equal(t, "content_block_start", events[1].Type)
+	assert.Equal(t, "content_block_stop", events[2].Type)
+	assert.Equal(t, "message_delta", events[3].Type)
+	assert.Equal(t, "end_turn", events[3].Delta.StopReason)
+	assert.Equal(t, 12, events[3].Usage.InputTokens)
+	assert.Equal(t, 4, events[3].Usage.OutputTokens)
+	assert.Equal(t, "message_stop", events[4].Type)
 	assert.Nil(t, FinalizeResponsesAnthropicStream(state))
 }
 
@@ -792,16 +793,18 @@ func TestResponsesEventToAnthropicEvents_TopLevelTerminalUsage(t *testing.T) {
 	}, state)
 
 	// TK US-027: terminal events always include an empty content block pair when
-	// no real content was emitted (anthropics/claude-code#24662).
-	require.Len(t, events, 4)
-	assert.Equal(t, "content_block_start", events[0].Type)
-	assert.Equal(t, "content_block_stop", events[1].Type)
-	assert.Equal(t, "message_delta", events[2].Type)
-	require.NotNil(t, events[2].Usage)
-	assert.Equal(t, 15, events[2].Usage.InputTokens)
-	assert.Equal(t, 5, events[2].Usage.CacheReadInputTokens)
-	assert.Equal(t, 6, events[2].Usage.OutputTokens)
-	assert.Equal(t, "message_stop", events[3].Type)
+	// no real content was emitted (anthropics/claude-code#24662). A lone
+	// completed event must also open the Anthropic stream with message_start.
+	require.Len(t, events, 5)
+	assert.Equal(t, "message_start", events[0].Type)
+	assert.Equal(t, "content_block_start", events[1].Type)
+	assert.Equal(t, "content_block_stop", events[2].Type)
+	assert.Equal(t, "message_delta", events[3].Type)
+	require.NotNil(t, events[3].Usage)
+	assert.Equal(t, 15, events[3].Usage.InputTokens)
+	assert.Equal(t, 5, events[3].Usage.CacheReadInputTokens)
+	assert.Equal(t, 6, events[3].Usage.OutputTokens)
+	assert.Equal(t, "message_stop", events[4].Type)
 }
 
 func TestResponsesEventToAnthropicEvents_ResponseDoneIncomplete(t *testing.T) {
@@ -816,12 +819,13 @@ func TestResponsesEventToAnthropicEvents_ResponseDoneIncomplete(t *testing.T) {
 			Usage:             &ResponsesUsage{InputTokens: 12, OutputTokens: 4},
 		},
 	}, state)
-	require.Len(t, events, 4)
-	assert.Equal(t, "content_block_start", events[0].Type)
-	assert.Equal(t, "content_block_stop", events[1].Type)
-	assert.Equal(t, "message_delta", events[2].Type)
-	assert.Equal(t, "max_tokens", events[2].Delta.StopReason)
-	assert.Equal(t, "message_stop", events[3].Type)
+	require.Len(t, events, 5)
+	assert.Equal(t, "message_start", events[0].Type)
+	assert.Equal(t, "content_block_start", events[1].Type)
+	assert.Equal(t, "content_block_stop", events[2].Type)
+	assert.Equal(t, "message_delta", events[3].Type)
+	assert.Equal(t, "max_tokens", events[3].Delta.StopReason)
+	assert.Equal(t, "message_stop", events[4].Type)
 	assert.Nil(t, FinalizeResponsesAnthropicStream(state))
 }
 
@@ -2309,4 +2313,77 @@ func TestMessageStartSSE_StopReasonIsJSONNull(t *testing.T) {
 	// Official Anthropic wire: "stop_reason":null
 	require.Contains(t, sse, `"stop_reason":null`)
 	require.NotContains(t, sse, `"stop_reason":""`)
+}
+
+func TestResponsesEventToAnthropic_CompletedBackfillsVisibleTextAfterReasoning(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+	state.Model = "gpt-5.4"
+
+	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:     "response.created",
+		Response: &ResponsesResponse{ID: "resp_late", Model: "gpt-5.4"},
+	}, state)
+	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 0,
+		Item:        &ResponsesOutput{Type: "reasoning"},
+	}, state)
+
+	events := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type: "response.completed",
+		Response: &ResponsesResponse{
+			ID:     "resp_late",
+			Status: "completed",
+			Usage:  &ResponsesUsage{InputTokens: 19449, OutputTokens: 608},
+			Output: []ResponsesOutput{
+				{Type: "reasoning", Summary: []ResponsesSummary{{Type: "summary_text", Text: "think"}}},
+				{Type: "message", Role: "assistant", Content: []ResponsesContentPart{{Type: "output_text", Text: "visible answer"}}},
+			},
+		},
+	}, state)
+
+	var types []string
+	var text string
+	for _, evt := range events {
+		types = append(types, evt.Type)
+		if evt.Delta != nil && evt.Delta.Type == "text_delta" {
+			text += evt.Delta.Text
+		}
+	}
+	require.Contains(t, types, "content_block_delta")
+	require.Equal(t, "visible answer", text)
+	require.Equal(t, 19449, state.InputTokens)
+	require.Equal(t, 608, state.OutputTokens)
+	require.True(t, state.TextEmitted)
+}
+
+func TestResponsesStreamEvent_ObjectDeltaUnmarshalsText(t *testing.T) {
+	var evt ResponsesStreamEvent
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"type":"response.output_text.delta",
+		"delta":{"type":"output_text","text":"hello"}
+	}`), &evt))
+	require.Equal(t, "response.output_text.delta", evt.Type)
+	require.Equal(t, "hello", evt.Delta)
+
+	state := NewResponsesEventToAnthropicState()
+	events := ResponsesEventToAnthropicEvents(&evt, state)
+	require.NotEmpty(t, events)
+	require.Equal(t, "hello", events[len(events)-1].Delta.Text)
+}
+
+func TestResponsesEventToAnthropic_EmptyCompletedStillInjectsTextBlock(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+	events := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type: "response.completed",
+		Response: &ResponsesResponse{
+			Status: "completed",
+			Usage:  &ResponsesUsage{InputTokens: 3, OutputTokens: 0},
+		},
+	}, state)
+	require.GreaterOrEqual(t, len(events), 4)
+	require.Equal(t, "message_start", events[0].Type)
+	require.Equal(t, "content_block_start", events[1].Type)
+	require.Equal(t, "text", events[1].ContentBlock.Type)
+	require.Equal(t, "", events[1].ContentBlock.Text)
 }

--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -2344,14 +2344,28 @@ func TestResponsesEventToAnthropic_CompletedBackfillsVisibleTextAfterReasoning(t
 
 	var types []string
 	var text string
+	var thinking string
+	thinkingAfterStop := false
+	sawContentBlockStop := false
 	for _, evt := range events {
 		types = append(types, evt.Type)
+		if evt.Type == "content_block_stop" {
+			sawContentBlockStop = true
+		}
 		if evt.Delta != nil && evt.Delta.Type == "text_delta" {
 			text += evt.Delta.Text
 		}
+		if evt.Delta != nil && evt.Delta.Type == "thinking_delta" {
+			thinking += evt.Delta.Thinking
+			if sawContentBlockStop {
+				thinkingAfterStop = true
+			}
+		}
 	}
 	require.Contains(t, types, "content_block_delta")
+	require.Equal(t, "think", thinking)
 	require.Equal(t, "visible answer", text)
+	require.False(t, thinkingAfterStop, "thinking_delta must precede content_block_stop, got %v", types)
 	require.Equal(t, 19449, state.InputTokens)
 	require.Equal(t, 608, state.OutputTokens)
 	require.True(t, state.TextEmitted)

--- a/backend/internal/pkg/apicompat/responses_to_anthropic.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic.go
@@ -194,6 +194,8 @@ type ResponsesEventToAnthropicState struct {
 	PendingThinkingSignature string
 	// ReasoningTextEmitted 避免 output_item.done 在已有 delta 时重复抄 thinking。
 	ReasoningTextEmitted bool
+	// TextEmitted 避免 response.completed.output 在已有 text delta 时重复抄正文。
+	TextEmitted bool
 
 	// OutputIndexToBlockIdx maps Responses output_index → Anthropic content block index.
 	OutputIndexToBlockIdx map[int]int
@@ -349,8 +351,14 @@ func ResponsesAnthropicEventToSSE(evt AnthropicStreamEvent) (string, error) {
 // --- internal handlers ---
 
 func resToAnthHandleCreated(evt *ResponsesStreamEvent, state *ResponsesEventToAnthropicState) []AnthropicStreamEvent {
-	if evt.Response != nil {
-		state.ResponseID = evt.Response.ID
+	return resToAnthEnsureMessageStart(state, evt)
+}
+
+func resToAnthEnsureMessageStart(state *ResponsesEventToAnthropicState, evt *ResponsesStreamEvent) []AnthropicStreamEvent {
+	if evt != nil && evt.Response != nil {
+		if id := strings.TrimSpace(evt.Response.ID); id != "" {
+			state.ResponseID = id
+		}
 		// Only use upstream model if no override was set (e.g. originalModel)
 		if state.Model == "" {
 			state.Model = evt.Response.Model
@@ -381,6 +389,70 @@ func resToAnthHandleCreated(evt *ResponsesStreamEvent, state *ResponsesEventToAn
 			},
 		},
 	}}
+}
+
+func resToAnthBackfillCompletedOutput(evt *ResponsesStreamEvent, state *ResponsesEventToAnthropicState) []AnthropicStreamEvent {
+	if evt == nil || evt.Response == nil {
+		return nil
+	}
+
+	var events []AnthropicStreamEvent
+	for _, item := range evt.Response.Output {
+		switch item.Type {
+		case "reasoning":
+			if state.ReasoningTextEmitted {
+				if sig := strings.TrimSpace(item.EncryptedContent); sig != "" && state.PendingThinkingSignature == "" {
+					state.PendingThinkingSignature = sig
+				}
+				continue
+			}
+			text := extractResponsesOutputReasoningText(&item)
+			if text == "" && strings.TrimSpace(item.EncryptedContent) == "" {
+				continue
+			}
+			events = append(events, resToAnthEnsureReasoningBlockOpen(state, 0)...)
+			if text != "" {
+				blockIdx := state.OutputIndexToBlockIdx[0]
+				events = append(events, AnthropicStreamEvent{
+					Type:  "content_block_delta",
+					Index: &blockIdx,
+					Delta: &AnthropicDelta{Type: "thinking_delta", Thinking: text},
+				})
+				state.ReasoningTextEmitted = true
+			}
+			if sig := strings.TrimSpace(item.EncryptedContent); sig != "" {
+				state.PendingThinkingSignature = sig
+			}
+			events = append(events, closeCurrentBlock(state)...)
+		case "message":
+			if state.TextEmitted {
+				continue
+			}
+			var text strings.Builder
+			for _, part := range item.Content {
+				if part.Type == "output_text" && part.Text != "" {
+					_, _ = text.WriteString(part.Text)
+				}
+			}
+			if text.Len() == 0 {
+				continue
+			}
+			events = append(events, resToAnthHandleTextDelta(&ResponsesStreamEvent{Delta: text.String()}, state)...)
+			events = append(events, closeCurrentBlock(state)...)
+		case "function_call", "custom_tool_call":
+			if state.HasToolCall {
+				continue
+			}
+			events = append(events, resToAnthHandleOutputItemAdded(&ResponsesStreamEvent{
+				Item: &item,
+			}, state)...)
+			if item.Arguments != "" {
+				events = append(events, resToAnthHandleFuncArgsDelta(&ResponsesStreamEvent{Delta: item.Arguments}, state)...)
+			}
+			events = append(events, closeCurrentBlock(state)...)
+		}
+	}
+	return events
 }
 
 func resToAnthHandleOutputItemAdded(evt *ResponsesStreamEvent, state *ResponsesEventToAnthropicState) []AnthropicStreamEvent {
@@ -463,6 +535,7 @@ func resToAnthHandleTextDelta(evt *ResponsesStreamEvent, state *ResponsesEventTo
 			Text: evt.Delta,
 		},
 	})
+	state.TextEmitted = true
 	return events
 }
 
@@ -714,7 +787,13 @@ func resToAnthHandleCompleted(evt *ResponsesStreamEvent, state *ResponsesEventTo
 	}
 
 	var events []AnthropicStreamEvent
+	events = append(events, resToAnthEnsureMessageStart(state, evt)...)
 	events = append(events, closeCurrentBlock(state)...)
+	// Codex / edge-mirror hops often buffer visible text into the terminal
+	// response.output after a long reasoning wait and omit output_text.delta.
+	// Backfill those items before the US-027 empty-text firewall so Claude
+	// Code receives the real answer instead of an empty content block.
+	events = append(events, resToAnthBackfillCompletedOutput(evt, state)...)
 	// US-027 schema firewall: a terminal event MUST be preceded by at least one
 	// content_block_start/_stop pair. If the upstream stream emitted neither
 	// real content nor a synthesizable delta, inject an empty-text block here so

--- a/backend/internal/pkg/apicompat/responses_to_anthropic.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic.go
@@ -788,12 +788,13 @@ func resToAnthHandleCompleted(evt *ResponsesStreamEvent, state *ResponsesEventTo
 
 	var events []AnthropicStreamEvent
 	events = append(events, resToAnthEnsureMessageStart(state, evt)...)
-	events = append(events, closeCurrentBlock(state)...)
 	// Codex / edge-mirror hops often buffer visible text into the terminal
 	// response.output after a long reasoning wait and omit output_text.delta.
-	// Backfill those items before the US-027 empty-text firewall so Claude
-	// Code receives the real answer instead of an empty content block.
+	// Backfill while the current thinking block is still open so reasoning
+	// text is not written after content_block_stop. Then close leftover
+	// blocks before the US-027 empty-text firewall.
 	events = append(events, resToAnthBackfillCompletedOutput(evt, state)...)
+	events = append(events, closeCurrentBlock(state)...)
 	// US-027 schema firewall: a terminal event MUST be preceded by at least one
 	// content_block_start/_stop pair. If the upstream stream emitted neither
 	// real content nor a synthesizable delta, inject an empty-text block here so

--- a/backend/internal/pkg/apicompat/types.go
+++ b/backend/internal/pkg/apicompat/types.go
@@ -626,6 +626,50 @@ type ResponsesStreamEvent struct {
 	SequenceNumber int `json:"sequence_number,omitempty"`
 }
 
+// UnmarshalJSON accepts both the public Responses string delta and Codex/compat
+// object deltas ({"text":"..."} / {"delta":"..."}). A typed object must not fail
+// the whole event — otherwise /v1/messages drops usage and visible text.
+func (e *ResponsesStreamEvent) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	deltaRaw := fields["delta"]
+	delete(fields, "delta")
+	normalized, err := json.Marshal(fields)
+	if err != nil {
+		return err
+	}
+	type responsesStreamEventAlias ResponsesStreamEvent
+	var decoded responsesStreamEventAlias
+	if err := json.Unmarshal(normalized, &decoded); err != nil {
+		return err
+	}
+	*e = ResponsesStreamEvent(decoded)
+	e.Delta = parseResponsesDeltaField(deltaRaw)
+	return nil
+}
+
+func parseResponsesDeltaField(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return text
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return ""
+	}
+	for _, key := range []string{"text", "delta", "content"} {
+		if value, ok := obj[key].(string); ok {
+			return value
+		}
+	}
+	return ""
+}
+
 // ---------------------------------------------------------------------------
 // OpenAI Chat Completions API types
 // ---------------------------------------------------------------------------

--- a/backend/internal/service/gateway_service_tk_header_wait_keepalive.go
+++ b/backend/internal/service/gateway_service_tk_header_wait_keepalive.go
@@ -3,10 +3,17 @@ package service
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/gin-gonic/gin"
+)
+
+const (
+	tkAnthropicStreamModelKey      = "tk_anthropic_stream_model"
+	tkAnthropicMessageStartSentKey = "tk_anthropic_message_start_sent"
 )
 
 // anthropicSSEPingFrame is the Anthropic-shaped SSE keepalive frame. It is byte
@@ -100,7 +107,74 @@ func (s *OpenAIGatewayService) beginAnthropicClientHeaderWaitKeepalive(c *gin.Co
 	if s == nil || s.cfg == nil {
 		return nil
 	}
-	return beginConfiguredHeaderWaitKeepalive(c, reqStream, s.cfg.Gateway.StreamKeepaliveInterval, anthropicSSEPingFrame)
+	if !reqStream || s.cfg.Gateway.StreamKeepaliveInterval <= 0 {
+		return nil
+	}
+	// Claude Code requires message_start as the first typed Anthropic event.
+	// A late Codex/edge first token (~12s) otherwise lets the 10s header-wait
+	// ping commit the stream first; CC then treats later deltas as idle/empty.
+	return startHeaderWaitKeepaliveWithPrefix(
+		c,
+		time.Duration(s.cfg.Gateway.StreamKeepaliveInterval)*time.Second,
+		anthropicStreamMessageStartSSE(anthropicStreamModelFromContext(c), ""),
+		anthropicSSEPingFrame,
+		func() { markAnthropicMessageStartSent(c) },
+	)
+}
+
+func setAnthropicStreamModel(c *gin.Context, model string) {
+	if c == nil {
+		return
+	}
+	c.Set(tkAnthropicStreamModelKey, strings.TrimSpace(model))
+}
+
+func anthropicStreamModelFromContext(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	if value, ok := c.Get(tkAnthropicStreamModelKey); ok {
+		if model, ok := value.(string); ok {
+			return model
+		}
+	}
+	return ""
+}
+
+func markAnthropicMessageStartSent(c *gin.Context) {
+	if c == nil {
+		return
+	}
+	c.Set(tkAnthropicMessageStartSentKey, true)
+}
+
+func anthropicMessageStartAlreadySent(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	value, ok := c.Get(tkAnthropicMessageStartSentKey)
+	sent, isBool := value.(bool)
+	return ok && isBool && sent
+}
+
+func anthropicStreamMessageStartSSE(model, id string) string {
+	state := apicompat.NewResponsesEventToAnthropicState()
+	state.Model = strings.TrimSpace(model)
+	events := apicompat.ResponsesEventToAnthropicEvents(&apicompat.ResponsesStreamEvent{
+		Type: "response.created",
+		Response: &apicompat.ResponsesResponse{
+			ID:    strings.TrimSpace(id),
+			Model: state.Model,
+		},
+	}, state)
+	if len(events) == 0 {
+		return ""
+	}
+	sse, err := apicompat.ResponsesAnthropicEventToSSE(events[0])
+	if err != nil {
+		return ""
+	}
+	return sse
 }
 
 // beginConfiguredHeaderWaitKeepalive is the shared constructor used by every
@@ -142,6 +216,16 @@ func (s *GeminiMessagesCompatService) beginSSECommentHeaderWaitKeepalive(c *gin.
 // bytes emitted each tick (platform specific). interval <= 0, a nil
 // context/writer, or a writer that cannot flush all yield a nil no-op.
 func startHeaderWaitKeepalive(c *gin.Context, interval time.Duration, frame string) *headerWaitKeepalive {
+	return startHeaderWaitKeepaliveWithPrefix(c, interval, "", frame, nil)
+}
+
+func startHeaderWaitKeepaliveWithPrefix(
+	c *gin.Context,
+	interval time.Duration,
+	firstFrame string,
+	frame string,
+	afterFirstWrite func(),
+) *headerWaitKeepalive {
 	if interval <= 0 || c == nil || c.Writer == nil || c.Request == nil {
 		return nil
 	}
@@ -160,6 +244,7 @@ func startHeaderWaitKeepalive(c *gin.Context, interval time.Duration, frame stri
 		defer ticker.Stop()
 		ctxDone := c.Request.Context().Done()
 		headersSent := false
+		wroteFirst := false
 		for {
 			select {
 			case <-k.stopCh:
@@ -186,11 +271,21 @@ func startHeaderWaitKeepalive(c *gin.Context, interval time.Duration, frame stri
 					h.Set("X-Accel-Buffering", "no")
 					headersSent = true
 				}
-				if _, err := fmt.Fprint(c.Writer, frame); err != nil {
+				toWrite := frame
+				if !wroteFirst && firstFrame != "" {
+					toWrite = firstFrame + frame
+				}
+				if _, err := fmt.Fprint(c.Writer, toWrite); err != nil {
 					// Client is gone; stop emitting. The upstream read path will
 					// observe the disconnect via context cancellation or its own
 					// write failure once it takes over.
 					return
+				}
+				if !wroteFirst {
+					wroteFirst = true
+					if afterFirstWrite != nil {
+						afterFirstWrite()
+					}
 				}
 				flusher.Flush()
 			}

--- a/backend/internal/service/gateway_service_tk_header_wait_keepalive.go
+++ b/backend/internal/service/gateway_service_tk_header_wait_keepalive.go
@@ -110,15 +110,22 @@ func (s *OpenAIGatewayService) beginAnthropicClientHeaderWaitKeepalive(c *gin.Co
 	if !reqStream || s.cfg.Gateway.StreamKeepaliveInterval <= 0 {
 		return nil
 	}
-	// Claude Code requires message_start as the first typed Anthropic event.
-	// A late Codex/edge first token (~12s) otherwise lets the 10s header-wait
-	// ping commit the stream first; CC then treats later deltas as idle/empty.
+	// Claude Code requires message_start as the first typed Anthropic event
+	// on the Responses→Anthropic compat path. Native Anthropic / chat
+	// fallback callers share this helper and must keep ping-only frames:
+	// a synthetic message_start would duplicate the real upstream one.
+	firstFrame := ""
+	var afterFirstWrite func()
+	if anthropicStreamModelWasSet(c) {
+		firstFrame = anthropicStreamMessageStartSSE(anthropicStreamModelFromContext(c), "")
+		afterFirstWrite = func() { markAnthropicMessageStartSent(c) }
+	}
 	return startHeaderWaitKeepaliveWithPrefix(
 		c,
 		time.Duration(s.cfg.Gateway.StreamKeepaliveInterval)*time.Second,
-		anthropicStreamMessageStartSSE(anthropicStreamModelFromContext(c), ""),
+		firstFrame,
 		anthropicSSEPingFrame,
-		func() { markAnthropicMessageStartSent(c) },
+		afterFirstWrite,
 	)
 }
 
@@ -139,6 +146,14 @@ func anthropicStreamModelFromContext(c *gin.Context) string {
 		}
 	}
 	return ""
+}
+
+func anthropicStreamModelWasSet(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	_, ok := c.Get(tkAnthropicStreamModelKey)
+	return ok
 }
 
 func markAnthropicMessageStartSent(c *gin.Context) {

--- a/backend/internal/service/gateway_service_tk_header_wait_keepalive_test.go
+++ b/backend/internal/service/gateway_service_tk_header_wait_keepalive_test.go
@@ -96,6 +96,12 @@ func TestOpenAIGatewayService_BeginAnthropicClientHeaderWaitKeepaliveUsesPingFra
 	if !strings.Contains(body, "event: ping") {
 		t.Fatalf("messages client keepalive must emit Anthropic ping, got %q", body)
 	}
+	if !strings.Contains(body, "event: message_start") {
+		t.Fatalf("messages client keepalive must emit message_start before ping, got %q", body)
+	}
+	if strings.Index(body, "event: message_start") > strings.Index(body, "event: ping") {
+		t.Fatalf("message_start must precede ping, got %q", body)
+	}
 	if strings.Contains(body, ":\n\n") && !strings.Contains(body, "event: ping") {
 		t.Fatalf("messages client keepalive must not be an OpenAI comment, got %q", body)
 	}

--- a/backend/internal/service/gateway_service_tk_header_wait_keepalive_test.go
+++ b/backend/internal/service/gateway_service_tk_header_wait_keepalive_test.go
@@ -84,6 +84,7 @@ func TestStartHeaderWaitKeepalive_DisabledReturnsNil(t *testing.T) {
 
 func TestOpenAIGatewayService_BeginAnthropicClientHeaderWaitKeepaliveUsesPingFrame(t *testing.T) {
 	c, rec := newKeepaliveTestContext(t)
+	setAnthropicStreamModel(c, "gpt-5.4")
 	svc := &OpenAIGatewayService{cfg: &config.Config{Gateway: config.GatewayConfig{StreamKeepaliveInterval: 1}}}
 	k := svc.beginAnthropicClientHeaderWaitKeepalive(c, true)
 	if k == nil {
@@ -104,6 +105,25 @@ func TestOpenAIGatewayService_BeginAnthropicClientHeaderWaitKeepaliveUsesPingFra
 	}
 	if strings.Contains(body, ":\n\n") && !strings.Contains(body, "event: ping") {
 		t.Fatalf("messages client keepalive must not be an OpenAI comment, got %q", body)
+	}
+}
+
+func TestOpenAIGatewayService_BeginAnthropicClientHeaderWaitKeepaliveNativePingOnly(t *testing.T) {
+	c, rec := newKeepaliveTestContext(t)
+	svc := &OpenAIGatewayService{cfg: &config.Config{Gateway: config.GatewayConfig{StreamKeepaliveInterval: 1}}}
+	k := svc.beginAnthropicClientHeaderWaitKeepalive(c, true)
+	if k == nil {
+		t.Fatal("expected non-nil Anthropic client keepalive handle")
+	}
+	time.Sleep(1100 * time.Millisecond)
+	k.stop()
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "event: ping") {
+		t.Fatalf("native messages keepalive must still emit Anthropic ping, got %q", body)
+	}
+	if strings.Contains(body, "event: message_start") {
+		t.Fatalf("native/chat fallback keepalive must not synthesize message_start, got %q", body)
 	}
 }
 

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -1384,13 +1384,22 @@ func (s *OpenAIGatewayService) handleAnthropicJSONResponsesAsStream(
 		return nil, s.newOpenAIStreamFailoverError(c, account, false, requestID, body, "OpenAI messages upstream returned non-SSE JSON without a Responses object")
 	}
 
+	status := strings.TrimSpace(finalResponse.Status)
+	if status == "failed" {
+		return s.handleAnthropicJSONResponsesFailed(resp, c, account, requestID, body, &finalResponse)
+	}
+
 	state := apicompat.NewResponsesEventToAnthropicState()
 	state.Model = originalModel
 	if anthropicMessageStartAlreadySent(c) {
 		state.MessageStartSent = true
 	}
+	eventType := "response.completed"
+	if status == "incomplete" {
+		eventType = "response.incomplete"
+	}
 	events := apicompat.ResponsesEventToAnthropicEvents(&apicompat.ResponsesStreamEvent{
-		Type:     "response.completed",
+		Type:     eventType,
 		Response: &finalResponse,
 	}, state)
 	writeStreamHeaders := s.newStreamHeaderWriter(c, resp.Header)
@@ -1429,8 +1438,64 @@ func (s *OpenAIGatewayService) handleAnthropicJSONResponsesAsStream(
 		IncompleteReason:              state.IncompleteReason,
 		ContentTextLen:                utf8.RuneCountInString(collectAnthropicStreamText(events)),
 	}
-	logOpenAISuccessMissingUsage(c.Request.Context(), c, account, resp, &usage, "response.completed", false)
+	logOpenAISuccessMissingUsage(c.Request.Context(), c, account, resp, &usage, eventType, false)
 	return result, nil
+}
+
+func (s *OpenAIGatewayService) handleAnthropicJSONResponsesFailed(
+	resp *http.Response,
+	c *gin.Context,
+	account *Account,
+	requestID string,
+	body []byte,
+	finalResponse *apicompat.ResponsesResponse,
+) (*OpenAIForwardResult, error) {
+	payload := body
+	if gjson.GetBytes(body, "type").String() != "response.failed" {
+		if wrapped, wrapErr := json.Marshal(gin.H{"type": "response.failed", "response": finalResponse}); wrapErr == nil {
+			payload = wrapped
+		}
+	}
+	usage := OpenAIUsage{}
+	if finalResponse != nil && finalResponse.Usage != nil {
+		usage = copyOpenAIUsageFromResponsesUsage(finalResponse.Usage)
+	}
+	if hit, code, msg := detectOpenAICyberPolicy(payload); hit {
+		MarkOpsCyberPolicy(c, CyberPolicyMark{
+			Code:           code,
+			Message:        msg,
+			Body:           truncateString(string(payload), 4096),
+			UpstreamStatus: http.StatusOK,
+			UpstreamInTok:  usage.InputTokens,
+			UpstreamOutTok: usage.OutputTokens,
+		})
+		clientMsg := msg
+		if clientMsg == "" {
+			clientMsg = "Request blocked by upstream cyber-security policy"
+		}
+		if c.Writer.Written() {
+			if _, writeErr := fmt.Fprint(c.Writer, buildAnthropicStreamErrorSSE("invalid_request_error", clientMsg)); writeErr == nil {
+				c.Writer.Flush()
+			}
+		} else {
+			writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", clientMsg)
+		}
+		return nil, fmt.Errorf("openai cyber_policy: %s", msg)
+	}
+	message := extractOpenAISSEErrorMessage(payload)
+	if !c.Writer.Written() && openAIStreamFailedEventShouldFailover(payload, message) {
+		return nil, s.newOpenAIStreamFailoverError(c, account, false, requestID, payload, message, resp.Header)
+	}
+	message = s.recordOpenAIStreamUpstreamError(c, account, false, requestID, "http_error", payload, message)
+	errStatus, errType := openAIStreamFailedClientResponse(payload, message, "api_error")
+	if c.Writer.Written() {
+		if _, writeErr := fmt.Fprint(c.Writer, buildAnthropicStreamErrorSSE(errType, message)); writeErr == nil {
+			c.Writer.Flush()
+		}
+	} else {
+		writeAnthropicError(c, errStatus, errType, message)
+	}
+	return nil, fmt.Errorf("upstream response failed: %s", message)
 }
 
 func collectAnthropicStreamText(events []apicompat.AnthropicStreamEvent) string {

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -363,6 +363,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 				return nil, fmt.Errorf("build grok retry request: %w", err)
 			}
 		}
+		setAnthropicStreamModel(c, originalModel)
 		hwka := s.beginAnthropicClientHeaderWaitKeepalive(c, isStream)
 		resp, err = s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
 		hwka.stop()
@@ -507,7 +508,11 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	var result *OpenAIForwardResult
 	var handleErr error
 	if clientStream {
-		result, handleErr = s.handleAnthropicStreamingResponse(resp, c, account, originalModel, billingModel, upstreamModel, startTime)
+		if resp != nil && !isEventStreamResponse(resp.Header) {
+			result, handleErr = s.handleAnthropicJSONResponsesAsStream(resp, c, account, originalModel, billingModel, upstreamModel, startTime)
+		} else {
+			result, handleErr = s.handleAnthropicStreamingResponse(resp, c, account, originalModel, billingModel, upstreamModel, startTime)
+		}
 	} else {
 		// Client wants JSON: buffer the streaming response and assemble a JSON reply.
 		result, handleErr = s.handleAnthropicBufferedStreamingResponse(resp, c, account, originalModel, billingModel, upstreamModel, startTime)
@@ -922,6 +927,9 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 
 	state := apicompat.NewResponsesEventToAnthropicState()
 	state.Model = originalModel
+	if anthropicMessageStartAlreadySent(c) {
+		state.MessageStartSent = true
+	}
 	var usage OpenAIUsage
 	responseID := ""
 	contentTextLen := 0
@@ -1317,8 +1325,27 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 			if time.Since(lastDataAt) < keepaliveInterval {
 				continue
 			}
-			// Send Anthropic-format ping event
+			// Send Anthropic-format ping event. message_start must precede the
+			// first ping so Claude Code does not drop a late-first-token stream.
 			writeStreamHeaders()
+			if !state.MessageStartSent {
+				for _, evt := range apicompat.ResponsesEventToAnthropicEvents(&apicompat.ResponsesStreamEvent{Type: "response.created"}, state) {
+					sse, err := apicompat.ResponsesAnthropicEventToSSE(evt)
+					if err != nil {
+						continue
+					}
+					if _, err := fmt.Fprint(c.Writer, sse); err != nil {
+						clientDisconnected = true
+						break
+					}
+				}
+				if !clientDisconnected {
+					markAnthropicMessageStartSent(c)
+				}
+			}
+			if clientDisconnected {
+				continue
+			}
 			if _, err := fmt.Fprint(c.Writer, "event: ping\ndata: {\"type\":\"ping\"}\n\n"); err != nil {
 				// Client disconnected
 				logger.L().Info("openai messages stream: client disconnected during keepalive",
@@ -1331,6 +1358,89 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 			c.Writer.Flush()
 		}
 	}
+}
+
+func (s *OpenAIGatewayService) handleAnthropicJSONResponsesAsStream(
+	resp *http.Response,
+	c *gin.Context,
+	account *Account,
+	originalModel string,
+	billingModel string,
+	upstreamModel string,
+	startTime time.Time,
+) (*OpenAIForwardResult, error) {
+	requestID := resp.Header.Get("x-request-id")
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read json responses body: %w", err)
+	}
+	if bodyHasSSEFraming(body) {
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		return s.handleAnthropicStreamingResponse(resp, c, account, originalModel, billingModel, upstreamModel, startTime)
+	}
+
+	var finalResponse apicompat.ResponsesResponse
+	if err := json.Unmarshal(body, &finalResponse); err != nil || (strings.TrimSpace(finalResponse.ID) == "" && strings.TrimSpace(finalResponse.Status) == "") {
+		return nil, s.newOpenAIStreamFailoverError(c, account, false, requestID, body, "OpenAI messages upstream returned non-SSE JSON without a Responses object")
+	}
+
+	state := apicompat.NewResponsesEventToAnthropicState()
+	state.Model = originalModel
+	if anthropicMessageStartAlreadySent(c) {
+		state.MessageStartSent = true
+	}
+	events := apicompat.ResponsesEventToAnthropicEvents(&apicompat.ResponsesStreamEvent{
+		Type:     "response.completed",
+		Response: &finalResponse,
+	}, state)
+	writeStreamHeaders := s.newStreamHeaderWriter(c, resp.Header)
+	for _, evt := range events {
+		sse, marshalErr := apicompat.ResponsesAnthropicEventToSSE(evt)
+		if marshalErr != nil {
+			continue
+		}
+		writeStreamHeaders()
+		if _, writeErr := fmt.Fprint(c.Writer, sse); writeErr != nil {
+			break
+		}
+	}
+	if len(events) > 0 {
+		c.Writer.Flush()
+	}
+
+	usage := OpenAIUsage{}
+	if finalResponse.Usage != nil {
+		usage = copyOpenAIUsageFromResponsesUsage(finalResponse.Usage)
+	}
+	ms := int(time.Since(startTime).Milliseconds())
+	result := &OpenAIForwardResult{
+		RequestID:                     requestID,
+		ResponseID:                    finalResponse.ID,
+		Usage:                         usage,
+		Model:                         originalModel,
+		BillingModel:                  billingModel,
+		UpstreamModel:                 upstreamModel,
+		UpstreamResponseModel:         observedUpstreamResponseModel(c),
+		UpstreamResponseModelConflict: observedUpstreamResponseModelConflict(c),
+		Stream:                        true,
+		Duration:                      time.Since(startTime),
+		FirstTokenMs:                  &ms,
+		StopReason:                    state.StopReason,
+		IncompleteReason:              state.IncompleteReason,
+		ContentTextLen:                utf8.RuneCountInString(collectAnthropicStreamText(events)),
+	}
+	logOpenAISuccessMissingUsage(c.Request.Context(), c, account, resp, &usage, "response.completed", false)
+	return result, nil
+}
+
+func collectAnthropicStreamText(events []apicompat.AnthropicStreamEvent) string {
+	var text strings.Builder
+	for _, evt := range events {
+		if evt.Delta != nil && evt.Delta.Type == "text_delta" {
+			_, _ = text.WriteString(evt.Delta.Text)
+		}
+	}
+	return text.String()
 }
 
 // writeAnthropicError writes an error response in Anthropic Messages API format.

--- a/backend/internal/service/openai_gateway_messages_native_test.go
+++ b/backend/internal/service/openai_gateway_messages_native_test.go
@@ -5,6 +5,7 @@ package service
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -274,4 +275,35 @@ func TestForwardAsAnthropic_JSONNonResponsesBodyIsFailover(t *testing.T) {
 	require.Error(t, err)
 	var failover *UpstreamFailoverError
 	require.ErrorAs(t, err, &failover)
+}
+
+func TestForwardAsAnthropic_JSONFailedResponsesIsError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+
+	upstreamJSON := `{
+		"id":"resp_failed","object":"response","model":"gpt-5.4","status":"failed",
+		"output":[],
+		"error":{"code":"invalid_request_error","message":"messages is not allowed for this model"},
+		"usage":{"input_tokens":3,"output_tokens":0}
+	}`
+	svc := &OpenAIGatewayService{
+		cfg: rawChatCompletionsTestConfig(),
+		httpUpstream: &httpUpstreamRecorder{resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(upstreamJSON)),
+		}},
+	}
+
+	_, err := svc.ForwardAsAnthropic(context.Background(), c, rawChatCompletionsTestAccount(), body, "", "")
+	require.Error(t, err)
+	var failover *UpstreamFailoverError
+	require.False(t, errors.As(err, &failover), "non-retryable failed JSON must not failover")
+	require.NotContains(t, rec.Body.String(), "event: message_stop")
+	require.NotContains(t, rec.Body.String(), `"stop_reason":"end_turn"`)
 }

--- a/backend/internal/service/openai_gateway_messages_native_test.go
+++ b/backend/internal/service/openai_gateway_messages_native_test.go
@@ -210,6 +210,68 @@ func TestForwardAsAnthropic_HeaderWaitKeepaliveEmitsAnthropicPing(t *testing.T) 
 	result, err := svc.ForwardAsAnthropic(context.Background(), c, rawChatCompletionsTestAccount(), body, "", "")
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Contains(t, rec.Body.String(), "event: ping",
+	bodyOut := rec.Body.String()
+	require.Contains(t, bodyOut, "event: ping",
 		"Claude /v1/messages clients must receive Anthropic ping while waiting on upstream headers")
+	require.Contains(t, bodyOut, "event: message_start")
+	require.Less(t, strings.Index(bodyOut, "event: message_start"), strings.Index(bodyOut, "event: ping"),
+		"message_start must precede the first ping so Claude Code keeps the late-first-token stream")
+	require.Contains(t, bodyOut, `"text_delta"`)
+	require.Contains(t, bodyOut, "ok")
+	require.Equal(t, 5, result.Usage.InputTokens)
+	require.Equal(t, 2, result.Usage.OutputTokens)
+}
+
+func TestForwardAsAnthropic_JSONResponsesBodyStreamsVisibleText(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+
+	upstreamJSON := `{
+		"id":"resp_json","object":"response","model":"gpt-5.4","status":"completed",
+		"output":[{"type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"from json"}]}],
+		"usage":{"input_tokens":11,"output_tokens":4,"total_tokens":15}
+	}`
+	svc := &OpenAIGatewayService{
+		cfg: rawChatCompletionsTestConfig(),
+		httpUpstream: &httpUpstreamRecorder{resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(upstreamJSON)),
+		}},
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, rawChatCompletionsTestAccount(), body, "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 11, result.Usage.InputTokens)
+	require.Equal(t, 4, result.Usage.OutputTokens)
+	require.Contains(t, rec.Body.String(), "event: message_start")
+	require.Contains(t, rec.Body.String(), "from json")
+}
+
+func TestForwardAsAnthropic_JSONNonResponsesBodyIsFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+
+	svc := &OpenAIGatewayService{
+		cfg: rawChatCompletionsTestConfig(),
+		httpUpstream: &httpUpstreamRecorder{resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+		}},
+	}
+
+	_, err := svc.ForwardAsAnthropic(context.Background(), c, rawChatCompletionsTestAccount(), body, "", "")
+	require.Error(t, err)
+	var failover *UpstreamFailoverError
+	require.ErrorAs(t, err, &failover)
 }


### PR DESCRIPTION
## 摘要
Claude Code 用 TokenKey key 打 `gpt-5.4`（`/v1/messages` → GPT专线 openai-us* → edge Codex）时，edge 已生成正文，但客户端显示 Cooked/done 且无输出。

根因是 prod 的 Responses→Anthropic 流式回写：
- 默认 10s keepalive 会在 `message_start` 之前先发 `event: ping`，晚首包（约 12s）时 Claude Code 丢掉后续流
- Codex/edge 常把可见正文只放在 `response.completed.output`，转换器只注入空 text block
- object 形态 `delta` 或 JSON（非 SSE）200 会被整帧丢掉，计量也变成 0

本 PR：兼容路径先发 `message_start` 再 ping（native/chat fallback 仍只 ping）；从 completed.output 回填正文且不写到已关闭 thinking 块；兼容 object-delta 与 JSON Responses 体；failed JSON 按错误处理。

sentinel-registry-reviewed

## 风险
常规偏高：核心 `/v1/messages` 兼容路径。不改对外字段契约，不改 schema。纯后端，无 Web 面对齐。

## 验证
- `go test -tags=unit -count=1 ./internal/pkg/apicompat/` PASS
- `go test -tags=unit -count=1 ./internal/service/` PASS
- `./scripts/preflight.sh` PASS
- 正向：completed 回填 thinking+可见 text + usage；JSON Responses 体转成 Anthropic SSE；兼容路径 ping 前有 message_start
- 负向：非 Responses JSON 仍 failover；failed JSON 不写成功流；native keepalive 不合成 message_start；空 completed 仍注入空 text block（US-027）

## 提交
- `1fbb23bf6` fix(protocol): Claude /v1/messages 经 GPT 专线时把 Codex 正文和计量回写给客户端
- `1d2776b27` fix(protocol): address R-001..R-003 — native ping-only, open thinking backfill, failed JSON errors
- 最新提交：`1d2776b27`