### PR TITLE
fix(scheduler): 协议 identity 跟账号凭证，不跟供应源绑定

### DIFF
--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -279,13 +279,10 @@ func (s *AccountRepoSuite) TestUS048_SupplierConfigurationProjectionPreservesRun
 		Platform:    service.PlatformNewAPI,
 		Type:        service.AccountTypeAPIKey,
 		ChannelType: 46,
-		Credentials: map[string]any{
-			"base_url": "https://old.example/v1",
-			"api_key":  "old-secret",
-			"model_mapping": map[string]any{
-				"old-model": "old-model",
-			},
-		},
+		Credentials: supplierExclusiveChatCredentials(
+			"https://old.example/v1", "old-secret",
+			map[string]any{"old-model": "old-model"},
+		),
 		Extra: map[string]any{
 			service.SupplierSourceIDExtraKey:     int64(7),
 			service.SupplierDiscountBandExtraKey: 3,
@@ -321,13 +318,10 @@ func (s *AccountRepoSuite) TestUS048_SupplierConfigurationProjectionPreservesRun
 	stale.Platform = service.PlatformNewAPI
 	stale.Type = service.AccountTypeAPIKey
 	stale.ChannelType = newapiconstant.ChannelTypeOpenAI
-	stale.Credentials = map[string]any{
-		"base_url": "https://new.example/v1",
-		"api_key":  "new-secret",
-		"model_mapping": map[string]string{
-			"deepseek-v4-pro": "deepseek-v4-pro",
-		},
-	}
+	stale.Credentials = supplierExclusiveChatCredentials(
+		"https://new.example/v1", "new-secret",
+		map[string]any{"deepseek-v4-pro": "deepseek-v4-pro"},
+	)
 	stale.Extra[service.SupplierSourceIDExtraKey] = int64(7)
 	stale.Extra[service.SupplierDiscountBandExtraKey] = 4
 	stale.Extra["runtime_observation"] = "stale-value-must-not-be-written"
@@ -384,13 +378,10 @@ func (s *AccountRepoSuite) TestUS048_SupplierConfigurationProjectionRebindsProto
 		Platform:    service.PlatformNewAPI,
 		Type:        service.AccountTypeAPIKey,
 		ChannelType: newapiconstant.ChannelTypeOpenAI,
-		Credentials: map[string]any{
-			"base_url": "https://old-supplier.example/v1",
-			"api_key":  "supplier-secret",
-			"model_mapping": map[string]any{
-				"deepseek-v4-pro": "deepseek-v4-pro",
-			},
-		},
+		Credentials: supplierExclusiveChatCredentials(
+			"https://old-supplier.example/v1", "supplier-secret",
+			map[string]any{"deepseek-v4-pro": "deepseek-v4-pro"},
+		),
 		Extra: map[string]any{
 			service.SupplierSourceIDExtraKey:     int64(7),
 			service.SupplierDiscountBandExtraKey: 3,
@@ -415,13 +406,10 @@ func (s *AccountRepoSuite) TestUS048_SupplierConfigurationProjectionRebindsProto
 	s.Require().NoError(err)
 	s.Require().True(previousCapabilityID.Valid)
 
-	account.Credentials = map[string]any{
-		"base_url": "https://new-supplier.example/v1",
-		"api_key":  "supplier-secret",
-		"model_mapping": map[string]any{
-			"deepseek-v4-pro": "deepseek-v4-pro",
-		},
-	}
+	account.Credentials = supplierExclusiveChatCredentials(
+		"https://new-supplier.example/v1", "supplier-secret",
+		map[string]any{"deepseek-v4-pro": "deepseek-v4-pro"},
+	)
 
 	err = s.repo.UpdateSupplierProjection(s.ctx, account, true)
 	s.Require().NoError(err)

--- a/backend/internal/repository/account_repo_supplier_cred_test.go
+++ b/backend/internal/repository/account_repo_supplier_cred_test.go
@@ -1,0 +1,23 @@
+package repository
+
+import (
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+// supplierExclusiveChatCredentials mirrors service.supplierManagedCredentials for
+// repository tests that cannot call the unexported helper: chat-only identity
+// via api_base_urls + protocol_endpoints_exclusive (not supplier_source_id).
+func supplierExclusiveChatCredentials(endpoint, apiKey string, mapping map[string]any) map[string]any {
+	baseURL := strings.TrimRight(strings.TrimSpace(endpoint), "/")
+	return map[string]any{
+		"base_url":      baseURL,
+		"api_key":       strings.TrimSpace(apiKey),
+		"model_mapping": mapping,
+		"api_base_urls": map[string]any{
+			service.APIProtocolChatCompletions: baseURL,
+		},
+		service.ProtocolEndpointsExclusiveCredentialKey: true,
+	}
+}

--- a/backend/internal/repository/account_repo_supplier_projection_test.go
+++ b/backend/internal/repository/account_repo_supplier_projection_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"encoding/json"
 	"regexp"
 	"strings"
 	"testing"
@@ -151,19 +152,19 @@ func TestUS048_SupplierConfigurationRepositoryWritesOnlyOwnedFields(t *testing.T
 	t.Cleanup(func() { _ = client.Close() })
 	repo := newAccountRepositoryWithSQL(client, db, nil, nil)
 
+	creds := supplierExclusiveChatCredentials(
+		"https://supplier.example/v1", "new-secret",
+		map[string]any{"deepseek-v4-pro": "deepseek-v4-pro"},
+	)
+	credJSON, err := json.Marshal(creds)
+	require.NoError(t, err)
 	account := &service.Account{
 		ID:          41,
 		Name:        "supplier/new · 档位 3",
 		Platform:    service.PlatformNewAPI,
 		Type:        service.AccountTypeAPIKey,
 		ChannelType: 1,
-		Credentials: map[string]any{
-			"base_url": "https://supplier.example/v1",
-			"api_key":  "new-secret",
-			"model_mapping": map[string]string{
-				"deepseek-v4-pro": "deepseek-v4-pro",
-			},
-		},
+		Credentials: creds,
 		Extra: map[string]any{
 			service.SupplierSourceIDExtraKey:     int64(7),
 			service.SupplierDiscountBandExtraKey: 3,
@@ -178,6 +179,7 @@ func TestUS048_SupplierConfigurationRepositoryWritesOnlyOwnedFields(t *testing.T
 	identity, governed, err := service.BuildProtocolEndpointIdentity(account)
 	require.NoError(t, err)
 	require.True(t, governed)
+	require.Len(t, identity.ProtocolEndpoints, 1)
 	identityJSON, err := identity.CanonicalJSON()
 	require.NoError(t, err)
 	now := time.Date(2026, time.August, 28, 0, 0, 0, 0, time.UTC)
@@ -189,7 +191,7 @@ func TestUS048_SupplierConfigurationRepositoryWritesOnlyOwnedFields(t *testing.T
 			service.PlatformNewAPI,
 			service.AccountTypeAPIKey,
 			1,
-			`{"api_key":"new-secret","base_url":"https://supplier.example/v1","model_mapping":{"deepseek-v4-pro":"deepseek-v4-pro"}}`,
+			string(credJSON),
 			`{"supplier_discount_band":3,"supplier_source_id":7}`,
 			113,
 			service.StatusActive,
@@ -204,7 +206,7 @@ func TestUS048_SupplierConfigurationRepositoryWritesOnlyOwnedFields(t *testing.T
 			"id", "platform", "type", "credentials", "extra", "channel_type", "protocol_endpoint_capability_id",
 		}).AddRow(
 			int64(41), service.PlatformNewAPI, service.AccountTypeAPIKey,
-			`{"api_key":"new-secret","base_url":"https://supplier.example/v1","model_mapping":{"deepseek-v4-pro":"deepseek-v4-pro"}}`,
+			string(credJSON),
 			`{"supplier_discount_band":3,"supplier_source_id":7,"supported_protocols":[]}`,
 			1,
 			int64(8),

--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -998,6 +998,7 @@ func filterSchedulerCredentials(credentials map[string]any) map[string]any {
 		"vertex_location",
 		"mirror_platform",
 		"pool_mode",
+		service.ProtocolEndpointsExclusiveCredentialKey,
 	}
 	filtered := make(map[string]any)
 	for _, key := range keys {
@@ -1074,13 +1075,6 @@ func filterSchedulerExtra(extra map[string]any) map[string]any {
 		"openai_responses_supported",
 		"openai_native_messages_supported",
 		service.SupportedProtocolsExtraKey,
-		// supplier_source_id decides IsSupplierManagedAccount → protocol
-		// identity (chat-only vs all OpenAI-compat paths). Dropping it makes
-		// the scheduler snapshot build a different identity than DB recheck /
-		// EnsureAccountLink, so supplier-managed accounts fail with
-		// no_legal_protocol_route after entering the selection pool.
-		service.SupplierSourceIDExtraKey,
-		service.SupplierDiscountBandExtraKey,
 		"codex_fingerprint_mode",
 		"codex_fingerprint_seed",
 		"codex_5h_used_percent",

--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -1074,6 +1074,13 @@ func filterSchedulerExtra(extra map[string]any) map[string]any {
 		"openai_responses_supported",
 		"openai_native_messages_supported",
 		service.SupportedProtocolsExtraKey,
+		// supplier_source_id decides IsSupplierManagedAccount → protocol
+		// identity (chat-only vs all OpenAI-compat paths). Dropping it makes
+		// the scheduler snapshot build a different identity than DB recheck /
+		// EnsureAccountLink, so supplier-managed accounts fail with
+		// no_legal_protocol_route after entering the selection pool.
+		service.SupplierSourceIDExtraKey,
+		service.SupplierDiscountBandExtraKey,
 		"codex_fingerprint_mode",
 		"codex_fingerprint_seed",
 		"codex_5h_used_percent",

--- a/backend/internal/repository/scheduler_cache_unit_test.go
+++ b/backend/internal/repository/scheduler_cache_unit_test.go
@@ -558,11 +558,11 @@ func TestBuildSchedulerMetadataAccount_KeepsExclusiveProtocolEndpointCredentials
 				service.APIProtocolChatCompletions: "https://dashscope.aliyuncs.com",
 			},
 			service.ProtocolEndpointsExclusiveCredentialKey: true,
-			"unused_large_field": "drop-me",
+			"unused_large_field":                            "drop-me",
 		},
 		Extra: map[string]any{
 			service.SupplierSourceIDExtraKey: int64(8),
-			"unrelated":                     "drop-me",
+			"unrelated":                      "drop-me",
 		},
 	}
 	got := buildSchedulerMetadataAccount(account)

--- a/backend/internal/repository/scheduler_cache_unit_test.go
+++ b/backend/internal/repository/scheduler_cache_unit_test.go
@@ -546,6 +546,27 @@ func TestSchedulerCacheSnapshotKeepsSupportedProtocolsForRouting(t *testing.T) {
 	require.NotContains(t, snapshot[0].Extra, "unrelated")
 }
 
+func TestBuildSchedulerMetadataAccount_KeepsSupplierManagedIdentityKeys(t *testing.T) {
+	account := service.Account{
+		ID:       109,
+		Platform: service.PlatformNewAPI,
+		Type:     service.AccountTypeAPIKey,
+		Extra: map[string]any{
+			service.SupplierSourceIDExtraKey:     int64(8),
+			service.SupplierDiscountBandExtraKey: 4,
+			service.SupportedProtocolsExtraKey:   []any{"chat_completions"},
+			"unrelated":                          "drop-me",
+		},
+	}
+	got := buildSchedulerMetadataAccount(account)
+	require.Equal(t, int64(8), got.Extra[service.SupplierSourceIDExtraKey])
+	require.Equal(t, 4, got.Extra[service.SupplierDiscountBandExtraKey])
+	require.Equal(t, []any{"chat_completions"}, got.Extra[service.SupportedProtocolsExtraKey])
+	require.NotContains(t, got.Extra, "unrelated")
+	require.True(t, service.IsSupplierManagedAccount(&got),
+		"scheduler snapshot must keep supplier_source_id so protocol identity matches EnsureAccountLink")
+}
+
 func TestBuildSchedulerMetadataAccountPreservesProtocolEndpointIdentity(t *testing.T) {
 	vertexCredential := `{"type":"service_account","project_id":"vertex-project","private_key":"private-key","client_email":"svc@vertex-project.iam.gserviceaccount.com"}`
 	tests := []struct {

--- a/backend/internal/repository/scheduler_cache_unit_test.go
+++ b/backend/internal/repository/scheduler_cache_unit_test.go
@@ -546,25 +546,42 @@ func TestSchedulerCacheSnapshotKeepsSupportedProtocolsForRouting(t *testing.T) {
 	require.NotContains(t, snapshot[0].Extra, "unrelated")
 }
 
-func TestBuildSchedulerMetadataAccount_KeepsSupplierManagedIdentityKeys(t *testing.T) {
+func TestBuildSchedulerMetadataAccount_KeepsExclusiveProtocolEndpointCredentials(t *testing.T) {
 	account := service.Account{
 		ID:       109,
 		Platform: service.PlatformNewAPI,
 		Type:     service.AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://dashscope.aliyuncs.com",
+			"api_key":  "secret",
+			"api_base_urls": map[string]any{
+				service.APIProtocolChatCompletions: "https://dashscope.aliyuncs.com",
+			},
+			service.ProtocolEndpointsExclusiveCredentialKey: true,
+			"unused_large_field": "drop-me",
+		},
 		Extra: map[string]any{
-			service.SupplierSourceIDExtraKey:     int64(8),
-			service.SupplierDiscountBandExtraKey: 4,
-			service.SupportedProtocolsExtraKey:   []any{"chat_completions"},
-			"unrelated":                          "drop-me",
+			service.SupplierSourceIDExtraKey: int64(8),
+			"unrelated":                     "drop-me",
 		},
 	}
 	got := buildSchedulerMetadataAccount(account)
-	require.Equal(t, int64(8), got.Extra[service.SupplierSourceIDExtraKey])
-	require.Equal(t, 4, got.Extra[service.SupplierDiscountBandExtraKey])
-	require.Equal(t, []any{"chat_completions"}, got.Extra[service.SupportedProtocolsExtraKey])
+	require.Equal(t, true, got.Credentials[service.ProtocolEndpointsExclusiveCredentialKey])
+	require.Equal(t, "https://dashscope.aliyuncs.com", got.Credentials["base_url"])
+	require.Equal(t, map[string]any{
+		service.APIProtocolChatCompletions: "https://dashscope.aliyuncs.com",
+	}, got.Credentials["api_base_urls"])
+	require.NotContains(t, got.Credentials, "unused_large_field")
+	require.NotContains(t, got.Extra, service.SupplierSourceIDExtraKey,
+		"supplier_source_id must stay out of scheduler Extra; identity uses account credentials only")
 	require.NotContains(t, got.Extra, "unrelated")
-	require.True(t, service.IsSupplierManagedAccount(&got),
-		"scheduler snapshot must keep supplier_source_id so protocol identity matches EnsureAccountLink")
+
+	identity, governed, err := service.BuildProtocolEndpointIdentity(&got)
+	require.NoError(t, err)
+	require.True(t, governed)
+	require.Equal(t, map[protocolrouter.Protocol]service.ProtocolEndpoint{
+		protocolrouter.ProtocolChatCompletions: {URL: "https://dashscope.aliyuncs.com/v1/chat/completions"},
+	}, identity.ProtocolEndpoints)
 }
 
 func TestBuildSchedulerMetadataAccountPreservesProtocolEndpointIdentity(t *testing.T) {

--- a/backend/internal/service/account_supported_protocols.go
+++ b/backend/internal/service/account_supported_protocols.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	newapiconstant "github.com/QuantumNous/new-api/constant"
 	newapitypes "github.com/QuantumNous/new-api/types"
 	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
 	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
@@ -15,6 +14,13 @@ import (
 )
 
 const SupportedProtocolsExtraKey = "supported_protocols"
+
+// ProtocolEndpointsExclusiveCredentialKey marks that credentials.api_base_urls
+// is the exclusive protocol-endpoint declaration for identity / probe routing.
+// When set, bare base_url must not fan out into undeclared protocols. This is
+// an account-self signal (not supplier_source_id): scheduling and gateway
+// identity stay decoupled from supplier-source binding.
+const ProtocolEndpointsExclusiveCredentialKey = "protocol_endpoints_exclusive"
 
 type supportedProtocolsExtraWriter interface {
 	UpdateExtra(ctx context.Context, id int64, updates map[string]any) error
@@ -473,22 +479,6 @@ func protocolAccountEndpoints(account *Account) (string, map[protocolrouter.Prot
 		return "", nil, protocolrouter.OfficialEndpointOpenAICodex
 	}
 	baseURL := strings.TrimSpace(account.GetCredential("base_url"))
-	if IsSupplierManagedAccount(account) {
-		if account.Platform != PlatformNewAPI || account.Type != AccountTypeAPIKey ||
-			!supplierManagedTransportOK(account) || baseURL == "" {
-			return "", nil, ""
-		}
-		chatBase := baseURL
-		if account.ChannelType == newapiconstant.ChannelTypeBaiduV2 {
-			// Qianfan Chat lives under /v2; declare the complete path so identity
-			// normalize does not invent a /v1 suffix. Non-supplier Qianfan accounts
-			// keep their historical identity key and are unchanged.
-			chatBase = strings.TrimRight(newapiintegration.QianfanBaseURL, "/") + "/v2/chat/completions"
-		}
-		return "", map[protocolrouter.Protocol]string{
-			protocolrouter.ProtocolChatCompletions: chatBase,
-		}, ""
-	}
 	baseURLs := make(map[protocolrouter.Protocol]string)
 	if raw, ok := account.Credentials["api_base_urls"].(map[string]any); ok {
 		copyProtocolBaseURL(raw, APIProtocolChatCompletions, protocolrouter.ProtocolChatCompletions, baseURLs)
@@ -498,7 +488,31 @@ func protocolAccountEndpoints(account *Account) (string, map[protocolrouter.Prot
 	if len(baseURLs) == 0 {
 		baseURLs = nil
 	}
+	// Exclusive declared endpoints: identity/probe use only api_base_urls, never
+	// fan bare base_url into messages/responses. Used by chat-only NewAPI
+	// transports (including supplier-projected accounts) without reading
+	// supplier_source_id.
+	if accountDeclaresExclusiveProtocolEndpoints(account) {
+		if len(baseURLs) == 0 {
+			return "", nil, ""
+		}
+		return "", baseURLs, ""
+	}
 	return baseURL, baseURLs, ""
+}
+
+func accountDeclaresExclusiveProtocolEndpoints(account *Account) bool {
+	if account == nil || account.Credentials == nil {
+		return false
+	}
+	switch typed := account.Credentials[ProtocolEndpointsExclusiveCredentialKey].(type) {
+	case bool:
+		return typed
+	case string:
+		return strings.EqualFold(strings.TrimSpace(typed), "true")
+	default:
+		return false
+	}
 }
 
 func copyProtocolBaseURL(raw map[string]any, key string, protocol protocolrouter.Protocol, out map[protocolrouter.Protocol]string) {

--- a/backend/internal/service/account_test_service_supplier_probe_test.go
+++ b/backend/internal/service/account_test_service_supplier_probe_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	newapiconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
 	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
 	"github.com/stretchr/testify/require"
@@ -86,6 +87,31 @@ func TestUS048_SupplierManagedAccountDeclaresOnlyChatProtocol(t *testing.T) {
 		protocolrouter.ProtocolChatCompletions: {URL: "https://supplier.example/v1/chat/completions"},
 	}, identity.ProtocolEndpoints)
 	require.Equal(t, []protocolrouter.Protocol{protocolrouter.ProtocolChatCompletions}, ProtocolProbeCandidates(account))
+}
+
+func TestUS048_ChatOnlyIdentityDoesNotRequireSupplierSourceBinding(t *testing.T) {
+	// Scheduling/gateway identity must follow account credentials, not Extra.supplier_source_id.
+	account := &Account{
+		ID:          109,
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeAli,
+		Credentials: supplierManagedCredentials(
+			"https://dashscope.aliyuncs.com", "secret",
+			map[string]string{"qwen3.6-flash": "qwen3.6-flash"}, newapiconstant.ChannelTypeAli),
+	}
+	delete(account.Extra, SupplierSourceIDExtraKey)
+	account.Extra = nil
+
+	identity, governed, err := BuildProtocolEndpointIdentity(account)
+
+	require.NoError(t, err)
+	require.True(t, governed)
+	require.False(t, IsSupplierManagedAccount(account))
+	require.Equal(t, true, account.Credentials[ProtocolEndpointsExclusiveCredentialKey])
+	require.Equal(t, map[protocolrouter.Protocol]ProtocolEndpoint{
+		protocolrouter.ProtocolChatCompletions: {URL: "https://dashscope.aliyuncs.com/v1/chat/completions"},
+	}, identity.ProtocolEndpoints)
 }
 
 func TestUS048_SupplierManagedQianfanDeclaresBaiduV2ChatProtocol(t *testing.T) {

--- a/backend/internal/service/account_test_service_supplier_probe_test.go
+++ b/backend/internal/service/account_test_service_supplier_probe_test.go
@@ -100,7 +100,6 @@ func TestUS048_ChatOnlyIdentityDoesNotRequireSupplierSourceBinding(t *testing.T)
 			"https://dashscope.aliyuncs.com", "secret",
 			map[string]string{"qwen3.6-flash": "qwen3.6-flash"}, newapiconstant.ChannelTypeAli),
 	}
-	delete(account.Extra, SupplierSourceIDExtraKey)
 	account.Extra = nil
 
 	identity, governed, err := BuildProtocolEndpointIdentity(account)

--- a/backend/internal/service/supplier_managed_account_commands.go
+++ b/backend/internal/service/supplier_managed_account_commands.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"maps"
 	"strings"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
 )
 
 type SupplierManagedAccountCreateInput struct {
@@ -260,9 +263,22 @@ func supplierManagedCredentials(endpoint, credential string, modelMapping map[st
 	if transport, err := resolveSupplierManagedTransport(endpoint, channelType); err == nil {
 		baseURL = transport.Endpoint
 	}
+	chatBase := baseURL
+	if channelType == newapiconstant.ChannelTypeBaiduV2 {
+		// Qianfan Chat lives under /v2; declare the complete path so identity
+		// normalize does not invent a /v1 suffix. Ordinary (non-exclusive)
+		// Qianfan accounts keep bare base_url fan-out and historical keys.
+		chatBase = strings.TrimRight(newapiintegration.QianfanBaseURL, "/") + "/v2/chat/completions"
+	}
 	return map[string]any{
-		"base_url":      baseURL,
-		"api_key":       strings.TrimSpace(credential),
+		"base_url": baseURL,
+		"api_key":  strings.TrimSpace(credential),
 		"model_mapping": mapping,
+		"api_base_urls": map[string]any{
+			APIProtocolChatCompletions: chatBase,
+		},
+		// Account-self exclusive endpoint declaration — scheduling identity
+		// reads this, not supplier_source_id.
+		ProtocolEndpointsExclusiveCredentialKey: true,
 	}
 }

--- a/backend/internal/service/supplier_managed_account_commands.go
+++ b/backend/internal/service/supplier_managed_account_commands.go
@@ -271,8 +271,8 @@ func supplierManagedCredentials(endpoint, credential string, modelMapping map[st
 		chatBase = strings.TrimRight(newapiintegration.QianfanBaseURL, "/") + "/v2/chat/completions"
 	}
 	return map[string]any{
-		"base_url": baseURL,
-		"api_key":  strings.TrimSpace(credential),
+		"base_url":      baseURL,
+		"api_key":       strings.TrimSpace(credential),
 		"model_mapping": mapping,
 		"api_base_urls": map[string]any{
 			APIProtocolChatCompletions: chatBase,

--- a/backend/internal/service/supplier_source_service.go
+++ b/backend/internal/service/supplier_source_service.go
@@ -594,6 +594,36 @@ func supplierAccountStructureMatches(account *Account, endpoint string, channelT
 	return supplierStringMapsEqual(supplierModelMapping(account.Credentials), mapping)
 }
 
+func supplierAccountNeedsProtocolRepublish(account *Account, sourceEndpoint string, sourceChannelType int) bool {
+	if account == nil || len(supplierModelMapping(account.Credentials)) == 0 {
+		return false
+	}
+	// Migrate legacy managed credentials that still fan identity from bare base_url.
+	if !accountDeclaresExclusiveProtocolEndpoints(account) {
+		return true
+	}
+	want, err := resolveSupplierManagedTransport(sourceEndpoint, sourceChannelType)
+	if err != nil {
+		return true
+	}
+	if account.ChannelType != want.ChannelType {
+		return true
+	}
+	baseURL, _ := account.Credentials["base_url"].(string)
+	if !supplierManagedEndpointsEqual(baseURL, sourceEndpoint) {
+		return true
+	}
+	identity, governed, err := BuildProtocolEndpointIdentity(account)
+	if err != nil || !governed {
+		return true
+	}
+	if account.ProtocolEndpointCapability != nil &&
+		identity.Key() != account.ProtocolEndpointCapability.CapabilityKey {
+		return true
+	}
+	return false
+}
+
 func supplierAccountMatchesDesired(
 	account *Account,
 	source *SupplierSource,
@@ -792,32 +822,6 @@ func (s *SupplierSourceService) ensureSupplierManagedConcurrency(
 		result.Changes = append(result.Changes, supplierAccountChange(before, readback, band, "updated"))
 	}
 	return nil
-}
-
-func supplierAccountNeedsProtocolRepublish(account *Account, sourceEndpoint string, sourceChannelType int) bool {
-	if account == nil || len(supplierModelMapping(account.Credentials)) == 0 {
-		return false
-	}
-	want, err := resolveSupplierManagedTransport(sourceEndpoint, sourceChannelType)
-	if err != nil {
-		return false
-	}
-	if account.ChannelType != want.ChannelType {
-		return true
-	}
-	baseURL, _ := account.Credentials["base_url"].(string)
-	if !supplierManagedEndpointsEqual(baseURL, sourceEndpoint) {
-		return true
-	}
-	identity, governed, err := BuildProtocolEndpointIdentity(account)
-	if err != nil || !governed {
-		return true
-	}
-	if account.ProtocolEndpointCapability != nil &&
-		identity.Key() != account.ProtocolEndpointCapability.CapabilityKey {
-		return true
-	}
-	return false
 }
 
 func (s *SupplierSourceService) protectCredential(credential string) (string, string, error) {

--- a/backend/internal/service/supplier_source_sync_test.go
+++ b/backend/internal/service/supplier_source_sync_test.go
@@ -86,10 +86,8 @@ func TestUS048_SupplierSyncMetadataOnlySkipsProbe(t *testing.T) {
 	}}
 	accounts := &supplierSyncAccountStoreFake{managed: []*Account{{
 		ID: 41, Name: "existing", Platform: PlatformNewAPI, Type: AccountTypeAPIKey, ChannelType: 1,
-		Credentials: map[string]any{
-			"base_url": "https://supplier.example/v1", "api_key": "secret",
-			"model_mapping": map[string]string{"model": "model"},
-		},
+		Credentials: supplierManagedCredentials(
+			"https://supplier.example/v1", "secret", map[string]string{"model": "model"}, 1),
 		Extra:    map[string]any{SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3},
 		Priority: 102, Status: StatusActive, Schedulable: true, Concurrency: SupplierSourceDefaultAccountConcurrency,
 	}}}
@@ -115,10 +113,8 @@ func TestUS048_SupplierSyncNameChangeUpdatesAccountWithoutProbe(t *testing.T) {
 	}}
 	accounts := &supplierSyncAccountStoreFake{managed: []*Account{{
 		ID: 41, Name: "佳杰/stbl-5 · 档位 3", Platform: PlatformNewAPI, Type: AccountTypeAPIKey, ChannelType: 1,
-		Credentials: map[string]any{
-			"base_url": "https://supplier.example/v1", "api_key": "secret",
-			"model_mapping": map[string]string{"model": "model"},
-		},
+		Credentials: supplierManagedCredentials(
+			"https://supplier.example/v1", "secret", map[string]string{"model": "model"}, 1),
 		Extra:    map[string]any{SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3},
 		Priority: 103, Status: StatusActive, Schedulable: true, Concurrency: SupplierSourceDefaultAccountConcurrency,
 	}}}
@@ -142,10 +138,8 @@ func TestUS048_SupplierSyncMovesModelByAddingBeforeRemoving(t *testing.T) {
 	}}
 	accounts := &supplierSyncAccountStoreFake{managed: []*Account{{
 		ID: 41, Platform: PlatformNewAPI, Type: AccountTypeAPIKey, ChannelType: 1,
-		Credentials: map[string]any{
-			"base_url": "https://supplier.example/v1", "api_key": "secret",
-			"model_mapping": map[string]string{"model": "model"},
-		},
+		Credentials: supplierManagedCredentials(
+			"https://supplier.example/v1", "secret", map[string]string{"model": "model"}, 1),
 		Extra:    map[string]any{SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3},
 		Priority: 103, Status: StatusActive, Schedulable: true, Concurrency: SupplierSourceDefaultAccountConcurrency,
 	}}}
@@ -839,10 +833,9 @@ func TestUS048_SupplierSyncAppliesSourceAccountConcurrency(t *testing.T) {
 	}}
 	accounts := &supplierSyncAccountStoreFake{managed: []*Account{{
 		ID: 41, Name: "supplier/佳杰 · 档位 3", Platform: PlatformNewAPI, Type: AccountTypeAPIKey, ChannelType: 1,
-		Credentials: map[string]any{
-			"base_url": "https://supplier.example/v1", "api_key": "secret",
-			"model_mapping": map[string]string{"deepseek-v4-pro": "deepseek-v4-pro"},
-		},
+		Credentials: supplierManagedCredentials(
+			"https://supplier.example/v1", "secret",
+			map[string]string{"deepseek-v4-pro": "deepseek-v4-pro"}, 1),
 		Extra:    map[string]any{SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3},
 		Priority: 103, Status: StatusActive, Schedulable: true, Concurrency: 1,
 	}}}

--- a/backend/internal/service/supplier_source_sync_test.go
+++ b/backend/internal/service/supplier_source_sync_test.go
@@ -898,3 +898,24 @@ func TestSupplierAccountNeedsProtocolRepublishDetectsTransportDrift(t *testing.T
 		account, "https://qianfan.baidubce.com", newapiconstant.ChannelTypeBaiduV2,
 	))
 }
+
+func TestSupplierAccountNeedsProtocolRepublishDetectsLegacyNonExclusiveCredentials(t *testing.T) {
+	// Pre-fix managed rows only had bare base_url; sync must republish exclusive shape.
+	account := &Account{
+		Platform: PlatformNewAPI, Type: AccountTypeAPIKey, ChannelType: 1,
+		Credentials: map[string]any{
+			"base_url":      "https://supplier.example/v1",
+			"api_key":       "secret",
+			"model_mapping": map[string]string{"model": "model"},
+		},
+	}
+	require.False(t, accountDeclaresExclusiveProtocolEndpoints(account))
+	require.True(t, supplierAccountNeedsProtocolRepublish(account, "https://supplier.example/v1", 1))
+
+	migrated := &Account{
+		Platform: PlatformNewAPI, Type: AccountTypeAPIKey, ChannelType: 1,
+		Credentials: supplierManagedCredentials(
+			"https://supplier.example/v1", "secret", map[string]string{"model": "model"}, 1),
+	}
+	require.False(t, supplierAccountNeedsProtocolRepublish(migrated, "https://supplier.example/v1", 1))
+}


### PR DESCRIPTION
## 摘要
- 调度/网关 protocol identity 只应由账号自身决定；原先用 `IsSupplierManagedAccount`（`supplier_source_id`）切换 chat-only 端点，违反该原则，并在调度快照丢掉 Extra 后触发 `no_legal_protocol_route`。
- 改为账号凭证声明：`api_base_urls` + `protocol_endpoints_exclusive`；托管账号写入这两项，identity/probe 只吃声明协议，不再读供应源标记。
- 调度快照保留 `protocol_endpoints_exclusive`（及已有的 `api_base_urls`）；撤回往 Extra 白名单塞 `supplier_source_id` 的临时方案。

## 风险
- 常规：行为变更限于 NewAPI 托管账号的 identity 派生路径；legacy 非 exclusive 账号仍走 base_url 扇出，不受影响。
- 发版后需对供应源做一次 sync：旧托管凭证无 exclusive 标记时会走 protocol republish，写回新凭证并重挂 capability。

## 验证
- `go test -tags=unit ./internal/service -run 'TestUS048_|TestSupplierAccountNeedsProtocolRepublish'` → PASS
- `go test -tags=unit ./internal/repository -run 'TestUS048_SupplierConfiguration'` → PASS
- `PREFLIGHT_BASE=origin/main ./scripts/preflight.sh` → PASS

## 提交
- `06b06ebcd` fix(scheduler): keep supplier_source_id in snapshot Extra
- `3364322f9` fix(scheduler): derive chat-only identity from account credentials
- `78aa1548e` fix(scheduler): address R-001 gofmt and legacy exclusive republish test
- `80a50aa91` fix(scheduler): gofmt scheduler cache exclusive-endpoint unit test
- `52dbddeaf` fix(scheduler): align supplier projection fixtures with exclusive chat identity
- 最新提交：`52dbddeaf`

sentinel-registry-reviewed