### PR TITLE
fix(supplier): models-discover 全量异步并发探测与失败反馈

### DIFF
--- a/.testing/user-stories/stories/US-048-model-supplier-source-management.md
+++ b/.testing/user-stories/stories/US-048-model-supplier-source-management.md
@@ -22,7 +22,7 @@
 6. AC-006 (ownership): Given 账号 Extra 存在 `supplier_source_id`，When 普通账号单项、批量、复制、删除、从父账号创建影子账号、credentials/Extra/刷新凭证、状态、可调度或 CRS 导入覆盖尝试写入，Then service 层整体拒绝；普通创建和 CRS 导入不能伪造保留 Extra；供应源同步只走不携带 `rate_multiplier` 的窄写命令，只合并 `supplier_source_id`、`supplier_discount_band` 两个受管 Extra 并保留所有非受管 Extra，同时修复解析后的 NewAPI transport（OpenAI 或 Qianfan BaiduV2）与目标 `status/schedulable`。已有账号匹配覆盖全部未删除 NewAPI 候选，但只有 active 唯一精确匹配可接管；disabled/error 精确匹配返回冲突且不新建重复账号。恢复错误、配额重置、代理 fallback 与探测仍允许。真实账号 UI 显示“供应源托管”徽标和统一只读原因，点击后按 `source_id` 直接选中对应供应源。
 7. AC-007 (安全): Given 创建、更新、探测或同步供应源，When API、日志和 Admin Audit Log 记录请求与结果，Then 不包含凭证明文、密文、HMAC 指纹或上游原始响应；探测只返回固定状态、协议分类和脱敏说明；HMAC 指纹跟随凭证加密密钥而非 JWT secret 的生命周期。
 8. AC-008 (首批证据): Given 首批运营表和只读生产库存，When 记录验收结果，Then 三个案例必须各自提供完整准确的供应事实才能同步；信息不完整或不匹配时不扩大已有账号匹配、不改网关调度。佳杰/VSTECS 只保留两个最低合法比例 `0.50` 模型且因无生产凭证标记 `not_run`；FMGo 只保留 Seedance 显式双 ID 与 `protocol_unsupported`；百度千帆在凭证齐备时以 BaiduV2 transport 接管账号 90（channel_type=46），不以 OpenAI Chat 伪探测冒充成功。
-9. AC-009 (上游发现): Given 已保存供应源，When 点击“校验并同步”，Then 系统先 `models-discover`：拉取上游 models、规整已配置 ID、对未配置且可探测类型的候选做真实 Chat 探测（每次最多 8 个，超出记 `probe_skipped_budget`）；仅探测通过的进入建议追加（默认 ratio `1.0`），探测失败或非 chat 类型不得建议追加；有规整变更时回填表单草稿要求保存，建议追加需运营主动加入表单；无规整变更时继续既有投影同步。discover 不写供应源也不写账号。失败时管理页必须展示可读错误与 `failed_step`，不得只露出空标题。
+9. AC-009 (上游发现): Given 已保存供应源，When 点击“校验并同步”，Then 系统先 `models-discover`：同步拉取上游 models 并规整已配置 ID，随后异步高并发探测**全部**未配置且可探测类型的候选（轮询 job 至完成）；仅探测通过的进入建议追加（默认 ratio `1.0`），探测失败或非 chat 类型不得建议追加；有规整变更时回填表单草稿要求保存，建议追加需运营主动加入表单；无规整变更且探测完成后继续既有投影同步。discover 不写供应源也不写账号。失败时管理页必须展示可读错误与 `failed_step`，不得只露出空标题。
 
 ## Assertions
 
@@ -97,7 +97,7 @@
 - `backend/internal/service/supplier_models_discover_test.go`::`TestUS048_DiscoverModelsSuggestionsAloneDoNotBlockProjection`
 - `backend/internal/service/supplier_models_discover_test.go`::`TestUS048_DiscoverModelsPreservesIntentionalClientUpstreamRemap`
 - `backend/internal/service/supplier_models_discover_test.go`::`TestUS048_DiscoverModelsAuthFailureStopsWithoutSuggesting`
-- `backend/internal/service/supplier_models_discover_test.go`::`TestUS048_DiscoverModelsCapsCandidateProbesAndSkipsRest`
+- `backend/internal/service/supplier_models_discover_test.go`::`TestUS048_StartDiscoverModelsProbesAllCandidatesAsynchronously`
 - `backend/internal/service/supplier_models_discover_test.go`::`TestUS048_ExtractSupplierUpstreamModelEntriesKeepsType`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_FMGoSeedanceIsProtocolUnsupportedWithoutAccountWrite`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_SupplierManagedAccountDeclaresOnlyChatProtocol`

--- a/.testing/user-stories/stories/US-048-model-supplier-source-management.md
+++ b/.testing/user-stories/stories/US-048-model-supplier-source-management.md
@@ -22,7 +22,7 @@
 6. AC-006 (ownership): Given 账号 Extra 存在 `supplier_source_id`，When 普通账号单项、批量、复制、删除、从父账号创建影子账号、credentials/Extra/刷新凭证、状态、可调度或 CRS 导入覆盖尝试写入，Then service 层整体拒绝；普通创建和 CRS 导入不能伪造保留 Extra；供应源同步只走不携带 `rate_multiplier` 的窄写命令，只合并 `supplier_source_id`、`supplier_discount_band` 两个受管 Extra 并保留所有非受管 Extra，同时修复解析后的 NewAPI transport（OpenAI 或 Qianfan BaiduV2）与目标 `status/schedulable`。已有账号匹配覆盖全部未删除 NewAPI 候选，但只有 active 唯一精确匹配可接管；disabled/error 精确匹配返回冲突且不新建重复账号。恢复错误、配额重置、代理 fallback 与探测仍允许。真实账号 UI 显示“供应源托管”徽标和统一只读原因，点击后按 `source_id` 直接选中对应供应源。
 7. AC-007 (安全): Given 创建、更新、探测或同步供应源，When API、日志和 Admin Audit Log 记录请求与结果，Then 不包含凭证明文、密文、HMAC 指纹或上游原始响应；探测只返回固定状态、协议分类和脱敏说明；HMAC 指纹跟随凭证加密密钥而非 JWT secret 的生命周期。
 8. AC-008 (首批证据): Given 首批运营表和只读生产库存，When 记录验收结果，Then 三个案例必须各自提供完整准确的供应事实才能同步；信息不完整或不匹配时不扩大已有账号匹配、不改网关调度。佳杰/VSTECS 只保留两个最低合法比例 `0.50` 模型且因无生产凭证标记 `not_run`；FMGo 只保留 Seedance 显式双 ID 与 `protocol_unsupported`；百度千帆在凭证齐备时以 BaiduV2 transport 接管账号 90（channel_type=46），不以 OpenAI Chat 伪探测冒充成功。
-9. AC-009 (上游发现): Given 已保存供应源，When 点击“校验并同步”，Then 系统先 `models-discover`：拉取上游 models、规整已配置 ID、对未配置且可探测类型的候选做真实 Chat 探测；仅探测通过的进入建议追加（默认 ratio `1.0`），探测失败或非 chat 类型不得建议追加；有规整变更时回填表单草稿要求保存，建议追加需运营主动加入表单；无规整变更时继续既有投影同步。discover 不写供应源也不写账号。
+9. AC-009 (上游发现): Given 已保存供应源，When 点击“校验并同步”，Then 系统先 `models-discover`：拉取上游 models、规整已配置 ID、对未配置且可探测类型的候选做真实 Chat 探测（每次最多 8 个，超出记 `probe_skipped_budget`）；仅探测通过的进入建议追加（默认 ratio `1.0`），探测失败或非 chat 类型不得建议追加；有规整变更时回填表单草稿要求保存，建议追加需运营主动加入表单；无规整变更时继续既有投影同步。discover 不写供应源也不写账号。失败时管理页必须展示可读错误与 `failed_step`，不得只露出空标题。
 
 ## Assertions
 
@@ -97,6 +97,7 @@
 - `backend/internal/service/supplier_models_discover_test.go`::`TestUS048_DiscoverModelsSuggestionsAloneDoNotBlockProjection`
 - `backend/internal/service/supplier_models_discover_test.go`::`TestUS048_DiscoverModelsPreservesIntentionalClientUpstreamRemap`
 - `backend/internal/service/supplier_models_discover_test.go`::`TestUS048_DiscoverModelsAuthFailureStopsWithoutSuggesting`
+- `backend/internal/service/supplier_models_discover_test.go`::`TestUS048_DiscoverModelsCapsCandidateProbesAndSkipsRest`
 - `backend/internal/service/supplier_models_discover_test.go`::`TestUS048_ExtractSupplierUpstreamModelEntriesKeepsType`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_FMGoSeedanceIsProtocolUnsupportedWithoutAccountWrite`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_SupplierManagedAccountDeclaresOnlyChatProtocol`
@@ -115,6 +116,8 @@
 - `frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts`::`requires saving edited supplier facts before syncing the selected source`
 - `frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts`::`applies discover normalize to the form and keeps suggestions opt-in`
 - `frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts`::`continues to account sync when discover only has optional suggestions`
+- `frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts`::`shows discover failure message and failed_step outside the sync-result block`
+- `backend/internal/handler/admin/supplier_source_handler_test.go`::`TestUS048_DiscoverUpstreamListFailureReturnsSafeMessageAndFailedStep`
 - `frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts`::`renders every probe result and actual account change returned by sync`
 - `frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts`::`does not show success when a resolved sync result reports a failed step`
 - `frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts`::`shows protocol_unsupported probe results from a 422 response without success wording`

--- a/backend/internal/handler/admin/supplier_source_handler.go
+++ b/backend/internal/handler/admin/supplier_source_handler.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/response"
@@ -213,7 +214,25 @@ func (h *SupplierSourceHandler) DiscoverModels(c *gin.Context) {
 	if !ok {
 		return
 	}
-	result, err := h.service.DiscoverModels(c.Request.Context(), id)
+	result, err := h.service.StartDiscoverModels(c.Request.Context(), id)
+	if err != nil {
+		writeSupplierSourceDiscoverError(c, result, err)
+		return
+	}
+	response.Success(c, result)
+}
+
+func (h *SupplierSourceHandler) GetDiscoverModelsJob(c *gin.Context) {
+	id, ok := supplierSourceID(c)
+	if !ok {
+		return
+	}
+	jobID := strings.TrimSpace(c.Param("job_id"))
+	if jobID == "" {
+		response.InvalidRequest(c)
+		return
+	}
+	result, err := h.service.GetDiscoverModelsJob(c.Request.Context(), id, jobID)
 	if err != nil {
 		writeSupplierSourceDiscoverError(c, result, err)
 		return

--- a/backend/internal/handler/admin/supplier_source_handler.go
+++ b/backend/internal/handler/admin/supplier_source_handler.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -222,6 +223,16 @@ func (h *SupplierSourceHandler) DiscoverModels(c *gin.Context) {
 
 func writeSupplierSourceDiscoverError(c *gin.Context, result *service.SupplierModelsDiscoverResult, err error) {
 	statusCode, message, reason, metadata := supplierSourceHTTPError(err)
+	failedStep := ""
+	if result != nil {
+		failedStep = result.FailedStep
+	}
+	slog.Warn("supplier_models_discover_failed",
+		"status_code", statusCode,
+		"failed_step", failedStep,
+		"message", message,
+		"err", err.Error(),
+	)
 	c.JSON(statusCode, response.Response{
 		Code: statusCode, Message: message, Reason: reason, Metadata: metadata, Data: result,
 	})
@@ -249,6 +260,7 @@ func writeSupplierSourceError(c *gin.Context, err error) {
 }
 
 func supplierSourceHTTPError(err error) (int, string, string, map[string]string) {
+	var syncErr *service.UpstreamModelSyncError
 	switch {
 	case errors.Is(err, service.ErrSupplierSourceInvalidInput),
 		errors.Is(err, service.ErrSupplierSourceInvalidPurchaseRatio),
@@ -263,6 +275,13 @@ func supplierSourceHTTPError(err error) (int, string, string, map[string]string)
 		errors.Is(err, service.ErrSupplierProjectionProtocolNotReady):
 		status := infraerrors.FromError(err)
 		return int(status.Code), status.Message, status.Reason, status.Metadata
+	case errors.As(err, &syncErr):
+		switch syncErr.Kind {
+		case service.UpstreamModelSyncErrorConfiguration, service.UpstreamModelSyncErrorUnsupported:
+			return http.StatusBadRequest, syncErr.SafeMessage(), "", nil
+		default:
+			return http.StatusBadGateway, syncErr.SafeMessage(), "", nil
+		}
 	default:
 		return http.StatusInternalServerError, "supplier source operation failed", "", nil
 	}

--- a/backend/internal/handler/admin/supplier_source_handler_test.go
+++ b/backend/internal/handler/admin/supplier_source_handler_test.go
@@ -79,13 +79,48 @@ func TestUS048_SupplierSourceErrorsUseStableHTTPClasses(t *testing.T) {
 		{service.ErrSupplierSourceIdentityConflict, http.StatusConflict},
 		{service.ErrSupplierSourceProbeFailed, http.StatusUnprocessableEntity},
 		{service.ErrSupplierProjectionProtocolNotReady, http.StatusUnprocessableEntity},
+		{&service.UpstreamModelSyncError{
+			Kind: service.UpstreamModelSyncErrorConfiguration, Message: "No supplier API key is available",
+		}, http.StatusBadRequest},
+		{&service.UpstreamModelSyncError{
+			Kind: service.UpstreamModelSyncErrorUpstream, Message: "Supplier model list request failed with HTTP 401",
+		}, http.StatusBadGateway},
 	}
 	for _, tt := range tests {
 		recorder := httptest.NewRecorder()
 		ctx, _ := gin.CreateTestContext(recorder)
 		writeSupplierSourceError(ctx, tt.err)
-		require.Equal(t, tt.want, recorder.Code)
+		require.Equal(t, tt.want, recorder.Code, tt.err.Error())
 	}
+}
+
+func TestUS048_DiscoverUpstreamListFailureReturnsSafeMessageAndFailedStep(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	result := &service.SupplierModelsDiscoverResult{
+		SourceID:           3,
+		UpstreamModels:     []service.SupplierUpstreamModelEntry{},
+		NormalizedModels:   []service.SupplierSourceModel{},
+		NormalizedChanges:  []service.SupplierModelNormalizeChange{},
+		SuggestedAppends:   []service.SupplierSourceModel{},
+		RejectedCandidates: []service.SupplierModelDiscoverRejection{},
+		ConfiguredIssues:   []service.SupplierModelDiscoverIssue{},
+		ProbeResults:       []service.SupplierProbeResult{},
+		FailedStep:         "list_upstream_models",
+	}
+	writeSupplierSourceDiscoverError(ctx, result, &service.UpstreamModelSyncError{
+		Kind:    service.UpstreamModelSyncErrorUpstream,
+		Message: "Supplier model list request failed with HTTP 401",
+		Err:     errors.New("supplier model list returned HTTP 401"),
+	})
+
+	require.Equal(t, http.StatusBadGateway, recorder.Code)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &payload))
+	require.Equal(t, "Supplier model list request failed with HTTP 401", payload["message"])
+	data, ok := payload["data"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "list_upstream_models", data["failed_step"])
 }
 
 func TestUS048_SupplierSourceProbeFailureReturns422WithCompleteResult(t *testing.T) {

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -151,6 +151,7 @@ func registerSupplierSourceRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 		sources.GET("/:id", h.Admin.SupplierSource.Get)
 		sources.PUT("/:id", h.Admin.SupplierSource.Update)
 		sources.POST("/:id/models-discover", h.Admin.SupplierSource.DiscoverModels)
+		sources.GET("/:id/models-discover/jobs/:job_id", h.Admin.SupplierSource.GetDiscoverModelsJob)
 		sources.POST("/:id/sync", h.Admin.SupplierSource.Sync)
 	}
 }

--- a/backend/internal/server/routes/admin_routes_test.go
+++ b/backend/internal/server/routes/admin_routes_test.go
@@ -55,6 +55,7 @@ func TestUS048_SupplierSourceRoutesAreRegistered(t *testing.T) {
 		{http.MethodGet, "/api/v1/admin/supplier-sources/:id"},
 		{http.MethodPut, "/api/v1/admin/supplier-sources/:id"},
 		{http.MethodPost, "/api/v1/admin/supplier-sources/:id/models-discover"},
+		{http.MethodGet, "/api/v1/admin/supplier-sources/:id/models-discover/jobs/:job_id"},
 		{http.MethodPost, "/api/v1/admin/supplier-sources/:id/sync"},
 	} {
 		require.True(t, registered[tt.method+" "+tt.path], "path=%s should be registered", tt.path)

--- a/backend/internal/service/supplier_models_discover.go
+++ b/backend/internal/service/supplier_models_discover.go
@@ -294,11 +294,12 @@ func (s *SupplierSourceService) GetDiscoverModelsJob(ctx context.Context, source
 	}
 	job, ok := s.discoverJobRegistry().get(sourceID, jobID)
 	if !ok || job == nil {
+		// Poll-friendly: expired/superseded jobs are not "source missing".
 		result := emptySupplierModelsDiscoverResult(sourceID)
 		result.JobID = jobID
 		result.FailedStep = "job_not_found"
 		result.ProbeStatus = SupplierDiscoverProbeFailed
-		return result, ErrSupplierSourceNotFound
+		return result, nil
 	}
 	result := job.snapshot()
 	return result, nil

--- a/backend/internal/service/supplier_models_discover.go
+++ b/backend/internal/service/supplier_models_discover.go
@@ -2,19 +2,32 @@ package service
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 const (
 	supplierDiscoverDefaultPurchaseRatio = 1.0
-	supplierDiscoverProbeConcurrency     = 4
-	// Cap live Chat probes so “校验并同步” stays within the admin UI timeout.
-	// Remaining probeable candidates are rejected as probe_skipped_budget (not suggested).
-	supplierDiscoverMaxCandidateProbes = 8
+	// Concurrent live Chat probes for one discover job. Admin-only, long-running.
+	supplierDiscoverProbeConcurrency = 8
+	supplierDiscoverJobTTL           = 30 * time.Minute
+	supplierDiscoverProbeTimeout     = 15 * time.Minute
+)
+
+// SupplierDiscoverProbeStatus is the async candidate-probe lifecycle for models-discover.
+type SupplierDiscoverProbeStatus string
+
+const (
+	SupplierDiscoverProbePending   SupplierDiscoverProbeStatus = "pending"
+	SupplierDiscoverProbeRunning   SupplierDiscoverProbeStatus = "running"
+	SupplierDiscoverProbeCompleted SupplierDiscoverProbeStatus = "completed"
+	SupplierDiscoverProbeFailed    SupplierDiscoverProbeStatus = "failed"
 )
 
 // SupplierModelNormalizeChange records a configured-row rewrite to a canonical upstream id.
@@ -41,10 +54,15 @@ type SupplierModelDiscoverRejection struct {
 }
 
 // SupplierModelsDiscoverResult is a read-only preview used by “校验并同步” before account projection.
+// List + normalize return immediately; candidate Chat probes continue asynchronously under JobID.
 // It never writes accounts or the supplier source row. The UI applies NormalizedModels when
 // NeedsConfirmation is set; SuggestedAppends stay opt-in via an explicit form action.
 type SupplierModelsDiscoverResult struct {
 	SourceID           int64                            `json:"source_id"`
+	JobID              string                           `json:"job_id,omitempty"`
+	ProbeStatus        SupplierDiscoverProbeStatus      `json:"probe_status"`
+	ProbeTotal         int                              `json:"probe_total"`
+	ProbeDone          int                              `json:"probe_done"`
 	UpstreamModels     []SupplierUpstreamModelEntry     `json:"upstream_models"`
 	NormalizedModels   []SupplierSourceModel            `json:"normalized_models"`
 	NormalizedChanges  []SupplierModelNormalizeChange   `json:"normalized_changes"`
@@ -56,39 +74,70 @@ type SupplierModelsDiscoverResult struct {
 	FailedStep         string                           `json:"failed_step,omitempty"`
 }
 
-func (s *SupplierSourceService) DiscoverModels(ctx context.Context, sourceID int64) (*SupplierModelsDiscoverResult, error) {
-	result := &SupplierModelsDiscoverResult{
-		SourceID:           sourceID,
-		UpstreamModels:     make([]SupplierUpstreamModelEntry, 0),
-		NormalizedModels:   make([]SupplierSourceModel, 0),
-		NormalizedChanges:  make([]SupplierModelNormalizeChange, 0),
-		SuggestedAppends:   make([]SupplierSourceModel, 0),
-		RejectedCandidates: make([]SupplierModelDiscoverRejection, 0),
-		ConfiguredIssues:   make([]SupplierModelDiscoverIssue, 0),
-		ProbeResults:       make([]SupplierProbeResult, 0),
+type supplierDiscoverJob struct {
+	cancel    context.CancelFunc
+	mu        sync.Mutex
+	result    *SupplierModelsDiscoverResult
+	err       error
+	seen      map[string]struct{}
+	createdAt time.Time
+}
+
+type supplierDiscoverJobRegistry struct {
+	mu       sync.Mutex
+	byID     map[string]*supplierDiscoverJob
+	bySource map[int64]string
+}
+
+func newSupplierDiscoverJobRegistry() *supplierDiscoverJobRegistry {
+	return &supplierDiscoverJobRegistry{
+		byID:     make(map[string]*supplierDiscoverJob),
+		bySource: make(map[int64]string),
 	}
+}
+
+func (s *SupplierSourceService) discoverJobRegistry() *supplierDiscoverJobRegistry {
+	if s == nil {
+		return nil
+	}
+	if s.discoverJobs == nil {
+		s.discoverJobs = newSupplierDiscoverJobRegistry()
+	}
+	return s.discoverJobs
+}
+
+// StartDiscoverModels lists/normalizes synchronously, then probes every probeable upstream
+// candidate asynchronously with high concurrency. Poll GetDiscoverModelsJob until ProbeStatus
+// is completed or failed. SuggestedAppends only include probe-passed models.
+func (s *SupplierSourceService) StartDiscoverModels(ctx context.Context, sourceID int64) (*SupplierModelsDiscoverResult, error) {
+	result := emptySupplierModelsDiscoverResult(sourceID)
 	if s == nil || s.repo == nil || s.probe == nil || s.encryptor == nil || sourceID <= 0 {
 		result.FailedStep = "validate_request"
+		result.ProbeStatus = SupplierDiscoverProbeFailed
 		return result, ErrSupplierSourceInvalidInput
 	}
 	lister, ok := s.probe.(SupplierUpstreamModelsLister)
 	if !ok || lister == nil {
 		result.FailedStep = "models_lister"
+		result.ProbeStatus = SupplierDiscoverProbeFailed
 		return result, ErrSupplierSourceInvalidInput
 	}
 	source, err := s.repo.Get(ctx, sourceID)
 	if err != nil {
 		result.FailedStep = "load_source"
+		result.ProbeStatus = SupplierDiscoverProbeFailed
 		return result, err
 	}
 	credential, err := s.encryptor.Decrypt(source.EncryptedCredential)
 	if err != nil {
 		result.FailedStep = "decrypt_credential"
+		result.ProbeStatus = SupplierDiscoverProbeFailed
 		return result, fmt.Errorf("decrypt supplier credential: %w", err)
 	}
 	upstream, err := lister.ListSupplierUpstreamModels(ctx, source.Endpoint, credential)
 	if err != nil {
 		result.FailedStep = "list_upstream_models"
+		result.ProbeStatus = SupplierDiscoverProbeFailed
 		return result, err
 	}
 	result.UpstreamModels = upstream
@@ -119,8 +168,6 @@ func (s *SupplierSourceService) DiscoverModels(ctx context.Context, sourceID int
 		}
 		coveredIDs[canonical] = struct{}{}
 		coveredKeys[supplierModelMatchKey(canonical)] = struct{}{}
-		// Preserve intentional client≠upstream remaps (e.g. FMGo Seedance). Only rewrite
-		// client_model_id when it was an identity/fuzzy twin of the configured upstream id.
 		nextClient := model.ClientModelID
 		if supplierConfiguredClientShouldNormalize(model.ClientModelID, model.UpstreamModelID, canonical) {
 			nextClient = canonical
@@ -152,15 +199,15 @@ func (s *SupplierSourceService) DiscoverModels(ctx context.Context, sourceID int
 	priority, priorityErr := SupplierAccountPriority(source.BasePriority, 6)
 	if priorityErr != nil {
 		result.FailedStep = "build_probe_account"
+		result.ProbeStatus = SupplierDiscoverProbeFailed
 		return result, priorityErr
 	}
 	probeAccount := supplierProbeAccount(nil, source, credential, supplierTargetBand{
 		Band: 6, Priority: priority, Mapping: map[string]string{},
 	})
-	// Isolate discover traffic from account-id 0 caches and allow limited parallel probes.
 	probeAccount.ID = supplierDiscoverProbeAccountID(source.ID)
 	probeAccount.Concurrency = supplierDiscoverProbeConcurrency
-	defaultRatio := supplierDiscoverDefaultPurchaseRatio
+
 	probeable := make([]SupplierUpstreamModelEntry, 0, len(candidates))
 	for _, entry := range candidates {
 		if !supplierUpstreamTypeProbeable(entry.Type) {
@@ -171,89 +218,330 @@ func (s *SupplierSourceService) DiscoverModels(ctx context.Context, sourceID int
 		}
 		probeable = append(probeable, entry)
 	}
-	if len(probeable) > supplierDiscoverMaxCandidateProbes {
-		for _, entry := range probeable[supplierDiscoverMaxCandidateProbes:] {
-			result.RejectedCandidates = append(result.RejectedCandidates, SupplierModelDiscoverRejection{
-				UpstreamModelID: entry.ID, Type: entry.Type, Reason: "probe_skipped_budget",
-				Detail: fmt.Sprintf("candidate probe budget is %d per discover", supplierDiscoverMaxCandidateProbes),
-			})
-		}
-		probeable = probeable[:supplierDiscoverMaxCandidateProbes]
-	}
+
+	result.NeedsConfirmation = len(result.NormalizedChanges) > 0
+	result.ProbeTotal = len(probeable)
 	if len(probeable) == 0 {
-		result.NeedsConfirmation = len(result.NormalizedChanges) > 0
-		return result, nil
+		result.ProbeStatus = SupplierDiscoverProbeCompleted
+		result.ProbeDone = 0
+		return cloneSupplierModelsDiscoverResult(result), nil
 	}
 
-	type probeOutcome struct {
-		entry  SupplierUpstreamModelEntry
-		result SupplierProbeResult
+	jobID, err := newSupplierDiscoverJobID()
+	if err != nil {
+		result.FailedStep = "create_job"
+		result.ProbeStatus = SupplierDiscoverProbeFailed
+		return result, fmt.Errorf("create discover job id: %w", err)
 	}
-	outcomes := make([]probeOutcome, len(probeable))
-	probeCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	result.JobID = jobID
+	result.ProbeStatus = SupplierDiscoverProbeRunning
+	result.ProbeDone = 0
+
+	jobCtx, cancel := context.WithTimeout(context.Background(), supplierDiscoverProbeTimeout)
+	job := &supplierDiscoverJob{
+		cancel:    cancel,
+		result:    cloneSupplierModelsDiscoverResult(result),
+		createdAt: time.Now().UTC(),
+	}
+	s.discoverJobRegistry().put(sourceID, jobID, job)
+	go s.runSupplierDiscoverProbes(jobCtx, job, probeAccount, probeable)
+	return cloneSupplierModelsDiscoverResult(job.snapshot()), nil
+}
+
+// DiscoverModels starts async discover and, for callers that expect a finished snapshot
+// (unit tests), waits until the probe job completes. HTTP handlers should use
+// StartDiscoverModels + GetDiscoverModelsJob instead.
+func (s *SupplierSourceService) DiscoverModels(ctx context.Context, sourceID int64) (*SupplierModelsDiscoverResult, error) {
+	result, err := s.StartDiscoverModels(ctx, sourceID)
+	if err != nil {
+		return result, err
+	}
+	if result == nil || result.JobID == "" || result.ProbeStatus != SupplierDiscoverProbeRunning {
+		return result, nil
+	}
+	deadline := time.Now().Add(supplierDiscoverProbeTimeout)
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		case <-time.After(20 * time.Millisecond):
+		}
+		next, getErr := s.GetDiscoverModelsJob(ctx, sourceID, result.JobID)
+		if getErr != nil {
+			return next, getErr
+		}
+		result = next
+		if result.ProbeStatus == SupplierDiscoverProbeCompleted {
+			return result, nil
+		}
+		if result.ProbeStatus == SupplierDiscoverProbeFailed {
+			if result.FailedStep == "probe_candidate" {
+				return result, ErrSupplierSourceProbeFailed
+			}
+			return result, fmt.Errorf("supplier discover probe failed")
+		}
+	}
+	result.FailedStep = "probe_timeout"
+	result.ProbeStatus = SupplierDiscoverProbeFailed
+	return result, fmt.Errorf("supplier discover probe timed out")
+}
+
+// GetDiscoverModelsJob returns the latest snapshot for an async models-discover job.
+func (s *SupplierSourceService) GetDiscoverModelsJob(ctx context.Context, sourceID int64, jobID string) (*SupplierModelsDiscoverResult, error) {
+	_ = ctx
+	if s == nil || sourceID <= 0 || strings.TrimSpace(jobID) == "" {
+		return emptySupplierModelsDiscoverResult(sourceID), ErrSupplierSourceInvalidInput
+	}
+	job, ok := s.discoverJobRegistry().get(sourceID, jobID)
+	if !ok || job == nil {
+		result := emptySupplierModelsDiscoverResult(sourceID)
+		result.JobID = jobID
+		result.FailedStep = "job_not_found"
+		result.ProbeStatus = SupplierDiscoverProbeFailed
+		return result, ErrSupplierSourceNotFound
+	}
+	result := job.snapshot()
+	return result, nil
+}
+
+func (s *SupplierSourceService) runSupplierDiscoverProbes(
+	ctx context.Context,
+	job *supplierDiscoverJob,
+	probeAccount *Account,
+	probeable []SupplierUpstreamModelEntry,
+) {
+	defer job.cancel()
+	defaultRatio := supplierDiscoverDefaultPurchaseRatio
 	var authFailed atomic.Bool
 	sem := make(chan struct{}, supplierDiscoverProbeConcurrency)
 	var wg sync.WaitGroup
-	for index, entry := range probeable {
+	for _, entry := range probeable {
 		wg.Add(1)
-		go func(index int, entry SupplierUpstreamModelEntry) {
+		go func(entry SupplierUpstreamModelEntry) {
 			defer wg.Done()
 			if authFailed.Load() {
+				job.markProbeSkipped(entry, "canceled")
 				return
 			}
 			select {
 			case sem <- struct{}{}:
-			case <-probeCtx.Done():
+			case <-ctx.Done():
+				job.markProbeSkipped(entry, "canceled")
 				return
 			}
 			defer func() { <-sem }()
 			if authFailed.Load() {
+				job.markProbeSkipped(entry, "canceled")
 				return
 			}
-			probeResult := s.probe.ProbeSupplierModel(probeCtx, SupplierProbeInput{
+			probeResult := s.probe.ProbeSupplierModel(ctx, SupplierProbeInput{
 				Account: probeAccount, ClientModelID: entry.ID, UpstreamModelID: entry.ID,
 			})
 			probeResult.ClientModelID = entry.ID
 			probeResult.UpstreamModelID = entry.ID
-			outcomes[index] = probeOutcome{entry: entry, result: probeResult}
 			if probeResult.Status == SupplierProbeStatusAuthFailed {
 				authFailed.Store(true)
-				cancel()
+				job.cancel()
+				job.applyProbeOutcome(entry, probeResult, &defaultRatio, true)
+				return
 			}
-		}(index, entry)
+			job.applyProbeOutcome(entry, probeResult, &defaultRatio, false)
+		}(entry)
 	}
 	wg.Wait()
+	job.finish(authFailed.Load())
+}
 
-	for _, outcome := range outcomes {
-		if outcome.entry.ID == "" && outcome.result.Status == "" {
-			continue
+func (r *supplierDiscoverJobRegistry) put(sourceID int64, jobID string, job *supplierDiscoverJob) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.evictExpiredLocked(time.Now().UTC())
+	if prevID, ok := r.bySource[sourceID]; ok {
+		if prev, exists := r.byID[prevID]; exists && prev != nil {
+			prev.cancel()
+			delete(r.byID, prevID)
 		}
-		entry := outcome.entry
-		probeResult := outcome.result
-		result.ProbeResults = append(result.ProbeResults, probeResult)
-		if probeResult.Status == SupplierProbeStatusAuthFailed {
-			result.RejectedCandidates = append(result.RejectedCandidates, SupplierModelDiscoverRejection{
-				UpstreamModelID: entry.ID, Type: entry.Type, Reason: string(probeResult.Status),
-				Detail: probeResult.Detail,
-			})
-			result.FailedStep = "probe_candidate"
-			return result, ErrSupplierSourceProbeFailed
-		}
-		if probeResult.Status != SupplierProbeStatusPassed {
-			result.RejectedCandidates = append(result.RejectedCandidates, SupplierModelDiscoverRejection{
-				UpstreamModelID: entry.ID, Type: entry.Type, Reason: string(probeResult.Status),
-				Detail: probeResult.Detail,
-			})
-			continue
-		}
-		result.SuggestedAppends = append(result.SuggestedAppends, SupplierSourceModel{
-			ClientModelID: entry.ID, UpstreamModelID: entry.ID, PurchaseRatio: cloneSupplierFloat64Ptr(&defaultRatio),
-		})
 	}
+	r.byID[jobID] = job
+	r.bySource[sourceID] = jobID
+}
 
-	result.NeedsConfirmation = len(result.NormalizedChanges) > 0
-	return result, nil
+func (r *supplierDiscoverJobRegistry) get(sourceID int64, jobID string) (*supplierDiscoverJob, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.evictExpiredLocked(time.Now().UTC())
+	job, ok := r.byID[jobID]
+	if !ok || job == nil {
+		return nil, false
+	}
+	if current, exists := r.bySource[sourceID]; !exists || current != jobID {
+		return nil, false
+	}
+	return job, true
+}
+
+func (r *supplierDiscoverJobRegistry) evictExpiredLocked(now time.Time) {
+	for id, job := range r.byID {
+		if job == nil || now.Sub(job.createdAt) <= supplierDiscoverJobTTL {
+			continue
+		}
+		job.cancel()
+		delete(r.byID, id)
+		for sourceID, jobID := range r.bySource {
+			if jobID == id {
+				delete(r.bySource, sourceID)
+			}
+		}
+	}
+}
+
+func (j *supplierDiscoverJob) snapshot() *SupplierModelsDiscoverResult {
+	result, _ := j.snapshotWithErr()
+	return result
+}
+
+func (j *supplierDiscoverJob) snapshotWithErr() (*SupplierModelsDiscoverResult, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return cloneSupplierModelsDiscoverResult(j.result), j.err
+}
+
+func (j *supplierDiscoverJob) applyProbeOutcome(
+	entry SupplierUpstreamModelEntry,
+	probeResult SupplierProbeResult,
+	defaultRatio *float64,
+	authFailed bool,
+) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.result == nil {
+		return
+	}
+	if !j.noteProbeDoneLocked(entry.ID) {
+		return
+	}
+	j.result.ProbeResults = append(j.result.ProbeResults, probeResult)
+	if authFailed || probeResult.Status == SupplierProbeStatusAuthFailed {
+		j.result.RejectedCandidates = append(j.result.RejectedCandidates, SupplierModelDiscoverRejection{
+			UpstreamModelID: entry.ID, Type: entry.Type, Reason: string(probeResult.Status),
+			Detail: probeResult.Detail,
+		})
+		j.result.FailedStep = "probe_candidate"
+		j.result.ProbeStatus = SupplierDiscoverProbeFailed
+		j.err = ErrSupplierSourceProbeFailed
+		return
+	}
+	if probeResult.Status != SupplierProbeStatusPassed {
+		j.result.RejectedCandidates = append(j.result.RejectedCandidates, SupplierModelDiscoverRejection{
+			UpstreamModelID: entry.ID, Type: entry.Type, Reason: string(probeResult.Status),
+			Detail: probeResult.Detail,
+		})
+		return
+	}
+	j.result.SuggestedAppends = append(j.result.SuggestedAppends, SupplierSourceModel{
+		ClientModelID: entry.ID, UpstreamModelID: entry.ID, PurchaseRatio: cloneSupplierFloat64Ptr(defaultRatio),
+	})
+}
+
+func (j *supplierDiscoverJob) markProbeSkipped(entry SupplierUpstreamModelEntry, reason string) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.result == nil {
+		return
+	}
+	if !j.noteProbeDoneLocked(entry.ID) {
+		return
+	}
+	j.result.RejectedCandidates = append(j.result.RejectedCandidates, SupplierModelDiscoverRejection{
+		UpstreamModelID: entry.ID, Type: entry.Type, Reason: reason,
+	})
+}
+
+func (j *supplierDiscoverJob) noteProbeDoneLocked(upstreamModelID string) bool {
+	if j.seen == nil {
+		j.seen = make(map[string]struct{})
+	}
+	if _, exists := j.seen[upstreamModelID]; exists {
+		return false
+	}
+	j.seen[upstreamModelID] = struct{}{}
+	j.result.ProbeDone++
+	if j.result.ProbeDone > j.result.ProbeTotal {
+		j.result.ProbeDone = j.result.ProbeTotal
+	}
+	return true
+}
+
+func (j *supplierDiscoverJob) finish(authFailed bool) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.result == nil {
+		return
+	}
+	if j.result.ProbeDone > j.result.ProbeTotal {
+		j.result.ProbeDone = j.result.ProbeTotal
+	}
+	if authFailed || j.result.ProbeStatus == SupplierDiscoverProbeFailed {
+		j.result.ProbeStatus = SupplierDiscoverProbeFailed
+		if j.err == nil {
+			j.err = ErrSupplierSourceProbeFailed
+		}
+		return
+	}
+	j.result.ProbeStatus = SupplierDiscoverProbeCompleted
+	j.result.NeedsConfirmation = len(j.result.NormalizedChanges) > 0
+}
+
+func emptySupplierModelsDiscoverResult(sourceID int64) *SupplierModelsDiscoverResult {
+	return &SupplierModelsDiscoverResult{
+		SourceID:           sourceID,
+		ProbeStatus:        SupplierDiscoverProbePending,
+		UpstreamModels:     make([]SupplierUpstreamModelEntry, 0),
+		NormalizedModels:   make([]SupplierSourceModel, 0),
+		NormalizedChanges:  make([]SupplierModelNormalizeChange, 0),
+		SuggestedAppends:   make([]SupplierSourceModel, 0),
+		RejectedCandidates: make([]SupplierModelDiscoverRejection, 0),
+		ConfiguredIssues:   make([]SupplierModelDiscoverIssue, 0),
+		ProbeResults:       make([]SupplierProbeResult, 0),
+	}
+}
+
+func cloneSupplierModelsDiscoverResult(in *SupplierModelsDiscoverResult) *SupplierModelsDiscoverResult {
+	if in == nil {
+		return emptySupplierModelsDiscoverResult(0)
+	}
+	out := *in
+	out.UpstreamModels = append([]SupplierUpstreamModelEntry(nil), in.UpstreamModels...)
+	out.NormalizedModels = cloneSupplierSourceModels(in.NormalizedModels)
+	out.NormalizedChanges = append([]SupplierModelNormalizeChange(nil), in.NormalizedChanges...)
+	out.SuggestedAppends = cloneSupplierSourceModels(in.SuggestedAppends)
+	out.RejectedCandidates = append([]SupplierModelDiscoverRejection(nil), in.RejectedCandidates...)
+	out.ConfiguredIssues = append([]SupplierModelDiscoverIssue(nil), in.ConfiguredIssues...)
+	out.ProbeResults = append([]SupplierProbeResult(nil), in.ProbeResults...)
+	return &out
+}
+
+func cloneSupplierSourceModels(in []SupplierSourceModel) []SupplierSourceModel {
+	if in == nil {
+		return make([]SupplierSourceModel, 0)
+	}
+	out := make([]SupplierSourceModel, len(in))
+	for i, model := range in {
+		out[i] = SupplierSourceModel{
+			ClientModelID:   model.ClientModelID,
+			UpstreamModelID: model.UpstreamModelID,
+			PurchaseRatio:   cloneSupplierFloat64Ptr(model.PurchaseRatio),
+		}
+	}
+	return out
+}
+
+func newSupplierDiscoverJobID() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(raw[:]), nil
 }
 
 func supplierDiscoverProbeAccountID(sourceID int64) int64 {

--- a/backend/internal/service/supplier_models_discover.go
+++ b/backend/internal/service/supplier_models_discover.go
@@ -12,6 +12,9 @@ import (
 const (
 	supplierDiscoverDefaultPurchaseRatio = 1.0
 	supplierDiscoverProbeConcurrency     = 4
+	// Cap live Chat probes so “校验并同步” stays within the admin UI timeout.
+	// Remaining probeable candidates are rejected as probe_skipped_budget (not suggested).
+	supplierDiscoverMaxCandidateProbes = 8
 )
 
 // SupplierModelNormalizeChange records a configured-row rewrite to a canonical upstream id.
@@ -154,6 +157,9 @@ func (s *SupplierSourceService) DiscoverModels(ctx context.Context, sourceID int
 	probeAccount := supplierProbeAccount(nil, source, credential, supplierTargetBand{
 		Band: 6, Priority: priority, Mapping: map[string]string{},
 	})
+	// Isolate discover traffic from account-id 0 caches and allow limited parallel probes.
+	probeAccount.ID = supplierDiscoverProbeAccountID(source.ID)
+	probeAccount.Concurrency = supplierDiscoverProbeConcurrency
 	defaultRatio := supplierDiscoverDefaultPurchaseRatio
 	probeable := make([]SupplierUpstreamModelEntry, 0, len(candidates))
 	for _, entry := range candidates {
@@ -164,6 +170,15 @@ func (s *SupplierSourceService) DiscoverModels(ctx context.Context, sourceID int
 			continue
 		}
 		probeable = append(probeable, entry)
+	}
+	if len(probeable) > supplierDiscoverMaxCandidateProbes {
+		for _, entry := range probeable[supplierDiscoverMaxCandidateProbes:] {
+			result.RejectedCandidates = append(result.RejectedCandidates, SupplierModelDiscoverRejection{
+				UpstreamModelID: entry.ID, Type: entry.Type, Reason: "probe_skipped_budget",
+				Detail: fmt.Sprintf("candidate probe budget is %d per discover", supplierDiscoverMaxCandidateProbes),
+			})
+		}
+		probeable = probeable[:supplierDiscoverMaxCandidateProbes]
 	}
 	if len(probeable) == 0 {
 		result.NeedsConfirmation = len(result.NormalizedChanges) > 0
@@ -239,6 +254,13 @@ func (s *SupplierSourceService) DiscoverModels(ctx context.Context, sourceID int
 
 	result.NeedsConfirmation = len(result.NormalizedChanges) > 0
 	return result, nil
+}
+
+func supplierDiscoverProbeAccountID(sourceID int64) int64 {
+	if sourceID <= 0 {
+		return -1
+	}
+	return -sourceID
 }
 
 func cloneSupplierFloat64Ptr(value *float64) *float64 {

--- a/backend/internal/service/supplier_models_discover_test.go
+++ b/backend/internal/service/supplier_models_discover_test.go
@@ -169,6 +169,18 @@ func TestUS048_DiscoverModelsAuthFailureStopsWithoutSuggesting(t *testing.T) {
 	require.Empty(t, result.SuggestedAppends)
 }
 
+func TestUS048_GetDiscoverModelsJobMissingReturnsFailedSnapshot(t *testing.T) {
+	svc := NewSupplierSourceService(
+		&supplierSourceRepoFake{}, nil, &supplierDiscoverProbeFake{},
+		supplierSyncEncryptor{}, supplierSourceTestFingerprinter{},
+	)
+	result, err := svc.GetDiscoverModelsJob(context.Background(), 3, "missing-job")
+	require.NoError(t, err)
+	require.Equal(t, "missing-job", result.JobID)
+	require.Equal(t, "job_not_found", result.FailedStep)
+	require.Equal(t, SupplierDiscoverProbeFailed, result.ProbeStatus)
+}
+
 func TestUS048_StartDiscoverModelsProbesAllCandidatesAsynchronously(t *testing.T) {
 	source := &SupplierSource{
 		ID: 8, SupplierName: "baidu", ChannelName: "default",

--- a/backend/internal/service/supplier_models_discover_test.go
+++ b/backend/internal/service/supplier_models_discover_test.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 
 	newapiconstant "github.com/QuantumNous/new-api/constant"
@@ -165,6 +167,35 @@ func TestUS048_DiscoverModelsAuthFailureStopsWithoutSuggesting(t *testing.T) {
 	require.Empty(t, result.SuggestedAppends)
 }
 
+func TestUS048_DiscoverModelsCapsCandidateProbesAndSkipsRest(t *testing.T) {
+	source := &SupplierSource{
+		ID: 8, SupplierName: "baidu", ChannelName: "default",
+		Endpoint: "https://qianfan.baidubce.com", EncryptedCredential: "enc:secret",
+		BasePriority: 100, Models: nil,
+	}
+	repo := &supplierSourceRepoFake{stored: cloneSupplierSourceForTest(source)}
+	entries := make([]SupplierUpstreamModelEntry, 0, supplierDiscoverMaxCandidateProbes+3)
+	probeStatus := make(map[string]SupplierProbeStatus, supplierDiscoverMaxCandidateProbes+3)
+	for i := 0; i < supplierDiscoverMaxCandidateProbes+3; i++ {
+		id := fmt.Sprintf("model-%02d", i)
+		entries = append(entries, SupplierUpstreamModelEntry{ID: id, Type: "chat"})
+		probeStatus[id] = SupplierProbeStatusPassed
+	}
+	lister := &supplierDiscoverProbeFake{entries: entries, probeStatus: probeStatus}
+	svc := NewSupplierSourceService(repo, nil, lister, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{})
+	result, err := svc.DiscoverModels(context.Background(), 8)
+	require.NoError(t, err)
+	require.Equal(t, int64(supplierDiscoverMaxCandidateProbes), lister.probeCalls.Load())
+	require.Len(t, result.SuggestedAppends, supplierDiscoverMaxCandidateProbes)
+	skipped := 0
+	for _, item := range result.RejectedCandidates {
+		if item.Reason == "probe_skipped_budget" {
+			skipped++
+		}
+	}
+	require.Equal(t, 3, skipped)
+}
+
 func TestUS048_ExtractSupplierUpstreamModelEntriesKeepsType(t *testing.T) {
 	entries, err := extractSupplierUpstreamModelEntries([]byte(`{
 		"data": [
@@ -183,6 +214,7 @@ type supplierDiscoverProbeFake struct {
 	entries     []SupplierUpstreamModelEntry
 	probeStatus map[string]SupplierProbeStatus
 	listErr     error
+	probeCalls  atomic.Int64
 }
 
 func (f *supplierDiscoverProbeFake) ListSupplierUpstreamModels(
@@ -197,6 +229,7 @@ func (f *supplierDiscoverProbeFake) ListSupplierUpstreamModels(
 }
 
 func (f *supplierDiscoverProbeFake) ProbeSupplierModel(_ context.Context, input SupplierProbeInput) SupplierProbeResult {
+	f.probeCalls.Add(1)
 	status := SupplierProbeStatusFailed
 	if f.probeStatus != nil {
 		if got, ok := f.probeStatus[input.UpstreamModelID]; ok {

--- a/backend/internal/service/supplier_models_discover_test.go
+++ b/backend/internal/service/supplier_models_discover_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	newapiconstant "github.com/QuantumNous/new-api/constant"
 	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
@@ -164,36 +165,46 @@ func TestUS048_DiscoverModelsAuthFailureStopsWithoutSuggesting(t *testing.T) {
 	result, err := svc.DiscoverModels(context.Background(), 4)
 	require.ErrorIs(t, err, ErrSupplierSourceProbeFailed)
 	require.Equal(t, "probe_candidate", result.FailedStep)
+	require.Equal(t, SupplierDiscoverProbeFailed, result.ProbeStatus)
 	require.Empty(t, result.SuggestedAppends)
 }
 
-func TestUS048_DiscoverModelsCapsCandidateProbesAndSkipsRest(t *testing.T) {
+func TestUS048_StartDiscoverModelsProbesAllCandidatesAsynchronously(t *testing.T) {
 	source := &SupplierSource{
 		ID: 8, SupplierName: "baidu", ChannelName: "default",
 		Endpoint: "https://qianfan.baidubce.com", EncryptedCredential: "enc:secret",
 		BasePriority: 100, Models: nil,
 	}
 	repo := &supplierSourceRepoFake{stored: cloneSupplierSourceForTest(source)}
-	entries := make([]SupplierUpstreamModelEntry, 0, supplierDiscoverMaxCandidateProbes+3)
-	probeStatus := make(map[string]SupplierProbeStatus, supplierDiscoverMaxCandidateProbes+3)
-	for i := 0; i < supplierDiscoverMaxCandidateProbes+3; i++ {
+	entries := make([]SupplierUpstreamModelEntry, 0, 12)
+	probeStatus := make(map[string]SupplierProbeStatus, 12)
+	for i := 0; i < 12; i++ {
 		id := fmt.Sprintf("model-%02d", i)
 		entries = append(entries, SupplierUpstreamModelEntry{ID: id, Type: "chat"})
 		probeStatus[id] = SupplierProbeStatusPassed
 	}
 	lister := &supplierDiscoverProbeFake{entries: entries, probeStatus: probeStatus}
 	svc := NewSupplierSourceService(repo, nil, lister, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{})
-	result, err := svc.DiscoverModels(context.Background(), 8)
+	started, err := svc.StartDiscoverModels(context.Background(), 8)
 	require.NoError(t, err)
-	require.Equal(t, int64(supplierDiscoverMaxCandidateProbes), lister.probeCalls.Load())
-	require.Len(t, result.SuggestedAppends, supplierDiscoverMaxCandidateProbes)
-	skipped := 0
-	for _, item := range result.RejectedCandidates {
-		if item.Reason == "probe_skipped_budget" {
-			skipped++
+	require.Equal(t, SupplierDiscoverProbeRunning, started.ProbeStatus)
+	require.Equal(t, 12, started.ProbeTotal)
+	require.NotEmpty(t, started.JobID)
+
+	deadline := time.Now().Add(2 * time.Second)
+	var result *SupplierModelsDiscoverResult
+	for time.Now().Before(deadline) {
+		result, err = svc.GetDiscoverModelsJob(context.Background(), 8, started.JobID)
+		require.NoError(t, err)
+		if result.ProbeStatus == SupplierDiscoverProbeCompleted {
+			break
 		}
+		time.Sleep(20 * time.Millisecond)
 	}
-	require.Equal(t, 3, skipped)
+	require.Equal(t, SupplierDiscoverProbeCompleted, result.ProbeStatus)
+	require.Equal(t, 12, result.ProbeDone)
+	require.Equal(t, int64(12), lister.probeCalls.Load())
+	require.Len(t, result.SuggestedAppends, 12)
 }
 
 func TestUS048_ExtractSupplierUpstreamModelEntriesKeepsType(t *testing.T) {

--- a/backend/internal/service/supplier_source_service.go
+++ b/backend/internal/service/supplier_source_service.go
@@ -82,6 +82,7 @@ type SupplierSourceService struct {
 	probe         SupplierSourceProbe
 	encryptor     SecretEncryptor
 	fingerprinter SupplierCredentialFingerprinter
+	discoverJobs  *supplierDiscoverJobRegistry
 }
 
 func NewSupplierSourceService(
@@ -93,6 +94,7 @@ func NewSupplierSourceService(
 ) *SupplierSourceService {
 	return &SupplierSourceService{
 		repo: repo, accounts: accounts, probe: probe, encryptor: encryptor, fingerprinter: fingerprinter,
+		discoverJobs: newSupplierDiscoverJobRegistry(),
 	}
 }
 

--- a/backend/internal/service/supplier_upstream_models.go
+++ b/backend/internal/service/supplier_upstream_models.go
@@ -56,7 +56,9 @@ func (s *AccountTestService) ListSupplierUpstreamModels(
 
 	account := &Account{
 		Platform: PlatformNewAPI, Type: AccountTypeAPIKey,
-		ChannelType: transport.ChannelType, Concurrency: 1,
+		// Negative sentinel avoids colliding with real account 0 / id-less caches while
+		// listing supplier catalogs (concurrent discovers previously contended here).
+		ID: -1001, ChannelType: transport.ChannelType, Concurrency: 4,
 		Credentials: map[string]any{
 			"base_url": transport.Endpoint,
 			"api_key":  credential,

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 714,
-  "hash": "34fb61ac3c5df67461c9eca195f8f49e86c11bb171dfd96d5c46388e55e57edd",
+  "hash": "8165a3da95b667bbabf2351b911eed9a438227c7a5af5df53536fbf6b8b9bdb1",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 714,
-  "hash": "acf1b84a679ac1e0cbc9ff946c56f42ce5fc28ea8386090b601a044f064ca842",
+  "hash": "4da4e898bb3f1d7a48d5c030d1ebc665e4d0df2ddcab6a0370af645e88ecd19d",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 714,
-  "hash": "8165a3da95b667bbabf2351b911eed9a438227c7a5af5df53536fbf6b8b9bdb1",
+  "hash": "acf1b84a679ac1e0cbc9ff946c56f42ce5fc28ea8386090b601a044f064ca842",
   "schema": 1,
   "source": "frontend/"
 }

--- a/docs/agent_integration.md
+++ b/docs/agent_integration.md
@@ -409,6 +409,7 @@ Generated from live Gin route registrations; do not edit this section.
 - `GET /api/v1/admin/supplier-sources/:id` from `backend/internal/server/routes/admin.go`
 - `PUT /api/v1/admin/supplier-sources/:id` from `backend/internal/server/routes/admin.go`
 - `POST /api/v1/admin/supplier-sources/:id/models-discover` from `backend/internal/server/routes/admin.go`
+- `GET /api/v1/admin/supplier-sources/:id/models-discover/jobs/:job_id` from `backend/internal/server/routes/admin.go`
 - `POST /api/v1/admin/supplier-sources/:id/sync` from `backend/internal/server/routes/admin.go`
 - `GET /api/v1/admin/supplier-sources/priority-preview` from `backend/internal/server/routes/admin.go`
 - `GET /api/v1/admin/system/check-updates` from `backend/internal/server/routes/admin.go`

--- a/docs/approved/model-supplier-source-management.md
+++ b/docs/approved/model-supplier-source-management.md
@@ -70,8 +70,10 @@ priority 自行判断和修改 `base_priority`。已选来源的表单存在未�
    `upstream_model_id` 为同一事实（相同或模糊等价）时同步规整 client，显式 remap（如 FMGo
    Seedance）保留 client。无法匹配的保留原值并标 `configured_issues`，不自动删除；
 3. 对列表中尚未配置、且 type 可探测（`chat` / `multimodal` / `image2text` / 空）的候选做真实
-   Chat Completions 探测；每次 discover 最多探测 8 个候选（超出记 `probe_skipped_budget`，不建议追加），
-   避免管理页 30s 超时与上游长尾探测把「校验并同步」拖到数分钟；`embeddings` / `text2image` 等直接拒绝建议；
+   Chat Completions 探测：`POST models-discover` 同步完成 list/规整后立即返回 `job_id`，后台以高并发
+   异步探测**全部**候选；管理页轮询 `GET .../models-discover/jobs/:job_id` 直到 `probe_status`
+   为 `completed`/`failed`，并展示 `probe_done/probe_total`。不得用固定条数裁剪可服务性判断；
+   `embeddings` / `text2image` 等直接拒绝建议；
 4. **仅探测通过**的候选进入 `suggested_appends`（默认 `purchase_ratio=1.0`）；探测失败的进入
    `rejected_candidates`，不得写入表单建议、更不得投影账号；
 5. 若有已配置 ID 规整变更，结果回填表单草稿并要求人工确认后保存；建议追加只展示，需运营主动

--- a/docs/approved/model-supplier-source-management.md
+++ b/docs/approved/model-supplier-source-management.md
@@ -70,13 +70,18 @@ priority 自行判断和修改 `base_priority`。已选来源的表单存在未�
    `upstream_model_id` 为同一事实（相同或模糊等价）时同步规整 client，显式 remap（如 FMGo
    Seedance）保留 client。无法匹配的保留原值并标 `configured_issues`，不自动删除；
 3. 对列表中尚未配置、且 type 可探测（`chat` / `multimodal` / `image2text` / 空）的候选做真实
-   Chat Completions 探测；`embeddings` / `text2image` 等直接拒绝建议；
+   Chat Completions 探测；每次 discover 最多探测 8 个候选（超出记 `probe_skipped_budget`，不建议追加），
+   避免管理页 30s 超时与上游长尾探测把「校验并同步」拖到数分钟；`embeddings` / `text2image` 等直接拒绝建议；
 4. **仅探测通过**的候选进入 `suggested_appends`（默认 `purchase_ratio=1.0`）；探测失败的进入
    `rejected_candidates`，不得写入表单建议、更不得投影账号；
 5. 若有已配置 ID 规整变更，结果回填表单草稿并要求人工确认后保存；建议追加只展示，需运营主动
    「加入表单」才进入草稿。discover 本身不写供应源、不写账号。保存后再点“校验并同步”才进入
    既有账号投影；
 6. 若无需规整确认，即使仍有建议追加，也继续执行下方投影同步（建议可在同屏查看后择机加入）。
+
+discover / sync 失败时，API 必须返回可读 `message`（含上游 models 列表的 `UpstreamModelSyncError.SafeMessage`）
+与结果体中的 `failed_step`；管理页必须在同步结果区之外独立展示错误文案，并在「上游模型发现」中展示
+`failed_step` 与计数摘要，禁止只露出空标题。
 
 同步按以下最小规则执行：
 

--- a/frontend/src/api/admin/supplierSources.ts
+++ b/frontend/src/api/admin/supplierSources.ts
@@ -108,8 +108,14 @@ export interface SupplierModelDiscoverRejection {
   detail?: string
 }
 
+export type SupplierDiscoverProbeStatus = 'pending' | 'running' | 'completed' | 'failed'
+
 export interface SupplierModelsDiscoverResult {
   source_id: number
+  job_id?: string
+  probe_status: SupplierDiscoverProbeStatus
+  probe_total: number
+  probe_done: number
   upstream_models: SupplierUpstreamModelEntry[]
   normalized_models: SupplierSourceModel[]
   normalized_changes: SupplierModelNormalizeChange[]
@@ -147,11 +153,16 @@ async function priorityPreview(): Promise<SupplierPriorityPreview> {
 }
 
 async function discoverModels(id: number): Promise<SupplierModelsDiscoverResult> {
-  // Discover may probe several upstream candidates; keep above the global 30s client timeout.
+  // Starts async candidate probing; returns list/normalize immediately with job_id.
   const { data } = await apiClient.post<SupplierModelsDiscoverResult>(
     `/admin/supplier-sources/${id}/models-discover`,
-    undefined,
-    { timeout: 90_000 },
+  )
+  return data
+}
+
+async function getDiscoverModelsJob(id: number, jobId: string): Promise<SupplierModelsDiscoverResult> {
+  const { data } = await apiClient.get<SupplierModelsDiscoverResult>(
+    `/admin/supplier-sources/${id}/models-discover/jobs/${encodeURIComponent(jobId)}`,
   )
   return data
 }
@@ -161,4 +172,4 @@ async function sync(id: number): Promise<SupplierSourceSyncResult> {
   return data
 }
 
-export default { list, get, create, update, priorityPreview, discoverModels, sync }
+export default { list, get, create, update, priorityPreview, discoverModels, getDiscoverModelsJob, sync }

--- a/frontend/src/api/admin/supplierSources.ts
+++ b/frontend/src/api/admin/supplierSources.ts
@@ -147,8 +147,11 @@ async function priorityPreview(): Promise<SupplierPriorityPreview> {
 }
 
 async function discoverModels(id: number): Promise<SupplierModelsDiscoverResult> {
+  // Discover may probe several upstream candidates; keep above the global 30s client timeout.
   const { data } = await apiClient.post<SupplierModelsDiscoverResult>(
     `/admin/supplier-sources/${id}/models-discover`,
+    undefined,
+    { timeout: 90_000 },
   )
   return data
 }

--- a/frontend/src/i18n/locales/en/admin/supplierSources.ts
+++ b/frontend/src/i18n/locales/en/admin/supplierSources.ts
@@ -32,6 +32,8 @@ export default {
     saveBeforeSync: 'Save the current changes before syncing.',
     discoverNeedsSave: 'Configured model IDs were normalized from the upstream models API. Confirm, save, then validate and sync again to project accounts. Probe-passed suggestions are added only via “Add suggestions to form”.',
     discoverResult: 'Upstream model discovery',
+    discoverSummary: 'Upstream {upstream} · normalized {normalized} · suggested {suggested} · unmatched {issues} · rejected {rejected}',
+    discoverEmpty: 'Upstream list processed: no normalization needed and no probe-passed suggestions.',
     normalizedChanges: 'Normalized changes',
     suggestedAppends: 'Suggested appends (probe passed)',
     appendSuggested: 'Add suggestions to form',

--- a/frontend/src/i18n/locales/en/admin/supplierSources.ts
+++ b/frontend/src/i18n/locales/en/admin/supplierSources.ts
@@ -33,6 +33,7 @@ export default {
     discoverNeedsSave: 'Configured model IDs were normalized from the upstream models API. Confirm, save, then validate and sync again to project accounts. Probe-passed suggestions are added only via “Add suggestions to form”.',
     discoverResult: 'Upstream model discovery',
     discoverSummary: 'Upstream {upstream} · normalized {normalized} · suggested {suggested} · unmatched {issues} · rejected {rejected}',
+    discoverProbeProgress: 'Candidate probing in progress: {done}/{total}',
     discoverEmpty: 'Upstream list processed: no normalization needed and no probe-passed suggestions.',
     normalizedChanges: 'Normalized changes',
     suggestedAppends: 'Suggested appends (probe passed)',

--- a/frontend/src/i18n/locales/zh/admin/supplierSources.ts
+++ b/frontend/src/i18n/locales/zh/admin/supplierSources.ts
@@ -32,6 +32,8 @@ export default {
     saveBeforeSync: '当前修改尚未保存，请先保存再同步。',
     discoverNeedsSave: '已根据上游 models 规整已配置模型 ID，请确认后保存，再点校验并同步投影账号。探测通过的建议追加需点「加入表单」后才会写入。',
     discoverResult: '上游模型发现',
+    discoverSummary: '上游 {upstream} 个 · 规整 {normalized} · 建议追加 {suggested} · 配置未匹配 {issues} · 未建议 {rejected}',
+    discoverEmpty: '上游列表已处理：当前配置无需规整，也没有探测通过的建议追加。',
     normalizedChanges: '规整变更',
     suggestedAppends: '建议追加（探测通过）',
     appendSuggested: '将建议加入表单',

--- a/frontend/src/i18n/locales/zh/admin/supplierSources.ts
+++ b/frontend/src/i18n/locales/zh/admin/supplierSources.ts
@@ -33,6 +33,7 @@ export default {
     discoverNeedsSave: '已根据上游 models 规整已配置模型 ID，请确认后保存，再点校验并同步投影账号。探测通过的建议追加需点「加入表单」后才会写入。',
     discoverResult: '上游模型发现',
     discoverSummary: '上游 {upstream} 个 · 规整 {normalized} · 建议追加 {suggested} · 配置未匹配 {issues} · 未建议 {rejected}',
+    discoverProbeProgress: '候选探测进行中：{done}/{total}',
     discoverEmpty: '上游列表已处理：当前配置无需规整，也没有探测通过的建议追加。',
     normalizedChanges: '规整变更',
     suggestedAppends: '建议追加（探测通过）',

--- a/frontend/src/views/admin/SupplierSourcesView.vue
+++ b/frontend/src/views/admin/SupplierSourcesView.vue
@@ -353,6 +353,7 @@
               </li>
             </ul>
             <button
+              v-if="discoverResult.probe_status === 'completed'"
               type="button"
               data-test="append-suggested"
               class="mt-2 text-sm text-primary-600"

--- a/frontend/src/views/admin/SupplierSourcesView.vue
+++ b/frontend/src/views/admin/SupplierSourcesView.vue
@@ -285,12 +285,38 @@
           </div>
         </form>
 
+        <p
+          v-if="syncError"
+          data-test="sync-error"
+          class="rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300"
+        >
+          {{ syncError }}
+        </p>
+
         <section
           v-if="discoverResult"
           data-test="discover-result"
           class="space-y-4 border-t border-gray-200 pt-4 dark:border-dark-700"
         >
-          <h2 class="font-medium">{{ t('admin.supplierSources.discoverResult') }}</h2>
+          <div class="flex flex-wrap items-center gap-3">
+            <h2 class="font-medium">{{ t('admin.supplierSources.discoverResult') }}</h2>
+            <span
+              v-if="discoverResult.failed_step"
+              data-test="discover-failed-step"
+              class="text-sm text-red-600"
+            >
+              {{ t('admin.supplierSources.failedStep') }}: {{ discoverResult.failed_step }}
+            </span>
+          </div>
+          <p data-test="discover-summary" class="text-sm text-gray-600 dark:text-gray-300">
+            {{ t('admin.supplierSources.discoverSummary', {
+              upstream: discoverResult.upstream_models.length,
+              normalized: discoverResult.normalized_changes.length,
+              suggested: discoverResult.suggested_appends.length,
+              issues: discoverResult.configured_issues.length,
+              rejected: discoverResult.rejected_candidates.length,
+            }) }}
+          </p>
           <p v-if="discoverNeedsSave" data-test="discover-needs-save" class="text-sm text-amber-700">
             {{ t('admin.supplierSources.discoverNeedsSave') }}
           </p>
@@ -349,6 +375,13 @@
               </li>
             </ul>
           </div>
+          <p
+            v-if="discoverEmptyDetail"
+            data-test="discover-empty"
+            class="text-sm text-gray-500"
+          >
+            {{ t('admin.supplierSources.discoverEmpty') }}
+          </p>
         </section>
 
         <section
@@ -365,7 +398,6 @@
               {{ t('admin.supplierSources.failedStep') }}: {{ syncResult.failed_step }}
             </span>
           </div>
-          <p v-if="syncError" class="text-sm text-red-600">{{ syncError }}</p>
 
           <div>
             <h3 class="text-sm font-medium">{{ t('admin.supplierSources.probes') }}</h3>
@@ -480,6 +512,15 @@ const syncSucceeded = computed(() => (
   && syncError.value === ''
   && !syncResult.value.failed_step
 ))
+
+const discoverEmptyDetail = computed(() => {
+  const result = discoverResult.value
+  if (!result || result.failed_step || syncError.value) return false
+  return result.normalized_changes.length === 0
+    && result.suggested_appends.length === 0
+    && result.configured_issues.length === 0
+    && result.rejected_candidates.length === 0
+})
 
 const emptyModel = (): SupplierSourceModel => ({
   client_model_id: '',
@@ -738,7 +779,18 @@ function supplierDiscoverResultFromError(error: unknown): SupplierModelsDiscover
   if (!data || typeof data !== 'object') return null
   const candidate = data as Partial<SupplierModelsDiscoverResult>
   if (!Array.isArray(candidate.normalized_models) || !Array.isArray(candidate.suggested_appends)) return null
-  return candidate as SupplierModelsDiscoverResult
+  return {
+    source_id: typeof candidate.source_id === 'number' ? candidate.source_id : 0,
+    upstream_models: Array.isArray(candidate.upstream_models) ? candidate.upstream_models : [],
+    normalized_models: candidate.normalized_models,
+    normalized_changes: Array.isArray(candidate.normalized_changes) ? candidate.normalized_changes : [],
+    suggested_appends: candidate.suggested_appends,
+    rejected_candidates: Array.isArray(candidate.rejected_candidates) ? candidate.rejected_candidates : [],
+    configured_issues: Array.isArray(candidate.configured_issues) ? candidate.configured_issues : [],
+    probe_results: Array.isArray(candidate.probe_results) ? candidate.probe_results : [],
+    needs_confirmation: Boolean(candidate.needs_confirmation),
+    failed_step: typeof candidate.failed_step === 'string' ? candidate.failed_step : undefined,
+  }
 }
 
 async function syncSelected(): Promise<void> {

--- a/frontend/src/views/admin/SupplierSourcesView.vue
+++ b/frontend/src/views/admin/SupplierSourcesView.vue
@@ -317,6 +317,16 @@
               rejected: discoverResult.rejected_candidates.length,
             }) }}
           </p>
+          <p
+            v-if="discoverResult.probe_status === 'running'"
+            data-test="discover-probe-progress"
+            class="text-sm text-amber-700"
+          >
+            {{ t('admin.supplierSources.discoverProbeProgress', {
+              done: discoverResult.probe_done,
+              total: discoverResult.probe_total,
+            }) }}
+          </p>
           <p v-if="discoverNeedsSave" data-test="discover-needs-save" class="text-sm text-amber-700">
             {{ t('admin.supplierSources.discoverNeedsSave') }}
           </p>
@@ -516,6 +526,7 @@ const syncSucceeded = computed(() => (
 const discoverEmptyDetail = computed(() => {
   const result = discoverResult.value
   if (!result || result.failed_step || syncError.value) return false
+  if (result.probe_status === 'running' || result.probe_status === 'pending') return false
   return result.normalized_changes.length === 0
     && result.suggested_appends.length === 0
     && result.configured_issues.length === 0
@@ -781,6 +792,15 @@ function supplierDiscoverResultFromError(error: unknown): SupplierModelsDiscover
   if (!Array.isArray(candidate.normalized_models) || !Array.isArray(candidate.suggested_appends)) return null
   return {
     source_id: typeof candidate.source_id === 'number' ? candidate.source_id : 0,
+    job_id: typeof candidate.job_id === 'string' ? candidate.job_id : undefined,
+    probe_status: candidate.probe_status === 'running'
+      || candidate.probe_status === 'completed'
+      || candidate.probe_status === 'failed'
+      || candidate.probe_status === 'pending'
+      ? candidate.probe_status
+      : 'failed',
+    probe_total: typeof candidate.probe_total === 'number' ? candidate.probe_total : 0,
+    probe_done: typeof candidate.probe_done === 'number' ? candidate.probe_done : 0,
     upstream_models: Array.isArray(candidate.upstream_models) ? candidate.upstream_models : [],
     normalized_models: candidate.normalized_models,
     normalized_changes: Array.isArray(candidate.normalized_changes) ? candidate.normalized_changes : [],
@@ -793,6 +813,34 @@ function supplierDiscoverResultFromError(error: unknown): SupplierModelsDiscover
   }
 }
 
+async function waitDiscoverJob(
+  sourceID: number,
+  started: SupplierModelsDiscoverResult,
+): Promise<SupplierModelsDiscoverResult> {
+  let current = started
+  discoverResult.value = current
+  const jobID = current.job_id
+  if (!jobID || current.probe_status !== 'running') {
+    return current
+  }
+  const deadline = Date.now() + 15 * 60 * 1000
+  while (Date.now() < deadline) {
+    await new Promise(resolve => window.setTimeout(resolve, 1000))
+    current = await adminAPI.supplierSources.getDiscoverModelsJob(sourceID, jobID)
+    discoverResult.value = current
+    if (current.probe_status === 'completed') {
+      return current
+    }
+    if (current.probe_status === 'failed') {
+      const message = current.failed_step
+        ? `${t('admin.supplierSources.failedStep')}: ${current.failed_step}`
+        : t('admin.supplierSources.discoverResult')
+      throw Object.assign(new Error(message), { data: current, status: 422 })
+    }
+  }
+  throw new Error('supplier discover probe timed out')
+}
+
 async function syncSelected(): Promise<void> {
   if (!selected.value || hasUnsavedChanges.value) return
   syncing.value = true
@@ -801,7 +849,8 @@ async function syncSelected(): Promise<void> {
   discoverNeedsSave.value = false
   syncError.value = ''
   try {
-    const discovered = await adminAPI.supplierSources.discoverModels(selected.value.id)
+    const started = await adminAPI.supplierSources.discoverModels(selected.value.id)
+    const discovered = await waitDiscoverJob(selected.value.id, started)
     discoverResult.value = discovered
     if (discovered.needs_confirmation) {
       applyDiscoverToForm(discovered)

--- a/frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts
+++ b/frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts
@@ -4,18 +4,19 @@ import { nextTick } from 'vue'
 
 import SupplierSourcesView from '../SupplierSourcesView.vue'
 
-const { list, create, update, priorityPreview, discoverModels, sync, routeQuery } = vi.hoisted(() => ({
+const { list, create, update, priorityPreview, discoverModels, getDiscoverModelsJob, sync, routeQuery } = vi.hoisted(() => ({
   list: vi.fn(),
   create: vi.fn(),
   update: vi.fn(),
   priorityPreview: vi.fn(),
   discoverModels: vi.fn(),
+  getDiscoverModelsJob: vi.fn(),
   sync: vi.fn(),
   routeQuery: {} as Record<string, unknown>,
 }))
 
 vi.mock('@/api/admin', () => ({
-  adminAPI: { supplierSources: { list, create, update, priorityPreview, discoverModels, sync } },
+  adminAPI: { supplierSources: { list, create, update, priorityPreview, discoverModels, getDiscoverModelsJob, sync } },
 }))
 
 vi.mock('vue-i18n', async () => {
@@ -52,6 +53,9 @@ describe('SupplierSourcesView', () => {
     priorityPreview.mockReset().mockResolvedValue({ entries: [], warnings: [] })
     discoverModels.mockReset().mockResolvedValue({
       source_id: 7,
+      probe_status: 'completed',
+      probe_total: 0,
+      probe_done: 0,
       upstream_models: [],
       normalized_models: source.models,
       normalized_changes: [],
@@ -61,6 +65,7 @@ describe('SupplierSourcesView', () => {
       probe_results: [],
       needs_confirmation: false,
     })
+    getDiscoverModelsJob.mockReset()
     sync.mockReset()
   })
 
@@ -181,6 +186,9 @@ describe('SupplierSourcesView', () => {
     list.mockResolvedValueOnce([source])
     discoverModels.mockResolvedValueOnce({
       source_id: 7,
+      probe_status: 'completed',
+      probe_total: 1,
+      probe_done: 1,
       upstream_models: [{ id: 'deepseek-v4-pro', type: 'chat' }, { id: 'glm-5.1', type: 'chat' }],
       normalized_models: [{
         client_model_id: 'deepseek-v4-pro',
@@ -238,6 +246,9 @@ describe('SupplierSourcesView', () => {
     list.mockResolvedValueOnce([source])
     discoverModels.mockResolvedValueOnce({
       source_id: 7,
+      probe_status: 'completed',
+      probe_total: 1,
+      probe_done: 1,
       upstream_models: [{ id: 'deepseek-v4-pro', type: 'chat' }, { id: 'glm-5.1', type: 'chat' }],
       normalized_models: source.models,
       normalized_changes: [],
@@ -271,6 +282,9 @@ describe('SupplierSourcesView', () => {
         status: 502,
         data: {
           source_id: 7,
+          probe_status: 'failed',
+          probe_total: 0,
+          probe_done: 0,
           upstream_models: [],
           normalized_models: [],
           normalized_changes: [],

--- a/frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts
+++ b/frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts
@@ -274,6 +274,89 @@ describe('SupplierSourcesView', () => {
     expect(wrapper.find('[data-test="discover-needs-save"]').exists()).toBe(false)
   })
 
+  it('polls a running models-discover job until completed before syncing', async () => {
+    vi.useFakeTimers()
+    list.mockResolvedValueOnce([source])
+    discoverModels.mockResolvedValueOnce({
+      source_id: 7,
+      job_id: 'job-async-1',
+      probe_status: 'running',
+      probe_total: 2,
+      probe_done: 0,
+      upstream_models: [{ id: 'deepseek-v4-pro', type: 'chat' }, { id: 'glm-5.1', type: 'chat' }],
+      normalized_models: source.models,
+      normalized_changes: [],
+      suggested_appends: [],
+      rejected_candidates: [],
+      configured_issues: [],
+      probe_results: [],
+      needs_confirmation: false,
+    })
+    getDiscoverModelsJob
+      .mockResolvedValueOnce({
+        source_id: 7,
+        job_id: 'job-async-1',
+        probe_status: 'running',
+        probe_total: 2,
+        probe_done: 1,
+        upstream_models: [{ id: 'deepseek-v4-pro', type: 'chat' }, { id: 'glm-5.1', type: 'chat' }],
+        normalized_models: source.models,
+        normalized_changes: [],
+        suggested_appends: [{
+          client_model_id: 'glm-5.1',
+          upstream_model_id: 'glm-5.1',
+          purchase_ratio: 1,
+        }],
+        rejected_candidates: [],
+        configured_issues: [],
+        probe_results: [],
+        needs_confirmation: false,
+      })
+      .mockResolvedValueOnce({
+        source_id: 7,
+        job_id: 'job-async-1',
+        probe_status: 'completed',
+        probe_total: 2,
+        probe_done: 2,
+        upstream_models: [{ id: 'deepseek-v4-pro', type: 'chat' }, { id: 'glm-5.1', type: 'chat' }],
+        normalized_models: source.models,
+        normalized_changes: [],
+        suggested_appends: [{
+          client_model_id: 'glm-5.1',
+          upstream_model_id: 'glm-5.1',
+          purchase_ratio: 1,
+        }],
+        rejected_candidates: [],
+        configured_issues: [],
+        probe_results: [],
+        needs_confirmation: false,
+      })
+    sync.mockResolvedValueOnce({ source_id: 7, probe_results: [], changes: [] })
+
+    const wrapper = mount(SupplierSourcesView)
+    await flushPromises()
+    await wrapper.get('[data-test="source-select-7"]').trigger('click')
+    await wrapper.get('[data-test="sync-source"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.get('[data-test="discover-probe-progress"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="append-suggested"]').exists()).toBe(false)
+    expect(sync).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1000)
+    await flushPromises()
+    expect(getDiscoverModelsJob).toHaveBeenCalledWith(7, 'job-async-1')
+    expect(wrapper.find('[data-test="append-suggested"]').exists()).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    await flushPromises()
+    expect(sync).toHaveBeenCalledWith(7)
+    expect(wrapper.find('[data-test="discover-probe-progress"]').exists()).toBe(false)
+    expect(wrapper.get('[data-test="append-suggested"]').exists()).toBe(true)
+
+    vi.useRealTimers()
+  })
+
   it('shows discover failure message and failed_step outside the sync-result block', async () => {
     list.mockResolvedValueOnce([source])
     discoverModels.mockRejectedValueOnce(Object.assign(

--- a/frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts
+++ b/frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts
@@ -263,6 +263,43 @@ describe('SupplierSourcesView', () => {
     expect(wrapper.find('[data-test="discover-needs-save"]').exists()).toBe(false)
   })
 
+  it('shows discover failure message and failed_step outside the sync-result block', async () => {
+    list.mockResolvedValueOnce([source])
+    discoverModels.mockRejectedValueOnce(Object.assign(
+      new Error('Supplier model list request failed with HTTP 401'),
+      {
+        status: 502,
+        data: {
+          source_id: 7,
+          upstream_models: [],
+          normalized_models: [],
+          normalized_changes: [],
+          suggested_appends: [],
+          rejected_candidates: [],
+          configured_issues: [],
+          probe_results: [],
+          needs_confirmation: false,
+          failed_step: 'list_upstream_models',
+        },
+      },
+    ))
+    const wrapper = mount(SupplierSourcesView)
+    await flushPromises()
+    await wrapper.get('[data-test="source-select-7"]').trigger('click')
+    await wrapper.get('[data-test="sync-source"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.get('[data-test="sync-error"]').text()).toContain(
+      'Supplier model list request failed with HTTP 401',
+    )
+    expect(wrapper.get('[data-test="discover-failed-step"]').text()).toContain('list_upstream_models')
+    expect(wrapper.get('[data-test="discover-summary"]').text()).toBe(
+      'admin.supplierSources.discoverSummary',
+    )
+    expect(wrapper.find('[data-test="sync-result"]').exists()).toBe(false)
+    expect(sync).not.toHaveBeenCalled()
+  })
+
   it('renders every probe result and actual account change returned by sync', async () => {
     list.mockResolvedValueOnce([source])
     sync.mockResolvedValueOnce({

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -1977,12 +1977,26 @@
         "const syncSucceeded = computed(() => (",
         "syncResult.value !== null",
         "syncError.value === ''",
-        "&& !syncResult.value.failed_step"
+        "&& !syncResult.value.failed_step",
+        "async function waitDiscoverJob(",
+        "adminAPI.supplierSources.getDiscoverModelsJob(sourceID, jobID)",
+        "data-test=\"discover-probe-progress\"",
+        "v-if=\"discoverResult.probe_status === 'completed'\""
       ],
       "must_not_contain": [
         "syncSucceeded = ref"
       ],
-      "rationale": "The supplier page derives success from the current response, the current request error, and absence of failed_step. A mutable success flag can drift from a resolved partial-failure result and falsely tell operations that account projection completed."
+      "rationale": "The supplier page derives success from the current response, the current request error, and absence of failed_step. It must poll async models-discover jobs to completion before projection sync, show probe progress, and only allow appending suggestions after probing finishes so partial candidate sets cannot enter the form."
+    },
+    {
+      "path": "frontend/src/api/admin/supplierSources.ts",
+      "must_contain": [
+        "async function discoverModels(id: number): Promise<SupplierModelsDiscoverResult>",
+        "`/admin/supplier-sources/${id}/models-discover`",
+        "async function getDiscoverModelsJob(id: number, jobId: string): Promise<SupplierModelsDiscoverResult>",
+        "`/admin/supplier-sources/${id}/models-discover/jobs/${encodeURIComponent(jobId)}`"
+      ],
+      "rationale": "Admin client must expose both models-discover start and job poll endpoints. Dropping the poll client forces synchronous long probes behind the browser timeout again."
     },
     {
       "path": "frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts",
@@ -1992,9 +2006,11 @@
         "renders every probe result and actual account change returned by sync",
         "does not show success when a resolved sync result reports a failed step",
         "shows protocol_unsupported probe results from a 422 response without success wording",
-        "contains no state machine, audit, activation, pause, or account-group controls"
+        "contains no state machine, audit, activation, pause, or account-group controls",
+        "polls a running models-discover job until completed before syncing",
+        "shows discover failure message and failed_step outside the sync-result block"
       ],
-      "rationale": "Focused UI regressions pin the final minimal workflow: save is side-effect free, unsaved edits cannot accidentally sync the previous database snapshot, sync renders current probes and real account changes, resolved failed_step responses cannot display success, private protocol failures remain closed, and no state machine or account-group controls return."
+      "rationale": "Focused UI regressions pin the final minimal workflow: save is side-effect free, unsaved edits cannot accidentally sync the previous database snapshot, sync renders current probes and real account changes, resolved failed_step responses cannot display success, private protocol failures remain closed, async discover polling must complete before projection sync, discover failures stay visible outside the sync block, and no state machine or account-group controls return."
     },
     {
       "path": "frontend/src/composables/useSupplierManagedAccount.ts",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7606,6 +7606,49 @@
         "supplier credential leaked into audit body"
       ],
       "rationale": "Regression evidence for the supplier-source audit boundary: a realistic create body must retain non-sensitive management facts while replacing credential with the audit placeholder."
+    },
+    {
+      "path": "backend/internal/service/supplier_models_discover.go",
+      "must_contain": [
+        "func (s *SupplierSourceService) StartDiscoverModels(",
+        "func (s *SupplierSourceService) GetDiscoverModelsJob(",
+        "supplierDiscoverProbeConcurrency = 8",
+        "go s.runSupplierDiscoverProbes(jobCtx, job, probeAccount, probeable)"
+      ],
+      "must_not_contain": [
+        "supplierDiscoverProbeBudget",
+        "probe_skipped_budget"
+      ],
+      "rationale": "models-discover must list/normalize synchronously then probe EVERY probeable candidate asynchronously at high concurrency. A fixed probe budget would silently leave remaining upstream models' servability unknown, which violates the supplier-source product definition."
+    },
+    {
+      "path": "backend/internal/service/supplier_models_discover_test.go",
+      "must_contain": [
+        "func TestUS048_StartDiscoverModelsProbesAllCandidatesAsynchronously(",
+        "func TestUS048_GetDiscoverModelsJobMissingReturnsFailedSnapshot(",
+        "require.Equal(t, int64(12), lister.probeCalls.Load())"
+      ],
+      "rationale": "Focused regressions pin full-candidate async probing without a budget cap, and prove missing/expired jobs return a failed snapshot rather than conflating with supplier-source-not-found."
+    },
+    {
+      "path": "backend/internal/handler/admin/supplier_source_handler.go",
+      "must_contain": [
+        "func (h *SupplierSourceHandler) DiscoverModels(c *gin.Context)",
+        "result, err := h.service.StartDiscoverModels(c.Request.Context(), id)",
+        "func (h *SupplierSourceHandler) GetDiscoverModelsJob(c *gin.Context)",
+        "result, err := h.service.GetDiscoverModelsJob(c.Request.Context(), id, jobID)",
+        "case errors.As(err, &syncErr):"
+      ],
+      "rationale": "Admin discover must start the async probe job and expose job polling; upstream models-list failures must map through UpstreamModelSyncError.SafeMessage so the page never shows only an empty discover title."
+    },
+    {
+      "path": "backend/internal/service/supplier_upstream_models.go",
+      "must_contain": [
+        "ListSupplierUpstreamModels(ctx context.Context, endpoint, credential string) ([]SupplierUpstreamModelEntry, error)",
+        "return strings.TrimRight(newapiintegration.QianfanBaseURL, \"/\") + \"/v2/models\"",
+        "ID: -1001, ChannelType: transport.ChannelType, Concurrency: 4,"
+      ],
+      "rationale": "Supplier upstream listing owns BaiduV2 /v2/models routing and a dedicated negative list identity so concurrent discovers do not contend on account-id caches. Losing either returns wrong OpenAI /v1/models paths for Qianfan or serializes catalog fetches incorrectly."
     }
   ]
 }

--- a/scripts/sentinels/handler-di-wire.json
+++ b/scripts/sentinels/handler-di-wire.json
@@ -78,6 +78,8 @@
         "registerSupplierSourceRoutes(admin, h)",
         "sources := admin.Group(\"/supplier-sources\")",
         "sources.GET(\"/priority-preview\", h.Admin.SupplierSource.PriorityPreview)",
+        "sources.POST(\"/:id/models-discover\", h.Admin.SupplierSource.DiscoverModels)",
+        "sources.GET(\"/:id/models-discover/jobs/:job_id\", h.Admin.SupplierSource.GetDiscoverModelsJob)",
         "sources.POST(\"/:id/sync\", h.Admin.SupplierSource.Sync)"
       ],
       "must_not_contain": [
@@ -85,7 +87,7 @@
         "sources.POST(\"/:id/activate\", h.Admin.SupplierSource.Activate)",
         "sources.POST(\"/:id/pause\", h.Admin.SupplierSource.Pause)"
       ],
-      "rationale": "Canonical six-endpoint supplier-source route owner. The page saves facts, previews supplier priorities and explicitly syncs one source; activation/pause routes would reintroduce the rejected state machine while the rest of the application could still compile."
+      "rationale": "Canonical supplier-source route owner including async models-discover start + job poll before sync. Activation/pause routes would reintroduce the rejected state machine while the rest of the application could still compile."
     },
     {
       "path": "backend/cmd/server/wire_gen.go",


### PR DESCRIPTION
## 摘要
- 线上 baidu「校验并同步」曾因同步探测全部候选长达约 320s，撞上管理页 30s 超时，只剩空标题；并发再点还会笼统 500。
- **去掉候选探测条数上限**（不符合「是否可服务」产品定义）。
- `POST .../models-discover`：同步完成 list/规整后立即返回 `job_id`；后台并发（8）探测**全部**可探测候选。
- `GET .../models-discover/jobs/:job_id`：轮询 `probe_status` / `probe_done` / `probe_total` 与建议追加。
- UI：独立错误条、`failed_step`、计数摘要、探测进度；探测完成前不可「加入表单」；上游列表错误映射可读 SafeMessage。
- 为 discover async 路径补 sentinel 锚点（handler / service / API / Vue）。

## 风险
- 常规偏高：供应源管理面公共契约从同步 discover 变为 start+poll；已更新审批基线与 US-048 / agent_integration。
- Job 存本机内存（30min TTL）；蓝绿切换瞬间可能 job_not_found，重点一次即可。

## 验证
- `go test -tags=unit ./internal/service/ -run 'TestUS048_Discover|TestUS048_StartDiscover|TestUS048_GetDiscover'`
- `pnpm exec vitest run src/views/admin/__tests__/SupplierSourcesView.spec.ts`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh` PASS
- 前端 dist freshness 已刷新

## 提交
- `78749ff7c` fix(supplier): 限制 models-discover 探测预算并暴露失败原因
- `e5ca9ffea` chore(web): refresh embedded frontend dist for supplier discover UX
- `b84654b9c` fix(supplier): models-discover 全量异步并发探测
- `499b8ca8c` fix(supplier): address R-001..R-004 — sentinel、轮询测试、job_not_found
- 最新提交：`499b8ca8c`