### PR TITLE
fix(ci): Go cache latest 超 6GiB 时按优先级自愈

### DIFF
--- a/.github/workflows/warm-release-cache-main.yml
+++ b/.github/workflows/warm-release-cache-main.yml
@@ -138,14 +138,28 @@ jobs:
             ${{ runner.os }}-gobuild-analysis-v1-${{ steps.go_version.outputs.version }}-
             ${{ runner.os }}-gobuild-analysis-
             ${{ runner.os }}-gobuild-lint-nodwarf-v1-
-      - name: Warm analysis build cache
+      # Skip warm/save when this family would be overflow-dropped under the 6 GiB
+      # budget — otherwise we thrash: upload then --heal deletes the same entry.
+      - name: Budget gate for analysis warm
+        id: analysis_budget
         if: steps.analysis_cache.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if python3 scripts/ci/go_cache_prune.py --fits analysis; then
+            echo "fits=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "fits=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::skip analysis warm/save; family would be overflow-dropped under 6 GiB budget"
+          fi
+      - name: Warm analysis build cache
+        if: steps.analysis_cache.outputs.cache-hit != 'true' && steps.analysis_budget.outputs.fits == 'true'
         working-directory: backend
         env:
           GOFLAGS: -trimpath -gcflags=all=-dwarf=false
         run: go test -run=^$ ./...
       - name: Warm golangci-lint cache
-        if: steps.analysis_cache.outputs.cache-hit != 'true'
+        if: steps.analysis_cache.outputs.cache-hit != 'true' && steps.analysis_budget.outputs.fits == 'true'
         uses: golangci/golangci-lint-action@v9
         env:
           GOFLAGS: -trimpath -gcflags=all=-dwarf=false
@@ -155,8 +169,21 @@ jobs:
           working-directory: backend
           only-new-issues: false
           skip-cache: "true"
+      - name: Budget gate for analysis save
+        id: analysis_save_budget
+        if: steps.analysis_cache.outputs.cache-hit != 'true' && steps.analysis_budget.outputs.fits == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          size="$(du -sb "$HOME/.cache/go-build" "$HOME/.cache/golangci-lint" 2>/dev/null | awk '{s+=$1} END {print s+0}')"
+          if python3 scripts/ci/go_cache_prune.py --fits analysis --size "$size"; then
+            echo "fits=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "fits=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::skip analysis cache save (size=${size}); would be overflow-dropped under 6 GiB budget"
+          fi
       - name: Save analysis build cache
-        if: steps.analysis_cache.outputs.cache-hit != 'true'
+        if: steps.analysis_cache.outputs.cache-hit != 'true' && steps.analysis_save_budget.outputs.fits == 'true'
         uses: actions/cache/save@v6
         with:
           path: |
@@ -175,8 +202,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-release-v1-${{ steps.go_version.outputs.version }}-
             ${{ runner.os }}-go-release-
-      - name: Warm cross-arch Go build cache
+      - name: Budget gate for release warm
+        id: release_budget
         if: steps.release_cache.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if python3 scripts/ci/go_cache_prune.py --fits release; then
+            echo "fits=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "fits=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::skip release warm/save; family would be overflow-dropped under 6 GiB budget"
+          fi
+      - name: Warm cross-arch Go build cache
+        if: steps.release_cache.outputs.cache-hit != 'true' && steps.release_budget.outputs.fits == 'true'
         working-directory: backend
         env:
           CGO_ENABLED: '0'
@@ -189,8 +228,21 @@ jobs:
             GOARCH="${arch}" go build -o /dev/null ./cmd/qa-archive
             echo "::endgroup::"
           done
+      - name: Budget gate for release save
+        id: release_save_budget
+        if: steps.release_cache.outputs.cache-hit != 'true' && steps.release_budget.outputs.fits == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          size="$(du -sb "$HOME/.cache/go-build" 2>/dev/null | awk '{print $1+0}')"
+          if python3 scripts/ci/go_cache_prune.py --fits release --size "$size"; then
+            echo "fits=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "fits=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::skip release cache save (size=${size}); would be overflow-dropped under 6 GiB budget"
+          fi
       - name: Save release build cache
-        if: steps.release_cache.outputs.cache-hit != 'true'
+        if: steps.release_cache.outputs.cache-hit != 'true' && steps.release_save_budget.outputs.fits == 'true'
         uses: actions/cache/save@v6
         with:
           path: ~/.cache/go-build
@@ -198,7 +250,8 @@ jobs:
 
       # Budget is hard at 6 GiB of latest generations. When latest alone overflows,
       # --heal drops lowest-priority family latest (analysis → release → …) and
-      # applies the prune plan so required CI stays correct on a miss.
+      # applies the prune plan so required CI stays correct on a miss. Warm/save
+      # gates above skip families that would only thrash under that policy.
       - name: Heal managed Go cache budget
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/warm-release-cache-main.yml
+++ b/.github/workflows/warm-release-cache-main.yml
@@ -196,7 +196,10 @@ jobs:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-go-release-v1-${{ steps.go_version.outputs.version }}-${{ hashFiles('backend/go.mod', 'backend/go.sum', '.new-api-ref') }}-${{ hashFiles('backend/**/*.go', 'backend/.golangci.yml', '.goreleaser.yaml') }}
 
-      - name: Check managed Go cache budget
+      # Budget is hard at 6 GiB of latest generations. When latest alone overflows,
+      # --heal drops lowest-priority family latest (analysis → release → …) and
+      # applies the prune plan so required CI stays correct on a miss.
+      - name: Heal managed Go cache budget
         env:
           GH_TOKEN: ${{ github.token }}
-        run: python3 scripts/ci/go_cache_prune.py --check
+        run: python3 scripts/ci/go_cache_prune.py --heal

--- a/scripts/checks/test_go_cache_boundary_contract.py
+++ b/scripts/checks/test_go_cache_boundary_contract.py
@@ -64,6 +64,8 @@ class GoCacheBoundaryContractTest(unittest.TestCase):
     def test_warm_release_cache_heals_budget_overflow(self) -> None:
         text = (WORKFLOWS / "warm-release-cache-main.yml").read_text(encoding="utf-8")
         self.assertIn("go_cache_prune.py --heal", text)
+        self.assertIn("go_cache_prune.py --fits analysis", text)
+        self.assertIn("go_cache_prune.py --fits release", text)
         self.assertNotIn("go_cache_prune.py --check", text)
 
 

--- a/scripts/checks/test_go_cache_boundary_contract.py
+++ b/scripts/checks/test_go_cache_boundary_contract.py
@@ -61,5 +61,11 @@ class GoCacheBoundaryContractTest(unittest.TestCase):
         self.assertEqual(offenders, [])
 
 
+    def test_warm_release_cache_heals_budget_overflow(self) -> None:
+        text = (WORKFLOWS / "warm-release-cache-main.yml").read_text(encoding="utf-8")
+        self.assertIn("go_cache_prune.py --heal", text)
+        self.assertNotIn("go_cache_prune.py --check", text)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/checks/test_release_cache_key_parity.py
+++ b/scripts/checks/test_release_cache_key_parity.py
@@ -96,9 +96,24 @@ class ReleaseCacheWorkflowTest(unittest.TestCase):
         self.assertIn("-tags=embed", release_warm["run"])
         self.assertIn("./cmd/server", release_warm["run"])
         self.assertIn("./cmd/qa-archive", release_warm["run"])
+        self.assertIn("steps.release_budget.outputs.fits == 'true'", release_warm["if"])
 
-        prune = next(step for step in steps if step.get("name") == "Check managed Go cache budget")
-        self.assertIn("go_cache_prune.py --check", prune["run"])
+        prune = next(step for step in steps if step.get("name") == "Heal managed Go cache budget")
+        self.assertIn("go_cache_prune.py --heal", prune["run"])
+        self.assertTrue(
+            any(
+                step.get("name") == "Budget gate for analysis warm"
+                and "go_cache_prune.py --fits analysis" in str(step.get("run", ""))
+                for step in steps
+            )
+        )
+        self.assertTrue(
+            any(
+                step.get("name") == "Budget gate for release warm"
+                and "go_cache_prune.py --fits release" in str(step.get("run", ""))
+                for step in steps
+            )
+        )
 
     def test_warm_analysis_runs_golangci_lint_to_fill_analysis_family(self) -> None:
         # Boundary: analysis family includes ~/.cache/golangci-lint. Warm must
@@ -115,7 +130,7 @@ class ReleaseCacheWorkflowTest(unittest.TestCase):
         )
         self.assertEqual(
             analysis_compile["if"],
-            "steps.analysis_cache.outputs.cache-hit != 'true'",
+            "steps.analysis_cache.outputs.cache-hit != 'true' && steps.analysis_budget.outputs.fits == 'true'",
         )
         self.assertEqual(
             analysis_compile["env"]["GOFLAGS"],
@@ -129,7 +144,7 @@ class ReleaseCacheWorkflowTest(unittest.TestCase):
         )
         self.assertEqual(
             lint_warm["if"],
-            "steps.analysis_cache.outputs.cache-hit != 'true'",
+            "steps.analysis_cache.outputs.cache-hit != 'true' && steps.analysis_budget.outputs.fits == 'true'",
         )
         self.assertEqual(
             lint_warm["env"]["GOFLAGS"],

--- a/scripts/ci/go_cache_prune.py
+++ b/scripts/ci/go_cache_prune.py
@@ -4,6 +4,10 @@
 When the five latest generations alone exceed BUDGET_BYTES, drop lowest-priority
 family latest entries until the remainder fits. Priority (keep first):
 test > gomod > integration > release > analysis.
+
+`--fits` asks whether a family would remain after that overflow logic (optionally
+with a replacement latest size), so warm writers can skip save/warm instead of
+uploading a cache that heal would immediately delete.
 """
 
 from __future__ import annotations
@@ -23,6 +27,8 @@ PREFIXES = {
     "analysis": "Linux-gobuild-analysis-v1-",
     "release": "Linux-go-release-v1-",
 }
+_SYNTHETIC_ID = -1
+_SYNTHETIC_CREATED = "9999-12-31T23:59:59Z"
 
 
 @dataclass(frozen=True)
@@ -31,6 +37,7 @@ class PrunePlan:
     delete_ids: tuple[int, ...]
     keep_ids: tuple[int, ...]
     evidence: tuple[str, ...]
+    overflow_delete_ids: tuple[int, ...] = ()
 
 
 def _family_for(key: str) -> str | None:
@@ -93,6 +100,7 @@ def plan_prune(
         if not dropped:
             break
 
+    overflow_ids = tuple(int(item["id"]) for item in overflow_delete)
     if latest_bytes > budget_bytes:
         keep = list(kept_latest.values()) + overflow_delete
         return PrunePlan(
@@ -100,6 +108,7 @@ def plan_prune(
             delete_ids=(),
             keep_ids=tuple(int(item["id"]) for item in keep),
             evidence=tuple(evidence),
+            overflow_delete_ids=overflow_ids,
         )
 
     remaining = latest_bytes + sum(int(item["sizeInBytes"]) for item in candidates)
@@ -121,7 +130,84 @@ def plan_prune(
         delete_ids=tuple(int(item["id"]) for item in delete),
         keep_ids=tuple(int(item["id"]) for item in keep),
         evidence=tuple(evidence),
+        overflow_delete_ids=overflow_ids,
     )
+
+
+def family_fits(
+    caches: Iterable[dict[str, object]],
+    family: str,
+    *,
+    size: int | None = None,
+    budget_bytes: int = BUDGET_BYTES,
+) -> bool:
+    """Return True when the family's latest would be kept under the budget.
+
+    When ``size`` is set, replace that family's latest with a synthetic entry of
+    that size (modeling a pending cache save) before planning.
+    """
+    if family not in FAMILIES:
+        raise ValueError(f"unknown family: {family}")
+    items = [dict(cache) for cache in caches]
+    if size is not None:
+        prefix = PREFIXES[family]
+        family_entries = [
+            item
+            for item in items
+            if item.get("ref") == DEFAULT_REF and _family_for(str(item["key"])) == family
+        ]
+        key = (
+            str(family_entries[0]["key"])
+            if family_entries
+            else f"{prefix}fits-synthetic"
+        )
+        items = [
+            item
+            for item in items
+            if not (
+                item.get("ref") == DEFAULT_REF and _family_for(str(item["key"])) == family
+            )
+        ]
+        # Preserve previous generations as candidates by re-adding all but the
+        # former latest (which we replace with the synthetic size).
+        if family_entries:
+            ordered = sorted(
+                family_entries,
+                key=lambda item: (str(item["createdAt"]), int(item["id"])),
+                reverse=True,
+            )
+            items.extend(ordered[1:])
+        items.append(
+            {
+                "id": _SYNTHETIC_ID,
+                "key": key,
+                "sizeInBytes": size,
+                "ref": DEFAULT_REF,
+                "createdAt": _SYNTHETIC_CREATED,
+            }
+        )
+        plan = plan_prune(items, budget_bytes=budget_bytes)
+        return plan.ok and _SYNTHETIC_ID in plan.keep_ids
+
+    plan = plan_prune(items, budget_bytes=budget_bytes)
+    if not plan.ok:
+        return False
+    latest_id = None
+    grouped: list[dict[str, object]] = []
+    for cache in items:
+        if cache.get("ref") != DEFAULT_REF:
+            continue
+        if _family_for(str(cache["key"])) == family:
+            grouped.append(cache)
+    if not grouped:
+        return True
+    latest = sorted(
+        grouped,
+        key=lambda item: (str(item["createdAt"]), int(item["id"])),
+        reverse=True,
+    )[0]
+    latest_id = int(latest["id"])
+    return latest_id in plan.keep_ids
 
 
 def _list_caches() -> list[dict[str, object]]:
@@ -170,15 +256,36 @@ def main(argv: list[str] | None = None) -> int:
     mode.add_argument(
         "--check",
         action="store_true",
-        help="plan-only budget check; never deletes caches",
+        help="plan-only; exit 1 when inventory needs overflow heal or cannot fit",
     )
     mode.add_argument(
         "--heal",
         action="store_true",
         help="apply prune plan, including overflow drops of lowest-priority latest caches",
     )
+    mode.add_argument(
+        "--fits",
+        metavar="FAMILY",
+        choices=FAMILIES,
+        help="exit 0 when FAMILY's latest would be kept under budget (see --size)",
+    )
+    parser.add_argument(
+        "--size",
+        type=int,
+        default=None,
+        help="with --fits, model a pending save of this many bytes as FAMILY's latest",
+    )
     args = parser.parse_args(argv)
-    plan = plan_prune(_list_caches())
+    caches = _list_caches()
+    if args.fits:
+        if args.size is not None and args.size < 0:
+            print("go_cache_prune: --size must be >= 0", file=sys.stderr)
+            return 2
+        ok = family_fits(caches, args.fits, size=args.size)
+        print(f"go_cache_prune: fits family={args.fits} size={args.size} ok={ok}")
+        return 0 if ok else 1
+
+    plan = plan_prune(caches)
     for line in plan.evidence:
         print(line)
     if not plan.ok:
@@ -189,6 +296,17 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
     if args.check:
+        if plan.overflow_delete_ids:
+            print(
+                "go_cache_prune: inventory exceeds budget until overflow heal "
+                f"drops ids={list(plan.overflow_delete_ids)}",
+                file=sys.stderr,
+            )
+            print(
+                f"go_cache_prune: needs_heal keep={list(plan.keep_ids)} "
+                f"delete_plan={list(plan.delete_ids)}"
+            )
+            return 1
         print(f"go_cache_prune: ok keep={list(plan.keep_ids)} delete_plan={list(plan.delete_ids)}")
         return 0
     if plan.delete_ids:

--- a/scripts/ci/go_cache_prune.py
+++ b/scripts/ci/go_cache_prune.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Plan GitHub Actions cache deletions for the five managed Go families."""
+"""Plan (and optionally apply) GitHub Actions cache deletions for managed Go families.
+
+When the five latest generations alone exceed BUDGET_BYTES, drop lowest-priority
+family latest entries until the remainder fits. Priority (keep first):
+test > gomod > integration > release > analysis.
+"""
 
 from __future__ import annotations
 
@@ -9,6 +14,8 @@ from typing import Iterable
 BUDGET_BYTES = 6 * 1024**3
 DEFAULT_REF = "refs/heads/main"
 FAMILIES = ("gomod", "test", "integration", "analysis", "release")
+# Drop first when latest generations overflow the budget.
+OVERFLOW_DROP_ORDER = ("analysis", "release", "integration", "gomod", "test")
 PREFIXES = {
     "gomod": "Linux-gomod-v1-",
     "test": "Linux-gobuild-test-v1-",
@@ -47,7 +54,7 @@ def plan_prune(
             continue
         grouped[family].append(cache)
 
-    latest: list[dict[str, object]] = []
+    latest_by_family: dict[str, dict[str, object]] = {}
     candidates: list[dict[str, object]] = []
     obsolete: list[dict[str, object]] = []
     evidence: list[str] = []
@@ -58,23 +65,45 @@ def plan_prune(
             reverse=True,
         )
         if entries:
-            latest.append(entries[0])
+            latest_by_family[family] = entries[0]
             evidence.append(f"{family} latest={entries[0]['key']} size={entries[0]['sizeInBytes']}")
         if len(entries) >= 2:
             candidates.append(entries[1])
         obsolete.extend(entries[2:])
 
-    latest_bytes = sum(int(item["sizeInBytes"]) for item in latest)
+    kept_latest = dict(latest_by_family)
+    overflow_delete: list[dict[str, object]] = []
+    latest_bytes = sum(int(item["sizeInBytes"]) for item in kept_latest.values())
+    # Never drop the final surviving family: if it alone exceeds the budget the
+    # plan is impossible and the warm job must fail closed.
+    while latest_bytes > budget_bytes and len(kept_latest) > 1:
+        dropped = False
+        for family in OVERFLOW_DROP_ORDER:
+            item = kept_latest.pop(family, None)
+            if item is None:
+                continue
+            overflow_delete.append(item)
+            size = int(item["sizeInBytes"])
+            latest_bytes -= size
+            evidence.append(
+                f"overflow_drop family={family} key={item['key']} size={size}"
+            )
+            dropped = True
+            break
+        if not dropped:
+            break
+
     if latest_bytes > budget_bytes:
+        keep = list(kept_latest.values()) + overflow_delete
         return PrunePlan(
             ok=False,
             delete_ids=(),
-            keep_ids=tuple(int(item["id"]) for item in latest),
+            keep_ids=tuple(int(item["id"]) for item in keep),
             evidence=tuple(evidence),
         )
 
     remaining = latest_bytes + sum(int(item["sizeInBytes"]) for item in candidates)
-    delete = list(obsolete)
+    delete = list(obsolete) + overflow_delete
     keep_candidates: list[dict[str, object]] = []
     for candidate in sorted(
         candidates,
@@ -86,7 +115,7 @@ def plan_prune(
         else:
             keep_candidates.append(candidate)
 
-    keep = latest + keep_candidates
+    keep = list(kept_latest.values()) + keep_candidates
     return PrunePlan(
         ok=True,
         delete_ids=tuple(int(item["id"]) for item in delete),
@@ -123,26 +152,48 @@ def _list_caches() -> list[dict[str, object]]:
     return payload
 
 
+def _delete_caches(cache_ids: Iterable[int]) -> None:
+    import subprocess
+
+    for cache_id in cache_ids:
+        subprocess.check_call(
+            ["gh", "cache", "delete", str(cache_id)],
+        )
+
+
 def main(argv: list[str] | None = None) -> int:
     import argparse
+    import sys
 
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
         "--check",
         action="store_true",
         help="plan-only budget check; never deletes caches",
     )
+    mode.add_argument(
+        "--heal",
+        action="store_true",
+        help="apply prune plan, including overflow drops of lowest-priority latest caches",
+    )
     args = parser.parse_args(argv)
-    if not args.check:
-        print("go_cache_prune: apply is a separate approval gate", file=__import__("sys").stderr)
-        return 2
     plan = plan_prune(_list_caches())
     for line in plan.evidence:
         print(line)
     if not plan.ok:
-        print("go_cache_prune: latest generations exceed the 6 GiB budget", file=__import__("sys").stderr)
+        print(
+            "go_cache_prune: latest generations exceed the 6 GiB budget "
+            "even after overflow drops",
+            file=sys.stderr,
+        )
         return 1
-    print(f"go_cache_prune: ok keep={list(plan.keep_ids)} delete_plan={list(plan.delete_ids)}")
+    if args.check:
+        print(f"go_cache_prune: ok keep={list(plan.keep_ids)} delete_plan={list(plan.delete_ids)}")
+        return 0
+    if plan.delete_ids:
+        _delete_caches(plan.delete_ids)
+    print(f"go_cache_prune: healed keep={list(plan.keep_ids)} deleted={list(plan.delete_ids)}")
     return 0
 
 

--- a/scripts/ci/test_go_cache_prune.py
+++ b/scripts/ci/test_go_cache_prune.py
@@ -19,6 +19,8 @@ BUDGET_BYTES = go_cache_prune.BUDGET_BYTES
 FAMILIES = go_cache_prune.FAMILIES
 OVERFLOW_DROP_ORDER = go_cache_prune.OVERFLOW_DROP_ORDER
 plan_prune = go_cache_prune.plan_prune
+family_fits = go_cache_prune.family_fits
+
 
 
 def _cache(
@@ -155,6 +157,7 @@ class GoCachePruneTest(unittest.TestCase):
         # drop integration (4) → kept test+gomod = 8.
         self.assertEqual(set(plan.delete_ids), {3, 4, 5})
         self.assertEqual(set(plan.keep_ids), {1, 2})
+        self.assertEqual(set(plan.overflow_delete_ids), {3, 4, 5})
         evidence = " ".join(plan.evidence)
         self.assertTrue(all(family in evidence for family in FAMILIES), plan.evidence)
         self.assertIn("overflow_drop family=analysis", evidence)
@@ -173,8 +176,26 @@ class GoCachePruneTest(unittest.TestCase):
         plan = plan_prune(caches, budget_bytes=10)
         self.assertTrue(plan.ok)
         self.assertEqual(plan.delete_ids, (4,))
+        self.assertEqual(plan.overflow_delete_ids, (4,))
         self.assertEqual(set(plan.keep_ids), {1, 2, 3, 5})
         self.assertEqual(OVERFLOW_DROP_ORDER[0], "analysis")
+        self.assertFalse(family_fits(caches, "analysis", budget_bytes=10))
+        self.assertTrue(family_fits(caches, "release", budget_bytes=10))
+        self.assertFalse(family_fits(caches, "analysis", size=3, budget_bytes=10))
+        self.assertTrue(family_fits(caches, "release", size=3, budget_bytes=10))
+
+    def test_fits_with_size_models_pending_save(self) -> None:
+        caches = [
+            _cache("Linux-gomod-v1-a", 2, cache_id=1),
+            _cache("Linux-gobuild-test-v1-a", 2, cache_id=2),
+            _cache("Linux-gobuild-integration-v1-a", 2, cache_id=3),
+            _cache("Linux-gobuild-analysis-v1-a", 1, cache_id=4),
+            _cache("Linux-go-release-v1-a", 2, cache_id=5),
+        ]
+        # current sum=9 ≤ 10, analysis fits; a pending 4-byte analysis tips over and drops.
+        self.assertTrue(family_fits(caches, "analysis", budget_bytes=10))
+        self.assertFalse(family_fits(caches, "analysis", size=4, budget_bytes=10))
+        self.assertTrue(family_fits(caches, "test", size=2, budget_bytes=10))
 
     def test_fails_when_single_latest_exceeds_budget(self) -> None:
         caches = [
@@ -220,6 +241,30 @@ class GoCachePruneTest(unittest.TestCase):
         self.assertGreaterEqual(limit, 10_000)
         fields = args[args.index("--json") + 1]
         self.assertIn("createdAt", fields)
+
+    def test_check_exits_nonzero_when_overflow_heal_is_required(self) -> None:
+        caches = [
+            _cache("Linux-gomod-v1-a", 2, cache_id=1),
+            _cache("Linux-gobuild-test-v1-a", 2, cache_id=2),
+            _cache("Linux-gobuild-integration-v1-a", 2, cache_id=3),
+            _cache("Linux-gobuild-analysis-v1-a", 3, cache_id=4),
+            _cache("Linux-go-release-v1-a", 3, cache_id=5),
+        ]
+
+        def _plan(caches_arg, budget_bytes=go_cache_prune.BUDGET_BYTES):
+            del budget_bytes
+            return plan_prune(caches_arg, budget_bytes=10)
+
+        def _fits(caches_arg, family, *, size=None, budget_bytes=go_cache_prune.BUDGET_BYTES):
+            del budget_bytes
+            return family_fits(caches_arg, family, size=size, budget_bytes=10)
+
+        with patch.object(go_cache_prune, "_list_caches", return_value=caches):
+            with patch.object(go_cache_prune, "plan_prune", side_effect=_plan):
+                self.assertEqual(go_cache_prune.main(["--check"]), 1)
+            with patch.object(go_cache_prune, "family_fits", side_effect=_fits):
+                self.assertEqual(go_cache_prune.main(["--fits", "analysis"]), 1)
+                self.assertEqual(go_cache_prune.main(["--fits", "release"]), 0)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_go_cache_prune.py
+++ b/scripts/ci/test_go_cache_prune.py
@@ -17,6 +17,7 @@ sys.modules[SPEC.name] = go_cache_prune
 SPEC.loader.exec_module(go_cache_prune)
 BUDGET_BYTES = go_cache_prune.BUDGET_BYTES
 FAMILIES = go_cache_prune.FAMILIES
+OVERFLOW_DROP_ORDER = go_cache_prune.OVERFLOW_DROP_ORDER
 plan_prune = go_cache_prune.plan_prune
 
 
@@ -140,7 +141,7 @@ class GoCachePruneTest(unittest.TestCase):
         self.assertEqual(plan.delete_ids, (999,))
         self.assertEqual(set(plan.keep_ids), {1, 2})
 
-    def test_fails_when_latest_generations_exceed_budget(self) -> None:
+    def test_overflow_drops_lowest_priority_latest_first(self) -> None:
         caches = [
             _cache("Linux-gomod-v1-a", 4, cache_id=1),
             _cache("Linux-gobuild-test-v1-a", 4, cache_id=2),
@@ -149,11 +150,45 @@ class GoCachePruneTest(unittest.TestCase):
             _cache("Linux-go-release-v1-a", 4, cache_id=5),
         ]
         plan = plan_prune(caches, budget_bytes=10)
-        self.assertFalse(plan.ok)
-        self.assertEqual(plan.delete_ids, ())
-        self.assertEqual(set(plan.keep_ids), {1, 2, 3, 4, 5})
+        self.assertTrue(plan.ok)
+        # 20 → drop analysis (4) then release (4) → kept 12 still over 10 →
+        # drop integration (4) → kept test+gomod = 8.
+        self.assertEqual(set(plan.delete_ids), {3, 4, 5})
+        self.assertEqual(set(plan.keep_ids), {1, 2})
         evidence = " ".join(plan.evidence)
         self.assertTrue(all(family in evidence for family in FAMILIES), plan.evidence)
+        self.assertIn("overflow_drop family=analysis", evidence)
+        self.assertIn("overflow_drop family=release", evidence)
+        self.assertIn("overflow_drop family=integration", evidence)
+
+    def test_overflow_drop_order_prefers_analysis_before_release(self) -> None:
+        caches = [
+            _cache("Linux-gomod-v1-a", 2, cache_id=1),
+            _cache("Linux-gobuild-test-v1-a", 2, cache_id=2),
+            _cache("Linux-gobuild-integration-v1-a", 2, cache_id=3),
+            _cache("Linux-gobuild-analysis-v1-a", 3, cache_id=4),
+            _cache("Linux-go-release-v1-a", 3, cache_id=5),
+        ]
+        # latest sum=12; dropping analysis alone → 9 ≤ 10.
+        plan = plan_prune(caches, budget_bytes=10)
+        self.assertTrue(plan.ok)
+        self.assertEqual(plan.delete_ids, (4,))
+        self.assertEqual(set(plan.keep_ids), {1, 2, 3, 5})
+        self.assertEqual(OVERFLOW_DROP_ORDER[0], "analysis")
+
+    def test_fails_when_single_latest_exceeds_budget(self) -> None:
+        caches = [
+            _cache("Linux-gomod-v1-a", 1, cache_id=1),
+            _cache("Linux-gobuild-test-v1-a", 20, cache_id=2),
+            _cache("Linux-gobuild-integration-v1-a", 1, cache_id=3),
+            _cache("Linux-gobuild-analysis-v1-a", 1, cache_id=4),
+            _cache("Linux-go-release-v1-a", 1, cache_id=5),
+        ]
+        plan = plan_prune(caches, budget_bytes=10)
+        self.assertFalse(plan.ok)
+        self.assertEqual(plan.delete_ids, ())
+        # test is highest keep priority; after dropping others, test alone still overflows.
+        self.assertIn(2, plan.keep_ids)
 
     def test_candidate_tie_breaks_by_key_ascending(self) -> None:
         caches = [


### PR DESCRIPTION
## 摘要
- Warm Release Cache 在五类 Go cache **latest 合计超过 6 GiB** 时，不再空删红灯；`--heal` 按优先级丢掉最低价值 family（analysis → release → …）并应用 prune。
- **防 thrash**：analysis/release 在 `--fits` 判定会被 overflow 丢掉时跳过 warm/save。
- `--check` 在库存需 overflow heal 时非零退出；对齐 release-cache parity 契约测试。

## 风险
- **常规**：analysis/release 在预算贴顶时可能不再被 warm；产品/发版产物不变。
- 单 family latest 单独超 6 GiB 仍 fail closed。

## 验证
- `python3 -m unittest scripts.ci.test_go_cache_prune scripts.checks.test_go_cache_boundary_contract scripts.checks.test_release_cache_key_parity`
- `./scripts/preflight.sh`（上一轮 PASS；本提交仅契约测试对齐）

## 提交
- `6fd49e9c9` fix(ci): Go cache latest 超 6GiB 时按优先级自愈而非红灯
- `749bccfd5` fix(ci): address R-001/R-002 — skip thrash saves and fail --check on overflow
- `10ba81d0e` fix(ci): align release-cache parity tests with --heal/--fits gates
- 最新提交：`10ba81d0e`