### PR TITLE
fix(protocol): 凭证 identity 原子化，避免 exclusive 端点滞留旧供应商

### DIFF
--- a/backend/internal/service/account_credentials_persistence.go
+++ b/backend/internal/service/account_credentials_persistence.go
@@ -23,7 +23,7 @@ func persistAccountCredentials(ctx context.Context, repo AccountRepository, acco
 		return nil
 	}
 
-	account.Credentials = shallowCopyMap(credentials)
+	account.Credentials = FinalizeAccountCredentials(shallowCopyMap(credentials), account.ChannelType)
 	if updater, ok := any(repo).(accountCredentialsUpdater); ok {
 		return updater.UpdateCredentials(ctx, account.ID, account.Credentials)
 	}

--- a/backend/internal/service/account_protocol_endpoint_credentials.go
+++ b/backend/internal/service/account_protocol_endpoint_credentials.go
@@ -1,0 +1,162 @@
+package service
+
+import (
+	"strings"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
+)
+
+// apiBaseURLsCredentialKey is the credentials map key for per-protocol base URLs.
+// Kept as a local alias so identity-key handling stays next to the exclusive flag.
+const apiBaseURLsCredentialKey = "api_base_urls"
+
+// CredentialMergeMode selects how non-identity credential keys are merged before
+// FinalizeAccountCredentials runs.
+type CredentialMergeMode int
+
+const (
+	// CredentialMergeAdmin mirrors MergePreservingSensitiveCreds: non-sensitive
+	// keys are wholly decided by incoming (omit = delete); sensitive keys are
+	// preserved when omitted.
+	CredentialMergeAdmin CredentialMergeMode = iota
+	// CredentialMergePreserveAll mirrors CRS mergeMap: existing keys survive
+	// unless incoming overwrites them. Protocol identity keys are still never
+	// inherited implicitly (see MergeAccountCredentials).
+	CredentialMergePreserveAll
+)
+
+// MergeAccountCredentials is the SSOT credential merge for every persistence
+// write that combines an existing map with an incoming patch/payload.
+//
+// Protocol identity keys (api_base_urls, protocol_endpoints_exclusive) are NEVER
+// inherited from existing unless incoming explicitly sets them. That stops
+// base_url / api_key rotations (CRS, admin edit, bulk patch) from keeping a
+// stale exclusive routing identity that would send new secrets to an old
+// upstream. Callers must then persist the returned map (or run Finalize alone
+// after a full replace).
+func MergeAccountCredentials(existing, incoming map[string]any, channelType int, mode CredentialMergeMode) map[string]any {
+	var merged map[string]any
+	switch mode {
+	case CredentialMergePreserveAll:
+		merged = mergeMap(existing, incoming)
+	default:
+		merged = MergePreservingSensitiveCreds(existing, incoming)
+	}
+	if incoming == nil || !credentialMapHasKey(incoming, apiBaseURLsCredentialKey) {
+		delete(merged, apiBaseURLsCredentialKey)
+	}
+	if incoming == nil || !credentialMapHasKey(incoming, ProtocolEndpointsExclusiveCredentialKey) {
+		delete(merged, ProtocolEndpointsExclusiveCredentialKey)
+	}
+	return FinalizeAccountCredentials(merged, channelType)
+}
+
+// FinalizeAccountCredentials is the SSOT post-write normalizer for account
+// credentials. Every create / full-replace / merge path must run it before
+// persistence so exclusive chat identity cannot diverge from base_url.
+func FinalizeAccountCredentials(credentials map[string]any, channelType int) map[string]any {
+	return reconcileExclusiveProtocolEndpointCredentials(credentials, channelType)
+}
+
+// PrepareBulkCredentialPatch ensures a JSONB-merge bulk credentials patch cannot
+// leave stale exclusive identity behind when it rotates base_url or api_key
+// without explicitly declaring protocol endpoints.
+func PrepareBulkCredentialPatch(patch map[string]any) map[string]any {
+	if len(patch) == 0 {
+		return patch
+	}
+	_, hasBaseURL := patch["base_url"]
+	_, hasAPIKey := patch["api_key"]
+	if !hasBaseURL && !hasAPIKey {
+		return patch
+	}
+	_, hasBaseURLs := patch[apiBaseURLsCredentialKey]
+	_, hasExclusive := patch[ProtocolEndpointsExclusiveCredentialKey]
+	if hasBaseURLs || hasExclusive {
+		return FinalizeAccountCredentials(patch, 0)
+	}
+	out := make(map[string]any, len(patch)+2)
+	for key, value := range patch {
+		out[key] = value
+	}
+	// JSON null clears the effective identity on JSONB || merge (nil does not
+	// type-assert to bool/map, so exclusive routing falls back to base_url).
+	out[apiBaseURLsCredentialKey] = nil
+	out[ProtocolEndpointsExclusiveCredentialKey] = nil
+	return out
+}
+
+// deriveExclusiveChatProtocolURL builds the chat_completions URL declared under
+// protocol_endpoints_exclusive. Shared by supplier projection and reconcile so
+// Qianfan / ordinary OpenAI chat shapes cannot drift.
+func deriveExclusiveChatProtocolURL(baseURL string, channelType int) string {
+	trimmed := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if channelType == newapiconstant.ChannelTypeBaiduV2 {
+		return strings.TrimRight(newapiintegration.QianfanBaseURL, "/") + "/v2/chat/completions"
+	}
+	return trimmed
+}
+
+// applyExclusiveChatProtocolEndpoints writes the chat-only exclusive identity
+// block used by supplier-managed NewAPI accounts.
+func applyExclusiveChatProtocolEndpoints(credentials map[string]any, baseURL string, channelType int) {
+	if credentials == nil {
+		return
+	}
+	trimmed := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	credentials["base_url"] = trimmed
+	credentials[apiBaseURLsCredentialKey] = map[string]any{
+		APIProtocolChatCompletions: deriveExclusiveChatProtocolURL(trimmed, channelType),
+	}
+	credentials[ProtocolEndpointsExclusiveCredentialKey] = true
+}
+
+func reconcileExclusiveProtocolEndpointCredentials(credentials map[string]any, channelType int) map[string]any {
+	if credentials == nil {
+		return nil
+	}
+	if !credentialsDeclareExclusiveProtocolEndpoints(credentials) {
+		return credentials
+	}
+	baseURL := strings.TrimSpace(credentialString(credentials["base_url"]))
+	if baseURL == "" {
+		delete(credentials, ProtocolEndpointsExclusiveCredentialKey)
+		delete(credentials, apiBaseURLsCredentialKey)
+		return credentials
+	}
+	wantChat := deriveExclusiveChatProtocolURL(baseURL, channelType)
+	raw, _ := credentials[apiBaseURLsCredentialKey].(map[string]any)
+	out := make(map[string]any, len(raw)+1)
+	for key, value := range raw {
+		out[key] = value
+	}
+	gotChat := strings.TrimSpace(credentialString(out[APIProtocolChatCompletions]))
+	if !exclusiveChatURLsAligned(gotChat, wantChat) {
+		out[APIProtocolChatCompletions] = wantChat
+	}
+	credentials[apiBaseURLsCredentialKey] = out
+	credentials[ProtocolEndpointsExclusiveCredentialKey] = true
+	return credentials
+}
+
+func credentialsDeclareExclusiveProtocolEndpoints(credentials map[string]any) bool {
+	return accountDeclaresExclusiveProtocolEndpoints(&Account{Credentials: credentials})
+}
+
+func exclusiveChatURLsAligned(got, want string) bool {
+	return strings.TrimRight(strings.TrimSpace(got), "/") == strings.TrimRight(strings.TrimSpace(want), "/")
+}
+
+func credentialMapHasKey(credentials map[string]any, key string) bool {
+	if credentials == nil {
+		return false
+	}
+	_, ok := credentials[key]
+	return ok
+}
+
+func credentialString(value any) string {
+	text, _ := value.(string)
+	return text
+}

--- a/backend/internal/service/account_protocol_endpoint_credentials.go
+++ b/backend/internal/service/account_protocol_endpoint_credentials.go
@@ -60,15 +60,14 @@ func FinalizeAccountCredentials(credentials map[string]any, channelType int) map
 }
 
 // PrepareBulkCredentialPatch ensures a JSONB-merge bulk credentials patch cannot
-// leave stale exclusive identity behind when it rotates base_url or api_key
-// without explicitly declaring protocol endpoints.
+// leave stale exclusive identity behind when it rotates base_url without
+// explicitly declaring protocol endpoints. api_key-only patches leave identity
+// alone so chat-only exclusive accounts keep #1907 routing shape.
 func PrepareBulkCredentialPatch(patch map[string]any) map[string]any {
 	if len(patch) == 0 {
 		return patch
 	}
-	_, hasBaseURL := patch["base_url"]
-	_, hasAPIKey := patch["api_key"]
-	if !hasBaseURL && !hasAPIKey {
+	if _, hasBaseURL := patch["base_url"]; !hasBaseURL {
 		return patch
 	}
 	_, hasBaseURLs := patch[apiBaseURLsCredentialKey]

--- a/backend/internal/service/account_protocol_endpoint_credentials_test.go
+++ b/backend/internal/service/account_protocol_endpoint_credentials_test.go
@@ -1,0 +1,120 @@
+package service
+
+import (
+	"strings"
+	"testing"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
+	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeAccountCredentials_CRSPreserveAllDropsStaleExclusive(t *testing.T) {
+	existing := supplierManagedCredentials(
+		"https://supplier.example/v1", "supplier-secret",
+		map[string]string{"deepseek-v4-pro": "deepseek-v4-pro"},
+		newapiconstant.ChannelTypeOpenAI,
+	)
+	incoming := map[string]any{
+		"base_url": "https://crs.example",
+		"api_key":  "crs-secret",
+	}
+
+	merged := MergeAccountCredentials(existing, incoming, newapiconstant.ChannelTypeOpenAI, CredentialMergePreserveAll)
+
+	require.Equal(t, "https://crs.example", merged["base_url"])
+	require.Equal(t, "crs-secret", merged["api_key"])
+	mapping, ok := merged["model_mapping"].(map[string]any)
+	require.True(t, ok, "CRS preserve-all must keep model_mapping")
+	require.Equal(t, "deepseek-v4-pro", mapping["deepseek-v4-pro"],
+		"CRS preserve-all must keep non-identity keys such as model_mapping")
+	require.NotContains(t, merged, apiBaseURLsCredentialKey)
+	require.NotContains(t, merged, ProtocolEndpointsExclusiveCredentialKey)
+
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Credentials: merged}
+	baseURL, baseURLs, _ := protocolAccountEndpoints(account)
+	require.Equal(t, "https://crs.example", baseURL)
+	require.Nil(t, baseURLs, "without exclusive, identity must fan from the new base_url only")
+}
+
+func TestMergeAccountCredentials_AdminRealignsExclusiveWhenIncomingSpreadsStaleURLs(t *testing.T) {
+	existing := supplierManagedCredentials(
+		"https://supplier.example/v1", "supplier-secret",
+		map[string]string{"m": "m"},
+		newapiconstant.ChannelTypeOpenAI,
+	)
+	// Frontend NewAPI edit spreads current credentials then overwrites base_url/api_key.
+	incoming := map[string]any{}
+	for key, value := range existing {
+		incoming[key] = value
+	}
+	incoming["base_url"] = "https://relay.example/v1"
+	incoming["api_key"] = "rotated-secret"
+
+	merged := MergeAccountCredentials(existing, incoming, newapiconstant.ChannelTypeOpenAI, CredentialMergeAdmin)
+
+	require.Equal(t, "https://relay.example/v1", merged["base_url"])
+	require.Equal(t, "rotated-secret", merged["api_key"])
+	require.Equal(t, true, merged[ProtocolEndpointsExclusiveCredentialKey])
+	require.Equal(t, map[string]any{
+		APIProtocolChatCompletions: "https://relay.example/v1",
+	}, merged[apiBaseURLsCredentialKey])
+
+	account := &Account{
+		Platform: PlatformNewAPI, Type: AccountTypeAPIKey, Credentials: merged,
+		ChannelType: newapiconstant.ChannelTypeOpenAI,
+	}
+	_, baseURLs, _ := protocolAccountEndpoints(account)
+	require.Equal(t, map[protocolrouter.Protocol]string{
+		protocolrouter.ProtocolChatCompletions: "https://relay.example/v1",
+	}, baseURLs)
+}
+
+func TestFinalizeAccountCredentials_RealignsQianfanExclusiveChatPath(t *testing.T) {
+	credentials := map[string]any{
+		"base_url": newapiintegration.QianfanBaseURL,
+		"api_key":  "qf-key",
+		apiBaseURLsCredentialKey: map[string]any{
+			APIProtocolChatCompletions: "https://stale.example/v2/chat/completions",
+		},
+		ProtocolEndpointsExclusiveCredentialKey: true,
+	}
+
+	got := FinalizeAccountCredentials(credentials, newapiconstant.ChannelTypeBaiduV2)
+	wantChat := strings.TrimRight(newapiintegration.QianfanBaseURL, "/") + "/v2/chat/completions"
+	require.Equal(t, map[string]any{
+		APIProtocolChatCompletions: wantChat,
+	}, got[apiBaseURLsCredentialKey])
+}
+
+func TestPrepareBulkCredentialPatch_ClearsIdentityWhenRotatingBaseURL(t *testing.T) {
+	patch := PrepareBulkCredentialPatch(map[string]any{
+		"base_url": "https://bulk.example/v1",
+		"api_key":  "bulk-secret",
+	})
+	require.Equal(t, "https://bulk.example/v1", patch["base_url"])
+	require.Nil(t, patch[apiBaseURLsCredentialKey])
+	require.Nil(t, patch[ProtocolEndpointsExclusiveCredentialKey])
+}
+
+func TestPrepareBulkCredentialPatch_LeavesUnrelatedPatchesAlone(t *testing.T) {
+	patch := PrepareBulkCredentialPatch(map[string]any{
+		"model_mapping": map[string]any{"a": "a"},
+	})
+	require.Equal(t, map[string]any{"a": "a"}, patch["model_mapping"])
+	require.NotContains(t, patch, apiBaseURLsCredentialKey)
+}
+
+func TestSupplierManagedCredentials_UsesSharedExclusiveChatSSOT(t *testing.T) {
+	got := supplierManagedCredentials(
+		"https://supplier.example/v1/", "secret",
+		map[string]string{"m": "m"},
+		newapiconstant.ChannelTypeOpenAI,
+	)
+	require.Equal(t, "https://supplier.example/v1", got["base_url"])
+	require.Equal(t, true, got[ProtocolEndpointsExclusiveCredentialKey])
+	require.Equal(t, map[string]any{
+		APIProtocolChatCompletions: "https://supplier.example/v1",
+	}, got[apiBaseURLsCredentialKey])
+}

--- a/backend/internal/service/account_protocol_endpoint_credentials_test.go
+++ b/backend/internal/service/account_protocol_endpoint_credentials_test.go
@@ -98,6 +98,15 @@ func TestPrepareBulkCredentialPatch_ClearsIdentityWhenRotatingBaseURL(t *testing
 	require.Nil(t, patch[ProtocolEndpointsExclusiveCredentialKey])
 }
 
+func TestPrepareBulkCredentialPatch_LeavesExclusiveAloneForAPIKeyOnlyRotate(t *testing.T) {
+	patch := PrepareBulkCredentialPatch(map[string]any{
+		"api_key": "rotated-only",
+	})
+	require.Equal(t, map[string]any{"api_key": "rotated-only"}, patch)
+	require.NotContains(t, patch, apiBaseURLsCredentialKey)
+	require.NotContains(t, patch, ProtocolEndpointsExclusiveCredentialKey)
+}
+
 func TestPrepareBulkCredentialPatch_LeavesUnrelatedPatchesAlone(t *testing.T) {
 	patch := PrepareBulkCredentialPatch(map[string]any{
 		"model_mapping": map[string]any{"a": "a"},

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -245,11 +245,14 @@ func (s *AccountService) Create(ctx context.Context, req CreateAccountRequest) (
 
 	// 创建账号
 	account := &Account{
-		Name:        req.Name,
-		Notes:       normalizeAccountNotes(req.Notes),
-		Platform:    req.Platform,
-		Type:        req.Type,
-		Credentials: SanitizeStoredCredentials(req.Platform, req.Credentials),
+		Name:     req.Name,
+		Notes:    normalizeAccountNotes(req.Notes),
+		Platform: req.Platform,
+		Type:     req.Type,
+		Credentials: FinalizeAccountCredentials(
+			SanitizeStoredCredentials(req.Platform, req.Credentials),
+			0,
+		),
 		Extra:       prepareCodexFingerprintExtraForCreate(req.Platform, req.Type, req.Extra),
 		ProxyID:     req.ProxyID,
 		Concurrency: req.Concurrency,
@@ -366,7 +369,10 @@ func (s *AccountService) Update(ctx context.Context, id int64, req UpdateAccount
 	}
 
 	if req.Credentials != nil {
-		account.Credentials = SanitizeStoredCredentials(account.Platform, *req.Credentials)
+		account.Credentials = FinalizeAccountCredentials(
+			SanitizeStoredCredentials(account.Platform, *req.Credentials),
+			account.ChannelType,
+		)
 	}
 
 	if req.Extra != nil {

--- a/backend/internal/service/admin_account.go
+++ b/backend/internal/service/admin_account.go
@@ -544,6 +544,7 @@ func (s *adminServiceImpl) createAccount(ctx context.Context, input *CreateAccou
 	}
 	// Never persist ephemeral SSO/password secrets after OAuth conversion.
 	input.Credentials = SanitizeStoredCredentials(input.Platform, input.Credentials)
+	input.Credentials = FinalizeAccountCredentials(input.Credentials, input.ChannelType)
 
 	account, err := buildAccountForCreate(input, accountExtra)
 	if err != nil {
@@ -684,15 +685,18 @@ func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *U
 	if account.IsCredentialShadow() && input.Credentials != nil {
 		account.Credentials = sanitizeSparkShadowCredentials(input.Credentials)
 	} else if len(input.Credentials) > 0 {
-		// 敏感子键采用"incoming 没提供就保留"的合并语义：前端响应已脱敏，
-		// 全对象 PUT 编辑时不会再带回 token，避免覆盖时清空已有凭证。
-		account.Credentials = MergePreservingSensitiveCreds(account.Credentials, input.Credentials)
+		// SSOT credential merge: sensitive preserve-when-omitted + never inherit
+		// stale protocol identity (api_base_urls / protocol_endpoints_exclusive).
+		account.Credentials = MergeAccountCredentials(
+			account.Credentials, input.Credentials, account.ChannelType, CredentialMergeAdmin,
+		)
 		// 校验并规范化请求头覆写配置（header 名小写化、格式检查）
 		if err := NormalizeHeaderOverrideCredentials(account.Credentials); err != nil {
 			return nil, err
 		}
 		// Strip SSO/password residue that must never sit next to OAuth tokens.
 		account.Credentials = SanitizeStoredCredentials(account.Platform, account.Credentials)
+		account.Credentials = FinalizeAccountCredentials(account.Credentials, account.ChannelType)
 	}
 	// Extra 使用 map：需要区分“未提供(nil)”与“显式清空({})”。
 	// 关闭配额限制时前端会删除 quota_* 键并提交 extra:{}，此时也必须落库。
@@ -1186,6 +1190,7 @@ func (s *adminServiceImpl) BulkUpdateAccounts(ctx context.Context, input *BulkUp
 	// only when platform is known Grok — empty platform still strips password/*).
 	if input.Credentials != nil {
 		input.Credentials = SanitizeStoredCredentials("", input.Credentials)
+		input.Credentials = PrepareBulkCredentialPatch(input.Credentials)
 	}
 
 	// Prepare bulk updates for columns and JSONB fields.

--- a/backend/internal/service/crs_sync_service.go
+++ b/backend/internal/service/crs_sync_service.go
@@ -388,7 +388,7 @@ func (s *CRSSyncService) SyncFromCRS(ctx context.Context, input SyncFromCRSInput
 				Name:        defaultName(src.Name, src.ID),
 				Platform:    PlatformAnthropic,
 				Type:        targetType,
-				Credentials: credentials,
+				Credentials: FinalizeAccountCredentials(credentials, 0),
 				Extra:       extra,
 				ProxyID:     proxyID,
 				Concurrency: concurrency,
@@ -429,7 +429,7 @@ func (s *CRSSyncService) SyncFromCRS(ctx context.Context, input SyncFromCRSInput
 		existing.Name = defaultName(src.Name, src.ID)
 		existing.Platform = PlatformAnthropic
 		existing.Type = targetType
-		existing.Credentials = mergeMap(existing.Credentials, credentials)
+		existing.Credentials = MergeAccountCredentials(existing.Credentials, credentials, existing.ChannelType, CredentialMergePreserveAll)
 		if proxyID != nil {
 			existing.ProxyID = proxyID
 		}
@@ -519,7 +519,7 @@ func (s *CRSSyncService) SyncFromCRS(ctx context.Context, input SyncFromCRSInput
 				Name:        defaultName(src.Name, src.ID),
 				Platform:    PlatformAnthropic,
 				Type:        AccountTypeAPIKey,
-				Credentials: credentials,
+				Credentials: FinalizeAccountCredentials(credentials, 0),
 				Extra:       extra,
 				ProxyID:     proxyID,
 				Concurrency: concurrency,
@@ -553,7 +553,7 @@ func (s *CRSSyncService) SyncFromCRS(ctx context.Context, input SyncFromCRSInput
 		existing.Name = defaultName(src.Name, src.ID)
 		existing.Platform = PlatformAnthropic
 		existing.Type = AccountTypeAPIKey
-		existing.Credentials = mergeMap(existing.Credentials, credentials)
+		existing.Credentials = MergeAccountCredentials(existing.Credentials, credentials, existing.ChannelType, CredentialMergePreserveAll)
 		if proxyID != nil {
 			existing.ProxyID = proxyID
 		}
@@ -677,7 +677,7 @@ func (s *CRSSyncService) SyncFromCRS(ctx context.Context, input SyncFromCRSInput
 				Name:        defaultName(src.Name, src.ID),
 				Platform:    PlatformOpenAI,
 				Type:        AccountTypeOAuth,
-				Credentials: credentials,
+				Credentials: FinalizeAccountCredentials(credentials, 0),
 				Extra:       extra,
 				ProxyID:     proxyID,
 				Concurrency: concurrency,
@@ -714,7 +714,7 @@ func (s *CRSSyncService) SyncFromCRS(ctx context.Context, input SyncFromCRSInput
 		existing.Name = defaultName(src.Name, src.ID)
 		existing.Platform = PlatformOpenAI
 		existing.Type = AccountTypeOAuth
-		existing.Credentials = mergeMap(existing.Credentials, credentials)
+		existing.Credentials = MergeAccountCredentials(existing.Credentials, credentials, existing.ChannelType, CredentialMergePreserveAll)
 		if proxyID != nil {
 			existing.ProxyID = proxyID
 		}
@@ -839,7 +839,7 @@ func (s *CRSSyncService) SyncFromCRS(ctx context.Context, input SyncFromCRSInput
 				Name:        defaultName(src.Name, src.ID),
 				Platform:    PlatformOpenAI,
 				Type:        AccountTypeAPIKey,
-				Credentials: credentials,
+				Credentials: FinalizeAccountCredentials(credentials, 0),
 				Extra:       extra,
 				ProxyID:     proxyID,
 				Concurrency: concurrency,
@@ -874,7 +874,7 @@ func (s *CRSSyncService) SyncFromCRS(ctx context.Context, input SyncFromCRSInput
 		existing.Name = defaultName(src.Name, src.ID)
 		existing.Platform = PlatformOpenAI
 		existing.Type = AccountTypeAPIKey
-		existing.Credentials = mergeMap(existing.Credentials, credentials)
+		existing.Credentials = MergeAccountCredentials(existing.Credentials, credentials, existing.ChannelType, CredentialMergePreserveAll)
 		if proxyID != nil {
 			existing.ProxyID = proxyID
 		}
@@ -971,7 +971,7 @@ func (s *CRSSyncService) SyncFromCRS(ctx context.Context, input SyncFromCRSInput
 				Name:        defaultName(src.Name, src.ID),
 				Platform:    PlatformGemini,
 				Type:        AccountTypeOAuth,
-				Credentials: credentials,
+				Credentials: FinalizeAccountCredentials(credentials, 0),
 				Extra:       extra,
 				ProxyID:     proxyID,
 				Concurrency: 3,
@@ -1008,7 +1008,7 @@ func (s *CRSSyncService) SyncFromCRS(ctx context.Context, input SyncFromCRSInput
 		existing.Name = defaultName(src.Name, src.ID)
 		existing.Platform = PlatformGemini
 		existing.Type = AccountTypeOAuth
-		existing.Credentials = mergeMap(existing.Credentials, credentials)
+		existing.Credentials = MergeAccountCredentials(existing.Credentials, credentials, existing.ChannelType, CredentialMergePreserveAll)
 		if proxyID != nil {
 			existing.ProxyID = proxyID
 		}
@@ -1103,7 +1103,7 @@ func (s *CRSSyncService) SyncFromCRS(ctx context.Context, input SyncFromCRSInput
 				Name:        defaultName(src.Name, src.ID),
 				Platform:    PlatformGemini,
 				Type:        AccountTypeAPIKey,
-				Credentials: credentials,
+				Credentials: FinalizeAccountCredentials(credentials, 0),
 				Extra:       extra,
 				ProxyID:     proxyID,
 				Concurrency: 3,
@@ -1137,7 +1137,7 @@ func (s *CRSSyncService) SyncFromCRS(ctx context.Context, input SyncFromCRSInput
 		existing.Name = defaultName(src.Name, src.ID)
 		existing.Platform = PlatformGemini
 		existing.Type = AccountTypeAPIKey
-		existing.Credentials = mergeMap(existing.Credentials, credentials)
+		existing.Credentials = MergeAccountCredentials(existing.Credentials, credentials, existing.ChannelType, CredentialMergePreserveAll)
 		if proxyID != nil {
 			existing.ProxyID = proxyID
 		}

--- a/backend/internal/service/crs_sync_supplier_managed_test.go
+++ b/backend/internal/service/crs_sync_supplier_managed_test.go
@@ -14,7 +14,11 @@ import (
 func TestUS048_CRSSyncAllowsSupplierManagedAccountOverwrite(t *testing.T) {
 	repo := &crsSupplierManagedAccountRepo{stored: &Account{
 		ID: 41, Name: "佳杰/stbl-5 · 档位 3", Platform: PlatformNewAPI, Type: AccountTypeAPIKey,
-		Credentials: map[string]any{"base_url": "https://supplier.example/v1", "api_key": "supplier-secret"},
+		Credentials: supplierManagedCredentials(
+			"https://supplier.example/v1", "supplier-secret",
+			map[string]string{"deepseek-v4-pro": "deepseek-v4-pro"},
+			1,
+		),
 		Extra: map[string]any{
 			"crs_account_id":             "crs-1",
 			SupplierSourceIDExtraKey:     int64(7),
@@ -34,7 +38,10 @@ func TestUS048_CRSSyncAllowsSupplierManagedAccountOverwrite(t *testing.T) {
 			"data": map[string]any{"claudeConsoleAccounts": []any{map[string]any{
 				"kind": "claude-console", "id": "crs-1", "name": "CRS overwrite",
 				"isActive": true, "schedulable": true, "priority": 1,
-				"credentials": map[string]any{"api_key": "crs-secret"},
+				"credentials": map[string]any{
+					"api_key":  "crs-secret",
+					"base_url": "https://crs.example",
+				},
 			}}},
 		}))
 	}))
@@ -54,6 +61,11 @@ func TestUS048_CRSSyncAllowsSupplierManagedAccountOverwrite(t *testing.T) {
 	require.Equal(t, 1, repo.updateCalls)
 	require.Equal(t, "CRS overwrite", repo.stored.Name)
 	require.Equal(t, "crs-secret", repo.stored.Credentials["api_key"])
+	require.Equal(t, "https://crs.example", repo.stored.Credentials["base_url"])
+	require.NotContains(t, repo.stored.Credentials, apiBaseURLsCredentialKey,
+		"CRS overwrite must drop stale exclusive api_base_urls")
+	require.NotContains(t, repo.stored.Credentials, ProtocolEndpointsExclusiveCredentialKey,
+		"CRS overwrite must drop protocol_endpoints_exclusive so new secrets are not sent to the old supplier")
 	_, hasSource := repo.stored.Extra[SupplierSourceIDExtraKey]
 	require.True(t, hasSource, "CRS overwrite must not drop supplier identity")
 }

--- a/backend/internal/service/supplier_managed_account_commands.go
+++ b/backend/internal/service/supplier_managed_account_commands.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"maps"
 	"strings"
-
-	newapiconstant "github.com/QuantumNous/new-api/constant"
-	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
 )
 
 type SupplierManagedAccountCreateInput struct {
@@ -263,22 +260,12 @@ func supplierManagedCredentials(endpoint, credential string, modelMapping map[st
 	if transport, err := resolveSupplierManagedTransport(endpoint, channelType); err == nil {
 		baseURL = transport.Endpoint
 	}
-	chatBase := baseURL
-	if channelType == newapiconstant.ChannelTypeBaiduV2 {
-		// Qianfan Chat lives under /v2; declare the complete path so identity
-		// normalize does not invent a /v1 suffix. Ordinary (non-exclusive)
-		// Qianfan accounts keep bare base_url fan-out and historical keys.
-		chatBase = strings.TrimRight(newapiintegration.QianfanBaseURL, "/") + "/v2/chat/completions"
-	}
-	return map[string]any{
-		"base_url":      baseURL,
+	credentials := map[string]any{
 		"api_key":       strings.TrimSpace(credential),
 		"model_mapping": mapping,
-		"api_base_urls": map[string]any{
-			APIProtocolChatCompletions: chatBase,
-		},
-		// Account-self exclusive endpoint declaration — scheduling identity
-		// reads this, not supplier_source_id.
-		ProtocolEndpointsExclusiveCredentialKey: true,
 	}
+	// Account-self exclusive endpoint declaration — scheduling identity
+	// reads this, not supplier_source_id. Shared with FinalizeAccountCredentials.
+	applyExclusiveChatProtocolEndpoints(credentials, baseURL, channelType)
+	return FinalizeAccountCredentials(credentials, channelType)
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 714,
-  "hash": "66b381bd3667604d568d33e678b56b58398d3a09a7c71ff74d34e04a00e1af18",
+  "hash": "b3d89998889fb4cd079fede83aaf5165b27a854360555ecaf99c355291082c1d",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/e2e/us048-supplier-source-management.e2e.ts
+++ b/frontend/e2e/us048-supplier-source-management.e2e.ts
@@ -473,13 +473,12 @@ test('US048 accounts UI marks supplier-managed accounts and allows ordinary edit
   await row.getByRole('button', { name: '更多' }).click()
   await expect(page.getByText('复制账号')).toBeVisible()
   await expect(page.getByRole('button', { name: '复制账号' })).toBeEnabled()
-  const menuBadge = page.locator('[data-testid="supplier-managed-badge"]').last()
-  await expect(menuBadge).toHaveAttribute(
-    'href',
-    '/admin/supplier-sources?source_id=7',
-  )
+  // Close the action menu first: its full-screen backdrop (z-9998) intercepts
+  // clicks on the row badge while the menu is open.
+  await page.keyboard.press('Escape')
+  await expect(page.getByRole('button', { name: '复制账号' })).toHaveCount(0)
 
-  await menuBadge.click()
+  await badge.click()
   await expect(page).toHaveURL(/\/admin\/supplier-sources\?source_id=7$/)
   await expect(page.locator('[data-test="source-select-7"]')).toHaveClass(/border-primary-500/)
   await expect(page.locator('[data-test="supplier-name"]')).toHaveValue('佳杰')

--- a/frontend/src/components/admin/account/AccountBulkActionsBar.vue
+++ b/frontend/src/components/admin/account/AccountBulkActionsBar.vue
@@ -62,15 +62,12 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 
-withDefaults(defineProps<{
+defineProps<{
   selectedIds: number[]
   totalResults: number
   selectingAll: boolean
   allResultsSelected: boolean
-  containsSupplierManaged?: boolean
-}>(), {
-  containsSupplierManaged: false
-})
+}>()
 
 defineEmits<{
   (e: 'select-page'): void

--- a/frontend/src/components/admin/account/__tests__/AccountBulkActionsBar.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountBulkActionsBar.spec.ts
@@ -54,8 +54,7 @@ describe('AccountBulkActionsBar', () => {
         selectedIds: [1, 2],
         totalResults: 45,
         selectingAll: false,
-        allResultsSelected: false,
-        containsSupplierManaged: true
+        allResultsSelected: false
       }
     })
 

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -497,7 +497,6 @@
             <div class="flex items-center gap-1">
               <button
                 data-testid="account-edit-btn"
-                
                 @click="handleEdit(row)"
                 class="flex flex-col items-center gap-0.5 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-gray-100 hover:text-primary-600 dark:hover:bg-dark-700 dark:hover:text-primary-400"
               >

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6385,9 +6385,12 @@
       "path": "backend/internal/service/admin_account.go",
       "must_contain": [
         "cachedTargets, err := s.accountRepo.GetByIDs(ctx, input.AccountIDs)",
-        "if needMixedChannelCheck || needPublicGroupAggregatorCheck {"
+        "if needMixedChannelCheck || needPublicGroupAggregatorCheck {",
+        "MergeAccountCredentials(\n\t\t\taccount.Credentials, input.Credentials, account.ChannelType, CredentialMergeAdmin,",
+        "PrepareBulkCredentialPatch(input.Credentials)",
+        "FinalizeAccountCredentials(input.Credentials, input.ChannelType)"
       ],
-      "rationale": "Bulk edits now hydrate every target once before any write so supplier-managed ownership and the existing public-group aggregator policy share one complete account snapshot. The later map fill remains required for group-only edits with SkipMixedChannelCheck."
+      "rationale": "Bulk edits now hydrate every target once before any write so supplier-managed ownership and the existing public-group aggregator policy share one complete account snapshot. The later map fill remains required for group-only edits with SkipMixedChannelCheck. Admin create/update/bulk must finalize protocol identity credentials. Without these call sites, ordinary NewAPI edits and bulk base_url rotations can keep exclusive urls pointing at a prior supplier."
     },
     {
       "path": "backend/internal/service/openai_gateway_chat_completions.go",
@@ -7475,9 +7478,11 @@
         "return updater.UpdateSupplierMetadata(ctx, account.ID, account.Name, account.Priority)",
         "updater.UpdateSupplierConcurrency(ctx, account.ID, concurrency)",
         "return updater.UpdateSupplierProjection(ctx, account, chatProbePassed)",
-        "account.Concurrency = ResolveSupplierSourceAccountConcurrency(input.Concurrency)"
+        "account.Concurrency = ResolveSupplierSourceAccountConcurrency(input.Concurrency)",
+        "applyExclusiveChatProtocolEndpoints(credentials, baseURL, channelType)",
+        "return FinalizeAccountCredentials(credentials, channelType)"
       ],
-      "rationale": "The supplier-source owner reads only the narrow projection, creates new managed accounts empty, unschedulable and ungrouped, resolves managed transport from the procurement endpoint (OpenAI Chat or Qianfan BaiduV2), preserves non-owned account metadata, requires current-call Chat probe evidence for every non-empty mapping, and fails closed unless both narrow repository writes are available."
+      "rationale": "The supplier-source owner reads only the narrow projection, creates new managed accounts empty, unschedulable and ungrouped, resolves managed transport from the procurement endpoint (OpenAI Chat or Qianfan BaiduV2), preserves non-owned account metadata, requires current-call Chat probe evidence for every non-empty mapping, and fails closed unless both narrow repository writes are available. Supplier projection writes exclusive chat identity only through the shared applyExclusiveChatProtocolEndpoints helper so Qianfan/OpenAI chat shapes cannot drift from FinalizeAccountCredentials."
     },
     {
       "path": "backend/internal/service/supplier_managed_account_commands_test.go",
@@ -7593,9 +7598,11 @@
       "path": "backend/internal/service/crs_sync_supplier_managed_test.go",
       "must_contain": [
         "TestUS048_CRSSyncAllowsSupplierManagedAccountOverwrite",
-        "TestUS048_CRSSyncRejectsReservedSupplierExtraOnNewAccount"
+        "TestUS048_CRSSyncRejectsReservedSupplierExtraOnNewAccount",
+        "CRS overwrite must drop stale exclusive api_base_urls",
+        "CRS overwrite must drop protocol_endpoints_exclusive so new secrets are not sent to the old supplier"
       ],
-      "rationale": "CRS import may overwrite an already supplier-managed account like any other account (preserving reserved identity via PreserveSupplierManagedExtraKeys), but must still reject forging supplier ownership Extra on a newly created account."
+      "rationale": "CRS import may overwrite an already supplier-managed account like any other account (preserving reserved identity via PreserveSupplierManagedExtraKeys), but must still reject forging supplier ownership Extra on a newly created account. US-048 regression proving CRS overwrite of a supplier-managed exclusive account drops stale identity keys instead of sending the new api_key to the old supplier URL."
     },
     {
       "path": "backend/internal/service/audit_log.go",
@@ -7672,6 +7679,56 @@
         "ID: -1001, ChannelType: transport.ChannelType, Concurrency: 4,"
       ],
       "rationale": "Supplier upstream listing owns channel_type-aware models paths (Ali compatible-mode, BaiduV2 /v2/models, default OpenAI /v1/models) and a dedicated negative list identity so concurrent discovers do not contend on account-id caches."
+    },
+    {
+      "path": "backend/internal/service/account_protocol_endpoint_credentials.go",
+      "must_contain": [
+        "func MergeAccountCredentials(existing, incoming map[string]any, channelType int, mode CredentialMergeMode) map[string]any",
+        "func FinalizeAccountCredentials(credentials map[string]any, channelType int) map[string]any",
+        "func PrepareBulkCredentialPatch(patch map[string]any) map[string]any",
+        "func applyExclusiveChatProtocolEndpoints(credentials map[string]any, baseURL string, channelType int)",
+        "func deriveExclusiveChatProtocolURL(baseURL string, channelType int) string",
+        "CredentialMergePreserveAll",
+        "delete(merged, apiBaseURLsCredentialKey)",
+        "delete(merged, ProtocolEndpointsExclusiveCredentialKey)"
+      ],
+      "rationale": "SSOT for protocol endpoint identity credentials. Merge/Finalize/bulk-patch must keep api_base_urls + protocol_endpoints_exclusive consistent with base_url; CRS/admin/bulk writers call these helpers so a future upstream merge cannot reintroduce stale exclusive routing that sends rotated secrets to an old supplier."
+    },
+    {
+      "path": "backend/internal/service/account_protocol_endpoint_credentials_test.go",
+      "must_contain": [
+        "TestMergeAccountCredentials_CRSPreserveAllDropsStaleExclusive",
+        "TestMergeAccountCredentials_AdminRealignsExclusiveWhenIncomingSpreadsStaleURLs",
+        "TestFinalizeAccountCredentials_RealignsQianfanExclusiveChatPath",
+        "TestPrepareBulkCredentialPatch_ClearsIdentityWhenRotatingBaseURL",
+        "TestSupplierManagedCredentials_UsesSharedExclusiveChatSSOT"
+      ],
+      "rationale": "Focused regressions for the exclusive-endpoint SSOT: CRS preserve-all drops stale identity, admin spread realigns chat URLs to the new base_url, Qianfan exclusive chat paths rebuild, bulk base_url/api_key patches clear identity keys, and supplierManagedCredentials shares applyExclusiveChatProtocolEndpoints."
+    },
+    {
+      "path": "backend/internal/service/account_supported_protocols.go",
+      "must_contain": [
+        "const ProtocolEndpointsExclusiveCredentialKey = \"protocol_endpoints_exclusive\"",
+        "if accountDeclaresExclusiveProtocolEndpoints(account) {",
+        "func accountDeclaresExclusiveProtocolEndpoints(account *Account) bool {"
+      ],
+      "rationale": "Gateway/scheduler identity reads protocol_endpoints_exclusive from account credentials. Dropping the exclusive branch silently fans bare base_url into undeclared protocols again and undoes the account-self identity contract from PR #1907."
+    },
+    {
+      "path": "backend/internal/repository/scheduler_cache.go",
+      "must_contain": [
+        "service.ProtocolEndpointsExclusiveCredentialKey",
+        "\"api_base_urls\""
+      ],
+      "rationale": "Scheduler snapshots must project protocol_endpoints_exclusive and api_base_urls or chat-only exclusive identity collapses after Extra filtering and recreates no_legal_protocol_route on supplier-managed accounts."
+    },
+    {
+      "path": "backend/internal/service/crs_sync_service.go",
+      "must_contain": [
+        "MergeAccountCredentials(existing.Credentials, credentials, existing.ChannelType, CredentialMergePreserveAll)",
+        "FinalizeAccountCredentials(credentials, 0)"
+      ],
+      "rationale": "Every CRS create/update path must go through the credential SSOT so rotating base_url/api_key cannot retain stale exclusive supplier endpoints."
     }
   ]
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7701,7 +7701,8 @@
         "TestMergeAccountCredentials_AdminRealignsExclusiveWhenIncomingSpreadsStaleURLs",
         "TestFinalizeAccountCredentials_RealignsQianfanExclusiveChatPath",
         "TestPrepareBulkCredentialPatch_ClearsIdentityWhenRotatingBaseURL",
-        "TestSupplierManagedCredentials_UsesSharedExclusiveChatSSOT"
+        "TestSupplierManagedCredentials_UsesSharedExclusiveChatSSOT",
+        "TestPrepareBulkCredentialPatch_LeavesExclusiveAloneForAPIKeyOnlyRotate"
       ],
       "rationale": "Focused regressions for the exclusive-endpoint SSOT: CRS preserve-all drops stale identity, admin spread realigns chat URLs to the new base_url, Qianfan exclusive chat paths rebuild, bulk base_url/api_key patches clear identity keys, and supplierManagedCredentials shares applyExclusiveChatProtocolEndpoints."
     },


### PR DESCRIPTION
## 摘要
- 修复 #1907/#1908 引入的 exclusive 端点滞留：CRS / 普通编辑 / 批量更新旋转 `base_url` 时，不再继承过期的 `api_base_urls` + `protocol_endpoints_exclusive`，避免新密钥打到旧供应商。
- 新增 SSOT：`MergeAccountCredentials` / `FinalizeAccountCredentials` / `PrepareBulkCredentialPatch` / `applyExclusiveChatProtocolEndpoints`，并接到 CRS、Admin、AccountService、persist、供应源投影全部写入路径。
- 批量 `api_key`-only 补丁保留 exclusive（R-001），避免托管 chat-only 账号退回 base_url 扇出。
- 同步清理 US-048 e2e 菜单遮罩点击、`containsSupplierManaged` 死 prop，以及 gateway-tk sentinel 锚定。

## 风险
- 常规偏高：触及账号凭证合并与协议 identity；行为仅在「exclusive 账号旋转 base_url」路径变化，legacy 非 exclusive 不受影响。
- 供应源 sync 仍完整替换 exclusive 形状；CRS 未声明 identity 时丢弃旧 exclusive，改为走新 `base_url`。

## 验证
- `PREFLIGHT_BASE=origin/main ./scripts/preflight.sh` → PASS
- `go test -tags=unit ./internal/service -run 'TestMergeAccountCredentials_|TestFinalizeAccountCredentials_|TestPrepareBulkCredentialPatch_|TestSupplierManagedCredentials_UsesShared|TestUS048_CRSSyncAllowsSupplierManaged'` → PASS
- `python3 scripts/sentinels/check-gateway-tk.py` → PASS (807/807)
- `pnpm exec vitest run` AccountBulkActionsBar / AccountsView.supplierManaged → PASS
- Playwright US-048：已改 Escape 关菜单后再点行徽标；本机无 `localhost:8080`，**未实跑浏览器**（等 CI）

## 提交
- `b92a93511` fix(protocol): 凭证 identity 原子化，避免 exclusive 端点滞留旧供应商
- `d983ec0a2` fix(protocol): address R-001 — bulk 仅 base_url 旋转时清 exclusive
- 最新提交：`d983ec0a2`

sentinel-registry-reviewed