### PR TITLE
fix(admin): 受管账号按普通账号编辑，仅 sync 覆盖投影

### DIFF
--- a/.testing/user-stories/stories/US-048-model-supplier-source-management.md
+++ b/.testing/user-stories/stories/US-048-model-supplier-source-management.md
@@ -19,7 +19,7 @@
 3. AC-003 (探测门禁): Given endpoint、credential、模型 ID、模型增减、跨档，或非空受管账号的 `status/schedulable` 与目标不一致，When 点击“校验并同步”，Then 系统用带 source/band 身份的内存账号逐模型使用明确 upstream ID 真实探测；任一失败返回全部当次结果且不写账号。只有 Chat Completions 正向结果生成本次同步内部证据；FMGo Seedance 显式映射及任何 Responses/Anthropic 等非 Chat 成功证据都返回 `protocol_unsupported`，不猜协议、不写账号。
 4. AC-004 (热更新): Given 全部结构探测成功，When 同步模型跨档或增减，Then 系统先以空 mapping、不可调度状态创建缺失账号；非空投影必须携带本次 Chat 正向证据，并在单账号事务内提交账号配置、Chat-only 现有协议能力、`InitialProbeCompleted=true`/`OfficialSeed=false` 证据和 scheduler outbox，再做配置读回确认而不进行写后二次网络探测，最后从旧档删除 mapping。单账号事务失败时已有账号保持旧配置、新账号保持空 mapping 不可调度；跨账号中途失败保留已完成增加、停止后续减少，返回 `failed_step + changes[]`，重试可继续收敛；空档账号保留并收敛为 `active + schedulable=false`。已选来源存在未保存表单修改时同步入口禁用并提示先保存，成功提示只能从当前结果派生。
 5. AC-005 (隔离回归): Given 供应源保存、预览或同步，When 执行任一路径，Then 供应源不读取、比较、返回或写入账号组，专用投影读取不调用通用 `GetByID`，并且只选择同步所需配置字段，不读取倍率或无关运行字段；新账号保持未分组且不借用 `newapi-default`，普通账号创建失败契约不变；受管/预探测账号只声明 Chat Completions；通用 host 末尾 `/v1` 只在 OpenAI 受管路径规范化，`qianfan.baidubce.com` 解析为 BaiduV2 + 根 URL 并声明 `/v2/chat/completions`，普通 NewAPI 账号行为不变；系统不修改倍率、定价或 scheduler，scheduler 继续只按更小的原有账号 priority 先调度，不读取供应来源 Extra。
-6. AC-006 (ownership): Given 账号 Extra 存在 `supplier_source_id`，When 普通账号单项、批量、复制、删除、从父账号创建影子账号、credentials/Extra/刷新凭证、状态、可调度或 CRS 导入覆盖尝试写入，Then service 层整体拒绝；普通创建和 CRS 导入不能伪造保留 Extra；供应源同步只走不携带 `rate_multiplier` 的窄写命令，只合并 `supplier_source_id`、`supplier_discount_band` 两个受管 Extra 并保留所有非受管 Extra，同时修复解析后的 NewAPI transport（OpenAI 或 Qianfan BaiduV2）与目标 `status/schedulable`。已有账号匹配覆盖全部未删除 NewAPI 候选，但只有 active 唯一精确匹配可接管；disabled/error 精确匹配返回冲突且不新建重复账号。恢复错误、配额重置、代理 fallback 与探测仍允许。真实账号 UI 显示“供应源托管”徽标和统一只读原因，点击后按 `source_id` 直接选中对应供应源。
+6. AC-006 (ownership): Given 账号 Extra 存在 `supplier_source_id`，When 运营在账号页编辑、删除、复制、切换调度或批量更新，Then 行为与普通账号一致；普通创建和 CRS 导入不能伪造保留 Extra，普通 Extra 编辑保留受管身份键，复制剥离受管身份键。When 在供应源点击「校验并同步」，Then 只走不携带 `rate_multiplier` 的窄写命令覆盖投影字段（含 priority/`model_mapping`/凭证/transport/`status/schedulable`），只合并 `supplier_source_id`、`supplier_discount_band` 并保留其他 Extra，不读写账号组。已有账号匹配覆盖全部未删除 NewAPI 候选，但只有 active 唯一精确匹配可接管；disabled/error 精确匹配返回冲突且不新建重复账号。恢复错误、配额重置、代理 fallback 与探测仍允许。真实账号 UI 显示“供应源托管”徽标与同步覆盖提示，点击徽标按 `source_id` 直接选中对应供应源。
 7. AC-007 (安全): Given 创建、更新、探测或同步供应源，When API、日志和 Admin Audit Log 记录请求与结果，Then 不包含凭证明文、密文、HMAC 指纹或上游原始响应；探测只返回固定状态、协议分类和脱敏说明；HMAC 指纹跟随凭证加密密钥而非 JWT secret 的生命周期。
 8. AC-008 (首批证据): Given 首批运营表和只读生产库存，When 记录验收结果，Then 三个案例必须各自提供完整准确的供应事实才能同步；信息不完整或不匹配时不扩大已有账号匹配、不改网关调度。佳杰/VSTECS 只保留两个最低合法比例 `0.50` 模型且因无生产凭证标记 `not_run`；FMGo 只保留 Seedance 显式双 ID 与 `protocol_unsupported`；百度千帆在凭证齐备时以 BaiduV2 transport 接管账号 90（channel_type=46），不以 OpenAI Chat 伪探测冒充成功。
 9. AC-009 (上游发现): Given 已保存供应源，When 点击“校验并同步”，Then 系统先 `models-discover`：同步拉取上游 models 并规整已配置 ID，随后异步高并发探测**全部**未配置且可探测类型的候选（轮询 job 至完成）；仅探测通过的进入建议追加（默认 ratio `1.0`），探测失败或非 chat 类型不得建议追加；有规整变更时回填表单草稿要求保存，建议追加需运营主动加入表单；无规整变更且探测完成后继续既有投影同步。discover 不写供应源也不写账号。失败时管理页必须展示可读错误与 `failed_step`，不得只露出空标题。
@@ -83,12 +83,13 @@
 - `backend/internal/repository/account_repo_supplier_projection_test.go`::`TestUS048_SupplierProjectionReadSelectsOnlyRequiredConfigurationFields`
 - `backend/internal/repository/account_repo_supplier_projection_test.go`::`TestUS048_SupplierMetadataRepositoryWritesOnlyNameAndPriority`
 - `backend/internal/repository/account_repo_integration_test.go`::`TestAccountRepoSuite`（子测试：`TestUS048_SupplierConfigurationProjectionRebindsProtocolEndpointCapability`）
-- `backend/internal/service/supplier_managed_account_guard_test.go`::`TestUS048_ManagedAccountRejectsEveryGenericUpdate`
-- `backend/internal/service/supplier_managed_account_guard_test.go`::`TestUS048_ManagedAccountRejectsDirectExtraUpdateDeleteDuplicateAndSchedulable`
-- `backend/internal/service/supplier_managed_account_guard_test.go`::`TestUS048_ManagedAccountRejectsGenericSparkShadowCreation`
-- `backend/internal/service/supplier_managed_account_guard_test.go`::`TestUS048_GenericAccountServiceUsesTheSameSupplierOwnershipGuard`
+- `backend/internal/service/supplier_managed_account_guard_test.go`::`TestUS048_ManagedAccountUsesSupplierSourceIDAsOnlyMarker`
+- `backend/internal/service/supplier_managed_account_guard_test.go`::`TestUS048_OrdinaryCreateRejectsSupplierReservedExtra`
+- `backend/internal/service/supplier_managed_account_guard_test.go`::`TestUS048_ManagedAccountBehavesLikeOrdinaryAccountForUpdates`
+- `backend/internal/service/supplier_managed_account_guard_test.go`::`TestUS048_ManagedAccountDuplicateStripsSupplierIdentity`
 - `backend/internal/service/supplier_managed_account_guard_test.go`::`TestUS048_UnmanagedAccountCannotForgeSupplierManagedExtra`
-- `backend/internal/service/crs_sync_supplier_managed_test.go`::`TestUS048_CRSSyncRejectsSupplierManagedAccountOverwrite`
+- `backend/internal/service/supplier_managed_account_guard_test.go`::`TestUS048_PreserveSupplierManagedExtraKeys`
+- `backend/internal/service/crs_sync_supplier_managed_test.go`::`TestUS048_CRSSyncAllowsSupplierManagedAccountOverwrite`
 - `backend/internal/service/crs_sync_supplier_managed_test.go`::`TestUS048_CRSSyncRejectsReservedSupplierExtraOnNewAccount`
 - `backend/internal/service/supplier_models_discover_test.go`::`TestUS048_SupplierModelMatchKeyNormalizesCaseAndSpaces`
 - `backend/internal/service/supplier_models_discover_test.go`::`TestUS048_MatchSupplierUpstreamModelIDPrefersCanonicalID`
@@ -123,11 +124,14 @@
 - `frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts`::`does not show success when a resolved sync result reports a failed step`
 - `frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts`::`shows protocol_unsupported probe results from a 422 response without success wording`
 - `frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts`::`selects the supplier source requested by source_id after loading the list`
-- `frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts`::`shows the badge and disables row and mixed-selection generic writes`
+- `frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts`::`shows the supplier-managed badge and treats managed rows like ordinary accounts`
+- `frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts`::`opens the account modal for supplier-managed rows`
+- `frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts`::`allows duplicate of supplier-managed accounts like ordinary accounts`
+- `frontend/src/components/account/__tests__/EditAccountModal.spec.ts`::`shows the supplier-managed hint and submits a normal account update`
 - `frontend/src/components/account/__tests__/SupplierManagedBadge.spec.ts`::`uses marker presence, maps known sources, falls back safely, and refreshes after remount`
 - `frontend/e2e/us048-supplier-source-management.e2e.ts`::`US048 Jiajie saves facts previews priority and syncs one band account`
 - `frontend/e2e/us048-supplier-source-management.e2e.ts`::`US048 FMGo shows the fixed protocol boundary without account changes`
-- `frontend/e2e/us048-supplier-source-management.e2e.ts`::`US048 accounts UI marks supplier-managed accounts and explains read-only ownership`
+- `frontend/e2e/us048-supplier-source-management.e2e.ts`::`US048 accounts UI marks supplier-managed accounts and allows ordinary edits`
 
 - Run command:
 

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -348,11 +348,11 @@ func (s *AccountService) Update(ctx context.Context, id int64, req UpdateAccount
 	if err != nil {
 		return nil, fmt.Errorf("get account: %w", err)
 	}
-	if err := ValidateSupplierManagedAccountUpdate(account); err != nil {
-		return nil, err
-	}
 	if req.Extra != nil {
-		if err := ValidateSupplierReservedAccountExtra(*req.Extra); err != nil {
+		if IsSupplierManagedAccount(account) {
+			stripped := StripSupplierReservedAccountExtra(*req.Extra)
+			req.Extra = &stripped
+		} else if err := ValidateSupplierReservedAccountExtra(*req.Extra); err != nil {
 			return nil, err
 		}
 	}
@@ -377,7 +377,7 @@ func (s *AccountService) Update(ctx context.Context, id int64, req UpdateAccount
 		delete(extra, OllamaCloudUsageSessionExtraKey)
 		delete(extra, OllamaCloudUsageAutoRefreshExtraKey)
 		delete(extra, OllamaCloudUsageSnapshotExtraKey)
-		account.Extra = prepareCodexFingerprintExtraForUpdate(account, extra)
+		account.Extra = PreserveSupplierManagedExtraKeys(account, prepareCodexFingerprintExtraForUpdate(account, extra))
 	} else {
 		account.Extra = prepareCodexFingerprintExtraForUpdate(account, account.Extra)
 	}
@@ -461,14 +461,6 @@ func (s *AccountService) Delete(ctx context.Context, id int64) error {
 	if !exists {
 		return ErrAccountNotFound
 	}
-	account, err := s.accountRepo.GetByID(ctx, id)
-	if err != nil {
-		return fmt.Errorf("get account: %w", err)
-	}
-	if err := ValidateSupplierManagedAccountUpdate(account); err != nil {
-		return err
-	}
-
 	// 注意:此处不级联删除 spark 影子账号。当前唯一的后台删除入口走 AdminService.DeleteAccount
 	// (已 ListShadowsByParent 先删影子再删母)。本方法目前无删除调用方;若未来有调用方经此
 	// 删除母账号,需在此补级联,否则会留下孤儿影子(外审第6轮 P3:当前不可达,记为残留)。
@@ -517,9 +509,6 @@ func (s *AccountService) UpdateStatus(ctx context.Context, id int64, status stri
 	account, err := s.accountRepo.GetByID(ctx, id)
 	if err != nil {
 		return fmt.Errorf("get account: %w", err)
-	}
-	if err := ValidateSupplierManagedAccountUpdate(account); err != nil {
-		return err
 	}
 
 	account.Status = status

--- a/backend/internal/service/admin_account.go
+++ b/backend/internal/service/admin_account.go
@@ -149,6 +149,8 @@ var duplicateAccountDiscardedExtraKeys = map[string]struct{}{
 	"codex_7d_window_minutes":              {},
 	"codex_7d_reset_at":                    {},
 	SupportedProtocolsExtraKey:             {},
+	SupplierSourceIDExtraKey:               {},
+	SupplierDiscountBandExtraKey:           {},
 }
 
 func duplicateAccountExtra(value map[string]any) (map[string]any, error) {
@@ -245,18 +247,12 @@ func (s *adminServiceImpl) DuplicateAccount(ctx context.Context, id int64, actor
 		return nil, err
 	}
 	if existing != nil {
-		if IsSupplierManagedAccount(existing) {
-			return nil, ErrSupplierManagedAccountProtected
-		}
 		return existing, nil
 	}
 
 	source, err := s.accountRepo.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
-	}
-	if IsSupplierManagedAccount(source) {
-		return nil, ErrSupplierManagedAccountProtected
 	}
 	if source.IsCredentialShadow() {
 		return nil, infraerrors.BadRequest(
@@ -624,10 +620,11 @@ func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *U
 	if err != nil {
 		return nil, err
 	}
-	if err := ValidateSupplierManagedAccountUpdate(account); err != nil {
-		return nil, err
-	}
-	if err := ValidateSupplierReservedAccountExtra(input.Extra); err != nil {
+	if IsSupplierManagedAccount(account) {
+		if input.Extra != nil {
+			input.Extra = StripSupplierReservedAccountExtra(input.Extra)
+		}
+	} else if err := ValidateSupplierReservedAccountExtra(input.Extra); err != nil {
 		return nil, err
 	}
 	var normalizedExtra map[string]any
@@ -735,13 +732,15 @@ func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *U
 			OllamaCloudUsageSessionExtraKey,
 			OllamaCloudUsageAutoRefreshExtraKey,
 			OllamaCloudUsageSnapshotExtraKey,
+			SupplierSourceIDExtraKey,
+			SupplierDiscountBandExtraKey,
 		} {
 			if v, ok := account.Extra[key]; ok {
 				normalizedExtra[key] = v
 			}
 		}
 		normalizedExtra = prepareCodexFingerprintExtraForUpdate(account, normalizedExtra)
-		account.Extra = normalizedExtra
+		account.Extra = PreserveSupplierManagedExtraKeys(account, normalizedExtra)
 		if account.Platform == PlatformAntigravity && wasOveragesEnabled && !account.IsOveragesEnabled() {
 			delete(account.Extra, "antigravity_credits_overages") // 清理旧版 overages 运行态
 			// 清除 AICredits 限流 key
@@ -989,9 +988,6 @@ func (s *adminServiceImpl) UpdateAccountExtra(ctx context.Context, id int64, upd
 	if err != nil {
 		return err
 	}
-	if IsSupplierManagedAccount(account) {
-		return ErrSupplierManagedAccountProtected
-	}
 	if err := ValidateSupplierReservedAccountExtra(updates); err != nil {
 		return err
 	}
@@ -1068,14 +1064,19 @@ func (s *adminServiceImpl) BulkUpdateAccounts(ctx context.Context, input *BulkUp
 			targetsByID[account.ID] = account
 		}
 	}
+	hasManaged := false
 	for _, account := range cachedTargets {
 		if IsSupplierManagedAccount(account) {
-			return nil, ErrSupplierManagedAccountProtected
+			hasManaged = true
+			break
 		}
 	}
-	if err := ValidateSupplierReservedAccountExtra(input.Extra); err != nil {
+	if hasManaged {
+		input.Extra = StripSupplierReservedAccountExtra(input.Extra)
+	} else if err := ValidateSupplierReservedAccountExtra(input.Extra); err != nil {
 		return nil, err
 	}
+
 	if openAISettings.any() {
 		inheritedCount, err := validateBulkOpenAISettingsTargets(input, openAISettings, targetsByID)
 		if err != nil {
@@ -1348,12 +1349,8 @@ func (s *adminServiceImpl) resolveBulkUpdateTargetIDs(ctx context.Context, filte
 }
 
 func (s *adminServiceImpl) DeleteAccount(ctx context.Context, id int64) error {
-	account, err := s.accountRepo.GetByID(ctx, id)
-	if err != nil {
+	if _, err := s.accountRepo.GetByID(ctx, id); err != nil {
 		return err
-	}
-	if IsSupplierManagedAccount(account) {
-		return ErrSupplierManagedAccountProtected
 	}
 	// 级联删除 spark 影子账号（先删影子，再删母账号）
 	shadows, err := s.accountRepo.ListShadowsByParent(ctx, id)
@@ -1374,9 +1371,6 @@ func (s *adminServiceImpl) DeleteAccount(ctx context.Context, id int64) error {
 func (s *adminServiceImpl) RefreshAccountCredentials(ctx context.Context, id int64) (*Account, error) {
 	account, err := s.accountRepo.GetByID(ctx, id)
 	if err != nil {
-		return nil, err
-	}
-	if err := ValidateSupplierManagedAccountUpdate(account); err != nil {
 		return nil, err
 	}
 	// TODO: Implement refresh logic
@@ -1410,13 +1404,6 @@ func (s *adminServiceImpl) SetAccountError(ctx context.Context, id int64, errorM
 }
 
 func (s *adminServiceImpl) SetAccountSchedulable(ctx context.Context, id int64, schedulable bool) (*Account, error) {
-	account, err := s.accountRepo.GetByID(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-	if IsSupplierManagedAccount(account) {
-		return nil, ErrSupplierManagedAccountProtected
-	}
 	if err := s.accountRepo.SetSchedulable(ctx, id, schedulable); err != nil {
 		return nil, err
 	}
@@ -1446,9 +1433,6 @@ func (s *adminServiceImpl) CreateShadow(ctx context.Context, parentID int64, opt
 	parent, err := s.accountRepo.GetByID(ctx, parentID)
 	if err != nil {
 		return nil, fmt.Errorf("get parent account: %w", err)
-	}
-	if err := ValidateSupplierManagedAccountUpdate(parent); err != nil {
-		return nil, err
 	}
 	if !parent.IsOpenAIOAuth() {
 		return nil, infraerrors.New(http.StatusBadRequest, "SPARK_SHADOW_INVALID_PARENT",

--- a/backend/internal/service/crs_sync_service.go
+++ b/backend/internal/service/crs_sync_service.go
@@ -72,9 +72,6 @@ func guardCRSShadowParentInvariant(ctx context.Context, repo AccountRepository, 
 }
 
 func guardCRSAccountUpdate(ctx context.Context, repo AccountRepository, existing *Account, newPlatform, newType string) error {
-	if IsSupplierManagedAccount(existing) {
-		return ErrSupplierManagedAccountProtected
-	}
 	return guardCRSShadowParentInvariant(ctx, repo, existing, newPlatform, newType)
 }
 
@@ -713,7 +710,7 @@ func (s *CRSSyncService) SyncFromCRS(ctx context.Context, input SyncFromCRSInput
 			continue
 		}
 
-		existing.Extra = extra
+		existing.Extra = PreserveSupplierManagedExtraKeys(existing, extra)
 		existing.Name = defaultName(src.Name, src.ID)
 		existing.Platform = PlatformOpenAI
 		existing.Type = AccountTypeOAuth
@@ -873,7 +870,7 @@ func (s *CRSSyncService) SyncFromCRS(ctx context.Context, input SyncFromCRSInput
 			continue
 		}
 
-		existing.Extra = extra
+		existing.Extra = PreserveSupplierManagedExtraKeys(existing, extra)
 		existing.Name = defaultName(src.Name, src.ID)
 		existing.Platform = PlatformOpenAI
 		existing.Type = AccountTypeAPIKey

--- a/backend/internal/service/crs_sync_supplier_managed_test.go
+++ b/backend/internal/service/crs_sync_supplier_managed_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUS048_CRSSyncRejectsSupplierManagedAccountOverwrite(t *testing.T) {
+func TestUS048_CRSSyncAllowsSupplierManagedAccountOverwrite(t *testing.T) {
 	repo := &crsSupplierManagedAccountRepo{stored: &Account{
 		ID: 41, Name: "佳杰/stbl-5 · 档位 3", Platform: PlatformNewAPI, Type: AccountTypeAPIKey,
 		Credentials: map[string]any{"base_url": "https://supplier.example/v1", "api_key": "supplier-secret"},
@@ -49,14 +49,13 @@ func TestUS048_CRSSyncRejectsSupplierManagedAccountOverwrite(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, 1, result.Failed)
-	require.Zero(t, result.Updated)
-	require.Len(t, result.Items, 1)
-	require.Equal(t, "failed", result.Items[0].Action)
-	require.Contains(t, result.Items[0].Error, "supplier-managed")
-	require.Zero(t, repo.updateCalls)
-	require.Equal(t, "佳杰/stbl-5 · 档位 3", repo.stored.Name)
-	require.Equal(t, "supplier-secret", repo.stored.Credentials["api_key"])
+	require.Equal(t, 1, result.Updated)
+	require.Zero(t, result.Failed)
+	require.Equal(t, 1, repo.updateCalls)
+	require.Equal(t, "CRS overwrite", repo.stored.Name)
+	require.Equal(t, "crs-secret", repo.stored.Credentials["api_key"])
+	_, hasSource := repo.stored.Extra[SupplierSourceIDExtraKey]
+	require.True(t, hasSource, "CRS overwrite must not drop supplier identity")
 }
 
 func TestUS048_CRSSyncRejectsReservedSupplierExtraOnNewAccount(t *testing.T) {

--- a/backend/internal/service/supplier_managed_account_guard.go
+++ b/backend/internal/service/supplier_managed_account_guard.go
@@ -1,5 +1,12 @@
 package service
 
+import (
+	"maps"
+)
+
+// IsSupplierManagedAccount reports whether Extra carries the supplier_source_id
+// marker used by supplier-source sync and admin UI badges. Presence alone is
+// enough (fail closed on malformed values).
 func IsSupplierManagedAccount(account *Account) bool {
 	if account == nil || account.Extra == nil {
 		return false
@@ -8,13 +15,9 @@ func IsSupplierManagedAccount(account *Account) bool {
 	return exists
 }
 
-func ValidateSupplierManagedAccountUpdate(account *Account) error {
-	if !IsSupplierManagedAccount(account) {
-		return nil
-	}
-	return ErrSupplierManagedAccountProtected
-}
-
+// ValidateSupplierReservedAccountExtra rejects forging supplier ownership keys
+// through ordinary create/import Extra payloads. Managed accounts receive these
+// keys only from supplier-source sync commands.
 func ValidateSupplierReservedAccountExtra(extra map[string]any) error {
 	if extra == nil {
 		return nil
@@ -26,6 +29,44 @@ func ValidateSupplierReservedAccountExtra(extra map[string]any) error {
 		return ErrSupplierReservedAccountExtra
 	}
 	return nil
+}
+
+// StripSupplierReservedAccountExtra removes reserved ownership keys from an
+// incoming Extra map so ordinary edits can echo Extra without forging.
+func StripSupplierReservedAccountExtra(extra map[string]any) map[string]any {
+	if extra == nil {
+		return nil
+	}
+	out := maps.Clone(extra)
+	delete(out, SupplierSourceIDExtraKey)
+	delete(out, SupplierDiscountBandExtraKey)
+	return out
+}
+
+// PreserveSupplierManagedExtraKeys re-applies reserved ownership keys from the
+// existing account onto a replacement Extra map so ordinary Extra edits cannot
+// drop supplier sync identity.
+func PreserveSupplierManagedExtraKeys(account *Account, extra map[string]any) map[string]any {
+	if account == nil || account.Extra == nil {
+		return extra
+	}
+	sourceID, sourceOK := account.Extra[SupplierSourceIDExtraKey]
+	band, bandOK := account.Extra[SupplierDiscountBandExtraKey]
+	if !sourceOK && !bandOK {
+		return extra
+	}
+	if extra == nil {
+		extra = make(map[string]any, 2)
+	} else {
+		extra = maps.Clone(extra)
+	}
+	if sourceOK {
+		extra[SupplierSourceIDExtraKey] = sourceID
+	}
+	if bandOK {
+		extra[SupplierDiscountBandExtraKey] = band
+	}
+	return extra
 }
 
 func supplierSourceIDFromAccount(account *Account) (int64, bool) {

--- a/backend/internal/service/supplier_managed_account_guard_test.go
+++ b/backend/internal/service/supplier_managed_account_guard_test.go
@@ -14,12 +14,6 @@ func TestUS048_ManagedAccountUsesSupplierSourceIDAsOnlyMarker(t *testing.T) {
 	require.False(t, IsSupplierManagedAccount(&Account{}))
 }
 
-func TestUS048_ManagedAccountRejectsEveryGenericUpdate(t *testing.T) {
-	account := &Account{Extra: map[string]any{SupplierSourceIDExtraKey: int64(7)}}
-
-	require.ErrorIs(t, ValidateSupplierManagedAccountUpdate(account), ErrSupplierManagedAccountProtected)
-}
-
 func TestUS048_OrdinaryCreateRejectsSupplierReservedExtra(t *testing.T) {
 	for _, key := range []string{SupplierSourceIDExtraKey, SupplierDiscountBandExtraKey} {
 		err := ValidateSupplierReservedAccountExtra(map[string]any{key: 7})
@@ -28,77 +22,48 @@ func TestUS048_OrdinaryCreateRejectsSupplierReservedExtra(t *testing.T) {
 	require.NoError(t, ValidateSupplierReservedAccountExtra(map[string]any{"operator_note": "ok"}))
 }
 
-func TestUS048_ManagedAccountRejectsDirectExtraUpdateDeleteDuplicateAndSchedulable(t *testing.T) {
+func TestUS048_ManagedAccountBehavesLikeOrdinaryAccountForUpdates(t *testing.T) {
 	repo := newManagedAccountAdminRepoFake()
-	svc := &adminServiceImpl{accountRepo: repo}
+	groups := &managedAccountGroupRepoFake{ids: map[int64]bool{11: true}}
+	svc := &adminServiceImpl{accountRepo: repo, groupRepo: groups}
+	priority := 50
+	groupIDs := []int64{11}
+	notes := "ops"
+	concurrency := 3
 
-	err := svc.UpdateAccountExtra(context.Background(), repo.account.ID, map[string]any{"operator_note": "changed"})
-	require.ErrorIs(t, err, ErrSupplierManagedAccountProtected)
-	require.Zero(t, repo.updateExtraCalls)
+	updated, err := svc.UpdateAccount(context.Background(), repo.account.ID, &UpdateAccountInput{
+		Name: "renamed-managed", Status: StatusDisabled, Concurrency: &concurrency,
+		Priority: &priority, GroupIDs: &groupIDs, Notes: &notes,
+		Credentials:           map[string]any{"api_key": "rotated"},
+		SkipMixedChannelCheck: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "renamed-managed", updated.Name)
+	require.Equal(t, StatusDisabled, updated.Status)
+	require.Equal(t, 50, updated.Priority)
+	require.Equal(t, []int64{11}, repo.boundGroups[repo.account.ID])
+	_, hasSource := repo.updated.Extra[SupplierSourceIDExtraKey]
+	require.True(t, hasSource, "ordinary Extra edits must preserve supplier identity")
+
+	_, err = svc.SetAccountSchedulable(context.Background(), repo.account.ID, false)
+	require.NoError(t, err)
+	require.Equal(t, 1, repo.setSchedulableCalls)
 
 	err = svc.DeleteAccount(context.Background(), repo.account.ID)
-	require.ErrorIs(t, err, ErrSupplierManagedAccountProtected)
-	require.Zero(t, repo.deleteCalls)
-
-	_, err = svc.DuplicateAccount(context.Background(), repo.account.ID, "admin:1", "")
-	require.ErrorIs(t, err, ErrSupplierManagedAccountProtected)
-
-	_, err = svc.SetAccountSchedulable(context.Background(), repo.account.ID, true)
-	require.ErrorIs(t, err, ErrSupplierManagedAccountProtected)
-	require.Zero(t, repo.setSchedulableCalls)
-
-	_, err = svc.RefreshAccountCredentials(context.Background(), repo.account.ID)
-	require.ErrorIs(t, err, ErrSupplierManagedAccountProtected)
+	require.NoError(t, err)
+	require.Equal(t, 1, repo.deleteCalls)
 }
 
-func TestUS048_ManagedAccountRejectsGenericSparkShadowCreation(t *testing.T) {
-	repo := newManagedAccountAdminRepoFake()
-	repo.account.Platform = PlatformOpenAI
-	repo.account.Type = AccountTypeOAuth
-	svc := &adminServiceImpl{accountRepo: repo}
-
-	_, err := svc.CreateShadow(context.Background(), repo.account.ID, ShadowOptions{Name: "managed-shadow"})
-
-	require.ErrorIs(t, err, ErrSupplierManagedAccountProtected)
-	require.Zero(t, repo.createCalls)
-}
-
-func TestUS048_ManagedAccountRejectsNameOnlyBulkUpdate(t *testing.T) {
-	repo := newManagedAccountAdminRepoFake()
-	svc := &adminServiceImpl{accountRepo: repo}
-
-	_, err := svc.BulkUpdateAccounts(context.Background(), &BulkUpdateAccountsInput{
-		AccountIDs: []int64{repo.account.ID}, Name: "renamed",
+func TestUS048_ManagedAccountDuplicateStripsSupplierIdentity(t *testing.T) {
+	extra, err := duplicateAccountExtra(map[string]any{
+		SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3, "operator_note": "keep",
 	})
-
-	require.ErrorIs(t, err, ErrSupplierManagedAccountProtected)
-	require.Zero(t, repo.updateCalls)
-}
-
-func TestUS048_GenericAccountServiceUsesTheSameSupplierOwnershipGuard(t *testing.T) {
-	repo := newManagedAccountAdminRepoFake()
-	svc := NewAccountService(repo, nil)
-	name := "renamed"
-	status := StatusDisabled
-
-	_, err := svc.Update(context.Background(), repo.account.ID, UpdateAccountRequest{Name: &name})
-	require.ErrorIs(t, err, ErrSupplierManagedAccountProtected)
-
-	err = svc.UpdateStatus(context.Background(), repo.account.ID, status, "operator disabled")
-	require.ErrorIs(t, err, ErrSupplierManagedAccountProtected)
-
-	err = svc.Delete(context.Background(), repo.account.ID)
-	require.ErrorIs(t, err, ErrSupplierManagedAccountProtected)
-
-	_, err = svc.Create(context.Background(), CreateAccountRequest{
-		Name: "forged supplier account", Platform: PlatformOpenAI, Type: AccountTypeOAuth,
-		Extra: map[string]any{SupplierSourceIDExtraKey: int64(7)},
-	})
-	require.ErrorIs(t, err, ErrSupplierReservedAccountExtra)
-
-	require.Zero(t, repo.createCalls)
-	require.Zero(t, repo.updateCalls)
-	require.Zero(t, repo.deleteCalls)
+	require.NoError(t, err)
+	require.Equal(t, "keep", extra["operator_note"])
+	_, hasSource := extra[SupplierSourceIDExtraKey]
+	_, hasBand := extra[SupplierDiscountBandExtraKey]
+	require.False(t, hasSource)
+	require.False(t, hasBand)
 }
 
 func TestUS048_UnmanagedAccountCannotForgeSupplierManagedExtra(t *testing.T) {
@@ -147,31 +112,51 @@ func TestUS048_UnmanagedAccountCannotForgeSupplierManagedExtra(t *testing.T) {
 			require.ErrorIs(t, err, ErrSupplierReservedAccountExtra)
 			require.Zero(t, repo.updateCalls)
 			require.Zero(t, repo.updateExtraCalls)
+			require.Zero(t, repo.bulkUpdateCalls)
 		})
 	}
+}
+
+func TestUS048_PreserveSupplierManagedExtraKeys(t *testing.T) {
+	account := &Account{Extra: map[string]any{
+		SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3, "keep": true,
+	}}
+	got := PreserveSupplierManagedExtraKeys(account, map[string]any{"operator_note": "x"})
+	require.Equal(t, int64(7), got[SupplierSourceIDExtraKey])
+	require.Equal(t, 3, got[SupplierDiscountBandExtraKey])
+	require.Equal(t, "x", got["operator_note"])
 }
 
 type managedAccountAdminRepoFake struct {
 	AccountRepository
 	account             *Account
+	updated             *Account
+	created             *Account
 	createCalls         int
 	deleteCalls         int
 	updateCalls         int
+	bulkUpdateCalls     int
 	updateExtraCalls    int
 	setSchedulableCalls int
+	boundGroups         map[int64][]int64
 }
 
 func newManagedAccountAdminRepoFake() *managedAccountAdminRepoFake {
-	return &managedAccountAdminRepoFake{account: &Account{
-		ID: 41, Platform: PlatformNewAPI, Type: AccountTypeAPIKey,
-		Credentials: map[string]any{"api_key": "secret"},
-		Extra:       map[string]any{SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3},
-	}}
+	return &managedAccountAdminRepoFake{
+		account: &Account{
+			ID: 41, Platform: PlatformNewAPI, Type: AccountTypeAPIKey,
+			Name: "managed", Status: StatusActive, Concurrency: 1000, Priority: 103,
+			Credentials: map[string]any{"api_key": "secret", "base_url": "https://supplier.example/v1"},
+			Extra:       map[string]any{SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3},
+		},
+		boundGroups: make(map[int64][]int64),
+	}
 }
 
 func (r *managedAccountAdminRepoFake) GetByID(context.Context, int64) (*Account, error) {
 	copyAccount := *r.account
 	copyAccount.Extra = cloneSupplierJSONMap(r.account.Extra)
+	copyAccount.Credentials = cloneSupplierJSONMap(r.account.Credentials)
 	return &copyAccount, nil
 }
 
@@ -192,13 +177,44 @@ func (r *managedAccountAdminRepoFake) ListShadowsByParent(context.Context, int64
 	return nil, nil
 }
 
-func (r *managedAccountAdminRepoFake) Update(context.Context, *Account) error {
+func (r *managedAccountAdminRepoFake) Update(_ context.Context, account *Account) error {
 	r.updateCalls++
+	copyAccount := *account
+	copyAccount.Extra = cloneSupplierJSONMap(account.Extra)
+	copyAccount.Credentials = cloneSupplierJSONMap(account.Credentials)
+	r.updated = &copyAccount
+	r.account.Name = account.Name
+	r.account.Status = account.Status
+	r.account.Priority = account.Priority
+	r.account.Concurrency = account.Concurrency
+	r.account.Notes = account.Notes
+	r.account.Credentials = cloneSupplierJSONMap(account.Credentials)
+	r.account.Extra = PreserveSupplierManagedExtraKeys(r.account, cloneSupplierJSONMap(account.Extra))
 	return nil
 }
 
-func (r *managedAccountAdminRepoFake) Create(context.Context, *Account) error {
+func (r *managedAccountAdminRepoFake) BulkUpdate(_ context.Context, _ []int64, updates AccountBulkUpdate) (int64, error) {
+	r.bulkUpdateCalls++
+	if updates.Priority != nil {
+		r.account.Priority = *updates.Priority
+	}
+	return 1, nil
+}
+
+func (r *managedAccountAdminRepoFake) BindGroups(_ context.Context, accountID int64, groupIDs []int64) error {
+	r.boundGroups[accountID] = append([]int64(nil), groupIDs...)
+	return nil
+}
+
+func (r *managedAccountAdminRepoFake) ListByGroup(context.Context, int64) ([]Account, error) {
+	return nil, nil
+}
+
+func (r *managedAccountAdminRepoFake) Create(_ context.Context, account *Account) error {
 	r.createCalls++
+	copyAccount := *account
+	copyAccount.Extra = cloneSupplierJSONMap(account.Extra)
+	r.created = &copyAccount
 	return nil
 }
 
@@ -215,4 +231,24 @@ func (r *managedAccountAdminRepoFake) UpdateExtra(context.Context, int64, map[st
 func (r *managedAccountAdminRepoFake) SetSchedulable(context.Context, int64, bool) error {
 	r.setSchedulableCalls++
 	return nil
+}
+
+type managedAccountGroupRepoFake struct {
+	GroupRepository
+	ids map[int64]bool
+}
+
+func (g *managedAccountGroupRepoFake) ExistsByIDs(_ context.Context, ids []int64) (map[int64]bool, error) {
+	out := make(map[int64]bool, len(ids))
+	for _, id := range ids {
+		out[id] = g.ids[id]
+	}
+	return out, nil
+}
+
+func (g *managedAccountGroupRepoFake) GetByID(_ context.Context, id int64) (*Group, error) {
+	if !g.ids[id] {
+		return nil, ErrGroupNotFound
+	}
+	return &Group{ID: id, Name: "g", Platform: PlatformNewAPI}, nil
 }

--- a/backend/internal/service/supplier_source.go
+++ b/backend/internal/service/supplier_source.go
@@ -38,7 +38,6 @@ var (
 	ErrSupplierProjectionProtocolNotReady = infraerrors.New(http.StatusUnprocessableEntity, "SUPPLIER_PROTOCOL_NOT_READY", "supplier account protocol capability is not ready")
 	ErrSupplierProjectionReaderMissing    = errors.New("supplier projection reader unavailable")
 	ErrSupplierProjectionUpdaterMissing   = errors.New("supplier projection updater unavailable")
-	ErrSupplierManagedAccountProtected    = infraerrors.Conflict("SUPPLIER_MANAGED_ACCOUNT_PROTECTED", "supplier-managed account fields are read-only; edit the supplier source instead")
 	ErrSupplierReservedAccountExtra       = infraerrors.BadRequest("SUPPLIER_RESERVED_ACCOUNT_EXTRA", "supplier_source_id and supplier_discount_band are reserved for supplier-source sync")
 )
 

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 714,
-  "hash": "7f0ebbfe9baa7686f9f679ff52c19716d9b0d8a170a142ec7392d96857226128",
+  "hash": "66b381bd3667604d568d33e678b56b58398d3a09a7c71ff74d34e04a00e1af18",
   "schema": 1,
   "source": "frontend/"
 }

--- a/docs/approved/model-supplier-source-management.md
+++ b/docs/approved/model-supplier-source-management.md
@@ -6,7 +6,7 @@ approved_at: 2026-08-27
 updated: 2026-08-31
 created: 2026-08-27
 owners: [tk-platform]
-scope: "supplier facts, admin API/UI, credential isolation, account projection, probe gate, and managed-account ownership"
+scope: "supplier facts, admin API/UI, credential isolation, account projection, probe gate; managed accounts behave like ordinary accounts after create, with sync overwriting projection fields"
 related_stories: ["US-048"]
 ---
 
@@ -125,27 +125,22 @@ supplier_discount_band
 识别凭证冲突；只有当前 `status=active` 的唯一精确匹配可自动接管，`disabled/error` 精确匹配返回冲突，
 不绕过它新建重复账号。
 
-存在 `supplier_source_id` 的账号，其供应源拥有字段只能由供应源同步服务通过专用账号命令写入。所有
-通用账号配置写入口和 CRS 导入覆盖在 service 层整体拒绝，普通创建和导入也拒绝伪造保留 Extra；
-通用 credentials 刷新同样拒绝。供应投影更新必须走不携带 `rate_multiplier` 的窄写路径，不能回退到
-通用账号 Update。恢复错误、重置配额、代理 fallback 和账号探测等运行期专用操作继续允许。
+受管账号创建后，在账号管理页按**普通账号**对待：可编辑、删除、复制、切换调度、批量更新等。
+普通创建与导入仍拒绝伪造 `supplier_source_id` / `supplier_discount_band`；普通 Extra 编辑会保留
+已有受管身份键，复制账号时剥离这些键以免重复身份。
 
-账号列表、详情和操作菜单显眼显示：
+仅在供应源点击「校验并同步」时，通过专用窄写命令覆盖供应源投影字段（名称、凭证含
+`model_mapping`、priority、concurrency、status/schedulable、transport 等），不读取或写入账号组，
+也不携带 `rate_multiplier`。供应投影更新不能回退到通用账号 Update。
+
+账号列表显示徽标：
 
 ```text
 供应源托管 · {supplier_name}/{channel_name}
 ```
 
-徽标链接携带 `source_id`，供应源页面加载列表后直接选中对应来源；账号页重新挂载时刷新名称目录，
-避免同一会话内供应源改名后仍显示旧名称。
-
-普通编辑、复制、删除、状态/可调度切换和通用批量写显示统一原因：
-
-```text
-该账号由供应源托管，请前往供应源管理修改。
-```
-
-账号组仍在账号组管理入口独立维护。
+徽标链接携带 `source_id`，供应源页面加载列表后直接选中对应来源。账号编辑提示说明：平时可按普通
+账号编辑；「校验并同步」会覆盖投影字段。
 
 ## 第一版 API 与页面
 

--- a/frontend/e2e/us048-supplier-source-management.e2e.ts
+++ b/frontend/e2e/us048-supplier-source-management.e2e.ts
@@ -388,7 +388,7 @@ test('US048 FMGo shows the fixed protocol boundary without account changes', asy
   await expect(page.getByRole('button', { name: /激活|暂停/ })).toHaveCount(0)
 })
 
-test('US048 accounts UI marks supplier-managed accounts and explains read-only ownership', async ({ page }) => {
+test('US048 accounts UI marks supplier-managed accounts and allows ordinary edits', async ({ page }) => {
   await installBase(page, async (route, path) => {
     const request = route.request()
     if (path === '/api/v1/admin/accounts' && request.method() === 'GET') {
@@ -458,20 +458,21 @@ test('US048 accounts UI marks supplier-managed accounts and explains read-only o
 
   const editButton = row.locator('[data-testid="account-edit-btn"]')
   await expect(editButton).toBeEnabled()
-  await expect(editButton).toHaveAttribute('title', '查看托管账号配置（只读）')
-  await expect(editButton).toContainText('查看')
+  await expect(editButton).toContainText('编辑')
 
   await editButton.click()
   // Scope to the edit dialog: page-level name:'更新' also matches toolbar「批量更新」.
   const dialog = page.getByRole('dialog')
-  await expect(dialog.getByRole('heading', { name: '查看账号' })).toBeVisible()
-  await expect(dialog.getByText('以下为只读快照；修改模型、凭证与 priority 请前往供应源管理。')).toBeVisible()
-  await expect(dialog.locator('[data-tour="account-form-submit"]')).toHaveCount(0)
-  await expect(dialog.getByRole('button', { name: '更新', exact: true })).toHaveCount(0)
-  await dialog.getByRole('button', { name: '关闭' }).click()
+  await expect(dialog.getByRole('heading', { name: '编辑账号' })).toBeVisible()
+  await expect(dialog.getByText('该账号由供应源创建；在供应源点击「校验并同步」会覆盖更新投影字段（如 priority、model_mapping 等）。平时可按普通账号编辑。')).toBeVisible()
+  await expect(dialog.locator('[data-tour="account-form-submit"]')).toBeVisible()
+  await expect(dialog.locator('[data-tour="edit-account-form-name"]')).toBeEnabled()
+  await expect(dialog.locator('[data-tour="account-form-priority"]')).toBeEnabled()
+  await dialog.getByRole('button', { name: '取消' }).click()
 
   await row.getByRole('button', { name: '更多' }).click()
-  await expect(page.getByText('该账号由供应源托管，请前往供应源管理修改。')).toBeVisible()
+  await expect(page.getByText('复制账号')).toBeVisible()
+  await expect(page.getByRole('button', { name: '复制账号' })).toBeEnabled()
   const menuBadge = page.locator('[data-testid="supplier-managed-badge"]').last()
   await expect(menuBadge).toHaveAttribute(
     'href',

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -26,10 +26,7 @@
           {{ t('admin.accounts.supplierManaged.openManagement') }}
         </a>
       </div>
-      <fieldset
-        :disabled="supplierManagedInfo.managed"
-        class="m-0 min-w-0 space-y-5 border-0 p-0 disabled:opacity-100"
-      >
+      <div class="space-y-5">
       <div>
         <label class="input-label">{{ t('common.name') }}</label>
         <input v-model="form.name" type="text" required class="input" data-tour="edit-account-form-name" />
@@ -2893,21 +2890,21 @@
         data-tour="account-form-groups"
       />
 
-      </fieldset>
+      </div>
 
     </form>
 
     <template #footer>
       <div v-if="account" class="flex justify-end gap-3">
         <button @click="handleClose" type="button" class="btn btn-secondary">
-          {{ supplierManagedInfo.managed ? t('common.close') : t('common.cancel') }}
+          {{ t('common.cancel') }}
         </button>
         <button
-          v-if="!supplierManagedInfo.managed"
           type="submit"
           form="edit-account-form"
           :disabled="submitting"
           class="btn btn-primary"
+          data-testid="account-form-submit"
           data-tour="account-form-submit"
         >
           <svg
@@ -3118,15 +3115,10 @@ const handleProtocolProbe = async () => {
 }
 const {
   inspect: inspectSupplierManaged,
-  readOnlyReason: supplierManagedReadOnlyReason,
   viewHint: supplierManagedViewHint,
 } = useSupplierManagedAccount()
 const supplierManagedInfo = computed(() => inspectSupplierManaged(props.account))
-const dialogTitle = computed(() => (
-  supplierManagedInfo.value.managed
-    ? t('admin.accounts.viewAccount')
-    : t('admin.accounts.editAccount')
-))
+const dialogTitle = computed(() => t('admin.accounts.editAccount'))
 
 // Spark 影子账号(parent_account_id 非空):代理恒继承母账号,不可独立编辑(外审 B/P1),
 // 故隐藏代理选择器。
@@ -4936,10 +4928,6 @@ const submitUpdateAccount = async (accountID: number, updatePayload: Record<stri
 
 const handleSubmit = async () => {
   if (!props.account) return
-  if (supplierManagedInfo.value.managed) {
-    appStore.showError(supplierManagedReadOnlyReason.value)
-    return
-  }
   const accountID = props.account.id
 
   if (!validateOpenAIMessagesCompactionForm()) {

--- a/frontend/src/components/account/SupplierManagedBadge.vue
+++ b/frontend/src/components/account/SupplierManagedBadge.vue
@@ -3,7 +3,7 @@
     v-if="info.managed"
     data-testid="supplier-managed-badge"
     :href="info.href"
-    :title="readOnlyReason"
+    :title="viewHint"
     class="inline-flex w-fit items-center rounded-md border border-amber-300 bg-amber-50 px-2 py-0.5 text-[11px] font-semibold text-amber-800 transition-colors hover:border-amber-400 hover:bg-amber-100 dark:border-amber-700/70 dark:bg-amber-950/30 dark:text-amber-200 dark:hover:bg-amber-900/40"
   >
     {{ info.label }}
@@ -22,7 +22,7 @@ const props = defineProps<{
   account: SupplierManagedAccountLike | null
 }>()
 
-const { inspect, readOnlyReason, ensureSourceDirectoryLoaded } = useSupplierManagedAccount()
+const { inspect, viewHint, ensureSourceDirectoryLoaded } = useSupplierManagedAccount()
 const info = computed(() => inspect(props.account))
 
 watch(

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 
 const { updateAccountMock, probeProtocolsMock, checkMixedChannelRiskMock, getWebSearchEmulationConfigMock, getSettingsMock, listTLSFingerprintProfilesMock, listSupplierSourcesMock, showErrorMock, showInfoMock, showSuccessMock, authIsSimpleMode } = vi.hoisted(() => ({
   updateAccountMock: vi.fn(),
@@ -377,19 +377,28 @@ describe('EditAccountModal', () => {
     authIsSimpleMode.value = true
   })
 
-  it('shows the supplier-managed reason and refuses generic account updates', async () => {
+  it('shows the supplier-managed hint and submits a normal account update', async () => {
     const account = {
       ...buildAccount(),
-      extra: { supplier_source_id: '7' }
+      extra: { supplier_source_id: '7' },
+      priority: 103,
+      group_ids: []
     }
     const wrapper = mountModal(account)
 
     expect(wrapper.text()).toContain('admin.accounts.supplierManaged.viewHint')
-    expect(wrapper.find('[data-tour="account-form-submit"]').exists()).toBe(false)
+    expect(wrapper.find('[data-tour="account-form-submit"]').exists()).toBe(true)
+    expect(wrapper.get('[data-tour="edit-account-form-name"]').attributes('disabled')).toBeUndefined()
 
+    const priorityInput = wrapper.get('[data-tour="account-form-priority"]')
+    await priorityInput.setValue(50)
     await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+    await flushPromises()
 
-    expect(updateAccountMock).not.toHaveBeenCalled()
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    const payload = updateAccountMock.mock.calls[0]?.[1]
+    expect(payload.priority).toBe(50)
+    expect(payload.name).toBe(account.name)
   })
 
   it('re-probes canonical native protocols and emits the refreshed account', async () => {

--- a/frontend/src/components/admin/account/AccountActionMenu.vue
+++ b/frontend/src/components/admin/account/AccountActionMenu.vue
@@ -11,14 +11,6 @@
       >
         <div class="py-1">
           <template v-if="account">
-            <div
-              v-if="isSupplierManaged"
-              data-testid="supplier-managed-action-notice"
-              class="mx-2 mb-2 rounded-lg border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800 dark:border-amber-800/70 dark:bg-amber-950/30 dark:text-amber-200"
-            >
-              <SupplierManagedBadge :account="account" />
-              <p class="mt-1 leading-5">{{ readOnlyReason }}</p>
-            </div>
             <button @click.stop.prevent="emitAction('test', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-dark-700">
               <Icon name="play" size="sm" class="text-green-500" :stroke-width="2" />
               {{ t('admin.accounts.testConnection') }}
@@ -31,30 +23,30 @@
               <Icon name="clock" size="sm" class="text-orange-500" />
               {{ t('admin.scheduledTests.schedule') }}
             </button>
-            <button v-if="canDuplicate" :disabled="isSupplierManaged" :title="isSupplierManaged ? readOnlyReason : undefined" @click="emitWriteAction('duplicate', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-dark-700">
+            <button v-if="canDuplicate" @click="emitWriteAction('duplicate', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-dark-700">
               <Icon name="copy" size="sm" class="text-sky-500" />
               {{ t('admin.accounts.duplicateAccount') }}
             </button>
             <!-- 影子账号不持凭据:重授权/刷新 token 对其无效(后端拒绝),故隐藏(外审 G4)。 -->
             <template v-if="(account.type === 'oauth' || account.type === 'setup-token') && !isShadow">
-              <button :disabled="isSupplierManaged" :title="isSupplierManaged ? readOnlyReason : undefined" @click.stop.prevent="emitWriteAction('reauth', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-blue-600 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-dark-700">
+              <button @click.stop.prevent="emitWriteAction('reauth', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-blue-600 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-dark-700">
                 <Icon name="link" size="sm" />
                 {{ t('admin.accounts.reAuthorize') }}
               </button>
-              <button :disabled="isSupplierManaged" :title="isSupplierManaged ? readOnlyReason : undefined" @click.stop.prevent="emitWriteAction('refresh-token', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-purple-600 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-dark-700">
+              <button @click.stop.prevent="emitWriteAction('refresh-token', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-purple-600 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-dark-700">
                 <Icon name="refresh" size="sm" />
                 {{ t('admin.accounts.refreshToken') }}
               </button>
             </template>
-            <button v-if="isOpenAIOAuthParent" :disabled="isSupplierManaged" :title="isSupplierManaged ? readOnlyReason : undefined" @click.stop.prevent="emitWriteAction('create-spark-shadow', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-amber-600 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-dark-700">
+            <button v-if="isOpenAIOAuthParent" @click.stop.prevent="emitWriteAction('create-spark-shadow', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-amber-600 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-dark-700">
               <Icon name="sparkles" size="sm" />
               {{ t('admin.accounts.createSparkShadow') }}
             </button>
-            <button v-if="supportsPrivacy" :disabled="isSupplierManaged" :title="isSupplierManaged ? readOnlyReason : undefined" @click.stop.prevent="emitWriteAction('set-privacy', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-emerald-600 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-dark-700">
+            <button v-if="supportsPrivacy" @click.stop.prevent="emitWriteAction('set-privacy', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-emerald-600 hover:bg-gray-100 dark:hover:bg-dark-700">
               <Icon name="shield" size="sm" />
               {{ t('admin.accounts.setPrivacy') }}
             </button>
-            <button v-if="canSetTier" :disabled="isSupplierManaged" :title="isSupplierManaged ? readOnlyReason : undefined" @click.stop.prevent="emitWriteAction('set-tier', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-amber-600 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-dark-700">
+            <button v-if="canSetTier" @click.stop.prevent="emitWriteAction('set-tier', account)" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-amber-600 hover:bg-gray-100 dark:hover:bg-dark-700">
               <Icon name="chart" size="sm" />
               {{ t('admin.accounts.setTierDialog.menuItem') }}
             </button>
@@ -78,8 +70,6 @@
 import { computed, watch, onUnmounted, nextTick, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Icon } from '@/components/icons'
-import SupplierManagedBadge from '@/components/account/SupplierManagedBadge.vue'
-import { useSupplierManagedAccount } from '@/composables/useSupplierManagedAccount'
 import type { Account } from '@/types'
 import { PLATFORM_ANTHROPIC, PLATFORM_ANTIGRAVITY, PLATFORM_OPENAI } from '@/constants/gatewayPlatforms'
 
@@ -91,8 +81,6 @@ const props = defineProps<{
 }>()
 const emit = defineEmits(['close', 'test', 'stats', 'schedule', 'duplicate', 'reauth', 'refresh-token', 'recover-state', 'reset-quota', 'set-privacy', 'set-tier', 'create-spark-shadow'])
 const { t } = useI18n()
-const { inspect: inspectSupplierManaged, readOnlyReason } = useSupplierManagedAccount()
-const isSupplierManaged = computed(() => inspectSupplierManaged(props.account).managed)
 
 const canDuplicate = computed(() => {
   if (!props.account || props.account.parent_account_id != null) return false
@@ -191,7 +179,6 @@ const emitAction = (event: MenuActionEvent, account: Account) => {
   void nextTick(() => emit('close'))
 }
 const emitWriteAction = (event: MenuActionEvent, account: Account) => {
-  if (isSupplierManaged.value) return
   emitAction(event, account)
 }
 const isAntigravityOAuth = computed(() => props.account?.platform === PLATFORM_ANTIGRAVITY && props.account?.type === 'oauth')

--- a/frontend/src/components/admin/account/AccountBulkActionsBar.vue
+++ b/frontend/src/components/admin/account/AccountBulkActionsBar.vue
@@ -41,28 +41,18 @@
           {{ t('admin.accounts.bulkActions.clear') }}
         </button>
       </template>
-      <div
-        v-if="containsSupplierManaged"
-        data-testid="supplier-managed-bulk-notice"
-        class="basis-full text-xs font-medium text-amber-800 dark:text-amber-200"
-      >
-        {{ readOnlyReason }}
-        <a class="ml-1 underline" href="/admin/supplier-sources">
-          {{ t('admin.accounts.supplierManaged.openManagement') }}
-        </a>
-      </div>
     </div>
     <div class="flex gap-2">
       <template v-if="selectedIds.length > 0">
-        <button :disabled="containsSupplierManaged" :title="writeTitle" @click="emitWrite('delete')" class="btn btn-danger btn-sm">{{ t('admin.accounts.bulkActions.delete') }}</button>
+        <button @click="$emit('delete')" class="btn btn-danger btn-sm">{{ t('admin.accounts.bulkActions.delete') }}</button>
         <button @click="$emit('reset-status')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.resetStatus') }}</button>
-        <button :disabled="containsSupplierManaged" :title="writeTitle" @click="emitWrite('refresh-token')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.refreshToken') }}</button>
+        <button @click="$emit('refresh-token')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.refreshToken') }}</button>
         <button @click="$emit('probe-upstream-billing')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.probeUpstreamBilling') }}</button>
-        <button :disabled="containsSupplierManaged" :title="writeTitle" @click="emitWrite('toggle-schedulable', true)" class="btn btn-success btn-sm">{{ t('admin.accounts.bulkActions.enableScheduling') }}</button>
-        <button :disabled="containsSupplierManaged" :title="writeTitle" @click="emitWrite('toggle-schedulable', false)" class="btn btn-warning btn-sm">{{ t('admin.accounts.bulkActions.disableScheduling') }}</button>
-        <button :disabled="containsSupplierManaged" :title="writeTitle" @click="emitWrite('edit-selected')" class="btn btn-primary btn-sm">{{ t('admin.accounts.bulkActions.edit') }}</button>
+        <button @click="$emit('toggle-schedulable', true)" class="btn btn-success btn-sm">{{ t('admin.accounts.bulkActions.enableScheduling') }}</button>
+        <button @click="$emit('toggle-schedulable', false)" class="btn btn-warning btn-sm">{{ t('admin.accounts.bulkActions.disableScheduling') }}</button>
+        <button @click="$emit('edit-selected')" class="btn btn-primary btn-sm">{{ t('admin.accounts.bulkActions.edit') }}</button>
       </template>
-      <button :disabled="containsSupplierManaged" :title="writeTitle" @click="emitWrite('edit-filtered')" class="btn btn-primary btn-sm">
+      <button @click="$emit('edit-filtered')" class="btn btn-primary btn-sm">
         {{ t('admin.accounts.bulkEdit.submit') }}
       </button>
     </div>
@@ -70,11 +60,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useSupplierManagedAccount } from '@/composables/useSupplierManagedAccount'
 
-const props = withDefaults(defineProps<{
+withDefaults(defineProps<{
   selectedIds: number[]
   totalResults: number
   selectingAll: boolean
@@ -84,31 +72,18 @@ const props = withDefaults(defineProps<{
   containsSupplierManaged: false
 })
 
-const emit = defineEmits([
-  'delete',
-  'edit-selected',
-  'edit-filtered',
-  'clear',
-  'select-page',
-  'select-all-results',
-  'toggle-schedulable',
-  'reset-status',
-  'refresh-token',
-  'probe-upstream-billing'
-])
+defineEmits<{
+  (e: 'select-page'): void
+  (e: 'select-all-results'): void
+  (e: 'clear'): void
+  (e: 'delete'): void
+  (e: 'reset-status'): void
+  (e: 'refresh-token'): void
+  (e: 'probe-upstream-billing'): void
+  (e: 'toggle-schedulable', value: boolean): void
+  (e: 'edit-selected'): void
+  (e: 'edit-filtered'): void
+}>()
 
 const { t } = useI18n()
-const { readOnlyReason } = useSupplierManagedAccount()
-const writeTitle = computed(() => props.containsSupplierManaged ? readOnlyReason.value : undefined)
-
-type WriteEvent = 'delete' | 'edit-selected' | 'edit-filtered' | 'toggle-schedulable' | 'refresh-token'
-
-const emitWrite = (event: WriteEvent, value?: boolean) => {
-  if (props.containsSupplierManaged) return
-  if (event === 'toggle-schedulable') {
-    emit(event, value)
-    return
-  }
-  emit(event)
-}
 </script>

--- a/frontend/src/components/admin/account/__tests__/AccountActionMenu.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountActionMenu.spec.ts
@@ -118,7 +118,7 @@ describe('AccountActionMenu — 恢复状态入口', () => {
 })
 
 describe('AccountActionMenu — 供应源托管账号', () => {
-  it('keeps configuration writes disabled while runtime recovery actions stay available', async () => {
+  it('treats supplier-managed accounts like ordinary accounts for writes', async () => {
     const wrapper = mountMenu(makeAccount({
       platform: 'openai',
       type: 'apikey',
@@ -139,8 +139,7 @@ describe('AccountActionMenu — 供应源托管账号', () => {
       button.text().includes('admin.accounts.testConnection')
     )
 
-    expect(wrapper.text()).toContain('admin.accounts.supplierManaged.readOnlyReason')
-    expect(duplicateButton?.attributes('disabled')).toBeDefined()
+    expect(duplicateButton?.attributes('disabled')).toBeUndefined()
     expect(recoverButton?.attributes('disabled')).toBeUndefined()
     expect(resetQuotaButton?.attributes('disabled')).toBeUndefined()
     expect(testButton?.attributes('disabled')).toBeUndefined()
@@ -149,7 +148,7 @@ describe('AccountActionMenu — 供应源托管账号', () => {
     await recoverButton!.trigger('click')
     await resetQuotaButton!.trigger('click')
 
-    expect(wrapper.emitted('duplicate')).toBeUndefined()
+    expect(wrapper.emitted('duplicate')?.[0]?.[0]).toMatchObject({ id: 1 })
     expect(wrapper.emitted('recover-state')?.[0]?.[0]).toMatchObject({ id: 1 })
     expect(wrapper.emitted('reset-quota')?.[0]?.[0]).toMatchObject({ id: 1 })
   })

--- a/frontend/src/components/admin/account/__tests__/AccountBulkActionsBar.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountBulkActionsBar.spec.ts
@@ -48,7 +48,7 @@ describe('AccountBulkActionsBar', () => {
     expect(wrapper.emitted('probe-upstream-billing')).toHaveLength(1)
   })
 
-  it('blocks generic bulk writes when the selection contains a supplier-managed account', async () => {
+  it('keeps bulk writes enabled when the selection contains a supplier-managed account', async () => {
     const wrapper = mount(AccountBulkActionsBar, {
       props: {
         selectedIds: [1, 2],
@@ -69,8 +69,7 @@ describe('AccountBulkActionsBar', () => {
       item.text().includes('admin.accounts.bulkActions.resetStatus')
     )
 
-    expect(wrapper.text()).toContain('admin.accounts.supplierManaged.readOnlyReason')
-    expect(deleteButton?.attributes('disabled')).toBeDefined()
+    expect(deleteButton?.attributes('disabled')).toBeUndefined()
     expect(probeButton?.attributes('disabled')).toBeUndefined()
     expect(resetStatusButton?.attributes('disabled')).toBeUndefined()
 
@@ -78,7 +77,7 @@ describe('AccountBulkActionsBar', () => {
     await probeButton!.trigger('click')
     await resetStatusButton!.trigger('click')
 
-    expect(wrapper.emitted('delete')).toBeUndefined()
+    expect(wrapper.emitted('delete')).toHaveLength(1)
     expect(wrapper.emitted('probe-upstream-billing')).toHaveLength(1)
     expect(wrapper.emitted('reset-status')).toHaveLength(1)
   })

--- a/frontend/src/composables/useSupplierManagedAccount.ts
+++ b/frontend/src/composables/useSupplierManagedAccount.ts
@@ -60,9 +60,7 @@ async function ensureSourceDirectoryLoaded(): Promise<void> {
 
 export function useSupplierManagedAccount() {
   const { t } = useI18n()
-  const readOnlyReason = computed(() => t('admin.accounts.supplierManaged.readOnlyReason'))
   const viewHint = computed(() => t('admin.accounts.supplierManaged.viewHint'))
-  const viewButtonTitle = computed(() => t('admin.accounts.supplierManaged.viewButtonTitle'))
 
   const inspect = (account: SupplierManagedAccountLike | null | undefined): SupplierManagedAccountInfo => {
     const marker = supplierSourceMarker(account)
@@ -91,9 +89,7 @@ export function useSupplierManagedAccount() {
 
   return {
     inspect,
-    readOnlyReason,
     viewHint,
-    viewButtonTitle,
     ensureSourceDirectoryLoaded
   }
 }

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -113,9 +113,7 @@ export default {
       failedToToggleSchedulable: 'Failed to toggle scheduling status',
       supplierManaged: {
         badge: 'Supplier managed',
-        readOnlyReason: 'This account is managed by a supplier source. Make changes in Supplier Sources.',
-        viewHint: 'Read-only snapshot. Edit models, credentials, and priority in Supplier Sources.',
-        viewButtonTitle: 'View supplier-managed account (read-only)',
+        viewHint: 'Created from a supplier source. Validate & Sync overwrites projection fields (priority, model_mapping, etc.). Edit like any other account otherwise.',
         openManagement: 'Open Supplier Sources'
       },
       groupCountTotal: '{count} groups total',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -111,9 +111,7 @@ export default {
       failedToToggleSchedulable: '切换调度状态失败',
       supplierManaged: {
         badge: '供应源托管',
-        readOnlyReason: '该账号由供应源托管，请前往供应源管理修改。',
-        viewHint: '以下为只读快照；修改模型、凭证与 priority 请前往供应源管理。',
-        viewButtonTitle: '查看托管账号配置（只读）',
+        viewHint: '该账号由供应源创建；在供应源点击「校验并同步」会覆盖更新投影字段（如 priority、model_mapping 等）。平时可按普通账号编辑。',
         openManagement: '前往供应源管理'
       },
       groupCountTotal: '共 {count} 个分组',

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -191,7 +191,6 @@
           :total-results="pagination.total"
           :selecting-all="selectingAllResults"
           :all-results-selected="allResultsSelected"
-          :contains-supplier-managed="selectedContainsSupplierManaged"
           @delete="handleBulkDelete"
           @reset-status="handleBulkResetStatus"
           @refresh-token="handleBulkRefreshToken"
@@ -361,7 +360,7 @@
             </div>
           </template>
           <template #cell-schedulable="{ row }">
-            <button @click="handleToggleSchedulable(row)" :disabled="togglingSchedulable === row.id || isSupplierManaged(row)" class="relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:focus:ring-offset-dark-800" :class="[row.schedulable ? 'bg-primary-500 hover:bg-primary-600' : 'bg-gray-200 hover:bg-gray-300 dark:bg-dark-600 dark:hover:bg-dark-500']" :title="isSupplierManaged(row) ? supplierManagedReadOnlyReason : (row.schedulable ? t('admin.accounts.schedulableEnabled') : t('admin.accounts.schedulableDisabled'))">
+            <button @click="handleToggleSchedulable(row)" :disabled="togglingSchedulable === row.id" class="relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:focus:ring-offset-dark-800" :class="[row.schedulable ? 'bg-primary-500 hover:bg-primary-600' : 'bg-gray-200 hover:bg-gray-300 dark:bg-dark-600 dark:hover:bg-dark-500']" :title="row.schedulable ? t('admin.accounts.schedulableEnabled') : t('admin.accounts.schedulableDisabled')">
               <span class="pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out" :class="[row.schedulable ? 'translate-x-4' : 'translate-x-0']" />
             </button>
           </template>
@@ -498,15 +497,14 @@
             <div class="flex items-center gap-1">
               <button
                 data-testid="account-edit-btn"
-                :title="isSupplierManaged(row) ? supplierManagedViewButtonTitle : undefined"
+                
                 @click="handleEdit(row)"
                 class="flex flex-col items-center gap-0.5 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-gray-100 hover:text-primary-600 dark:hover:bg-dark-700 dark:hover:text-primary-400"
               >
-                <svg v-if="!isSupplierManaged(row)" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" /></svg>
-                <svg v-else class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" /><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
-                <span class="text-xs">{{ isSupplierManaged(row) ? t('common.view') : t('common.edit') }}</span>
+                <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" /></svg>
+                <span class="text-xs">{{ t('common.edit') }}</span>
               </button>
-              <button :disabled="isSupplierManaged(row)" :title="isSupplierManaged(row) ? supplierManagedReadOnlyReason : undefined" @click="handleDelete(row)" class="flex flex-col items-center gap-0.5 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-red-50 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-red-900/20 dark:hover:text-red-400">
+              <button @click="handleDelete(row)" class="flex flex-col items-center gap-0.5 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-red-50 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-red-900/20 dark:hover:text-red-400">
                 <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" /></svg>
                 <span class="text-xs">{{ t('common.delete') }}</span>
               </button>
@@ -614,7 +612,6 @@ import type { SelectOption } from '@/components/common/Select.vue'
 import AccountStatusIndicator from '@/components/account/AccountStatusIndicator.vue'
 import AccountProtocolCapabilities from '@/components/account/AccountProtocolCapabilities.vue'
 import SupplierManagedBadge from '@/components/account/SupplierManagedBadge.vue'
-import { useSupplierManagedAccount } from '@/composables/useSupplierManagedAccount'
 const AccountUsageCell = defineAsyncComponent(() => import('@/components/account/AccountUsageCell.vue'))
 import AccountTodayStatsCell from '@/components/account/AccountTodayStatsCell.vue'
 import AccountGroupsCell from '@/components/account/AccountGroupsCell.vue'
@@ -640,12 +637,6 @@ import { formatMultiplier } from '@/utils/formatters'
 const { t } = useI18n()
 const appStore = useAppStore()
 const authStore = useAuthStore()
-const {
-  inspect: inspectSupplierManaged,
-  readOnlyReason: supplierManagedReadOnlyReason,
-  viewButtonTitle: supplierManagedViewButtonTitle,
-} = useSupplierManagedAccount()
-const isSupplierManaged = (account: Account | null | undefined) => inspectSupplierManaged(account).managed
 
 const proxies = ref<AccountProxy[]>([])
 // Active groups — feeds the filter dropdown + create/edit/bulk modals (unchanged).
@@ -1207,31 +1198,6 @@ const allResultsSelected = computed(() => {
   if (!snapshot || snapshot.size === 0 || snapshot.size !== selectedSet.value.size) return false
   return Array.from(snapshot).every(id => selectedSet.value.has(id))
 })
-const supplierManagedByAccountID = ref(new Map<number, boolean>())
-const recordSupplierManagedAccounts = (rows: Account[]) => {
-  const next = new Map(supplierManagedByAccountID.value)
-  for (const account of rows) {
-    next.set(account.id, isSupplierManaged(account))
-  }
-  supplierManagedByAccountID.value = next
-}
-watch(accounts, recordSupplierManagedAccounts, { immediate: true })
-const selectedContainsSupplierManaged = computed(() =>
-  selIds.value.some(accountID => supplierManagedByAccountID.value.get(accountID) === true)
-)
-
-const rejectSupplierManagedAccountWrite = (account: Account | null | undefined): boolean => {
-  if (!isSupplierManaged(account)) return false
-  appStore.showError(supplierManagedReadOnlyReason.value)
-  return true
-}
-
-const rejectSupplierManagedSelectionWrite = (): boolean => {
-  if (!selectedContainsSupplierManaged.value) return false
-  appStore.showError(supplierManagedReadOnlyReason.value)
-  return true
-}
-
 const clearSelection = () => {
   selectionRequestVersion.value++
   selectingAllResults.value = false
@@ -1988,7 +1954,6 @@ const toggleSelectAllVisible = (event: Event) => {
 }
 const handleBulkDelete = async () => {
   const accountIds = [...selIds.value]
-  if (rejectSupplierManagedSelectionWrite()) return
   if (!confirm(t('admin.accounts.bulkActions.confirmDelete', { count: accountIds.length }))) return
   try {
     const result = await adminAPI.accounts.batchDelete(accountIds)
@@ -2025,7 +1990,6 @@ const handleBulkResetStatus = async () => {
   }
 }
 const handleBulkRefreshToken = async () => {
-  if (rejectSupplierManagedSelectionWrite()) return
   if (!confirm(t('common.confirm'))) return
   try {
     const result = await adminAPI.accounts.batchRefresh(selIds.value)
@@ -2142,7 +2106,6 @@ const normalizeBulkSchedulableResult = (
 }
 const handleBulkToggleSchedulable = async (schedulable: boolean) => {
   const accountIds = [...selIds.value]
-  if (rejectSupplierManagedSelectionWrite()) return
   try {
     const result = await adminAPI.accounts.bulkUpdate(accountIds, { schedulable })
     const { successIds, failedIds, successCount, failedCount, hasIds, hasCounts } = normalizeBulkSchedulableResult(result, accountIds)
@@ -2207,7 +2170,6 @@ const handleSelectAllResults = async () => {
     const ids = await fetchAllAccountIds(
       async (page, pageSize, requestFilters) => {
         const result = await adminAPI.accounts.list(page, pageSize, requestFilters)
-        recordSupplierManagedAccounts(result.items)
         return result
       },
       filters
@@ -2234,7 +2196,6 @@ const collectSelectionMetadata = (rows: Account[]) => {
 }
 
 const openBulkEditSelected = () => {
-  if (rejectSupplierManagedSelectionWrite()) return
   bulkEditTarget.value = {
     mode: 'selected',
     accountIds: [...selIds.value],
@@ -2406,7 +2367,6 @@ const handleAccountUpdated = (updatedAccount: Account) => {
 // handleAccountUpdated as the applied callback (patch row + silent refresh).
 const tierCtl = useTkAccountTier(handleAccountUpdated)
 const handleSetTier = (a: Account) => {
-  if (rejectSupplierManagedAccountWrite(a)) return
   tierCtl.open(a)
 }
 const formatExportTimestamp = () => {
@@ -2482,13 +2442,11 @@ const handleSchedule = async (a: Account) => {
 }
 const closeSchedulePanel = () => { showSchedulePanel.value = false; scheduleAcc.value = null; scheduleModelOptions.value = [] }
 const handleReAuth = (a: Account) => {
-  if (rejectSupplierManagedAccountWrite(a)) return
   reAuthAcc.value = a
   showReAuth.value = true
 }
 const duplicatingAccountIDs = new Set<number>()
 const handleDuplicateAccount = async (a: Account) => {
-  if (rejectSupplierManagedAccountWrite(a)) return
   if (duplicatingAccountIDs.has(a.id)) return
   duplicatingAccountIDs.add(a.id)
   try {
@@ -2503,7 +2461,6 @@ const handleDuplicateAccount = async (a: Account) => {
   }
 }
 const handleRefresh = async (a: Account) => {
-  if (rejectSupplierManagedAccountWrite(a)) return
   try {
     const updated = await adminAPI.accounts.refreshCredentials(a.id)
     patchAccountInList(updated)
@@ -2556,7 +2513,6 @@ const privacyResultMessageKey = (account: Account): { type: 'success' | 'error';
 }
 
 const handleSetPrivacy = async (a: Account) => {
-  if (rejectSupplierManagedAccountWrite(a)) return
   try {
     const updated = await adminAPI.accounts.setPrivacy(a.id)
     patchAccountInList(updated)
@@ -2583,7 +2539,6 @@ const onRevertFallback = async (a: Account) => {
   }
 }
 const handleCreateSparkShadow = (a: Account) => {
-  if (rejectSupplierManagedAccountWrite(a)) return
   creatingShadowAcc.value = a
   showCreateShadowDialog.value = true
 }
@@ -2602,12 +2557,11 @@ const confirmCreateSparkShadow = async () => {
   }
 }
 const handleDelete = (a: Account) => {
-  if (rejectSupplierManagedAccountWrite(a)) return
   deletingAcc.value = a
   showDeleteDialog.value = true
 }
 const confirmDelete = async () => {
-  if (!deletingAcc.value || rejectSupplierManagedAccountWrite(deletingAcc.value)) return
+  if (!deletingAcc.value) return
   try {
     await adminAPI.accounts.delete(deletingAcc.value.id)
     showDeleteDialog.value = false
@@ -2618,7 +2572,6 @@ const confirmDelete = async () => {
   }
 }
 const handleToggleSchedulable = async (a: Account) => {
-  if (rejectSupplierManagedAccountWrite(a)) return
   const nextSchedulable = !a.schedulable
   togglingSchedulable.value = a.id
   try {

--- a/frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts
@@ -122,77 +122,47 @@ const managedAccount = {
   type: 'apikey',
   status: 'active',
   schedulable: true,
-  supported_protocols: ['chat_completions'],
-  extra: { supplier_source_id: 3, supplier_discount_band: 3 },
   priority: 103,
   concurrency: 1,
+  group_ids: [],
+  extra: { supplier_source_id: 7, supplier_discount_band: 3 },
   created_at: '2026-08-28T00:00:00Z',
   updated_at: '2026-08-28T00:00:00Z'
 }
 
 const ordinaryAccount = {
-  ...managedAccount,
   id: 8,
   name: 'ordinary-account',
-  extra: {}
+  platform: 'anthropic',
+  type: 'apikey',
+  status: 'active',
+  schedulable: true,
+  priority: 1,
+  concurrency: 1,
+  group_ids: [],
+  extra: {},
+  created_at: '2026-08-28T00:00:00Z',
+  updated_at: '2026-08-28T00:00:00Z'
 }
 
 function mountView() {
   return mount(AccountsView, {
     global: {
       stubs: {
-        AppLayout: { template: '<div><slot /></div>' },
-        TablePageLayout: { template: '<div><slot name="table" /></div>' },
         DataTable: DataTableStub,
-        Pagination: true,
-        ConfirmDialog: true,
-        AccountTableActions: { template: '<div><slot name="beforeCreate" /><slot name="after" /></div>' },
-        AccountTableFilters: true,
         AccountActionMenu: AccountActionMenuStub,
-        ImportDataModal: true,
-        ReAuthAccountModal: true,
-        AccountTestModal: true,
-        AccountStatsModal: true,
-        ScheduledTestsPanel: true,
-        SyncFromCrsModal: true,
-        TempUnschedStatusModal: true,
-        ErrorPassthroughRulesModal: true,
-        TLSFingerprintProfilesModal: true,
-        CreateAccountModal: true,
         EditAccountModal: EditAccountModalStub,
-        BulkEditAccountModal: true,
-        PlatformTypeBadge: true,
-        ChannelTypeBadge: true,
-        AccountCapacityCell: true,
-        AccountStatusIndicator: true,
-        AccountTodayStatsCell: true,
-        AccountGroupsCell: true,
-        AccountUsageCell: true,
-        Icon: true
+        AccountBulkActionsBar: false,
+        RouterLink: true,
+        Teleport: true
       }
     }
   })
 }
 
-describe('admin AccountsView supplier-managed ownership', () => {
+describe('AccountsView supplier-managed accounts', () => {
   beforeEach(() => {
-    localStorage.clear()
-    listAccounts.mockReset()
-    listWithEtag.mockReset()
-    getBatchTodayStats.mockReset()
-    getBatchPassiveUsage.mockReset()
-    getAllProxies.mockReset()
-    getAllGroups.mockReset()
-    getAllIncludingInactive.mockReset()
-    listEdgeAccounts.mockReset()
-    listSupplierSources.mockReset()
-    duplicateAccount.mockReset()
-    setSchedulable.mockReset()
-    recoverState.mockReset()
-    resetAccountQuota.mockReset()
-    batchClearError.mockReset()
-    showError.mockReset()
-
+    vi.clearAllMocks()
     listAccounts.mockResolvedValue({
       items: [managedAccount, ordinaryAccount],
       total: 2,
@@ -200,23 +170,30 @@ describe('admin AccountsView supplier-managed ownership', () => {
       page_size: 20,
       pages: 1
     })
-    listWithEtag.mockResolvedValue({ notModified: true, etag: null, data: null })
+    listWithEtag.mockResolvedValue({
+      notModified: false,
+      etag: 'etag',
+      data: {
+        items: [managedAccount, ordinaryAccount],
+        total: 2,
+        page: 1,
+        page_size: 20,
+        pages: 1
+      }
+    })
     getBatchTodayStats.mockResolvedValue({ stats: {} })
     getBatchPassiveUsage.mockResolvedValue({ usage: {} })
     getAllProxies.mockResolvedValue([])
     getAllGroups.mockResolvedValue([])
     getAllIncludingInactive.mockResolvedValue([])
-    listEdgeAccounts.mockResolvedValue({
-      notModified: false,
-      etag: null,
-      data: { platform: '__by_stub__', edges: [], ts: 1 }
-    })
+    listEdgeAccounts.mockResolvedValue({ platform: '__by_stub__', edges: [], ts: 1 })
     listSupplierSources.mockResolvedValue([
       {
-        id: 3,
+        id: 7,
         supplier_name: '佳杰',
         channel_name: 'VSTECS',
-        endpoint: 'https://example.com/v1',
+        endpoint: 'https://example.com',
+        channel_type: 1,
         base_priority: 100,
         models: [],
         notes: '',
@@ -224,12 +201,14 @@ describe('admin AccountsView supplier-managed ownership', () => {
         updated_at: '2026-08-28T00:00:00Z'
       }
     ])
+    duplicateAccount.mockResolvedValue({ ...managedAccount, id: 99, name: 'copy' })
+    setSchedulable.mockResolvedValue({ ...managedAccount, schedulable: false })
     recoverState.mockResolvedValue({ ...managedAccount, status: 'active', schedulable: true })
     resetAccountQuota.mockResolvedValue({ ...managedAccount })
     batchClearError.mockResolvedValue({ total: 1, success: 1, failed: 0, errors: [] })
   })
 
-  it('shows the badge and disables row and mixed-selection generic writes', async () => {
+  it('shows the supplier-managed badge and treats managed rows like ordinary accounts', async () => {
     const wrapper = mountView()
     await flushPromises()
 
@@ -237,23 +216,13 @@ describe('admin AccountsView supplier-managed ownership', () => {
     const ordinaryRow = wrapper.get('[data-test="account-row-8"]')
 
     expect(managedRow.text()).toContain('admin.accounts.supplierManaged.badge · 佳杰/VSTECS')
-    expect(managedRow.get('[data-test="schedulable"] button').attributes('disabled')).toBeDefined()
-    expect(managedRow.get('[data-testid="account-edit-btn"]').attributes('disabled')).toBeUndefined()
-    expect(managedRow.get('[data-testid="account-edit-btn"]').text()).toContain('common.view')
-    expect(managedRow.findAll('[data-test="actions"] button')[1].attributes('disabled')).toBeDefined()
+    expect(managedRow.get('[data-test="schedulable"] button').attributes('disabled')).toBeUndefined()
+    expect(managedRow.get('[data-testid="account-edit-btn"]').text()).toContain('common.edit')
+    expect(managedRow.findAll('[data-test="actions"] button')[1].attributes('disabled')).toBeUndefined()
     expect(ordinaryRow.get('[data-test="schedulable"] button').attributes('disabled')).toBeUndefined()
-
-    await managedRow.get('[data-test="select"] input').trigger('change')
-    await ordinaryRow.get('[data-test="select"] input').trigger('change')
-
-    const bulkDelete = wrapper.findAll('button').find(button =>
-      button.text().includes('admin.accounts.bulkActions.delete')
-    )
-    expect(wrapper.text()).toContain('admin.accounts.supplierManaged.readOnlyReason')
-    expect(bulkDelete?.attributes('disabled')).toBeDefined()
   })
 
-  it('opens the read-only account modal for supplier-managed rows', async () => {
+  it('opens the account modal for supplier-managed rows', async () => {
     const wrapper = mountView()
     await flushPromises()
 
@@ -266,16 +235,17 @@ describe('admin AccountsView supplier-managed ownership', () => {
     expect(showError).not.toHaveBeenCalled()
   })
 
-  it('rejects a stale child write event before calling the account API', async () => {
+  it('allows duplicate of supplier-managed accounts like ordinary accounts', async () => {
     const wrapper = mountView()
     await flushPromises()
 
     const managedRow = wrapper.get('[data-test="account-row-7"]')
     await managedRow.findAll('[data-test="actions"] button')[2].trigger('click')
     await wrapper.get('[data-test="menu-duplicate"]').trigger('click')
+    await flushPromises()
 
-    expect(duplicateAccount).not.toHaveBeenCalled()
-    expect(showError).toHaveBeenCalledWith('admin.accounts.supplierManaged.readOnlyReason')
+    expect(duplicateAccount).toHaveBeenCalledWith(7)
+    expect(showError).not.toHaveBeenCalled()
   })
 
   it('allows supplier-managed runtime recovery and quota reset actions', async () => {
@@ -290,7 +260,6 @@ describe('admin AccountsView supplier-managed ownership', () => {
 
     expect(recoverState).toHaveBeenCalledWith(7)
     expect(resetAccountQuota).toHaveBeenCalledWith(7)
-    expect(showError).not.toHaveBeenCalledWith('admin.accounts.supplierManaged.readOnlyReason')
   })
 
   it('allows supplier-managed bulk runtime recovery', async () => {
@@ -298,17 +267,13 @@ describe('admin AccountsView supplier-managed ownership', () => {
     const wrapper = mountView()
     await flushPromises()
 
-    const managedRow = wrapper.get('[data-test="account-row-7"]')
-    await managedRow.get('[data-test="select"] input').trigger('change')
-    const resetStatusButton = wrapper.findAll('button').find(button =>
+    await wrapper.get('[data-test="account-row-7"]').get('[data-test="select"] input').trigger('change')
+    const bulkReset = wrapper.findAll('button').find(button =>
       button.text().includes('admin.accounts.bulkActions.resetStatus')
     )
-    expect(resetStatusButton?.attributes('disabled')).toBeUndefined()
-
-    await resetStatusButton!.trigger('click')
+    await bulkReset!.trigger('click')
     await flushPromises()
 
-    expect(batchClearError).toHaveBeenCalledWith([7])
-    expect(showError).not.toHaveBeenCalledWith('admin.accounts.supplierManaged.readOnlyReason')
+    expect(batchClearError).toHaveBeenCalled()
   })
 })

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -2024,11 +2024,10 @@
       "path": "frontend/src/composables/useSupplierManagedAccount.ts",
       "must_contain": [
         "Object.prototype.hasOwnProperty.call(extra, 'supplier_source_id')",
-        "const readOnlyReason = computed(() => t('admin.accounts.supplierManaged.readOnlyReason'))",
         "const viewHint = computed(() => t('admin.accounts.supplierManaged.viewHint'))",
         "href: `/admin/supplier-sources?source_id=${marker.sourceId}`"
       ],
-      "rationale": "Single frontend owner for the supplier-managed marker, source-name lookup, fallback labels, navigation and canonical read-only reason. Account rows, modals and menus must not grow separate ownership rules."
+      "rationale": "Single frontend owner for the supplier-managed marker, source-name lookup, fallback labels, navigation and sync-overwrite hint. Managed accounts are edited like ordinary accounts; UI must not invent a second ownership/read-only policy."
     },
     {
       "path": "frontend/src/components/account/SupplierManagedBadge.vue",
@@ -2042,41 +2041,40 @@
     {
       "path": "frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts",
       "must_contain": [
-        "shows the badge and disables row and mixed-selection generic writes",
-        "opens the read-only account modal for supplier-managed rows",
-        "rejects a stale child write event before calling the account API",
+        "shows the supplier-managed badge and treats managed rows like ordinary accounts",
+        "opens the account modal for supplier-managed rows",
+        "allows duplicate of supplier-managed accounts like ordinary accounts",
         "allows supplier-managed runtime recovery and quota reset actions",
         "allows supplier-managed bulk runtime recovery"
       ],
-      "rationale": "Real account-page ownership regressions: visible badges and disabled controls are not enough, so the page also rejects stale child configuration-write events before any generic API can run while preserving recovery and quota-reset operations."
+      "rationale": "Account-page regressions: supplier-managed rows keep the badge and sync-overwrite hint, but edit/delete/duplicate/bulk/runtime actions stay available like ordinary accounts. Sync from supplier sources remains the only path that overwrites projection fields."
     },
     {
       "path": "frontend/src/components/admin/account/__tests__/AccountActionMenu.spec.ts",
       "must_contain": [
-        "keeps configuration writes disabled while runtime recovery actions stay available",
-        "admin.accounts.supplierManaged.readOnlyReason",
+        "treats supplier-managed accounts like ordinary accounts for writes",
         "recover-state",
         "reset-quota"
       ],
-      "rationale": "The row action menu must make supplier ownership obvious, block configuration actions such as duplicate/reauth/credential refresh, and keep account test, error recovery and quota reset available as runtime operations."
+      "rationale": "The row action menu must keep supplier-managed accounts writable like ordinary accounts (including duplicate) while still exposing runtime recovery and quota reset."
     },
     {
       "path": "frontend/src/components/admin/account/__tests__/AccountBulkActionsBar.spec.ts",
       "must_contain": [
-        "blocks generic bulk writes when the selection contains a supplier-managed account",
+        "keeps bulk writes enabled when the selection contains a supplier-managed account",
         "preserves the upstream billing probe action from v0.1.166",
         "reset-status",
         "probe-upstream-billing"
       ],
-      "rationale": "Mixed selections must block generic bulk configuration writes without disabling runtime reset-status or upstream probe actions. This prevents the supplier badge from accidentally becoming a broad account-operations shutdown."
+      "rationale": "Mixed selections with supplier-managed accounts must keep bulk configuration writes available. Runtime reset-status and upstream probe actions stay available; the badge must not become a broad account-operations shutdown."
     },
     {
       "path": "frontend/src/components/account/__tests__/EditAccountModal.spec.ts",
       "must_contain": [
-        "shows the supplier-managed reason and refuses generic account updates",
+        "shows the supplier-managed hint and submits a normal account update",
         "admin.accounts.supplierManaged.viewHint"
       ],
-      "rationale": "The generic edit modal is a second UI entry point and must remain read-only for supplier-managed accounts with the same view hint and disabled submit path, even if it is opened from stale state or another caller."
+      "rationale": "The generic edit modal shows the sync-overwrite hint for supplier-managed accounts but still submits ordinary account updates. Field-level read-only special cases are intentionally absent."
     }
   ]
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7387,38 +7387,38 @@
     {
       "path": "backend/internal/service/admin_account.go",
       "must_contain": [
-        "ValidateSupplierManagedAccountUpdate(account)",
         "ValidateSupplierReservedAccountExtra(input.Extra)",
+        "StripSupplierReservedAccountExtra(input.Extra)",
+        "PreserveSupplierManagedExtraKeys(account, normalizedExtra)",
+        "SupplierSourceIDExtraKey:",
         "func (s *adminServiceImpl) RefreshAccountCredentials(ctx context.Context, id int64)",
         "func (s *adminServiceImpl) CreateShadow(ctx context.Context, parentID int64, opts ShadowOptions)",
-        "ValidateSupplierManagedAccountUpdate(parent)",
-        "if IsSupplierManagedAccount(account) {",
-        "return nil, ErrSupplierManagedAccountProtected"
+        "if IsSupplierManagedAccount(account) {"
       ],
-      "rationale": "The ordinary account admin surface must delegate supplier-managed configuration mutations back to the supplier-source owner. Single-account edits, bulk changes, credential refresh, shadow creation, reserved Extra injection, and destructive account actions live in this upstream-shaped service; losing these guards would create two competing owners for credentials, model mapping, priority, status, and schedulability."
+      "rationale": "Ordinary account admin writes treat supplier-managed accounts like ordinary accounts. Reserved Extra keys cannot be forged on create/import; managed Extra edits strip/forge-guard reserved keys and PreserveSupplierManagedExtraKeys keeps sync identity; duplicate strips supplier identity keys. Projection field overwrite remains owned by supplier-source sync narrow writes, not by these generic guards."
     },
     {
       "path": "backend/internal/service/supplier_managed_account_guard_test.go",
       "must_contain": [
-        "TestUS048_ManagedAccountRejectsEveryGenericUpdate",
-        "TestUS048_ManagedAccountRejectsDirectExtraUpdateDeleteDuplicateAndSchedulable",
-        "TestUS048_ManagedAccountRejectsGenericSparkShadowCreation",
-        "TestUS048_ManagedAccountRejectsNameOnlyBulkUpdate",
-        "TestUS048_GenericAccountServiceUsesTheSameSupplierOwnershipGuard",
+        "TestUS048_ManagedAccountUsesSupplierSourceIDAsOnlyMarker",
+        "TestUS048_OrdinaryCreateRejectsSupplierReservedExtra",
+        "TestUS048_ManagedAccountBehavesLikeOrdinaryAccountForUpdates",
+        "TestUS048_ManagedAccountDuplicateStripsSupplierIdentity",
         "TestUS048_UnmanagedAccountCannotForgeSupplierManagedExtra",
-        "RefreshAccountCredentials"
+        "TestUS048_PreserveSupplierManagedExtraKeys"
       ],
-      "rationale": "Focused regressions prove that AdminService and the generic AccountService both fail closed for supplier-managed configuration writes, including credential refresh, shadow creation and deletion, while unmanaged callers cannot forge the reserved marker. This pins single ownership at service boundaries rather than relying on UI-only disabling or metadata helpers."
+      "rationale": "Focused regressions prove managed accounts accept ordinary update/delete/schedulable/bulk paths, duplicate strips supplier identity, Extra edits preserve reserved keys, and unmanaged create/import cannot forge supplier_source_id / supplier_discount_band."
     },
     {
       "path": "backend/internal/service/account_service.go",
       "must_contain": [
         "ValidateSupplierReservedAccountExtra(req.Extra)",
-        "ValidateSupplierManagedAccountUpdate(account)",
+        "StripSupplierReservedAccountExtra(*req.Extra)",
+        "PreserveSupplierManagedExtraKeys(account, prepareCodexFingerprintExtraForUpdate(account, extra))",
         "func (s *AccountService) Delete(ctx context.Context, id int64) error",
         "func (s *AccountService) UpdateStatus(ctx context.Context, id int64, status string, errorMessage string) error"
       ],
-      "rationale": "The generic account service is another ordinary write owner. It must reject reserved supplier Extra on create and delegate update, delete and status mutations back to the supplier-source owner whenever supplier_source_id is present."
+      "rationale": "The generic account service rejects reserved supplier Extra on create, strips reserved keys from managed Extra updates, and preserves sync identity keys. It does not reject ordinary update/delete/status for supplier-managed accounts."
     },
     {
       "path": "backend/internal/repository/account_repo.go",
@@ -7592,10 +7592,10 @@
     {
       "path": "backend/internal/service/crs_sync_supplier_managed_test.go",
       "must_contain": [
-        "TestUS048_CRSSyncRejectsSupplierManagedAccountOverwrite",
+        "TestUS048_CRSSyncAllowsSupplierManagedAccountOverwrite",
         "TestUS048_CRSSyncRejectsReservedSupplierExtraOnNewAccount"
       ],
-      "rationale": "CRS import must neither overwrite a supplier-managed account nor forge supplier ownership on a new account. Both directions are service-level security boundaries."
+      "rationale": "CRS import may overwrite an already supplier-managed account like any other account (preserving reserved identity via PreserveSupplierManagedExtraKeys), but must still reject forging supplier ownership Extra on a newly created account."
     },
     {
       "path": "backend/internal/service/audit_log.go",


### PR DESCRIPTION
## 摘要
- 供应源创建的受管账号在账号页与普通账号同权（编辑/删除/复制/调度/批量），去掉字段级与整账号只读写守卫，避免双轨特殊路径出错。
- 仅在供应源「校验并同步」时用窄写覆盖投影字段；普通创建/导入仍禁止伪造 `supplier_source_id` / `supplier_discount_band`，Extra 编辑保留身份键，复制剥离托管身份。
- 同步更新审批基线、US-048、前后端 sentinel 与前端提示文案。

## 风险
- 常规偏高：改变此前「受管账号只读」的运营约定，但投影覆盖仍由供应源 sync 窄写路径独占；身份 Extra 防伪造保留。
- 审批锚点：`docs/approved/model-supplier-source-management.md`（ownership 段）。
- sentinel-registry-reviewed

## 验证
- `./scripts/preflight.sh` PASS（含 frontend/gateway TK sentinel 与 frontend-source freshness）
- `cd backend && go test ./internal/service -run 'TestUS048_ManagedAccount|TestUS048_CRSSync|TestUS048_OrdinaryCreate|TestUS048_Unmanaged|TestUS048_Preserve' -count=1` PASS
- `cd frontend && pnpm exec vitest run`（AccountsView/EditAccountModal/AccountActionMenu/AccountBulkActionsBar/SupplierManagedBadge）74 tests PASS
- `cd frontend && pnpm run build` PASS（已写回 `frontend-source.json`）

## 提交
- f77bb7cef fix(admin): 受管账号按普通账号编辑，仅 sync 覆盖投影
- 最新提交：f77bb7cef

Made with [Cursor](https://cursor.com)