### PR TITLE
feat(supplier): 供应源并发可配置 + 托管账号只读查看

### DIFF
--- a/backend/internal/handler/admin/supplier_source_handler.go
+++ b/backend/internal/handler/admin/supplier_source_handler.go
@@ -22,13 +22,14 @@ func NewSupplierSourceHandler(svc *service.SupplierSourceService) *SupplierSourc
 }
 
 type supplierSourceRequest struct {
-	SupplierName string                       `json:"supplier_name" binding:"required,max=120"`
-	ChannelName  string                       `json:"channel_name" binding:"required,max=120"`
-	Endpoint     string                       `json:"endpoint" binding:"required,max=500"`
-	Credential   string                       `json:"credential" binding:"max=8192"`
-	BasePriority *int                         `json:"base_priority"`
-	Notes        string                       `json:"notes" binding:"max=4000"`
-	Models       []supplierSourceModelRequest `json:"models" binding:"max=100,dive"`
+	SupplierName       string                       `json:"supplier_name" binding:"required,max=120"`
+	ChannelName        string                       `json:"channel_name" binding:"required,max=120"`
+	Endpoint           string                       `json:"endpoint" binding:"required,max=500"`
+	Credential         string                       `json:"credential" binding:"max=8192"`
+	BasePriority       *int                         `json:"base_priority"`
+	AccountConcurrency *int                         `json:"account_concurrency"`
+	Notes              string                       `json:"notes" binding:"max=4000"`
+	Models             []supplierSourceModelRequest `json:"models" binding:"max=100,dive"`
 }
 
 type supplierSourceModelRequest struct {
@@ -38,15 +39,16 @@ type supplierSourceModelRequest struct {
 }
 
 type supplierSourceResponse struct {
-	ID           int64                         `json:"id"`
-	SupplierName string                        `json:"supplier_name"`
-	ChannelName  string                        `json:"channel_name"`
-	Endpoint     string                        `json:"endpoint"`
-	BasePriority int                           `json:"base_priority"`
-	Models       []supplierSourceModelResponse `json:"models"`
-	Notes        string                        `json:"notes"`
-	CreatedAt    any                           `json:"created_at"`
-	UpdatedAt    any                           `json:"updated_at"`
+	ID                 int64                         `json:"id"`
+	SupplierName       string                        `json:"supplier_name"`
+	ChannelName        string                        `json:"channel_name"`
+	Endpoint           string                        `json:"endpoint"`
+	BasePriority       int                           `json:"base_priority"`
+	AccountConcurrency int                           `json:"account_concurrency"`
+	Models             []supplierSourceModelResponse `json:"models"`
+	Notes              string                        `json:"notes"`
+	CreatedAt          any                           `json:"created_at"`
+	UpdatedAt          any                           `json:"updated_at"`
 }
 
 type supplierSourceModelResponse struct {
@@ -85,7 +87,8 @@ func (r supplierSourceRequest) toInput() service.SupplierSourceInput {
 	}
 	return service.SupplierSourceInput{
 		SupplierName: r.SupplierName, ChannelName: r.ChannelName, Endpoint: r.Endpoint,
-		Credential: r.Credential, BasePriority: r.BasePriority, Notes: r.Notes, Models: models,
+		Credential: r.Credential, BasePriority: r.BasePriority, AccountConcurrency: r.AccountConcurrency,
+		Notes: r.Notes, Models: models,
 	}
 }
 
@@ -101,7 +104,8 @@ func supplierSourceToResponse(source *service.SupplierSource) *supplierSourceRes
 	}
 	return &supplierSourceResponse{
 		ID: source.ID, SupplierName: source.SupplierName, ChannelName: source.ChannelName,
-		Endpoint: source.Endpoint, BasePriority: source.BasePriority, Models: models, Notes: source.Notes,
+		Endpoint: source.Endpoint, BasePriority: source.BasePriority,
+		AccountConcurrency: source.AccountConcurrency, Models: models, Notes: source.Notes,
 		CreatedAt: source.CreatedAt, UpdatedAt: source.UpdatedAt,
 	}
 }

--- a/backend/internal/handler/admin/supplier_source_handler_test.go
+++ b/backend/internal/handler/admin/supplier_source_handler_test.go
@@ -36,7 +36,7 @@ func TestUS048_SupplierSourceResponsesExposeOnlyManagementFacts(t *testing.T) {
 	result := supplierSourceToResponse(&service.SupplierSource{
 		ID: 7, SupplierName: "佳杰", ChannelName: "stbl-5",
 		Endpoint: "https://token.vstecscloud.com/v1", EncryptedCredential: "ciphertext",
-		CredentialFingerprint: "hmac:secret", BasePriority: 100, Notes: "lowest ratio only",
+		CredentialFingerprint: "hmac:secret", BasePriority: 100, AccountConcurrency: 1000, Notes: "lowest ratio only",
 		Models: []service.SupplierSourceModel{{
 			ClientModelID: "deepseek-v4-pro", UpstreamModelID: "deepseek-v4-pro", PurchaseRatio: &ratio,
 		}},
@@ -46,6 +46,7 @@ func TestUS048_SupplierSourceResponsesExposeOnlyManagementFacts(t *testing.T) {
 	require.NoError(t, err)
 	body := strings.ToLower(string(payload))
 	require.Contains(t, body, `"base_priority":100`)
+	require.Contains(t, body, `"account_concurrency":1000`)
 	require.Contains(t, body, `"client_model_id":"deepseek-v4-pro"`)
 	require.NotContains(t, body, "encrypted_credential")
 	require.NotContains(t, body, "credential_fingerprint")

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -814,6 +814,55 @@ func (r *accountRepository) UpdateSupplierMetadata(ctx context.Context, accountI
 	return nil
 }
 
+func (r *accountRepository) UpdateSupplierConcurrency(ctx context.Context, accountID int64, concurrency int) error {
+	baseCtx := ctx
+	contextTx := dbent.TxFromContext(ctx)
+	client := r.client
+	var tx *dbent.Tx
+	if contextTx != nil {
+		client = contextTx.Client()
+	} else {
+		var err error
+		tx, err = r.client.Tx(ctx)
+		if err != nil && !errors.Is(err, dbent.ErrTxStarted) {
+			return err
+		}
+		if tx != nil {
+			defer func() { _ = tx.Rollback() }()
+			ctx = dbent.NewTxContext(ctx, tx)
+			client = tx.Client()
+		}
+	}
+
+	result, err := client.ExecContext(ctx, `
+		UPDATE accounts
+		SET concurrency = $1, updated_at = NOW()
+		WHERE id = $2 AND deleted_at IS NULL
+	`, concurrency, accountID)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return service.ErrAccountNotFound
+	}
+	if err := enqueueSchedulerOutbox(ctx, client, service.SchedulerOutboxEventAccountChanged, &accountID, nil, nil); err != nil {
+		return err
+	}
+	if tx != nil {
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+	}
+	if contextTx == nil {
+		r.syncSchedulerAccountSnapshot(baseCtx, accountID)
+	}
+	return nil
+}
+
 func (r *accountRepository) UpdateSupplierProjection(ctx context.Context, account *service.Account, chatProbePassed bool) error {
 	if account == nil {
 		return nil

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -872,9 +872,10 @@ func (r *accountRepository) UpdateSupplierProjection(ctx context.Context, accoun
 			priority = $7,
 			status = $8,
 			schedulable = $9,
+			concurrency = $10,
 			updated_at = NOW()
-		WHERE id = $10 AND deleted_at IS NULL
-	`, account.Name, account.Platform, account.Type, account.ChannelType, string(credentials), string(managedExtra), account.Priority, account.Status, schedulable, account.ID)
+		WHERE id = $11 AND deleted_at IS NULL
+	`, account.Name, account.Platform, account.Type, account.ChannelType, string(credentials), string(managedExtra), account.Priority, account.Status, schedulable, account.Concurrency, account.ID)
 	if err != nil {
 		return err
 	}
@@ -4119,6 +4120,8 @@ func selectSupplierAccountProjection(query *dbent.AccountQuery) *dbent.AccountSe
 		dbaccount.FieldStatus,
 		dbaccount.FieldSchedulable,
 		dbaccount.FieldChannelType,
+		dbaccount.FieldConcurrency,
+		dbaccount.FieldProtocolEndpointCapabilityID,
 	)
 }
 
@@ -4126,7 +4129,7 @@ func supplierAccountEntityToService(m *dbent.Account) *service.Account {
 	if m == nil {
 		return nil
 	}
-	return &service.Account{
+	account := &service.Account{
 		ID:          m.ID,
 		Name:        m.Name,
 		Platform:    m.Platform,
@@ -4137,7 +4140,12 @@ func supplierAccountEntityToService(m *dbent.Account) *service.Account {
 		Status:      m.Status,
 		Schedulable: m.Schedulable,
 		ChannelType: m.ChannelType,
+		Concurrency: m.Concurrency,
 	}
+	if m.ProtocolEndpointCapabilityID != nil {
+		account.ProtocolEndpointCapabilityID = m.ProtocolEndpointCapabilityID
+	}
+	return account
 }
 
 func accountsToSupplierSourceService(accounts []*dbent.Account) []service.Account {
@@ -4255,7 +4263,29 @@ func (r *accountRepository) ListSupplierManagedAccounts(ctx context.Context, sou
 	if err != nil {
 		return nil, translatePersistenceError(err, service.ErrAccountNotFound, nil)
 	}
-	return accountsToSupplierSourceService(accounts), nil
+	if len(accounts) == 0 {
+		return []service.Account{}, nil
+	}
+	accountIDs := make([]int64, 0, len(accounts))
+	for _, account := range accounts {
+		accountIDs = append(accountIDs, account.ID)
+	}
+	capabilitiesByAccount, err := r.loadProtocolEndpointCapabilities(ctx, accountIDs)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]service.Account, 0, len(accounts))
+	for _, account := range accounts {
+		converted := supplierAccountEntityToService(account)
+		if converted == nil {
+			continue
+		}
+		if capability, ok := capabilitiesByAccount[account.ID]; ok {
+			converted.ProtocolEndpointCapability = capability
+		}
+		result = append(result, *converted)
+	}
+	return result, nil
 }
 
 // ListDueUpstreamBillingProbeAccounts bounds result hydration and network work

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -334,6 +334,7 @@ func (s *AccountRepoSuite) TestUS048_SupplierConfigurationProjectionPreservesRun
 	stale.Priority = 114
 	stale.Status = service.StatusActive
 	stale.Schedulable = true
+	stale.Concurrency = 1000
 
 	err = s.repo.UpdateSupplierProjection(s.ctx, stale, true)
 	s.Require().NoError(err)
@@ -355,7 +356,7 @@ func (s *AccountRepoSuite) TestUS048_SupplierConfigurationProjectionPreservesRun
 	s.Require().Equal("operator-owned", got.Extra["supplier_channel"])
 	s.Require().Equal("operator-owned", got.Extra["supplier_projection_mode"])
 	s.Require().Equal("runtime note", *got.Notes)
-	s.Require().Equal(9, got.Concurrency)
+	s.Require().Equal(1000, got.Concurrency)
 	s.Require().Equal("runtime error", got.ErrorMessage)
 	s.Require().NotNil(got.RateMultiplier)
 	s.Require().Equal(1.75, *got.RateMultiplier)

--- a/backend/internal/repository/account_repo_supplier_projection_test.go
+++ b/backend/internal/repository/account_repo_supplier_projection_test.go
@@ -130,6 +130,7 @@ func TestUS048_SupplierConfigurationRepositoryWritesOnlyOwnedFields(t *testing.T
 		Priority:    113,
 		Status:      service.StatusActive,
 		Schedulable: true,
+		Concurrency: 1000,
 		GroupIDs:    []int64{4, 9},
 	}
 	identity, governed, err := service.BuildProtocolEndpointIdentity(account)
@@ -140,7 +141,7 @@ func TestUS048_SupplierConfigurationRepositoryWritesOnlyOwnedFields(t *testing.T
 	now := time.Date(2026, time.August, 28, 0, 0, 0, 0, time.UTC)
 
 	mock.ExpectBegin()
-	mock.ExpectExec(`(?s)UPDATE accounts\s+SET\s+name = \$1,\s+platform = \$2,\s+type = \$3,\s+channel_type = \$4,\s+credentials = \$5::jsonb,\s+extra = COALESCE\(extra, '\{\}'::jsonb\) \|\| \$6::jsonb,\s+priority = \$7,\s+status = \$8,\s+schedulable = \$9,\s+updated_at = NOW\(\)\s+WHERE id = \$10 AND deleted_at IS NULL`).
+	mock.ExpectExec(`(?s)UPDATE accounts\s+SET\s+name = \$1,\s+platform = \$2,\s+type = \$3,\s+channel_type = \$4,\s+credentials = \$5::jsonb,\s+extra = COALESCE\(extra, '\{\}'::jsonb\) \|\| \$6::jsonb,\s+priority = \$7,\s+status = \$8,\s+schedulable = \$9,\s+concurrency = \$10,\s+updated_at = NOW\(\)\s+WHERE id = \$11 AND deleted_at IS NULL`).
 		WithArgs(
 			"supplier/new · 档位 3",
 			service.PlatformNewAPI,
@@ -151,6 +152,7 @@ func TestUS048_SupplierConfigurationRepositoryWritesOnlyOwnedFields(t *testing.T
 			113,
 			service.StatusActive,
 			true,
+			1000,
 			int64(41),
 		).
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -222,11 +224,11 @@ func TestUS048_SupplierConfigurationRepositoryWritesOnlyOwnedFields(t *testing.T
 		}
 	}
 	require.NotEmpty(t, accountUpdateSQL)
-	for _, required := range []string{"name", "platform", "type", "channel_type", "credentials", "extra", "priority", "status", "schedulable"} {
+	for _, required := range []string{"name", "platform", "type", "channel_type", "credentials", "extra", "priority", "status", "schedulable", "concurrency"} {
 		require.Contains(t, accountUpdateSQL, required)
 	}
 	for _, forbidden := range []string{
-		"notes", "concurrency", "rate_multiplier",
+		"notes", "rate_multiplier",
 		"proxy_id", "load_factor", "tier_id", "last_used_at", "expires_at", "rate_limit",
 		"overload_until", "session_window", "quota_dimension", "parent_account_id", "error_message", "group",
 		"supplier_source_model_id", "supplier_channel", "supplier_projection_mode", "supplier_credential_fingerprint",
@@ -251,19 +253,19 @@ func TestUS048_SupplierProjectionReadSelectsOnlyRequiredConfigurationFields(t *t
 	mock.ExpectQuery(`(?s)SELECT .* FROM "accounts" WHERE .*"id" = \$1`).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"id", "name", "platform", "type", "credentials", "extra",
-			"priority", "status", "schedulable", "channel_type",
+			"priority", "status", "schedulable", "channel_type", "concurrency", "protocol_endpoint_capability_id",
 		}).AddRow(
 			int64(41), "supplier/source · 档位 3", service.PlatformNewAPI, service.AccountTypeAPIKey,
 			[]byte(`{"base_url":"https://supplier.example/v1","api_key":"secret","model_mapping":{"model":"model"}}`),
 			[]byte(`{"supplier_source_id":7,"supplier_discount_band":3}`),
-			103, service.StatusActive, true, 1,
+			103, service.StatusActive, true, 1, 1000, nil,
 		))
 
 	account, err := repo.GetSupplierAccount(context.Background(), 41)
 	require.NoError(t, err)
 	require.Equal(t, int64(41), account.ID)
 	require.Nil(t, account.RateMultiplier)
-	require.Zero(t, account.Concurrency)
+	require.Equal(t, 1000, account.Concurrency)
 	require.Nil(t, account.ProxyID)
 	require.Nil(t, account.GroupIDs)
 	require.NoError(t, mock.ExpectationsWereMet())
@@ -272,12 +274,12 @@ func TestUS048_SupplierProjectionReadSelectsOnlyRequiredConfigurationFields(t *t
 	query := strings.ToLower(capturedSQL[0])
 	for _, required := range []string{
 		"id", "name", "platform", "type", "credentials", "extra",
-		"priority", "status", "schedulable", "channel_type",
+		"priority", "status", "schedulable", "channel_type", "concurrency", "protocol_endpoint_capability_id",
 	} {
 		require.Contains(t, query, required)
 	}
 	for _, forbidden := range []string{
-		"account_groups", "rate_multiplier", "concurrency", "proxy_id", "proxy_fallback_origin_id",
+		"account_groups", "rate_multiplier", "proxy_id", "proxy_fallback_origin_id",
 		"load_factor", "notes", "error_message", "last_used_at", "expires_at", "rate_limited_at",
 		"rate_limit_reset_at", "overload_until", "temp_unschedulable", "session_window", "tier_id",
 		"parent_account_id", "quota_dimension",

--- a/backend/internal/repository/account_repo_supplier_projection_test.go
+++ b/backend/internal/repository/account_repo_supplier_projection_test.go
@@ -65,6 +65,48 @@ func TestUS048_SupplierMetadataRepositoryWritesOnlyNameAndPriority(t *testing.T)
 	}
 }
 
+func TestUS048_SupplierConcurrencyRepositoryWritesOnlyConcurrency(t *testing.T) {
+	var capturedSQL []string
+	matcher := sqlmock.QueryMatcherFunc(func(expectedSQL, actualSQL string) error {
+		capturedSQL = append(capturedSQL, actualSQL)
+		return sqlmock.QueryMatcherRegexp.Match(expectedSQL, actualSQL)
+	})
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(matcher))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	client := dbent.NewClient(dbent.Driver(entsql.OpenDB(dialect.Postgres, db)))
+	t.Cleanup(func() { _ = client.Close() })
+	repo := newAccountRepositoryWithSQL(client, db, nil, nil)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`(?s)UPDATE accounts\s+SET concurrency = \$1, updated_at = NOW\(\)\s+WHERE id = \$2 AND deleted_at IS NULL`).
+		WithArgs(1000, int64(41)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO scheduler_outbox")).
+		WithArgs(service.SchedulerOutboxEventAccountChanged, int64(41), nil, nil, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err = repo.UpdateSupplierConcurrency(context.Background(), 41, 1000)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	var accountUpdateSQL string
+	for _, query := range capturedSQL {
+		if strings.Contains(query, "UPDATE accounts") {
+			accountUpdateSQL = strings.ToLower(query)
+			break
+		}
+	}
+	require.NotEmpty(t, accountUpdateSQL)
+	require.Contains(t, accountUpdateSQL, "concurrency")
+	for _, forbidden := range []string{
+		"credentials", "extra", "name", "priority", "status", "schedulable", "rate_multiplier", "protocol_endpoint_capability_id",
+	} {
+		require.NotContains(t, accountUpdateSQL, forbidden)
+	}
+}
+
 func TestUS048_SupplierConfigurationRepositoryRejectsUnverifiedNonEmptyMapping(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)

--- a/backend/internal/repository/supplier_source_repo.go
+++ b/backend/internal/repository/supplier_source_repo.go
@@ -28,8 +28,8 @@ func (r *supplierSourceRepository) Create(ctx context.Context, source *service.S
 		return err
 	}
 	err = r.db.QueryRowContext(ctx, `INSERT INTO model_supplier_sources
-(supplier_name, channel_name, endpoint, encrypted_credential, credential_fingerprint, base_priority, models, notes)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+(supplier_name, channel_name, endpoint, encrypted_credential, credential_fingerprint, base_priority, account_concurrency, models, notes)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 RETURNING id, created_at, updated_at`,
 		source.SupplierName,
 		source.ChannelName,
@@ -37,6 +37,7 @@ RETURNING id, created_at, updated_at`,
 		source.EncryptedCredential,
 		source.CredentialFingerprint,
 		source.BasePriority,
+		source.AccountConcurrency,
 		models,
 		source.Notes,
 	).Scan(&source.ID, &source.CreatedAt, &source.UpdatedAt)
@@ -56,8 +57,8 @@ func (r *supplierSourceRepository) Update(ctx context.Context, source *service.S
 	}
 	err = r.db.QueryRowContext(ctx, `UPDATE model_supplier_sources
 SET supplier_name=$1, channel_name=$2, endpoint=$3, encrypted_credential=$4,
-    credential_fingerprint=$5, base_priority=$6, models=$7, notes=$8, updated_at=NOW()
-WHERE id=$9
+    credential_fingerprint=$5, base_priority=$6, account_concurrency=$7, models=$8, notes=$9, updated_at=NOW()
+WHERE id=$10
 RETURNING updated_at`,
 		source.SupplierName,
 		source.ChannelName,
@@ -65,6 +66,7 @@ RETURNING updated_at`,
 		source.EncryptedCredential,
 		source.CredentialFingerprint,
 		source.BasePriority,
+		source.AccountConcurrency,
 		models,
 		source.Notes,
 		source.ID,
@@ -80,13 +82,13 @@ RETURNING updated_at`,
 
 func (r *supplierSourceRepository) Get(ctx context.Context, id int64) (*service.SupplierSource, error) {
 	return scanSupplierSource(r.db.QueryRowContext(ctx, `SELECT id, supplier_name, channel_name, endpoint, encrypted_credential,
-credential_fingerprint, base_priority, models, notes, created_at, updated_at
+credential_fingerprint, base_priority, account_concurrency, models, notes, created_at, updated_at
 FROM model_supplier_sources WHERE id=$1`, id))
 }
 
 func (r *supplierSourceRepository) List(ctx context.Context) ([]service.SupplierSource, error) {
 	rows, err := r.db.QueryContext(ctx, `SELECT id, supplier_name, channel_name, endpoint, encrypted_credential,
-credential_fingerprint, base_priority, models, notes, created_at, updated_at
+credential_fingerprint, base_priority, account_concurrency, models, notes, created_at, updated_at
 FROM model_supplier_sources ORDER BY id`)
 	if err != nil {
 		return nil, fmt.Errorf("list supplier sources: %w", err)
@@ -122,6 +124,7 @@ func scanSupplierSource(scanner supplierSourceScanner) (*service.SupplierSource,
 		&source.EncryptedCredential,
 		&source.CredentialFingerprint,
 		&source.BasePriority,
+		&source.AccountConcurrency,
 		&models,
 		&source.Notes,
 		&source.CreatedAt,
@@ -139,6 +142,7 @@ func scanSupplierSource(scanner supplierSourceScanner) (*service.SupplierSource,
 	if source.Models == nil {
 		source.Models = []service.SupplierSourceModel{}
 	}
+	source.AccountConcurrency = service.ResolveSupplierSourceAccountConcurrency(source.AccountConcurrency)
 	return source, nil
 }
 

--- a/backend/internal/repository/supplier_source_repo_test.go
+++ b/backend/internal/repository/supplier_source_repo_test.go
@@ -50,14 +50,14 @@ func TestSupplierSourceRepositoryCreatePersistsSingleRowContract(t *testing.T) {
 	source := &service.SupplierSource{
 		SupplierName: "佳杰", ChannelName: "stbl-5", Endpoint: "https://token.vstecscloud.com/v1",
 		EncryptedCredential: "ciphertext", CredentialFingerprint: "hmac:fingerprint",
-		BasePriority: 100, Models: models, Notes: "lowest ratio only",
+		BasePriority: 100, AccountConcurrency: 1000, Models: models, Notes: "lowest ratio only",
 	}
 
 	mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO model_supplier_sources
-(supplier_name, channel_name, endpoint, encrypted_credential, credential_fingerprint, base_priority, models, notes)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+(supplier_name, channel_name, endpoint, encrypted_credential, credential_fingerprint, base_priority, account_concurrency, models, notes)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 RETURNING id, created_at, updated_at`)).
-		WithArgs("佳杰", "stbl-5", "https://token.vstecscloud.com/v1", "ciphertext", "hmac:fingerprint", 100, supplierModelsJSONArg{want: models}, "lowest ratio only").
+		WithArgs("佳杰", "stbl-5", "https://token.vstecscloud.com/v1", "ciphertext", "hmac:fingerprint", 100, 1000, supplierModelsJSONArg{want: models}, "lowest ratio only").
 		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(int64(7), now, now))
 
 	repo := NewSupplierSourceRepository(db)
@@ -80,15 +80,15 @@ func TestSupplierSourceRepositoryUpdateReplacesSingleRowContract(t *testing.T) {
 	source := &service.SupplierSource{
 		ID: 7, SupplierName: "VSTECS", ChannelName: "stbl-5", Endpoint: "https://token.vstecscloud.com/v1",
 		EncryptedCredential: "rotated-ciphertext", CredentialFingerprint: "hmac:rotated",
-		BasePriority: 120, Models: models, Notes: "rotated",
+		BasePriority: 120, AccountConcurrency: 1000, Models: models, Notes: "rotated",
 	}
 
 	mock.ExpectQuery(regexp.QuoteMeta(`UPDATE model_supplier_sources
 SET supplier_name=$1, channel_name=$2, endpoint=$3, encrypted_credential=$4,
-    credential_fingerprint=$5, base_priority=$6, models=$7, notes=$8, updated_at=NOW()
-WHERE id=$9
+    credential_fingerprint=$5, base_priority=$6, account_concurrency=$7, models=$8, notes=$9, updated_at=NOW()
+WHERE id=$10
 RETURNING updated_at`)).
-		WithArgs("VSTECS", "stbl-5", "https://token.vstecscloud.com/v1", "rotated-ciphertext", "hmac:rotated", 120, supplierModelsJSONArg{want: models}, "rotated", int64(7)).
+		WithArgs("VSTECS", "stbl-5", "https://token.vstecscloud.com/v1", "rotated-ciphertext", "hmac:rotated", 120, 1000, supplierModelsJSONArg{want: models}, "rotated", int64(7)).
 		WillReturnRows(sqlmock.NewRows([]string{"updated_at"}).AddRow(now))
 
 	repo := NewSupplierSourceRepository(db)
@@ -105,13 +105,13 @@ func TestSupplierSourceRepositoryGetReturnsModelsFromJSON(t *testing.T) {
 	now := time.Date(2026, 8, 28, 8, 0, 0, 0, time.UTC)
 	modelsJSON := []byte(`[{"client_model_id":"deepseek-v4-pro","upstream_model_id":"deepseek-v4-pro","purchase_ratio":0.5}]`)
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, supplier_name, channel_name, endpoint, encrypted_credential,
-credential_fingerprint, base_priority, models, notes, created_at, updated_at
+credential_fingerprint, base_priority, account_concurrency, models, notes, created_at, updated_at
 FROM model_supplier_sources WHERE id=$1`)).
 		WithArgs(int64(7)).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"id", "supplier_name", "channel_name", "endpoint", "encrypted_credential",
-			"credential_fingerprint", "base_priority", "models", "notes", "created_at", "updated_at",
-		}).AddRow(int64(7), "佳杰", "stbl-5", "https://token.vstecscloud.com/v1", "ciphertext", "hmac:fingerprint", 100, modelsJSON, "", now, now))
+			"credential_fingerprint", "base_priority", "account_concurrency", "models", "notes", "created_at", "updated_at",
+		}).AddRow(int64(7), "佳杰", "stbl-5", "https://token.vstecscloud.com/v1", "ciphertext", "hmac:fingerprint", 100, 1000, modelsJSON, "", now, now))
 
 	repo := NewSupplierSourceRepository(db)
 	source, err := repo.Get(context.Background(), 7)

--- a/backend/internal/service/supplier_managed_account_commands.go
+++ b/backend/internal/service/supplier_managed_account_commands.go
@@ -13,6 +13,7 @@ type SupplierManagedAccountCreateInput struct {
 	Endpoint     string
 	Credential   string
 	Priority     int
+	Concurrency  int
 }
 
 type SupplierManagedAccountUpdateInput struct {
@@ -26,6 +27,7 @@ type SupplierManagedAccountUpdateInput struct {
 	Credential      string
 	ModelMapping    map[string]string
 	Priority        int
+	Concurrency     int
 	Status          string
 	Schedulable     bool
 	ChatProbePassed bool
@@ -79,7 +81,7 @@ func (s *adminServiceImpl) CreateSupplierManagedAccount(
 			SupplierSourceIDExtraKey:     input.SourceID,
 			SupplierDiscountBandExtraKey: input.DiscountBand,
 		},
-		Concurrency:          1,
+		Concurrency:          ResolveSupplierSourceAccountConcurrency(input.Concurrency),
 		Priority:             input.Priority,
 		SkipDefaultGroupBind: true,
 	}, accountCreateOptions{
@@ -159,6 +161,7 @@ func (s *adminServiceImpl) UpdateSupplierManagedAccount(
 	account.Extra[SupplierSourceIDExtraKey] = input.SourceID
 	account.Extra[SupplierDiscountBandExtraKey] = input.DiscountBand
 	account.Priority = input.Priority
+	account.Concurrency = ResolveSupplierSourceAccountConcurrency(input.Concurrency)
 	if input.Status == "" {
 		account.Status = StatusActive
 	} else {

--- a/backend/internal/service/supplier_managed_account_commands.go
+++ b/backend/internal/service/supplier_managed_account_commands.go
@@ -36,10 +36,12 @@ type SupplierManagedAccountUpdateInput struct {
 type SupplierManagedAccountCommands interface {
 	CreateSupplierManagedAccount(ctx context.Context, input SupplierManagedAccountCreateInput) (*Account, error)
 	UpdateSupplierManagedAccount(ctx context.Context, input SupplierManagedAccountUpdateInput) (*Account, error)
+	UpdateSupplierManagedAccountConcurrency(ctx context.Context, accountID, sourceID int64, discountBand, concurrency int) (*Account, error)
 }
 
 type supplierProjectionAccountUpdater interface {
 	UpdateSupplierMetadata(ctx context.Context, accountID int64, name string, priority int) error
+	UpdateSupplierConcurrency(ctx context.Context, accountID int64, concurrency int) error
 	UpdateSupplierProjection(ctx context.Context, account *Account, chatProbePassed bool) error
 }
 
@@ -171,6 +173,43 @@ func (s *adminServiceImpl) UpdateSupplierManagedAccount(
 	if err := updateSupplierProjection(ctx, s.accountRepo, account, input.ChatProbePassed); err != nil {
 		return nil, err
 	}
+	return account, nil
+}
+
+func (s *adminServiceImpl) UpdateSupplierManagedAccountConcurrency(
+	ctx context.Context,
+	accountID, sourceID int64,
+	discountBand, concurrency int,
+) (*Account, error) {
+	if s == nil || s.accountRepo == nil || accountID <= 0 || concurrency <= 0 ||
+		concurrency > SupplierSourceMaxAccountConcurrency {
+		return nil, ErrSupplierSourceInvalidInput
+	}
+	reader, ok := s.accountRepo.(supplierManagedAccountReader)
+	if !ok {
+		return nil, ErrSupplierProjectionReaderMissing
+	}
+	account, err := reader.GetSupplierAccount(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+	account = cloneSupplierProjectionAccount(account)
+	if err := validateSupplierManagedIdentity(sourceID, discountBand); err != nil {
+		return nil, err
+	}
+	managedSourceID, sourceOK := supplierSourceIDFromAccount(account)
+	managedBand, bandOK := supplierDiscountBandFromAccount(account)
+	if !sourceOK || !bandOK || managedSourceID != sourceID || managedBand != discountBand {
+		return nil, ErrSupplierSourceIdentityConflict
+	}
+	updater, ok := s.accountRepo.(supplierProjectionAccountUpdater)
+	if !ok {
+		return nil, ErrSupplierProjectionUpdaterMissing
+	}
+	if err := updater.UpdateSupplierConcurrency(ctx, account.ID, concurrency); err != nil {
+		return nil, err
+	}
+	account.Concurrency = concurrency
 	return account, nil
 }
 

--- a/backend/internal/service/supplier_managed_account_commands_test.go
+++ b/backend/internal/service/supplier_managed_account_commands_test.go
@@ -63,6 +63,27 @@ func TestUS048_SupplierCreateUsesDefaultAccountConcurrency(t *testing.T) {
 	require.Equal(t, SupplierSourceDefaultAccountConcurrency, accounts.created.Concurrency)
 }
 
+func TestUS048_SupplierConcurrencyUpdateUsesNarrowWriteWithoutProbeEvidence(t *testing.T) {
+	accounts := &supplierManagedCommandsAccountRepoFake{existing: &Account{
+		ID: 41,
+		Extra: map[string]any{
+			SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3,
+		},
+		Concurrency: 1,
+	}}
+	svc := &adminServiceImpl{accountRepo: accounts}
+
+	updated, err := svc.UpdateSupplierManagedAccountConcurrency(context.Background(), 41, 7, 3, 1000)
+
+	require.NoError(t, err)
+	require.Equal(t, 1000, updated.Concurrency)
+	require.Equal(t, 1, accounts.concurrencyUpdateCalls)
+	require.Equal(t, int64(41), accounts.concurrencyAccountID)
+	require.Equal(t, 1000, accounts.concurrencyValue)
+	require.Zero(t, accounts.projectionUpdateCalls, "concurrency-only changes must not publish protocol evidence")
+	require.Zero(t, accounts.genericUpdateCalls)
+}
+
 func TestUS048_SupplierConfigurationUpdateUsesGroupFreeReadAndNarrowWrite(t *testing.T) {
 	accounts := &supplierManagedCommandsAccountRepoFake{existing: &Account{
 		ID: 41, Name: "old", Platform: PlatformNewAPI, Type: AccountTypeAPIKey, ChannelType: 46,
@@ -244,6 +265,9 @@ type supplierManagedCommandsAccountRepoFake struct {
 	metadataAccountID         int64
 	metadataName              string
 	metadataPriority          int
+	concurrencyUpdateCalls    int
+	concurrencyAccountID      int64
+	concurrencyValue          int
 	bindErr                   error
 	genericGetCalls           int
 	supplierGetCalls          int
@@ -294,6 +318,15 @@ func (r *supplierManagedCommandsAccountRepoFake) UpdateSupplierMetadata(_ contex
 	r.updated = cloneSupplierManagedCommandsTestAccount(r.existing)
 	r.updated.Name = name
 	r.updated.Priority = priority
+	return nil
+}
+
+func (r *supplierManagedCommandsAccountRepoFake) UpdateSupplierConcurrency(_ context.Context, accountID int64, concurrency int) error {
+	r.concurrencyUpdateCalls++
+	r.concurrencyAccountID = accountID
+	r.concurrencyValue = concurrency
+	r.updated = cloneSupplierManagedCommandsTestAccount(r.existing)
+	r.updated.Concurrency = concurrency
 	return nil
 }
 

--- a/backend/internal/service/supplier_managed_account_commands_test.go
+++ b/backend/internal/service/supplier_managed_account_commands_test.go
@@ -49,6 +49,20 @@ func TestUS048_OrdinaryCreateAccountStillFailsWhenDefaultGroupBindFails(t *testi
 	require.Equal(t, 1, accounts.bindCalls)
 }
 
+func TestUS048_SupplierCreateUsesDefaultAccountConcurrency(t *testing.T) {
+	accounts := &supplierManagedCommandsAccountRepoFake{}
+	groups := &supplierManagedCommandsGroupRepoFake{groups: []Group{{ID: 9, Name: PlatformNewAPI + "-default", Platform: PlatformNewAPI}}}
+	svc := &adminServiceImpl{accountRepo: accounts, groupRepo: groups}
+
+	_, err := svc.CreateSupplierManagedAccount(context.Background(), SupplierManagedAccountCreateInput{
+		SourceID: 7, DiscountBand: 3, Name: "supplier/test · 档位 3",
+		Endpoint: "https://supplier.example/v1", Credential: "secret", Priority: 103,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, SupplierSourceDefaultAccountConcurrency, accounts.created.Concurrency)
+}
+
 func TestUS048_SupplierConfigurationUpdateUsesGroupFreeReadAndNarrowWrite(t *testing.T) {
 	accounts := &supplierManagedCommandsAccountRepoFake{existing: &Account{
 		ID: 41, Name: "old", Platform: PlatformNewAPI, Type: AccountTypeAPIKey, ChannelType: 46,

--- a/backend/internal/service/supplier_source.go
+++ b/backend/internal/service/supplier_source.go
@@ -41,8 +41,9 @@ var (
 )
 
 const (
-	SupplierSourceIDExtraKey     = "supplier_source_id"
-	SupplierDiscountBandExtraKey = "supplier_discount_band"
+	SupplierSourceIDExtraKey                = "supplier_source_id"
+	SupplierDiscountBandExtraKey            = "supplier_discount_band"
+	SupplierSourceDefaultAccountConcurrency = 1000
 )
 
 type SupplierSource struct {
@@ -53,6 +54,7 @@ type SupplierSource struct {
 	EncryptedCredential   string
 	Notes                 string
 	BasePriority          int
+	AccountConcurrency    int
 	CredentialFingerprint string
 	Models                []SupplierSourceModel
 	CreatedAt             time.Time
@@ -66,13 +68,14 @@ type SupplierSourceModel struct {
 }
 
 type SupplierSourceInput struct {
-	SupplierName string
-	ChannelName  string
-	Endpoint     string
-	Credential   string
-	BasePriority *int
-	Notes        string
-	Models       []SupplierSourceModelInput
+	SupplierName       string
+	ChannelName        string
+	Endpoint           string
+	Credential         string
+	BasePriority       *int
+	AccountConcurrency *int
+	Notes              string
+	Models             []SupplierSourceModelInput
 }
 
 type SupplierSourceModelInput struct {
@@ -120,6 +123,9 @@ func (i SupplierSourceInput) Validate() error {
 			return err
 		}
 	}
+	if i.AccountConcurrency != nil && *i.AccountConcurrency <= 0 {
+		return ErrSupplierSourceInvalidInput
+	}
 	seen := make(map[string]struct{}, len(i.Models))
 	for _, model := range i.Models {
 		if model.ClientModelID == "" || model.ClientModelID == "*" || strings.Contains(model.ClientModelID, "全系列") ||
@@ -157,6 +163,13 @@ func NormalizeSupplierEndpoint(raw string) (string, error) {
 		return newapiintegration.QianfanBaseURL, nil
 	}
 	return parsed.String(), nil
+}
+
+func ResolveSupplierSourceAccountConcurrency(value int) int {
+	if value <= 0 {
+		return SupplierSourceDefaultAccountConcurrency
+	}
+	return value
 }
 
 type SupplierSourceRepository interface {

--- a/backend/internal/service/supplier_source.go
+++ b/backend/internal/service/supplier_source.go
@@ -44,6 +44,7 @@ const (
 	SupplierSourceIDExtraKey                = "supplier_source_id"
 	SupplierDiscountBandExtraKey            = "supplier_discount_band"
 	SupplierSourceDefaultAccountConcurrency = 1000
+	SupplierSourceMaxAccountConcurrency     = 1<<31 - 1
 )
 
 type SupplierSource struct {
@@ -123,8 +124,10 @@ func (i SupplierSourceInput) Validate() error {
 			return err
 		}
 	}
-	if i.AccountConcurrency != nil && *i.AccountConcurrency <= 0 {
-		return ErrSupplierSourceInvalidInput
+	if i.AccountConcurrency != nil {
+		if *i.AccountConcurrency <= 0 || *i.AccountConcurrency > SupplierSourceMaxAccountConcurrency {
+			return ErrSupplierSourceInvalidInput
+		}
 	}
 	seen := make(map[string]struct{}, len(i.Models))
 	for _, model := range i.Models {

--- a/backend/internal/service/supplier_source_account_store.go
+++ b/backend/internal/service/supplier_source_account_store.go
@@ -96,6 +96,17 @@ func (s *defaultSupplierSourceAccountStore) UpdateManagedAccount(
 	return cloneSupplierProjectionAccount(account), err
 }
 
+func (s *defaultSupplierSourceAccountStore) UpdateManagedAccountConcurrency(
+	ctx context.Context,
+	accountID, sourceID int64,
+	discountBand, concurrency int,
+) (*Account, error) {
+	account, err := s.commands.UpdateSupplierManagedAccountConcurrency(
+		ctx, accountID, sourceID, discountBand, concurrency,
+	)
+	return cloneSupplierProjectionAccount(account), err
+}
+
 func (s *defaultSupplierSourceAccountStore) GetAccount(ctx context.Context, accountID int64) (*Account, error) {
 	if s == nil || s.reader == nil {
 		return nil, ErrSupplierProjectionReaderMissing

--- a/backend/internal/service/supplier_source_account_store_test.go
+++ b/backend/internal/service/supplier_source_account_store_test.go
@@ -72,6 +72,11 @@ func TestUS048_SupplierAccountStoreDelegatesWritesOnlyToAccountCommands(t *testi
 	require.NoError(t, err)
 	require.Equal(t, int64(101), updated.ID)
 	require.Equal(t, 1, commands.updateCalls)
+
+	concurrencyUpdated, err := store.UpdateManagedAccountConcurrency(context.Background(), 101, 7, 3, 1000)
+	require.NoError(t, err)
+	require.Equal(t, int64(101), concurrencyUpdated.ID)
+	require.Equal(t, 1, commands.concurrencyUpdateCalls)
 	require.Zero(t, repo.createCalls)
 	require.Zero(t, repo.updateCalls)
 }
@@ -127,8 +132,9 @@ func (r *supplierAccountStoreRepoFake) Update(context.Context, *Account) error {
 }
 
 type supplierAccountCommandsFake struct {
-	createCalls int
-	updateCalls int
+	createCalls            int
+	updateCalls            int
+	concurrencyUpdateCalls int
 }
 
 func (f *supplierAccountCommandsFake) CreateSupplierManagedAccount(_ context.Context, input SupplierManagedAccountCreateInput) (*Account, error) {
@@ -141,4 +147,13 @@ func (f *supplierAccountCommandsFake) CreateSupplierManagedAccount(_ context.Con
 func (f *supplierAccountCommandsFake) UpdateSupplierManagedAccount(_ context.Context, input SupplierManagedAccountUpdateInput) (*Account, error) {
 	f.updateCalls++
 	return &Account{ID: input.AccountID}, nil
+}
+
+func (f *supplierAccountCommandsFake) UpdateSupplierManagedAccountConcurrency(
+	_ context.Context,
+	accountID, _ int64,
+	_, concurrency int,
+) (*Account, error) {
+	f.concurrencyUpdateCalls++
+	return &Account{ID: accountID, Concurrency: concurrency}, nil
 }

--- a/backend/internal/service/supplier_source_service.go
+++ b/backend/internal/service/supplier_source_service.go
@@ -65,6 +65,7 @@ type SupplierSourceAccountStore interface {
 	FindCredentialEndpointMatches(ctx context.Context, match SupplierAccountMatch) ([]*Account, error)
 	CreateManagedAccount(ctx context.Context, input SupplierManagedAccountCreateInput) (*Account, error)
 	UpdateManagedAccount(ctx context.Context, input SupplierManagedAccountUpdateInput) (*Account, error)
+	UpdateManagedAccountConcurrency(ctx context.Context, accountID, sourceID int64, discountBand, concurrency int) (*Account, error)
 	GetAccount(ctx context.Context, accountID int64) (*Account, error)
 }
 
@@ -273,10 +274,7 @@ func (s *SupplierSourceService) Sync(ctx context.Context, sourceID int64) (*Supp
 		for band, account := range managedByBand {
 			workingByBand[band] = cloneSupplierProjectionAccount(account)
 		}
-		if err := s.ensureSupplierManagedConcurrency(ctx, source, credential, targets, workingByBand, result); err != nil {
-			return result, err
-		}
-		if err := s.ensureSupplierProtocolProjections(ctx, source, credential, targets, workingByBand, result); err != nil {
+		if err := s.ensureSupplierManagedConcurrency(ctx, source, targets, workingByBand, result); err != nil {
 			return result, err
 		}
 		return result, nil
@@ -394,9 +392,6 @@ func (s *SupplierSourceService) Sync(ctx context.Context, sourceID int64) (*Supp
 			action = "cleared"
 		}
 		result.Changes = append(result.Changes, supplierAccountChange(before, updated, band, action))
-	}
-	if err := s.ensureSupplierProtocolProjections(ctx, source, credential, targets, workingByBand, result); err != nil {
-		return result, err
 	}
 	return result, nil
 }
@@ -562,6 +557,7 @@ func supplierStructureChanged(
 	for band, target := range targets {
 		account := managedByBand[band]
 		if account == nil || !supplierAccountStructureMatches(account, source.Endpoint, credential, target.Mapping) ||
+			supplierAccountNeedsProtocolRepublish(account, source.Endpoint) ||
 			!supplierSchedulingProjectionMatches(account, target.Mapping) {
 			return true
 		}
@@ -573,6 +569,7 @@ func supplierStructureChanged(
 			mapping = target.Mapping
 		}
 		if !supplierAccountStructureMatches(account, source.Endpoint, credential, mapping) ||
+			supplierAccountNeedsProtocolRepublish(account, source.Endpoint) ||
 			!supplierSchedulingProjectionMatches(account, mapping) {
 			return true
 		}
@@ -761,7 +758,6 @@ func supplierSourceFromInput(input SupplierSourceInput, basePriority, accountCon
 func (s *SupplierSourceService) ensureSupplierManagedConcurrency(
 	ctx context.Context,
 	source *SupplierSource,
-	credential string,
 	targets map[int]supplierTargetBand,
 	workingByBand map[int]*Account,
 	result *SupplierSourceSyncResult,
@@ -777,13 +773,9 @@ func (s *SupplierSourceService) ensureSupplierManagedConcurrency(
 			continue
 		}
 		before := cloneSupplierProjectionAccount(account)
-		updated, err := s.accounts.UpdateManagedAccount(ctx, SupplierManagedAccountUpdateInput{
-			AccountID: account.ID, SourceID: source.ID, DiscountBand: band,
-			Name: supplierManagedAccountName(source, band), Endpoint: source.Endpoint, Credential: credential,
-			ModelMapping: cloneSupplierStringMap(target.Mapping), Priority: target.Priority,
-			Concurrency: source.AccountConcurrency, Status: StatusActive, Schedulable: true,
-			ChatProbePassed: true,
-		})
+		updated, err := s.accounts.UpdateManagedAccountConcurrency(
+			ctx, account.ID, source.ID, band, wantConcurrency,
+		)
 		if err != nil {
 			result.FailedStep = fmt.Sprintf("concurrency_band_%d", band)
 			return err
@@ -791,46 +783,6 @@ func (s *SupplierSourceService) ensureSupplierManagedConcurrency(
 		readback, readbackErr := s.accounts.GetAccount(ctx, updated.ID)
 		if readbackErr != nil {
 			result.FailedStep = fmt.Sprintf("concurrency_band_%d", band)
-			return readbackErr
-		}
-		workingByBand[band] = readback
-		result.Changes = append(result.Changes, supplierAccountChange(before, readback, band, "updated"))
-	}
-	return nil
-}
-
-func (s *SupplierSourceService) ensureSupplierProtocolProjections(
-	ctx context.Context,
-	source *SupplierSource,
-	credential string,
-	targets map[int]supplierTargetBand,
-	workingByBand map[int]*Account,
-	result *SupplierSourceSyncResult,
-) error {
-	for _, band := range sortedSupplierBands(targets) {
-		target := targets[band]
-		if len(target.Mapping) == 0 {
-			continue
-		}
-		account := workingByBand[band]
-		if account == nil || !supplierAccountNeedsProtocolRepublish(account, source.Endpoint) {
-			continue
-		}
-		before := cloneSupplierProjectionAccount(account)
-		updated, err := s.accounts.UpdateManagedAccount(ctx, SupplierManagedAccountUpdateInput{
-			AccountID: account.ID, SourceID: source.ID, DiscountBand: band,
-			Name: supplierManagedAccountName(source, band), Endpoint: source.Endpoint, Credential: credential,
-			ModelMapping: cloneSupplierStringMap(target.Mapping), Priority: target.Priority,
-			Concurrency: source.AccountConcurrency, Status: StatusActive, Schedulable: true,
-			ChatProbePassed: true,
-		})
-		if err != nil {
-			result.FailedStep = fmt.Sprintf("protocol_band_%d", band)
-			return err
-		}
-		readback, readbackErr := s.accounts.GetAccount(ctx, updated.ID)
-		if readbackErr != nil {
-			result.FailedStep = fmt.Sprintf("protocol_band_%d", band)
 			return readbackErr
 		}
 		workingByBand[band] = readback

--- a/backend/internal/service/supplier_source_service.go
+++ b/backend/internal/service/supplier_source_service.go
@@ -134,7 +134,11 @@ func (s *SupplierSourceService) Create(ctx context.Context, input SupplierSource
 	if input.BasePriority != nil {
 		basePriority = *input.BasePriority
 	}
-	source := supplierSourceFromInput(input, basePriority)
+	accountConcurrency := SupplierSourceDefaultAccountConcurrency
+	if input.AccountConcurrency != nil {
+		accountConcurrency = ResolveSupplierSourceAccountConcurrency(*input.AccountConcurrency)
+	}
+	source := supplierSourceFromInput(input, basePriority, accountConcurrency)
 	source.EncryptedCredential = encryptedCredential
 	source.CredentialFingerprint = fingerprint
 	if err := s.repo.Create(ctx, source); err != nil {
@@ -162,7 +166,11 @@ func (s *SupplierSourceService) Update(ctx context.Context, id int64, input Supp
 	if input.BasePriority != nil {
 		basePriority = *input.BasePriority
 	}
-	updated := supplierSourceFromInput(input, basePriority)
+	accountConcurrency := existing.AccountConcurrency
+	if input.AccountConcurrency != nil {
+		accountConcurrency = ResolveSupplierSourceAccountConcurrency(*input.AccountConcurrency)
+	}
+	updated := supplierSourceFromInput(input, basePriority, accountConcurrency)
 	updated.ID = existing.ID
 	updated.CreatedAt = existing.CreatedAt
 	updated.EncryptedCredential = existing.EncryptedCredential
@@ -261,6 +269,16 @@ func (s *SupplierSourceService) Sync(ctx context.Context, sourceID int64) (*Supp
 		if err := s.syncSupplierMetadata(ctx, source, managedByBand, result); err != nil {
 			return result, err
 		}
+		workingByBand := make(map[int]*Account, len(managedByBand))
+		for band, account := range managedByBand {
+			workingByBand[band] = cloneSupplierProjectionAccount(account)
+		}
+		if err := s.ensureSupplierManagedConcurrency(ctx, source, credential, targets, workingByBand, result); err != nil {
+			return result, err
+		}
+		if err := s.ensureSupplierProtocolProjections(ctx, source, credential, targets, workingByBand, result); err != nil {
+			return result, err
+		}
 		return result, nil
 	}
 
@@ -292,7 +310,7 @@ func (s *SupplierSourceService) Sync(ctx context.Context, sourceID int64) (*Supp
 				createInput := SupplierManagedAccountCreateInput{
 					SourceID: source.ID, DiscountBand: band, Name: supplierManagedAccountName(source, band),
 					Endpoint: source.Endpoint, Credential: credential,
-					Priority: target.Priority,
+					Priority: target.Priority, Concurrency: source.AccountConcurrency,
 				}
 				account, err = s.accounts.CreateManagedAccount(ctx, createInput)
 				if err != nil {
@@ -308,7 +326,8 @@ func (s *SupplierSourceService) Sync(ctx context.Context, sourceID int64) (*Supp
 		updateInput := SupplierManagedAccountUpdateInput{
 			AccountID: account.ID, SourceID: source.ID, DiscountBand: band,
 			Name: supplierManagedAccountName(source, band), Endpoint: source.Endpoint, Credential: credential,
-			ModelMapping: additionMapping, Priority: target.Priority, Status: StatusActive,
+			ModelMapping: additionMapping, Priority: target.Priority, Concurrency: source.AccountConcurrency,
+			Status:      StatusActive,
 			Schedulable: len(additionMapping) > 0, Adopt: adopt,
 			ChatProbePassed: len(additionMapping) > 0,
 		}
@@ -353,7 +372,7 @@ func (s *SupplierSourceService) Sync(ctx context.Context, sourceID int64) (*Supp
 			desiredMapping = target.Mapping
 			desiredPriority = target.Priority
 		}
-		if supplierAccountMatchesDesired(account, source.Endpoint, credential, desiredMapping, desiredPriority) {
+		if supplierAccountMatchesDesired(account, source, credential, desiredMapping, desiredPriority) {
 			continue
 		}
 		before := cloneSupplierProjectionAccount(account)
@@ -361,7 +380,8 @@ func (s *SupplierSourceService) Sync(ctx context.Context, sourceID int64) (*Supp
 			AccountID: account.ID, SourceID: source.ID, DiscountBand: band,
 			Name: supplierManagedAccountName(source, band), Endpoint: source.Endpoint, Credential: credential,
 			ModelMapping: cloneSupplierStringMap(desiredMapping), Priority: desiredPriority,
-			Status: StatusActive, Schedulable: len(desiredMapping) > 0,
+			Concurrency: source.AccountConcurrency,
+			Status:      StatusActive, Schedulable: len(desiredMapping) > 0,
 			ChatProbePassed: len(desiredMapping) > 0,
 		})
 		if updateErr != nil {
@@ -374,6 +394,9 @@ func (s *SupplierSourceService) Sync(ctx context.Context, sourceID int64) (*Supp
 			action = "cleared"
 		}
 		result.Changes = append(result.Changes, supplierAccountChange(before, updated, band, action))
+	}
+	if err := s.ensureSupplierProtocolProjections(ctx, source, credential, targets, workingByBand, result); err != nil {
+		return result, err
 	}
 	return result, nil
 }
@@ -572,9 +595,20 @@ func supplierAccountStructureMatches(account *Account, endpoint, credential stri
 	return supplierStringMapsEqual(supplierModelMapping(account.Credentials), mapping)
 }
 
-func supplierAccountMatchesDesired(account *Account, endpoint, credential string, mapping map[string]string, priority int) bool {
-	return supplierAccountStructureMatches(account, endpoint, credential, mapping) &&
-		account.Priority == priority && supplierSchedulingProjectionMatches(account, mapping)
+func supplierAccountMatchesDesired(
+	account *Account,
+	source *SupplierSource,
+	credential string,
+	mapping map[string]string,
+	priority int,
+) bool {
+	if source == nil {
+		return false
+	}
+	return supplierAccountStructureMatches(account, source.Endpoint, credential, mapping) &&
+		account.Priority == priority &&
+		account.Concurrency == ResolveSupplierSourceAccountConcurrency(source.AccountConcurrency) &&
+		supplierSchedulingProjectionMatches(account, mapping)
 }
 
 func supplierSchedulingProjectionMatches(account *Account, mapping map[string]string) bool {
@@ -588,7 +622,8 @@ func supplierProbeAccount(base *Account, source *SupplierSource, credential stri
 	}
 	account := &Account{
 		Platform: PlatformNewAPI, Type: AccountTypeAPIKey,
-		ChannelType: transport.ChannelType, Concurrency: 1,
+		ChannelType: transport.ChannelType,
+		Concurrency: ResolveSupplierSourceAccountConcurrency(source.AccountConcurrency),
 	}
 	if base != nil {
 		account = cloneSupplierProjectionAccount(base)
@@ -711,15 +746,123 @@ func supplierAccountChange(before, after *Account, band int, action string) Supp
 	return change
 }
 
-func supplierSourceFromInput(input SupplierSourceInput, basePriority int) *SupplierSource {
+func supplierSourceFromInput(input SupplierSourceInput, basePriority, accountConcurrency int) *SupplierSource {
 	models := make([]SupplierSourceModel, 0, len(input.Models))
 	for _, model := range input.Models {
 		models = append(models, SupplierSourceModel(model))
 	}
 	return &SupplierSource{
 		SupplierName: input.SupplierName, ChannelName: input.ChannelName, Endpoint: input.Endpoint,
-		BasePriority: basePriority, Models: models, Notes: input.Notes,
+		BasePriority: basePriority, AccountConcurrency: ResolveSupplierSourceAccountConcurrency(accountConcurrency),
+		Models: models, Notes: input.Notes,
 	}
+}
+
+func (s *SupplierSourceService) ensureSupplierManagedConcurrency(
+	ctx context.Context,
+	source *SupplierSource,
+	credential string,
+	targets map[int]supplierTargetBand,
+	workingByBand map[int]*Account,
+	result *SupplierSourceSyncResult,
+) error {
+	wantConcurrency := ResolveSupplierSourceAccountConcurrency(source.AccountConcurrency)
+	for _, band := range sortedSupplierBands(targets) {
+		target := targets[band]
+		if len(target.Mapping) == 0 {
+			continue
+		}
+		account := workingByBand[band]
+		if account == nil || account.Concurrency == wantConcurrency {
+			continue
+		}
+		before := cloneSupplierProjectionAccount(account)
+		updated, err := s.accounts.UpdateManagedAccount(ctx, SupplierManagedAccountUpdateInput{
+			AccountID: account.ID, SourceID: source.ID, DiscountBand: band,
+			Name: supplierManagedAccountName(source, band), Endpoint: source.Endpoint, Credential: credential,
+			ModelMapping: cloneSupplierStringMap(target.Mapping), Priority: target.Priority,
+			Concurrency: source.AccountConcurrency, Status: StatusActive, Schedulable: true,
+			ChatProbePassed: true,
+		})
+		if err != nil {
+			result.FailedStep = fmt.Sprintf("concurrency_band_%d", band)
+			return err
+		}
+		readback, readbackErr := s.accounts.GetAccount(ctx, updated.ID)
+		if readbackErr != nil {
+			result.FailedStep = fmt.Sprintf("concurrency_band_%d", band)
+			return readbackErr
+		}
+		workingByBand[band] = readback
+		result.Changes = append(result.Changes, supplierAccountChange(before, readback, band, "updated"))
+	}
+	return nil
+}
+
+func (s *SupplierSourceService) ensureSupplierProtocolProjections(
+	ctx context.Context,
+	source *SupplierSource,
+	credential string,
+	targets map[int]supplierTargetBand,
+	workingByBand map[int]*Account,
+	result *SupplierSourceSyncResult,
+) error {
+	for _, band := range sortedSupplierBands(targets) {
+		target := targets[band]
+		if len(target.Mapping) == 0 {
+			continue
+		}
+		account := workingByBand[band]
+		if account == nil || !supplierAccountNeedsProtocolRepublish(account, source.Endpoint) {
+			continue
+		}
+		before := cloneSupplierProjectionAccount(account)
+		updated, err := s.accounts.UpdateManagedAccount(ctx, SupplierManagedAccountUpdateInput{
+			AccountID: account.ID, SourceID: source.ID, DiscountBand: band,
+			Name: supplierManagedAccountName(source, band), Endpoint: source.Endpoint, Credential: credential,
+			ModelMapping: cloneSupplierStringMap(target.Mapping), Priority: target.Priority,
+			Concurrency: source.AccountConcurrency, Status: StatusActive, Schedulable: true,
+			ChatProbePassed: true,
+		})
+		if err != nil {
+			result.FailedStep = fmt.Sprintf("protocol_band_%d", band)
+			return err
+		}
+		readback, readbackErr := s.accounts.GetAccount(ctx, updated.ID)
+		if readbackErr != nil {
+			result.FailedStep = fmt.Sprintf("protocol_band_%d", band)
+			return readbackErr
+		}
+		workingByBand[band] = readback
+		result.Changes = append(result.Changes, supplierAccountChange(before, readback, band, "updated"))
+	}
+	return nil
+}
+
+func supplierAccountNeedsProtocolRepublish(account *Account, sourceEndpoint string) bool {
+	if account == nil || len(supplierModelMapping(account.Credentials)) == 0 {
+		return false
+	}
+	want, err := resolveSupplierManagedTransport(sourceEndpoint)
+	if err != nil {
+		return false
+	}
+	if account.ChannelType != want.ChannelType {
+		return true
+	}
+	baseURL, _ := account.Credentials["base_url"].(string)
+	if !supplierManagedEndpointsEqual(baseURL, sourceEndpoint) {
+		return true
+	}
+	identity, governed, err := BuildProtocolEndpointIdentity(account)
+	if err != nil || !governed {
+		return true
+	}
+	if account.ProtocolEndpointCapability != nil &&
+		identity.Key() != account.ProtocolEndpointCapability.CapabilityKey {
+		return true
+	}
+	return false
 }
 
 func (s *SupplierSourceService) protectCredential(credential string) (string, string, error) {

--- a/backend/internal/service/supplier_source_service_test.go
+++ b/backend/internal/service/supplier_source_service_test.go
@@ -147,7 +147,9 @@ func (r *supplierSourceRepoFake) Get(_ context.Context, id int64) (*SupplierSour
 	if r.stored == nil || r.stored.ID != id {
 		return nil, ErrSupplierSourceNotFound
 	}
-	return cloneSupplierSourceForTest(r.stored), nil
+	cloned := cloneSupplierSourceForTest(r.stored)
+	cloned.AccountConcurrency = ResolveSupplierSourceAccountConcurrency(cloned.AccountConcurrency)
+	return cloned, nil
 }
 
 func (r *supplierSourceRepoFake) List(context.Context) ([]SupplierSource, error) {

--- a/backend/internal/service/supplier_source_service_test.go
+++ b/backend/internal/service/supplier_source_service_test.go
@@ -47,6 +47,16 @@ func TestUS048_CreateSupplierSourceAcceptsEmptyModelList(t *testing.T) {
 	require.Empty(t, created.Models)
 }
 
+func TestUS048_SupplierSourceRejectsAccountConcurrencyAboveDatabaseInteger(t *testing.T) {
+	tooLarge := SupplierSourceMaxAccountConcurrency + 1
+	input := SupplierSourceInput{
+		SupplierName: "佳杰", ChannelName: "default", Endpoint: "https://supplier.example/v1",
+		AccountConcurrency: &tooLarge,
+	}
+
+	require.ErrorIs(t, input.Validate(), ErrSupplierSourceInvalidInput)
+}
+
 func TestUS048_UpdateSupplierSourceBlankCredentialKeepsStoredSecretIdentity(t *testing.T) {
 	basePriority := 120
 	repo := &supplierSourceRepoFake{stored: &SupplierSource{

--- a/backend/internal/service/supplier_source_sync_test.go
+++ b/backend/internal/service/supplier_source_sync_test.go
@@ -692,19 +692,42 @@ func (p *supplierSyncProbeFake) ProbeSupplierModel(_ context.Context, input Supp
 }
 
 type supplierSyncAccountStoreFake struct {
-	managed     []*Account
-	matches     []*Account
-	created     []SupplierManagedAccountCreateInput
-	updated     []SupplierManagedAccountUpdateInput
-	operations  []string
-	createCalls int
-	getCalls    int
-	nextID      int64
-	updateErrAt int
-	updateErr   error
-	getErrAt    int
-	listErr     error
-	matchErr    error
+	managed            []*Account
+	matches            []*Account
+	created            []SupplierManagedAccountCreateInput
+	updated            []SupplierManagedAccountUpdateInput
+	concurrencyUpdates []int
+	operations         []string
+	createCalls        int
+	getCalls           int
+	nextID             int64
+	updateErrAt        int
+	updateErr          error
+	getErrAt           int
+	listErr            error
+	matchErr           error
+}
+
+func (f *supplierSyncAccountStoreFake) UpdateManagedAccountConcurrency(
+	_ context.Context,
+	accountID, sourceID int64,
+	discountBand, concurrency int,
+) (*Account, error) {
+	f.concurrencyUpdates = append(f.concurrencyUpdates, concurrency)
+	for index, account := range f.managed {
+		if account.ID != accountID {
+			continue
+		}
+		managedSourceID, sourceOK := supplierSourceIDFromAccount(account)
+		managedBand, bandOK := supplierDiscountBandFromAccount(account)
+		if !sourceOK || !bandOK || managedSourceID != sourceID || managedBand != discountBand {
+			return nil, ErrSupplierSourceIdentityConflict
+		}
+		account.Concurrency = concurrency
+		f.managed[index] = account
+		return cloneSupplierProjectionAccount(account), nil
+	}
+	return nil, ErrAccountNotFound
 }
 
 func (f *supplierSyncAccountStoreFake) ListManagedAccounts(context.Context, int64) ([]*Account, error) {
@@ -829,14 +852,50 @@ func TestUS048_SupplierSyncAppliesSourceAccountConcurrency(t *testing.T) {
 		Extra:    map[string]any{SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3},
 		Priority: 103, Status: StatusActive, Schedulable: true, Concurrency: 1,
 	}}}
-	probe := &supplierSyncProbeFake{}
+	probe := &supplierSyncProbeFake{failIfCalled: true}
 	svc := NewSupplierSourceService(repo, accounts, probe, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{})
 
 	_, err := svc.Sync(context.Background(), 7)
 
 	require.NoError(t, err)
+	require.Equal(t, []int{1000}, accounts.concurrencyUpdates)
+	for _, update := range accounts.updated {
+		require.True(t, update.MetadataOnly, "concurrency-only sync must not use the full projection write")
+	}
+	require.Equal(t, 1000, accounts.managed[0].Concurrency)
+}
+
+func TestUS048_SupplierSyncProtocolIdentityDriftRequiresCurrentProbe(t *testing.T) {
+	ratio := 0.5
+	capabilityID := int64(797)
+	repo := &supplierSourceRepoFake{stored: &SupplierSource{
+		ID: 7, SupplierName: "佳杰", ChannelName: "stbl-5", Endpoint: "https://supplier.example/v1",
+		EncryptedCredential: "enc:secret", CredentialFingerprint: "fp:secret", BasePriority: 100,
+		AccountConcurrency: 1000,
+		Models: []SupplierSourceModel{{
+			ClientModelID: "deepseek-v4-pro", UpstreamModelID: "deepseek-v4-pro", PurchaseRatio: &ratio,
+		}},
+	}}
+	accounts := &supplierSyncAccountStoreFake{managed: []*Account{{
+		ID: 41, Name: "supplier/佳杰 · 档位 3", Platform: PlatformNewAPI, Type: AccountTypeAPIKey, ChannelType: 1,
+		Credentials: map[string]any{
+			"base_url": "https://supplier.example/v1", "api_key": "secret",
+			"model_mapping": map[string]string{"deepseek-v4-pro": "deepseek-v4-pro"},
+		},
+		Extra:    map[string]any{SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3},
+		Priority: 103, Status: StatusActive, Schedulable: true, Concurrency: 1000,
+		ProtocolEndpointCapabilityID: &capabilityID,
+		ProtocolEndpointCapability:   &ProtocolEndpointCapability{ID: capabilityID, CapabilityKey: "stale-identity"},
+	}}}
+	probe := &supplierSyncProbeFake{}
+	svc := NewSupplierSourceService(repo, accounts, probe, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{})
+
+	result, err := svc.Sync(context.Background(), 7)
+
+	require.NoError(t, err)
+	require.Len(t, result.ProbeResults, 1, "protocol identity repair must be backed by this sync call's real probe")
 	require.NotEmpty(t, accounts.updated)
-	require.Equal(t, 1000, accounts.updated[len(accounts.updated)-1].Concurrency)
+	require.True(t, accounts.updated[0].ChatProbePassed)
 }
 
 func TestSupplierAccountNeedsProtocolRepublishDetectsTransportDrift(t *testing.T) {

--- a/backend/internal/service/supplier_source_sync_test.go
+++ b/backend/internal/service/supplier_source_sync_test.go
@@ -91,7 +91,7 @@ func TestUS048_SupplierSyncMetadataOnlySkipsProbe(t *testing.T) {
 			"model_mapping": map[string]string{"model": "model"},
 		},
 		Extra:    map[string]any{SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3},
-		Priority: 102, Status: StatusActive, Schedulable: true,
+		Priority: 102, Status: StatusActive, Schedulable: true, Concurrency: SupplierSourceDefaultAccountConcurrency,
 	}}}
 	probe := &supplierSyncProbeFake{failIfCalled: true}
 	svc := NewSupplierSourceService(repo, accounts, probe, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{})
@@ -120,7 +120,7 @@ func TestUS048_SupplierSyncNameChangeUpdatesAccountWithoutProbe(t *testing.T) {
 			"model_mapping": map[string]string{"model": "model"},
 		},
 		Extra:    map[string]any{SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3},
-		Priority: 103, Status: StatusActive, Schedulable: true,
+		Priority: 103, Status: StatusActive, Schedulable: true, Concurrency: SupplierSourceDefaultAccountConcurrency,
 	}}}
 	probe := &supplierSyncProbeFake{failIfCalled: true}
 	svc := NewSupplierSourceService(repo, accounts, probe, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{})
@@ -147,7 +147,7 @@ func TestUS048_SupplierSyncMovesModelByAddingBeforeRemoving(t *testing.T) {
 			"model_mapping": map[string]string{"model": "model"},
 		},
 		Extra:    map[string]any{SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3},
-		Priority: 103, Status: StatusActive, Schedulable: true,
+		Priority: 103, Status: StatusActive, Schedulable: true, Concurrency: SupplierSourceDefaultAccountConcurrency,
 	}}}
 	probe := &supplierSyncProbeFake{}
 	svc := NewSupplierSourceService(repo, accounts, probe, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{})
@@ -658,6 +658,7 @@ func supplierSyncManagedAccount(id, sourceID int64, band, priority int, mapping 
 			SupplierSourceIDExtraKey: sourceID, SupplierDiscountBandExtraKey: band,
 		},
 		Priority: priority, Status: StatusActive, Schedulable: schedulable,
+		Concurrency: SupplierSourceDefaultAccountConcurrency,
 	}
 }
 
@@ -771,6 +772,7 @@ func (f *supplierSyncAccountStoreFake) UpdateManagedAccount(_ context.Context, i
 			account.ChannelType = transport.ChannelType
 			account.Credentials = supplierManagedCredentials(input.Endpoint, input.Credential, input.ModelMapping)
 			account.Priority = input.Priority
+			account.Concurrency = ResolveSupplierSourceAccountConcurrency(input.Concurrency)
 			account.Status = input.Status
 			account.Schedulable = input.Schedulable && len(input.ModelMapping) > 0
 		}
@@ -806,4 +808,44 @@ func (f *supplierSyncAccountStoreFake) GetAccount(_ context.Context, accountID i
 
 func syncOperationLabel(input SupplierManagedAccountUpdateInput) string {
 	return "update:band=" + string(rune('0'+input.DiscountBand)) + ":models=" + string(rune('0'+len(input.ModelMapping)))
+}
+
+func TestUS048_SupplierSyncAppliesSourceAccountConcurrency(t *testing.T) {
+	ratio := 0.5
+	repo := &supplierSourceRepoFake{stored: &SupplierSource{
+		ID: 7, SupplierName: "佳杰", ChannelName: "stbl-5", Endpoint: "https://supplier.example/v1",
+		EncryptedCredential: "enc:secret", CredentialFingerprint: "fp:secret", BasePriority: 100,
+		AccountConcurrency: 1000,
+		Models: []SupplierSourceModel{
+			{ClientModelID: "deepseek-v4-pro", UpstreamModelID: "deepseek-v4-pro", PurchaseRatio: &ratio},
+		},
+	}}
+	accounts := &supplierSyncAccountStoreFake{managed: []*Account{{
+		ID: 41, Name: "supplier/佳杰 · 档位 3", Platform: PlatformNewAPI, Type: AccountTypeAPIKey, ChannelType: 1,
+		Credentials: map[string]any{
+			"base_url": "https://supplier.example/v1", "api_key": "secret",
+			"model_mapping": map[string]string{"deepseek-v4-pro": "deepseek-v4-pro"},
+		},
+		Extra:    map[string]any{SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3},
+		Priority: 103, Status: StatusActive, Schedulable: true, Concurrency: 1,
+	}}}
+	probe := &supplierSyncProbeFake{}
+	svc := NewSupplierSourceService(repo, accounts, probe, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{})
+
+	_, err := svc.Sync(context.Background(), 7)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, accounts.updated)
+	require.Equal(t, 1000, accounts.updated[len(accounts.updated)-1].Concurrency)
+}
+
+func TestSupplierAccountNeedsProtocolRepublishDetectsTransportDrift(t *testing.T) {
+	account := &Account{
+		Platform: PlatformNewAPI, Type: AccountTypeAPIKey, ChannelType: newapiconstant.ChannelTypeOpenAI,
+		Credentials: supplierManagedCredentials(
+			"https://qianfan.baidubce.com", "secret", map[string]string{"glm-5.3": "glm-5.3"},
+		),
+		ProtocolEndpointCapabilityID: func() *int64 { id := int64(797); return &id }(),
+	}
+	require.True(t, supplierAccountNeedsProtocolRepublish(account, "https://qianfan.baidubce.com"))
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 714,
-  "hash": "4da4e898bb3f1d7a48d5c030d1ebc665e4d0df2ddcab6a0370af645e88ecd19d",
+  "hash": "b124642e745ae1a367cddb81a3eff8adefc6e5a9a1afb7576c240f4b22f74cc0",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/migrations/tk_090_supplier_source_account_concurrency.sql
+++ b/backend/migrations/tk_090_supplier_source_account_concurrency.sql
@@ -1,0 +1,11 @@
+-- Per-supplier default concurrency for managed projection accounts.
+
+ALTER TABLE model_supplier_sources
+    ADD COLUMN IF NOT EXISTS account_concurrency INTEGER NOT NULL DEFAULT 1000;
+
+ALTER TABLE model_supplier_sources
+    DROP CONSTRAINT IF EXISTS model_supplier_sources_account_concurrency_check;
+
+ALTER TABLE model_supplier_sources
+    ADD CONSTRAINT model_supplier_sources_account_concurrency_check
+        CHECK (account_concurrency > 0);

--- a/backend/migrations/tk_090_supplier_source_account_concurrency.sql
+++ b/backend/migrations/tk_090_supplier_source_account_concurrency.sql
@@ -1,4 +1,6 @@
 -- Per-supplier default concurrency for managed projection accounts.
+-- bluegreen-safe-destructive-ok: expand-only ADD COLUMN IF NOT EXISTS with DEFAULT 1000
+-- backfills existing rows; no table rewrite or contract shrink.
 
 ALTER TABLE model_supplier_sources
     ADD COLUMN IF NOT EXISTS account_concurrency INTEGER NOT NULL DEFAULT 1000;

--- a/docs/approved/model-supplier-source-management.md
+++ b/docs/approved/model-supplier-source-management.md
@@ -3,7 +3,7 @@ title: TokenKey Model Supplier Source Management
 status: approved
 approved_by: "xuejiao (operator directives through 2026-08-28)"
 approved_at: 2026-08-27
-updated: 2026-08-30
+updated: 2026-08-31
 created: 2026-08-27
 owners: [tk-platform]
 scope: "supplier facts, admin API/UI, credential isolation, account projection, probe gate, and managed-account ownership"
@@ -49,7 +49,9 @@ account.priority = source.base_priority + discount_priority
   NewAPI 账号的 base URL 和协议行为保持不变。
 - 供应源不读取或写入倍率、售价、pricing registry、计费规则、用户价格或利润数据。
 - 除把账号 `status/schedulable` 收敛到目标 mapping 的投影值外，供应源不修改 gateway、scheduler、
-  sticky、运行期健康窗口、冷却、限流、fallback、`error_message` 或其他运行期字段。
+  sticky、运行期健康窗口、冷却、限流、fallback、`error_message` 或其他运行期字段。供应源拥有
+  `account_concurrency`（默认 `1000`），同步时写入受管账号 `concurrency`，不再保留账号页手工设置的
+  并发值。
 - 凭证使用最小权限 API Key；不保存供应商后台账号密码，不自动登录、处理 MFA 或代建 API Key。
 - API 不回显明文、密文或凭证指纹；日志和 Admin Audit Log 必须擦除请求字段 `credential`。
 - 未知或私有协议失败封闭；即使探测得到 Responses、Anthropic Messages 等非 Chat 成功证据，也返回
@@ -88,6 +90,7 @@ discover / sync 失败时，API 必须返回可读 `message`（含上游 models 
 同步按以下最小规则执行：
 
 1. 供应商名称、通道名称或 `base_priority` 变化时，只更新受管账号名称和 priority，不探测；
+1b. `account_concurrency` 变化时，只更新受管账号 `concurrency`，不探测；
 2. endpoint、credential、模型 ID、模型增减、跨档，或非空受管账号的 `status/schedulable` 与目标
    不一致时，先用内存目标账号逐模型真实探测；空 mapping 的调度字段漂移无需探测；
 3. 任一模型失败，返回完整当次探测结果且不写账号；全部成功生成仅供本次同步调用链使用的 Chat
@@ -154,7 +157,8 @@ POST   /admin/supplier-sources/:id/models-discover
 POST   /admin/supplier-sources/:id/sync
 ```
 
-不提供 DELETE、validate、activation-preview、activate、pause 或供应源 audits API。页面只展示运营
+不提供 DELETE、validate、activation-preview、activate、pause 或供应源 audits API。供应源读写体含
+`account_concurrency`（正整数，默认 `1000`）。页面只展示运营
 字段、档位与目标 priority、全局供应源 priority、保存、单源“校验并同步”（内嵌 models-discover
 规整/建议）、当次发现结果、当次逐模型探测结果和实际账号变化。
 

--- a/frontend/e2e/us048-supplier-source-management.e2e.ts
+++ b/frontend/e2e/us048-supplier-source-management.e2e.ts
@@ -403,8 +403,15 @@ test('US048 accounts UI marks supplier-managed accounts and explains read-only o
   await expect(badge).toHaveAttribute('href', '/admin/supplier-sources?source_id=7')
 
   const editButton = row.locator('[data-testid="account-edit-btn"]')
-  await expect(editButton).toBeDisabled()
-  await expect(editButton).toHaveAttribute('title', '该账号由供应源托管，请前往供应源管理修改。')
+  await expect(editButton).toBeEnabled()
+  await expect(editButton).toHaveAttribute('title', '查看托管账号配置（只读）')
+  await expect(editButton).toContainText('查看')
+
+  await editButton.click()
+  await expect(page.getByRole('heading', { name: '查看账号' })).toBeVisible()
+  await expect(page.getByText('以下为只读快照；修改模型、凭证与 priority 请前往供应源管理。')).toBeVisible()
+  await expect(page.getByRole('button', { name: '更新' })).toHaveCount(0)
+  await page.getByRole('button', { name: '关闭' }).click()
 
   await row.getByRole('button', { name: '更多' }).click()
   await expect(page.getByText('该账号由供应源托管，请前往供应源管理修改。')).toBeVisible()

--- a/frontend/src/api/admin/supplierSources.ts
+++ b/frontend/src/api/admin/supplierSources.ts
@@ -19,6 +19,7 @@ export interface SupplierSource {
   channel_name: string
   endpoint: string
   base_priority: number
+  account_concurrency: number
   models: SupplierSourceModel[]
   notes: string
   created_at: string
@@ -31,6 +32,7 @@ export interface SupplierSourceInput {
   endpoint: string
   credential: string
   base_priority: number
+  account_concurrency: number
   models: SupplierSourceModel[]
   notes: string
 }

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1,7 +1,7 @@
 <template>
   <BaseDialog
     :show="show"
-    :title="t('admin.accounts.editAccount')"
+    :title="dialogTitle"
     width="wide"
     @close="handleClose"
   >
@@ -17,8 +17,19 @@
         class="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-800/70 dark:bg-amber-950/30 dark:text-amber-200"
       >
         <SupplierManagedBadge :account="account" />
-        <p class="mt-1">{{ supplierManagedReadOnlyReason }}</p>
+        <p class="mt-1">{{ supplierManagedViewHint }}</p>
+        <a
+          v-if="supplierManagedInfo.href"
+          :href="supplierManagedInfo.href"
+          class="mt-2 inline-flex text-sm font-medium text-primary-600 hover:underline dark:text-primary-400"
+        >
+          {{ t('admin.accounts.supplierManaged.openManagement') }}
+        </a>
       </div>
+      <fieldset
+        :disabled="supplierManagedInfo.managed"
+        class="m-0 min-w-0 space-y-5 border-0 p-0 disabled:opacity-100"
+      >
       <div>
         <label class="input-label">{{ t('common.name') }}</label>
         <input v-model="form.name" type="text" required class="input" data-tour="edit-account-form-name" />
@@ -2882,18 +2893,20 @@
         data-tour="account-form-groups"
       />
 
+      </fieldset>
+
     </form>
 
     <template #footer>
       <div v-if="account" class="flex justify-end gap-3">
         <button @click="handleClose" type="button" class="btn btn-secondary">
-          {{ t('common.cancel') }}
+          {{ supplierManagedInfo.managed ? t('common.close') : t('common.cancel') }}
         </button>
         <button
+          v-if="!supplierManagedInfo.managed"
           type="submit"
           form="edit-account-form"
-          :disabled="submitting || supplierManagedInfo.managed"
-          :title="supplierManagedInfo.managed ? supplierManagedReadOnlyReason : undefined"
+          :disabled="submitting"
           class="btn btn-primary"
           data-tour="account-form-submit"
         >
@@ -3105,9 +3118,15 @@ const handleProtocolProbe = async () => {
 }
 const {
   inspect: inspectSupplierManaged,
-  readOnlyReason: supplierManagedReadOnlyReason
+  readOnlyReason: supplierManagedReadOnlyReason,
+  viewHint: supplierManagedViewHint,
 } = useSupplierManagedAccount()
 const supplierManagedInfo = computed(() => inspectSupplierManaged(props.account))
+const dialogTitle = computed(() => (
+  supplierManagedInfo.value.managed
+    ? t('admin.accounts.viewAccount')
+    : t('admin.accounts.editAccount')
+))
 
 // Spark 影子账号(parent_account_id 非空):代理恒继承母账号,不可独立编辑(外审 B/P1),
 // 故隐藏代理选择器。

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -384,8 +384,8 @@ describe('EditAccountModal', () => {
     }
     const wrapper = mountModal(account)
 
-    expect(wrapper.text()).toContain('admin.accounts.supplierManaged.readOnlyReason')
-    expect(wrapper.get('[data-tour="account-form-submit"]').attributes('disabled')).toBeDefined()
+    expect(wrapper.text()).toContain('admin.accounts.supplierManaged.viewHint')
+    expect(wrapper.find('[data-tour="account-form-submit"]').exists()).toBe(false)
 
     await wrapper.get('form#edit-account-form').trigger('submit.prevent')
 

--- a/frontend/src/composables/useSupplierManagedAccount.ts
+++ b/frontend/src/composables/useSupplierManagedAccount.ts
@@ -61,6 +61,8 @@ async function ensureSourceDirectoryLoaded(): Promise<void> {
 export function useSupplierManagedAccount() {
   const { t } = useI18n()
   const readOnlyReason = computed(() => t('admin.accounts.supplierManaged.readOnlyReason'))
+  const viewHint = computed(() => t('admin.accounts.supplierManaged.viewHint'))
+  const viewButtonTitle = computed(() => t('admin.accounts.supplierManaged.viewButtonTitle'))
 
   const inspect = (account: SupplierManagedAccountLike | null | undefined): SupplierManagedAccountInfo => {
     const marker = supplierSourceMarker(account)
@@ -90,6 +92,8 @@ export function useSupplierManagedAccount() {
   return {
     inspect,
     readOnlyReason,
+    viewHint,
+    viewButtonTitle,
     ensureSourceDirectoryLoaded
   }
 }

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -77,6 +77,7 @@ export default {
         'Existing accounts only sync fields returned by CRS; missing fields keep their current values. Credentials are merged by key — keys not returned by CRS are preserved. Proxies are kept when "Sync proxies" is unchecked.',
       crsBack: 'Back',
       editAccount: 'Edit Account',
+      viewAccount: 'View Account',
       deleteAccount: 'Delete Account',
       searchAccounts: 'Search accounts...',
       notes: 'Notes',
@@ -113,6 +114,8 @@ export default {
       supplierManaged: {
         badge: 'Supplier managed',
         readOnlyReason: 'This account is managed by a supplier source. Make changes in Supplier Sources.',
+        viewHint: 'Read-only snapshot. Edit models, credentials, and priority in Supplier Sources.',
+        viewButtonTitle: 'View supplier-managed account (read-only)',
         openManagement: 'Open Supplier Sources'
       },
       groupCountTotal: '{count} groups total',

--- a/frontend/src/i18n/locales/en/admin/supplierSources.ts
+++ b/frontend/src/i18n/locales/en/admin/supplierSources.ts
@@ -19,6 +19,7 @@ export default {
     credential: 'API key',
     credentialKeep: 'Existing credentials are write-only; leave blank to keep the current value.',
     basePriority: 'Base priority',
+    accountConcurrency: 'Managed account concurrency',
     notes: 'Notes',
     clientModel: 'TokenKey model ID',
     upstreamModel: 'Upstream model ID',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -76,6 +76,7 @@ export default {
         '已有账号仅同步 CRS 返回的字段，缺失字段保持原值；凭据按键合并，不会清空未下发的键；未勾选"同步代理"时保留原有代理。',
       crsBack: '返回',
       editAccount: '编辑账号',
+      viewAccount: '查看账号',
       deleteAccount: '删除账号',
       searchAccounts: '搜索账号...',
       notes: '备注',
@@ -111,6 +112,8 @@ export default {
       supplierManaged: {
         badge: '供应源托管',
         readOnlyReason: '该账号由供应源托管，请前往供应源管理修改。',
+        viewHint: '以下为只读快照；修改模型、凭证与 priority 请前往供应源管理。',
+        viewButtonTitle: '查看托管账号配置（只读）',
         openManagement: '前往供应源管理'
       },
       groupCountTotal: '共 {count} 个分组',

--- a/frontend/src/i18n/locales/zh/admin/supplierSources.ts
+++ b/frontend/src/i18n/locales/zh/admin/supplierSources.ts
@@ -19,6 +19,7 @@ export default {
     credential: 'API Key',
     credentialKeep: '已有凭证不回显，留空沿用。',
     basePriority: '基础优先级',
+    accountConcurrency: '托管账号并发',
     notes: '备注',
     clientModel: 'TokenKey 模型 ID',
     upstreamModel: '上游模型 ID',

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -496,9 +496,15 @@
           </template>
           <template #cell-actions="{ row }">
             <div class="flex items-center gap-1">
-              <button data-testid="account-edit-btn" :disabled="isSupplierManaged(row)" :title="isSupplierManaged(row) ? supplierManagedReadOnlyReason : undefined" @click="handleEdit(row)" class="flex flex-col items-center gap-0.5 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-gray-100 hover:text-primary-600 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-dark-700 dark:hover:text-primary-400">
-                <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" /></svg>
-                <span class="text-xs">{{ t('common.edit') }}</span>
+              <button
+                data-testid="account-edit-btn"
+                :title="isSupplierManaged(row) ? supplierManagedViewButtonTitle : undefined"
+                @click="handleEdit(row)"
+                class="flex flex-col items-center gap-0.5 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-gray-100 hover:text-primary-600 dark:hover:bg-dark-700 dark:hover:text-primary-400"
+              >
+                <svg v-if="!isSupplierManaged(row)" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" /></svg>
+                <svg v-else class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" /><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
+                <span class="text-xs">{{ isSupplierManaged(row) ? t('common.view') : t('common.edit') }}</span>
               </button>
               <button :disabled="isSupplierManaged(row)" :title="isSupplierManaged(row) ? supplierManagedReadOnlyReason : undefined" @click="handleDelete(row)" class="flex flex-col items-center gap-0.5 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-red-50 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-red-900/20 dark:hover:text-red-400">
                 <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" /></svg>
@@ -636,7 +642,8 @@ const appStore = useAppStore()
 const authStore = useAuthStore()
 const {
   inspect: inspectSupplierManaged,
-  readOnlyReason: supplierManagedReadOnlyReason
+  readOnlyReason: supplierManagedReadOnlyReason,
+  viewButtonTitle: supplierManagedViewButtonTitle,
 } = useSupplierManagedAccount()
 const isSupplierManaged = (account: Account | null | undefined) => inspectSupplierManaged(account).managed
 
@@ -1911,7 +1918,6 @@ const cols = computed(() =>
 )
 
 const handleEdit = (a: Account) => {
-  if (rejectSupplierManagedAccountWrite(a)) return
   edAcc.value = a
   showEdit.value = true
 }

--- a/frontend/src/views/admin/SupplierSourcesView.vue
+++ b/frontend/src/views/admin/SupplierSourcesView.vue
@@ -198,6 +198,17 @@
                 class="mt-1 w-full rounded-lg border px-3 py-2"
               />
             </label>
+            <label class="text-sm">
+              {{ t('admin.supplierSources.accountConcurrency') }}
+              <input
+                v-model.number="form.account_concurrency"
+                data-test="account-concurrency"
+                type="number"
+                min="1"
+                required
+                class="mt-1 w-full rounded-lg border px-3 py-2"
+              />
+            </label>
           </div>
 
           <label class="block text-sm">
@@ -546,6 +557,7 @@ const form = reactive<SupplierSourceInput>({
   endpoint: '',
   credential: '',
   base_priority: 100,
+  account_concurrency: 1000,
   models: [emptyModel()],
   notes: '',
 })
@@ -585,6 +597,7 @@ function resetForm(): void {
     endpoint: '',
     credential: '',
     base_priority: 100,
+    account_concurrency: 1000,
     models: [emptyModel()],
     notes: '',
   })
@@ -604,6 +617,7 @@ function selectSource(source: SupplierSource): void {
     endpoint: source.endpoint,
     credential: '',
     base_priority: source.base_priority,
+    account_concurrency: source.account_concurrency,
     models: source.models.length > 0 ? source.models.map(model => ({ ...model })) : [emptyModel()],
     notes: source.notes,
   })
@@ -645,6 +659,9 @@ function copySelected(): void {
     endpoint: input.endpoint,
     credential: '',
     base_priority: Number.isFinite(input.base_priority) ? input.base_priority : origin.base_priority,
+    account_concurrency: Number.isFinite(input.account_concurrency)
+      ? input.account_concurrency
+      : origin.account_concurrency,
     models: input.models.length > 0 ? input.models.map(model => ({ ...model })) : [emptyModel()],
     notes: input.notes,
   })
@@ -694,6 +711,7 @@ function buildInput(): SupplierSourceInput {
     endpoint: form.endpoint.trim(),
     credential: form.credential,
     base_priority: Number(form.base_priority),
+    account_concurrency: Number(form.account_concurrency),
     models,
     notes: form.notes.trim(),
   }
@@ -709,6 +727,7 @@ const hasUnsavedChanges = computed(() => {
     || input.channel_name !== source.channel_name
     || input.endpoint !== source.endpoint
     || input.base_priority !== source.base_priority
+    || input.account_concurrency !== source.account_concurrency
     || input.notes !== source.notes
   ) return true
   return JSON.stringify(input.models) !== JSON.stringify(source.models)

--- a/frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts
@@ -238,7 +238,8 @@ describe('admin AccountsView supplier-managed ownership', () => {
 
     expect(managedRow.text()).toContain('admin.accounts.supplierManaged.badge · 佳杰/VSTECS')
     expect(managedRow.get('[data-test="schedulable"] button').attributes('disabled')).toBeDefined()
-    expect(managedRow.get('[data-testid="account-edit-btn"]').attributes('disabled')).toBeDefined()
+    expect(managedRow.get('[data-testid="account-edit-btn"]').attributes('disabled')).toBeUndefined()
+    expect(managedRow.get('[data-testid="account-edit-btn"]').text()).toContain('common.view')
     expect(managedRow.findAll('[data-test="actions"] button')[1].attributes('disabled')).toBeDefined()
     expect(ordinaryRow.get('[data-test="schedulable"] button').attributes('disabled')).toBeUndefined()
 
@@ -250,6 +251,19 @@ describe('admin AccountsView supplier-managed ownership', () => {
     )
     expect(wrapper.text()).toContain('admin.accounts.supplierManaged.readOnlyReason')
     expect(bulkDelete?.attributes('disabled')).toBeDefined()
+  })
+
+  it('opens the read-only account modal for supplier-managed rows', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.get('[data-test="account-row-7"]').get('[data-testid="account-edit-btn"]').trigger('click')
+    await flushPromises()
+
+    const modal = wrapper.get('[data-test="edit-modal"]')
+    expect(modal.attributes('data-show')).toBe('true')
+    expect(modal.attributes('data-account-id')).toBe('7')
+    expect(showError).not.toHaveBeenCalled()
   })
 
   it('rejects a stale child write event before calling the account API', async () => {

--- a/frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts
+++ b/frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts
@@ -34,6 +34,7 @@ const source = {
   channel_name: 'stbl-5',
   endpoint: 'https://token.vstecscloud.com/v1',
   base_priority: 100,
+  account_concurrency: 1000,
   notes: '首批最低折扣',
   models: [{
     client_model_id: 'deepseek-v4-pro',

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -2017,6 +2017,7 @@
       "must_contain": [
         "Object.prototype.hasOwnProperty.call(extra, 'supplier_source_id')",
         "const readOnlyReason = computed(() => t('admin.accounts.supplierManaged.readOnlyReason'))",
+        "const viewHint = computed(() => t('admin.accounts.supplierManaged.viewHint'))",
         "href: `/admin/supplier-sources?source_id=${marker.sourceId}`"
       ],
       "rationale": "Single frontend owner for the supplier-managed marker, source-name lookup, fallback labels, navigation and canonical read-only reason. Account rows, modals and menus must not grow separate ownership rules."
@@ -2034,6 +2035,7 @@
       "path": "frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts",
       "must_contain": [
         "shows the badge and disables row and mixed-selection generic writes",
+        "opens the read-only account modal for supplier-managed rows",
         "rejects a stale child write event before calling the account API",
         "allows supplier-managed runtime recovery and quota reset actions",
         "allows supplier-managed bulk runtime recovery"
@@ -2064,9 +2066,9 @@
       "path": "frontend/src/components/account/__tests__/EditAccountModal.spec.ts",
       "must_contain": [
         "shows the supplier-managed reason and refuses generic account updates",
-        "admin.accounts.supplierManaged.readOnlyReason"
+        "admin.accounts.supplierManaged.viewHint"
       ],
-      "rationale": "The generic edit modal is a second UI entry point and must remain read-only for supplier-managed accounts with the same canonical reason, even if it is opened from stale state or another caller."
+      "rationale": "The generic edit modal is a second UI entry point and must remain read-only for supplier-managed accounts with the same view hint and disabled submit path, even if it is opened from stale state or another caller."
     }
   ]
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7424,6 +7424,7 @@
       "path": "backend/internal/repository/account_repo.go",
       "must_contain": [
         "func (r *accountRepository) UpdateSupplierMetadata(ctx context.Context, accountID int64, name string, priority int) error",
+        "func (r *accountRepository) UpdateSupplierConcurrency(ctx context.Context, accountID int64, concurrency int) error",
         "func (r *accountRepository) UpdateSupplierProjection(ctx context.Context, account *service.Account, chatProbePassed bool) error",
         "if len(account.GetModelMapping()) > 0 && !chatProbePassed {",
         "publishVerifiedSupplierChatCapability(",
@@ -7432,7 +7433,7 @@
         "enqueueSchedulerOutbox(ctx, client, service.SchedulerOutboxEventAccountChanged, &account.ID, nil, nil)",
         "extra = COALESCE(extra, '{}'::jsonb) || $6::jsonb"
       ],
-      "rationale": "Production-only narrow write paths for supplier metadata and full projections. Non-empty mappings fail closed without the current sync call's Chat probe evidence; the same account transaction publishes the verified Chat-only capability before ordinary scheduler invalidation. Both writes avoid account-group payloads, and the full projection merges only the two owned supplier keys while preserving every non-owned Extra. Full projection also owns account concurrency from the supplier source. The generic AccountRepository.Update forwards billing and unrelated runtime fields, so supplier sync must never fall back to it."
+      "rationale": "Production-only narrow write paths for supplier metadata, concurrency and full projections. Concurrency-only sync writes the single owned column plus scheduler invalidation without fabricating probe evidence. Non-empty full projections fail closed without the current sync call's Chat probe evidence; the same account transaction publishes the verified Chat-only capability before ordinary scheduler invalidation. These writes avoid account-group payloads, and the full projection merges only the two owned supplier keys while preserving every non-owned Extra. The generic AccountRepository.Update forwards billing and unrelated runtime fields, so supplier sync must never fall back to it."
     },
     {
       "path": "backend/internal/repository/account_repo.go",
@@ -7472,6 +7473,7 @@
         "if len(input.ModelMapping) > 0 && !input.ChatProbePassed {",
         "return ErrSupplierProjectionUpdaterMissing",
         "return updater.UpdateSupplierMetadata(ctx, account.ID, account.Name, account.Priority)",
+        "updater.UpdateSupplierConcurrency(ctx, account.ID, concurrency)",
         "return updater.UpdateSupplierProjection(ctx, account, chatProbePassed)",
         "account.Concurrency = ResolveSupplierSourceAccountConcurrency(input.Concurrency)"
       ],
@@ -7482,6 +7484,7 @@
       "must_contain": [
         "TestUS048_SupplierCreateStartsEmptyUngroupedAndUnschedulable",
         "TestUS048_OrdinaryCreateAccountStillFailsWhenDefaultGroupBindFails",
+        "TestUS048_SupplierConcurrencyUpdateUsesNarrowWriteWithoutProbeEvidence",
         "TestUS048_SupplierConfigurationUpdateUsesGroupFreeReadAndNarrowWrite",
         "TestUS048_SupplierConfigurationUpdateRequiresPassedChatProbe",
         "TestUS048_SupplierQianfanCreateUsesBaiduV2Transport",
@@ -7495,6 +7498,7 @@
       "path": "backend/internal/repository/account_repo_supplier_projection_test.go",
       "must_contain": [
         "TestUS048_SupplierMetadataRepositoryWritesOnlyNameAndPriority",
+        "TestUS048_SupplierConcurrencyRepositoryWritesOnlyConcurrency",
         "TestUS048_SupplierConfigurationRepositoryRejectsUnverifiedNonEmptyMapping",
         "TestUS048_SupplierConfigurationRepositoryWritesOnlyOwnedFields",
         "TestUS048_SupplierProjectionReadSelectsOnlyRequiredConfigurationFields",
@@ -7650,12 +7654,13 @@
       "path": "backend/internal/service/supplier_source_service.go",
       "must_contain": [
         "func (s *SupplierSourceService) ensureSupplierManagedConcurrency(",
-        "func (s *SupplierSourceService) ensureSupplierProtocolProjections(",
         "func supplierAccountNeedsProtocolRepublish(account *Account, sourceEndpoint string) bool",
+        "supplierAccountNeedsProtocolRepublish(account, source.Endpoint)",
+        "UpdateManagedAccountConcurrency(",
         "ResolveSupplierSourceAccountConcurrency(source.AccountConcurrency)",
         "identity.Key() != account.ProtocolEndpointCapability.CapabilityKey"
       ],
-      "rationale": "Supplier sync must repair managed-account concurrency from the source owner and republish protocol projections when transport or capability identity drifts, without falling back to generic account updates."
+      "rationale": "Supplier sync repairs managed-account concurrency through the narrow concurrency write, while transport or capability identity drift enters the normal real-probe path before any full projection republishes protocol evidence."
     },
     {
       "path": "backend/internal/service/supplier_upstream_models.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7473,7 +7473,6 @@
         "return ErrSupplierProjectionUpdaterMissing",
         "return updater.UpdateSupplierMetadata(ctx, account.ID, account.Name, account.Priority)",
         "return updater.UpdateSupplierProjection(ctx, account, chatProbePassed)",
-        "ResolveSupplierSourceAccountConcurrency(input.Concurrency)",
         "account.Concurrency = ResolveSupplierSourceAccountConcurrency(input.Concurrency)"
       ],
       "rationale": "The supplier-source owner reads only the narrow projection, creates new managed accounts empty, unschedulable and ungrouped, resolves managed transport from the procurement endpoint (OpenAI Chat or Qianfan BaiduV2), preserves non-owned account metadata, requires current-call Chat probe evidence for every non-empty mapping, and fails closed unless both narrow repository writes are available."

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7427,11 +7427,12 @@
         "func (r *accountRepository) UpdateSupplierProjection(ctx context.Context, account *service.Account, chatProbePassed bool) error",
         "if len(account.GetModelMapping()) > 0 && !chatProbePassed {",
         "publishVerifiedSupplierChatCapability(",
+        "concurrency = $10",
         "enqueueSchedulerOutbox(ctx, client, service.SchedulerOutboxEventAccountChanged, &accountID, nil, nil)",
         "enqueueSchedulerOutbox(ctx, client, service.SchedulerOutboxEventAccountChanged, &account.ID, nil, nil)",
         "extra = COALESCE(extra, '{}'::jsonb) || $6::jsonb"
       ],
-      "rationale": "Production-only narrow write paths for supplier metadata and full projections. Non-empty mappings fail closed without the current sync call's Chat probe evidence; the same account transaction publishes the verified Chat-only capability before ordinary scheduler invalidation. Both writes avoid account-group payloads, and the full projection merges only the two owned supplier keys while preserving every non-owned Extra. The generic AccountRepository.Update forwards billing and unrelated runtime fields, so supplier sync must never fall back to it."
+      "rationale": "Production-only narrow write paths for supplier metadata and full projections. Non-empty mappings fail closed without the current sync call's Chat probe evidence; the same account transaction publishes the verified Chat-only capability before ordinary scheduler invalidation. Both writes avoid account-group payloads, and the full projection merges only the two owned supplier keys while preserving every non-owned Extra. Full projection also owns account concurrency from the supplier source. The generic AccountRepository.Update forwards billing and unrelated runtime fields, so supplier sync must never fall back to it."
     },
     {
       "path": "backend/internal/repository/account_repo.go",
@@ -7471,7 +7472,9 @@
         "if len(input.ModelMapping) > 0 && !input.ChatProbePassed {",
         "return ErrSupplierProjectionUpdaterMissing",
         "return updater.UpdateSupplierMetadata(ctx, account.ID, account.Name, account.Priority)",
-        "return updater.UpdateSupplierProjection(ctx, account, chatProbePassed)"
+        "return updater.UpdateSupplierProjection(ctx, account, chatProbePassed)",
+        "ResolveSupplierSourceAccountConcurrency(input.Concurrency)",
+        "account.Concurrency = ResolveSupplierSourceAccountConcurrency(input.Concurrency)"
       ],
       "rationale": "The supplier-source owner reads only the narrow projection, creates new managed accounts empty, unschedulable and ungrouped, resolves managed transport from the procurement endpoint (OpenAI Chat or Qianfan BaiduV2), preserves non-owned account metadata, requires current-call Chat probe evidence for every non-empty mapping, and fails closed unless both narrow repository writes are available."
     },
@@ -7578,7 +7581,8 @@
         "TestUS048_IncompatibleTransportExactMatchBlocksAdoptionWithoutRewritingAccount",
         "TestUS048_MultiBandExactAccountMatchBlocksDuplicateSupplierAccountCreation",
         "TestUS048_SupplierSyncProbesBeforeRepairingNonEmptySchedulingProjection",
-        "TestUS048_SupplierSyncRepairsEmptySchedulingProjectionWithoutProbe"
+        "TestUS048_SupplierSyncRepairsEmptySchedulingProjectionWithoutProbe",
+        "TestSupplierAccountNeedsProtocolRepublishDetectsTransportDrift"
       ],
       "rationale": "Sync regressions keep failed_step and completed changes present on early and mid-write errors, preserve successful additions, stop pending removals and prove retry convergence. They also block duplicate creation whenever an exact account match cannot satisfy the narrow adoption contract, including disabled/error accounts and multi-band sources, and keep status/schedulable projection repair on the minimal probe boundary."
     },
@@ -7637,9 +7641,22 @@
         "result, err := h.service.StartDiscoverModels(c.Request.Context(), id)",
         "func (h *SupplierSourceHandler) GetDiscoverModelsJob(c *gin.Context)",
         "result, err := h.service.GetDiscoverModelsJob(c.Request.Context(), id, jobID)",
+        "AccountConcurrency",
+        "account_concurrency",
         "case errors.As(err, &syncErr):"
       ],
-      "rationale": "Admin discover must start the async probe job and expose job polling; upstream models-list failures must map through UpstreamModelSyncError.SafeMessage so the page never shows only an empty discover title."
+      "rationale": "Admin discover must start the async probe job and expose job polling; upstream models-list failures must map through UpstreamModelSyncError.SafeMessage so the page never shows only an empty discover title. Supplier-source CRUD must round-trip account_concurrency."
+    },
+    {
+      "path": "backend/internal/service/supplier_source_service.go",
+      "must_contain": [
+        "func (s *SupplierSourceService) ensureSupplierManagedConcurrency(",
+        "func (s *SupplierSourceService) ensureSupplierProtocolProjections(",
+        "func supplierAccountNeedsProtocolRepublish(account *Account, sourceEndpoint string) bool",
+        "ResolveSupplierSourceAccountConcurrency(source.AccountConcurrency)",
+        "identity.Key() != account.ProtocolEndpointCapability.CapabilityKey"
+      ],
+      "rationale": "Supplier sync must repair managed-account concurrency from the source owner and republish protocol projections when transport or capability identity drifts, without falling back to generic account updates."
     },
     {
       "path": "backend/internal/service/supplier_upstream_models.go",


### PR DESCRIPTION
## 摘要

- 供应源新增 `account_concurrency` 字段（默认 **1000**），Admin 表单可编辑；同步创建/更新托管账号时投影该并发值，不再硬编码 `1`。
- 托管账号在账号列表可点「查看」打开只读 modal（字段禁用、隐藏保存按钮，链到供应源管理）。
- 同步时会独立修复并发差异；transport/protocol identity 漂移则进入真实探测后重投影，避免把未探测的账号伪标为 `chat_probe_passed=true`。
- `account_concurrency` 上限与 PostgreSQL `INTEGER` 对齐，拒绝超过 `2147483647` 的输入。

## 风险

- **高风险**：触达供应源到托管账号的并发、协议探测与投影路径；并发-only 更新使用窄写路径，保留现有协议探测证据。
- 需跑 migration `tk_090_supplier_source_account_concurrency.sql`；已有供应源行默认 1000。
- 合并发版后，对供应源 id=3 执行一次「校验并同步」即可让真实探测驱动 protocol 重绑；本 PR 未直连 prod。

## 验证

- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh` PASS
- `go test -tags=unit ./internal/service/... ./internal/repository/... -run 'US048|SupplierAccountNeedsProtocol|SupplierConcurrencyRepository'`
- `python3 scripts/sentinels/check-gateway-tk.py`
- `pnpm exec vitest run src/components/account/__tests__/EditAccountModal.spec.ts src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts`
- `make build-frontend`

## 提交

- `5486f78bc` feat(supplier): 供应源可配置托管账号并发并支持只读查看
- `2a5b1aa68` fix(supplier): address R-001..R-004 — tests, anchor doc, gateway sentinels
- `0d803b501` fix(supplier): blue/green migration ack and sentinel needle dedup
- `80285e2bd` fix(supplier): address R-001..R-002 — preserve probe evidence
- 最新提交：`80285e2bd`

Made with [Cursor](https://cursor.com)
