### PR TITLE
fix(supplier): 供应源档位 discount_priority 相邻增量改为 10

### DIFF
--- a/.testing/user-stories/stories/US-048-model-supplier-source-management.md
+++ b/.testing/user-stories/stories/US-048-model-supplier-source-management.md
@@ -15,7 +15,7 @@
 ## Acceptance Criteria
 
 1. AC-001 (正向): Given 运营新增供应源，When 只点击保存，Then 系统只写单表采购事实，凭证加密且不回显，新供应源默认 `base_priority=100`，不探测、不创建或修改账号。
-2. AC-002 (优先级): Given 模型采购比例落入六个固定档位，When 查看表单与全局预览，Then 档位分别贡献 `1..6`，账号 priority 严格等于 `base_priority + discount_priority`；同源同档模型合并为一个目标账号，预览只比较供应源目标 priority，且 `base_priority + 6` 不得越过 PostgreSQL `INTEGER`。
+2. AC-002 (优先级): Given 模型采购比例落入六个固定档位，When 查看表单与全局预览，Then 档位分别贡献 `10, 20, …, 60`（相邻增量 10），账号 priority 严格等于 `base_priority + discount_priority`；同源同档模型合并为一个目标账号，预览只比较供应源目标 priority，且 `base_priority + 60` 不得越过 PostgreSQL `INTEGER`。
 3. AC-003 (探测门禁): Given endpoint、credential、模型 ID、模型增减、跨档，或非空受管账号的 `status/schedulable` 与目标不一致，When 点击“校验并同步”，Then 系统用带 source/band 身份的内存账号逐模型使用明确 upstream ID 真实探测；任一失败返回全部当次结果且不写账号。只有 Chat Completions 正向结果生成本次同步内部证据；FMGo Seedance 显式映射及任何 Responses/Anthropic 等非 Chat 成功证据都返回 `protocol_unsupported`，不猜协议、不写账号。
 4. AC-004 (热更新): Given 全部结构探测成功，When 同步模型跨档或增减，Then 系统先以空 mapping、不可调度状态创建缺失账号；非空投影必须携带本次 Chat 正向证据，并在单账号事务内提交账号配置、Chat-only 现有协议能力、`InitialProbeCompleted=true`/`OfficialSeed=false` 证据和 scheduler outbox，再做配置读回确认而不进行写后二次网络探测，最后从旧档删除 mapping。单账号事务失败时已有账号保持旧配置、新账号保持空 mapping 不可调度；跨账号中途失败保留已完成增加、停止后续减少，返回 `failed_step + changes[]`，重试可继续收敛；空档账号保留并收敛为 `active + schedulable=false`。已选来源存在未保存表单修改时同步入口禁用并提示先保存，成功提示只能从当前结果派生。
 5. AC-005 (隔离回归): Given 供应源保存、预览或同步，When 执行任一路径，Then 供应源不读取、比较、返回或写入账号组，专用投影读取不调用通用 `GetByID`，并且只选择同步所需配置字段，不读取倍率或无关运行字段；新账号保持未分组且不借用 `newapi-default`，普通账号创建失败契约不变；受管/预探测账号只声明 Chat Completions；通用 host 末尾 `/v1` 只在 OpenAI 受管路径规范化，`qianfan.baidubce.com` 解析为 BaiduV2 + 根 URL 并声明 `/v2/chat/completions`，普通 NewAPI 账号行为不变；系统不修改倍率、定价或 scheduler，scheduler 继续只按更小的原有账号 priority 先调度，不读取供应来源 Extra。
@@ -45,7 +45,7 @@
 ## Linked Tests
 
 - `backend/internal/service/supplier_source_priority_test.go`::`TestUS048_DiscountBandBoundaries`
-- `backend/internal/service/supplier_source_priority_test.go`::`TestUS048_SupplierPriorityIsBasePlusBand`
+- `backend/internal/service/supplier_source_priority_test.go`::`TestUS048_SupplierPriorityIsBasePlusBandTimesStep`
 - `backend/internal/service/supplier_source_priority_test.go`::`TestUS048_SupplierPriorityStaysWithinPostgresIntegerRange`
 - `backend/internal/service/supplier_source_service_test.go`::`TestUS048_CreateSupplierSourceEncryptsCredentialAndDefaultsBasePriority`
 - `backend/internal/service/supplier_source_service_test.go`::`TestUS048_PriorityPreviewGroupsModelsBySourceBand`

--- a/backend/internal/service/crs_sync_supplier_managed_test.go
+++ b/backend/internal/service/crs_sync_supplier_managed_test.go
@@ -24,7 +24,7 @@ func TestUS048_CRSSyncAllowsSupplierManagedAccountOverwrite(t *testing.T) {
 			SupplierSourceIDExtraKey:     int64(7),
 			SupplierDiscountBandExtraKey: 3,
 		},
-		Priority: 103, Status: StatusActive, Schedulable: true,
+		Priority: 130, Status: StatusActive, Schedulable: true,
 	}}
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		response.Header().Set("Content-Type", "application/json")

--- a/backend/internal/service/supplier_managed_account_commands_test.go
+++ b/backend/internal/service/supplier_managed_account_commands_test.go
@@ -18,7 +18,7 @@ func TestUS048_SupplierCreateStartsEmptyUngroupedAndUnschedulable(t *testing.T) 
 	created, err := svc.CreateSupplierManagedAccount(context.Background(), SupplierManagedAccountCreateInput{
 		SourceID: 7, DiscountBand: 3, Name: "佳杰/stbl-5 · 档位 3",
 		Endpoint: "https://token.vstecscloud.com/v1", Credential: "secret",
-		Priority: 103,
+		Priority: 130,
 	})
 
 	require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestUS048_SupplierCreateUsesDefaultAccountConcurrency(t *testing.T) {
 
 	_, err := svc.CreateSupplierManagedAccount(context.Background(), SupplierManagedAccountCreateInput{
 		SourceID: 7, DiscountBand: 3, Name: "supplier/test · 档位 3",
-		Endpoint: "https://supplier.example/v1", Credential: "secret", Priority: 103,
+		Endpoint: "https://supplier.example/v1", Credential: "secret", Priority: 130,
 	})
 
 	require.NoError(t, err)
@@ -91,7 +91,7 @@ func TestUS048_SupplierConfigurationUpdateUsesGroupFreeReadAndNarrowWrite(t *tes
 		Extra: map[string]any{
 			SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3, "runtime_observation": "keep",
 		},
-		Priority: 103, Status: StatusActive, Schedulable: true, GroupIDs: []int64{4, 9},
+		Priority: 130, Status: StatusActive, Schedulable: true, GroupIDs: []int64{4, 9},
 	}}
 	svc := &adminServiceImpl{accountRepo: accounts}
 
@@ -127,7 +127,7 @@ func TestUS048_SupplierQianfanCreateUsesBaiduV2Transport(t *testing.T) {
 	_, err := svc.CreateSupplierManagedAccount(context.Background(), SupplierManagedAccountCreateInput{
 		SourceID: 7, DiscountBand: 3, Name: "百度/千帆 · 档位 3",
 		Endpoint: "https://qianfan.baidubce.com/v2", Credential: "secret",
-		Priority: 103,
+		Priority: 130,
 	})
 
 	require.NoError(t, err)
@@ -146,7 +146,7 @@ func TestUS048_SupplierConfigurationUpdateRequiresPassedChatProbe(t *testing.T) 
 			SupplierSourceIDExtraKey:     int64(7),
 			SupplierDiscountBandExtraKey: 3,
 		},
-		Priority: 103, Status: StatusActive, Schedulable: true,
+		Priority: 130, Status: StatusActive, Schedulable: true,
 	}}
 	svc := &adminServiceImpl{accountRepo: accounts}
 
@@ -171,7 +171,7 @@ func TestUS048_SupplierMetadataUpdateChangesOnlyNameAndPriority(t *testing.T) {
 		Extra: map[string]any{
 			SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3, "runtime_observation": "keep",
 		},
-		Priority: 103, Status: StatusActive, Schedulable: true, GroupIDs: []int64{4, 9},
+		Priority: 130, Status: StatusActive, Schedulable: true, GroupIDs: []int64{4, 9},
 	}
 	accounts := &supplierManagedCommandsAccountRepoFake{existing: existing}
 	svc := &adminServiceImpl{accountRepo: accounts}

--- a/backend/internal/service/supplier_managed_account_guard_test.go
+++ b/backend/internal/service/supplier_managed_account_guard_test.go
@@ -169,7 +169,7 @@ func newManagedAccountAdminRepoFake() *managedAccountAdminRepoFake {
 	return &managedAccountAdminRepoFake{
 		account: &Account{
 			ID: 41, Platform: PlatformNewAPI, Type: AccountTypeAPIKey,
-			Name: "managed", Status: StatusActive, Concurrency: 1000, Priority: 103,
+			Name: "managed", Status: StatusActive, Concurrency: 1000, Priority: 130,
 			Credentials: map[string]any{"api_key": "secret", "base_url": "https://supplier.example/v1"},
 			Extra:       map[string]any{SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3},
 		},

--- a/backend/internal/service/supplier_source_account_store_test.go
+++ b/backend/internal/service/supplier_source_account_store_test.go
@@ -58,7 +58,7 @@ func TestUS048_SupplierAccountStoreDelegatesWritesOnlyToAccountCommands(t *testi
 
 	created, err := store.CreateManagedAccount(context.Background(), SupplierManagedAccountCreateInput{
 		SourceID: 7, DiscountBand: 3, Name: "source-7-band-3", Endpoint: "https://supplier.example/v1",
-		Credential: "secret", Priority: 103,
+		Credential: "secret", Priority: 130,
 	})
 	require.NoError(t, err)
 	require.Equal(t, int64(101), created.ID)
@@ -67,7 +67,7 @@ func TestUS048_SupplierAccountStoreDelegatesWritesOnlyToAccountCommands(t *testi
 	updated, err := store.UpdateManagedAccount(context.Background(), SupplierManagedAccountUpdateInput{
 		AccountID: 101, SourceID: 7, DiscountBand: 3, Name: "source-7-band-3",
 		Endpoint: "https://supplier.example/v1", Credential: "secret",
-		ModelMapping: map[string]string{"model": "upstream"}, Priority: 103, Status: StatusActive, Schedulable: true,
+		ModelMapping: map[string]string{"model": "upstream"}, Priority: 130, Status: StatusActive, Schedulable: true,
 	})
 	require.NoError(t, err)
 	require.Equal(t, int64(101), updated.ID)

--- a/backend/internal/service/supplier_source_priority.go
+++ b/backend/internal/service/supplier_source_priority.go
@@ -3,6 +3,9 @@ package service
 const (
 	postgresInt32Min = -1 << 31
 	postgresInt32Max = 1<<31 - 1
+
+	// SupplierDiscountPriorityStep is the priority gap between adjacent discount bands.
+	SupplierDiscountPriorityStep = 10
 )
 
 func SupplierDiscountBandForRatio(ratio *float64) (int, error) {
@@ -26,12 +29,21 @@ func SupplierDiscountBandForRatio(ratio *float64) (int, error) {
 	}
 }
 
-func SupplierAccountPriority(basePriority, discountBand int) (int, error) {
+// SupplierDiscountPriority returns the priority contribution for a discount band (10, 20, …, 60).
+func SupplierDiscountPriority(discountBand int) (int, error) {
 	if discountBand < 1 || discountBand > 6 {
 		return 0, ErrSupplierSourceInvalidInput
 	}
-	if basePriority < postgresInt32Min || basePriority > postgresInt32Max-discountBand {
+	return discountBand * SupplierDiscountPriorityStep, nil
+}
+
+func SupplierAccountPriority(basePriority, discountBand int) (int, error) {
+	discountPriority, err := SupplierDiscountPriority(discountBand)
+	if err != nil {
+		return 0, err
+	}
+	if basePriority < postgresInt32Min || basePriority > postgresInt32Max-discountPriority {
 		return 0, ErrSupplierSourceInvalidInput
 	}
-	return basePriority + discountBand, nil
+	return basePriority + discountPriority, nil
 }

--- a/backend/internal/service/supplier_source_priority_test.go
+++ b/backend/internal/service/supplier_source_priority_test.go
@@ -1,7 +1,11 @@
 package service
 
 import (
+	"fmt"
 	"math"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -58,6 +62,18 @@ func TestUS048_SupplierPriorityIsBasePlusBandTimesStep(t *testing.T) {
 
 	_, err = SupplierAccountPriority(100, 0)
 	require.ErrorIs(t, err, ErrSupplierSourceInvalidInput)
+}
+
+// Pins FE SUPPLIER_DISCOUNT_PRIORITY_STEP to backend SupplierDiscountPriorityStep
+// so Admin form live preview cannot drift from sync/account priority.
+func TestUS048_DiscountPriorityStepMatchesFrontendConstant(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	feConst := filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "frontend", "src", "constants", "supplierSource.tk.ts")
+	raw, err := os.ReadFile(feConst)
+	require.NoError(t, err, "frontend constant file must exist at %s", feConst)
+	needle := fmt.Sprintf("export const SUPPLIER_DISCOUNT_PRIORITY_STEP = %d", SupplierDiscountPriorityStep)
+	require.Contains(t, string(raw), needle)
 }
 
 func TestUS048_SupplierPriorityStaysWithinPostgresIntegerRange(t *testing.T) {

--- a/backend/internal/service/supplier_source_priority_test.go
+++ b/backend/internal/service/supplier_source_priority_test.go
@@ -47,21 +47,25 @@ func TestUS048_DiscountBandRejectsOutOfRangeRatios(t *testing.T) {
 	}
 }
 
-func TestUS048_SupplierPriorityIsBasePlusBand(t *testing.T) {
+func TestUS048_SupplierPriorityIsBasePlusBandTimesStep(t *testing.T) {
 	got, err := SupplierAccountPriority(100, 3)
 	require.NoError(t, err)
-	require.Equal(t, 103, got)
+	require.Equal(t, 130, got)
+
+	discount, err := SupplierDiscountPriority(3)
+	require.NoError(t, err)
+	require.Equal(t, 30, discount)
 
 	_, err = SupplierAccountPriority(100, 0)
 	require.ErrorIs(t, err, ErrSupplierSourceInvalidInput)
 }
 
 func TestUS048_SupplierPriorityStaysWithinPostgresIntegerRange(t *testing.T) {
-	got, err := SupplierAccountPriority((1<<31)-7, 6)
+	got, err := SupplierAccountPriority((1<<31)-61, 6)
 	require.NoError(t, err)
 	require.Equal(t, (1<<31)-1, got)
 
-	for _, basePriority := range []int{(1 << 31) - 6, -(1 << 31) - 1} {
+	for _, basePriority := range []int{(1 << 31) - 60, -(1 << 31) - 1} {
 		_, err := SupplierAccountPriority(basePriority, 6)
 		require.ErrorIs(t, err, ErrSupplierSourceInvalidInput)
 

--- a/backend/internal/service/supplier_source_priority_test.go
+++ b/backend/internal/service/supplier_source_priority_test.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -66,10 +65,28 @@ func TestUS048_SupplierPriorityIsBasePlusBandTimesStep(t *testing.T) {
 
 // Pins FE SUPPLIER_DISCOUNT_PRIORITY_STEP to backend SupplierDiscountPriorityStep
 // so Admin form live preview cannot drift from sync/account priority.
+// Locates the monorepo root via Getwd (not runtime.Caller): CI builds with
+// -trimpath, so Caller paths are module-shaped and not on disk.
 func TestUS048_DiscountPriorityStepMatchesFrontendConstant(t *testing.T) {
-	_, thisFile, _, ok := runtime.Caller(0)
-	require.True(t, ok)
-	feConst := filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "frontend", "src", "constants", "supplierSource.tk.ts")
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	root := ""
+	for dir := wd; ; dir = filepath.Dir(dir) {
+		feDir := filepath.Join(dir, "frontend", "src", "constants")
+		backendMod := filepath.Join(dir, "backend", "go.mod")
+		if st, err := os.Stat(feDir); err == nil && st.IsDir() {
+			if _, err := os.Stat(backendMod); err == nil {
+				root = dir
+				break
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+	}
+	require.NotEmpty(t, root, "monorepo root not found from wd=%s", wd)
+	feConst := filepath.Join(root, "frontend", "src", "constants", "supplierSource.tk.ts")
 	raw, err := os.ReadFile(feConst)
 	require.NoError(t, err, "frontend constant file must exist at %s", feConst)
 	needle := fmt.Sprintf("export const SUPPLIER_DISCOUNT_PRIORITY_STEP = %d", SupplierDiscountPriorityStep)

--- a/backend/internal/service/supplier_source_service.go
+++ b/backend/internal/service/supplier_source_service.go
@@ -203,9 +203,13 @@ func (s *SupplierSourceService) PriorityPreview(ctx context.Context) (*SupplierP
 		}
 		for _, band := range sortedSupplierBands(targets) {
 			modelIDs := sortedSupplierMappingKeys(targets[band].Mapping)
+			discountPriority, priorityErr := SupplierDiscountPriority(band)
+			if priorityErr != nil {
+				return nil, priorityErr
+			}
 			preview.Entries = append(preview.Entries, SupplierPriorityPreviewEntry{
 				SourceID: source.ID, SupplierName: source.SupplierName, ChannelName: source.ChannelName,
-				DiscountBand: band, DiscountPriority: band * SupplierDiscountPriorityStep, Priority: targets[band].Priority,
+				DiscountBand: band, DiscountPriority: discountPriority, Priority: targets[band].Priority,
 				ClientModelIDs: modelIDs,
 			})
 		}

--- a/backend/internal/service/supplier_source_service.go
+++ b/backend/internal/service/supplier_source_service.go
@@ -205,7 +205,7 @@ func (s *SupplierSourceService) PriorityPreview(ctx context.Context) (*SupplierP
 			modelIDs := sortedSupplierMappingKeys(targets[band].Mapping)
 			preview.Entries = append(preview.Entries, SupplierPriorityPreviewEntry{
 				SourceID: source.ID, SupplierName: source.SupplierName, ChannelName: source.ChannelName,
-				DiscountBand: band, DiscountPriority: band, Priority: targets[band].Priority,
+				DiscountBand: band, DiscountPriority: band * SupplierDiscountPriorityStep, Priority: targets[band].Priority,
 				ClientModelIDs: modelIDs,
 			})
 		}

--- a/backend/internal/service/supplier_source_service_test.go
+++ b/backend/internal/service/supplier_source_service_test.go
@@ -114,8 +114,8 @@ func TestUS048_PriorityPreviewGroupsModelsBySourceBand(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, []SupplierPriorityPreviewEntry{
-		{SourceID: 7, SupplierName: "佳杰", ChannelName: "stbl-5", DiscountBand: 3, DiscountPriority: 3, Priority: 103, ClientModelIDs: []string{"deepseek-v4-pro", "qwen-3.7-max"}},
-		{SourceID: 7, SupplierName: "佳杰", ChannelName: "stbl-5", DiscountBand: 5, DiscountPriority: 5, Priority: 105, ClientModelIDs: []string{"fallback-model"}},
+		{SourceID: 7, SupplierName: "佳杰", ChannelName: "stbl-5", DiscountBand: 3, DiscountPriority: 30, Priority: 130, ClientModelIDs: []string{"deepseek-v4-pro", "qwen-3.7-max"}},
+		{SourceID: 7, SupplierName: "佳杰", ChannelName: "stbl-5", DiscountBand: 5, DiscountPriority: 50, Priority: 150, ClientModelIDs: []string{"fallback-model"}},
 	}, preview.Entries)
 }
 

--- a/backend/internal/service/supplier_source_sync_test.go
+++ b/backend/internal/service/supplier_source_sync_test.go
@@ -30,7 +30,7 @@ func TestUS048_SupplierSyncGroupsSameBandModelsIntoOneAccount(t *testing.T) {
 	require.Len(t, result.ProbeResults, 2)
 	require.Equal(t, 1, accounts.createCalls)
 	require.Equal(t, 3, accounts.created[0].DiscountBand)
-	require.Equal(t, 103, accounts.created[0].Priority)
+	require.Equal(t, 130, accounts.created[0].Priority)
 	require.NotEmpty(t, accounts.updated)
 	require.Equal(t, map[string]string{
 		"deepseek-v4-pro": "deepseek-v4-pro",
@@ -43,7 +43,7 @@ func TestUS048_SupplierSyncGroupsSameBandModelsIntoOneAccount(t *testing.T) {
 func TestUS048_SupplierProbeAccountCarriesManagedIdentity(t *testing.T) {
 	source := &SupplierSource{ID: 7, SupplierName: "佳杰", ChannelName: "stbl-5", ChannelType: 1, Endpoint: "https://supplier.example/v1"}
 	account := supplierProbeAccount(nil, source, "secret", supplierTargetBand{
-		Band: 3, Priority: 103, Mapping: map[string]string{"client-model": "vendor-model"},
+		Band: 3, Priority: 130, Mapping: map[string]string{"client-model": "vendor-model"},
 	})
 
 	require.True(t, IsSupplierManagedAccount(account))
@@ -101,7 +101,7 @@ func TestUS048_SupplierSyncMetadataOnlySkipsProbe(t *testing.T) {
 	require.Len(t, accounts.updated, 1)
 	require.True(t, accounts.updated[0].MetadataOnly)
 	require.Equal(t, "佳杰/stbl-5 · 档位 3", accounts.updated[0].Name)
-	require.Equal(t, 103, accounts.updated[0].Priority)
+	require.Equal(t, 130, accounts.updated[0].Priority)
 }
 
 func TestUS048_SupplierSyncNameChangeUpdatesAccountWithoutProbe(t *testing.T) {
@@ -116,7 +116,7 @@ func TestUS048_SupplierSyncNameChangeUpdatesAccountWithoutProbe(t *testing.T) {
 		Credentials: supplierManagedCredentials(
 			"https://supplier.example/v1", "secret", map[string]string{"model": "model"}, 1),
 		Extra:    map[string]any{SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3},
-		Priority: 103, Status: StatusActive, Schedulable: true, Concurrency: SupplierSourceDefaultAccountConcurrency,
+		Priority: 130, Status: StatusActive, Schedulable: true, Concurrency: SupplierSourceDefaultAccountConcurrency,
 	}}}
 	probe := &supplierSyncProbeFake{failIfCalled: true}
 	svc := NewSupplierSourceService(repo, accounts, probe, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{})
@@ -141,7 +141,7 @@ func TestUS048_SupplierSyncMovesModelByAddingBeforeRemoving(t *testing.T) {
 		Credentials: supplierManagedCredentials(
 			"https://supplier.example/v1", "secret", map[string]string{"model": "model"}, 1),
 		Extra:    map[string]any{SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3},
-		Priority: 103, Status: StatusActive, Schedulable: true, Concurrency: SupplierSourceDefaultAccountConcurrency,
+		Priority: 130, Status: StatusActive, Schedulable: true, Concurrency: SupplierSourceDefaultAccountConcurrency,
 	}}}
 	probe := &supplierSyncProbeFake{}
 	svc := NewSupplierSourceService(repo, accounts, probe, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{})
@@ -171,7 +171,7 @@ func TestUS048_SupplierSyncStopsBeforeRemovalWhenVerifiedProjectionWriteFails(t 
 	}}
 	accounts := &supplierSyncAccountStoreFake{
 		managed: []*Account{supplierSyncManagedAccount(
-			41, 7, 3, 103, map[string]string{"model": "model"}, true,
+			41, 7, 3, 130, map[string]string{"model": "model"}, true,
 		)},
 		updateErrAt: 1,
 		updateErr:   ErrSupplierProjectionProtocolNotReady,
@@ -198,7 +198,7 @@ func TestUS048_SupplierSyncClearsEmptyBandWithoutDeletingAccount(t *testing.T) {
 		Models: []SupplierSourceModel{},
 	}}
 	accounts := &supplierSyncAccountStoreFake{managed: []*Account{supplierSyncManagedAccount(
-		41, 7, 3, 103, map[string]string{"model": "model"}, true,
+		41, 7, 3, 130, map[string]string{"model": "model"}, true,
 	)}}
 	probe := &supplierSyncProbeFake{failIfCalled: true}
 	svc := NewSupplierSourceService(repo, accounts, probe, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{})
@@ -444,7 +444,7 @@ func TestUS048_SupplierSyncProbesBeforeRepairingNonEmptySchedulingProjection(t *
 		EncryptedCredential: "enc:secret", CredentialFingerprint: "fp:secret", BasePriority: 100,
 		Models: []SupplierSourceModel{{ClientModelID: "model", UpstreamModelID: "model", PurchaseRatio: &ratio}},
 	}}
-	account := supplierSyncManagedAccount(41, 7, 3, 103, map[string]string{"model": "model"}, false)
+	account := supplierSyncManagedAccount(41, 7, 3, 130, map[string]string{"model": "model"}, false)
 	account.Name = supplierManagedAccountName(repo.stored, 3)
 	account.Status = StatusError
 	accounts := &supplierSyncAccountStoreFake{managed: []*Account{account}}
@@ -468,7 +468,7 @@ func TestUS048_SupplierSyncRepairsEmptySchedulingProjectionWithoutProbe(t *testi
 		EncryptedCredential: "enc:secret", CredentialFingerprint: "fp:secret", BasePriority: 100,
 		Models: []SupplierSourceModel{},
 	}}
-	account := supplierSyncManagedAccount(41, 7, 3, 103, map[string]string{}, true)
+	account := supplierSyncManagedAccount(41, 7, 3, 130, map[string]string{}, true)
 	account.Name = supplierManagedAccountName(repo.stored, 3)
 	account.Status = StatusDisabled
 	accounts := &supplierSyncAccountStoreFake{managed: []*Account{account}}
@@ -574,7 +574,7 @@ func TestUS048_SupplierSyncSameBandRatioChangeDoesNotTouchAccounts(t *testing.T)
 		EncryptedCredential: "enc:secret", CredentialFingerprint: "fp:secret", BasePriority: 100,
 		Models: []SupplierSourceModel{{ClientModelID: "model", UpstreamModelID: "model", PurchaseRatio: &ratio}},
 	}}
-	account := supplierSyncManagedAccount(41, 7, 3, 103, map[string]string{"model": "model"}, true)
+	account := supplierSyncManagedAccount(41, 7, 3, 130, map[string]string{"model": "model"}, true)
 	account.Name = supplierManagedAccountName(repo.stored, 3)
 	accounts := &supplierSyncAccountStoreFake{managed: []*Account{account}}
 	probe := &supplierSyncProbeFake{failIfCalled: true}
@@ -837,7 +837,7 @@ func TestUS048_SupplierSyncAppliesSourceAccountConcurrency(t *testing.T) {
 			"https://supplier.example/v1", "secret",
 			map[string]string{"deepseek-v4-pro": "deepseek-v4-pro"}, 1),
 		Extra:    map[string]any{SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3},
-		Priority: 103, Status: StatusActive, Schedulable: true, Concurrency: 1,
+		Priority: 130, Status: StatusActive, Schedulable: true, Concurrency: 1,
 	}}}
 	probe := &supplierSyncProbeFake{failIfCalled: true}
 	svc := NewSupplierSourceService(repo, accounts, probe, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{})
@@ -870,7 +870,7 @@ func TestUS048_SupplierSyncProtocolIdentityDriftRequiresCurrentProbe(t *testing.
 			"model_mapping": map[string]string{"deepseek-v4-pro": "deepseek-v4-pro"},
 		},
 		Extra:    map[string]any{SupplierSourceIDExtraKey: int64(7), SupplierDiscountBandExtraKey: 3},
-		Priority: 103, Status: StatusActive, Schedulable: true, Concurrency: 1000,
+		Priority: 130, Status: StatusActive, Schedulable: true, Concurrency: 1000,
 		ProtocolEndpointCapabilityID: &capabilityID,
 		ProtocolEndpointCapability:   &ProtocolEndpointCapability{ID: capabilityID, CapabilityKey: "stale-identity"},
 	}}}

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 714,
-  "hash": "08fc87bfde7588b1e19caaeac09e9afb3cfeb47272709ca5e56ee2e1a3ba6ad6",
+  "file_count": 715,
+  "hash": "131cf82f69eff86d55fa513358be918e596dbe431cabdfdd9d9e4775d9243d5b",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 714,
-  "hash": "b3d89998889fb4cd079fede83aaf5165b27a854360555ecaf99c355291082c1d",
+  "hash": "08fc87bfde7588b1e19caaeac09e9afb3cfeb47272709ca5e56ee2e1a3ba6ad6",
   "schema": 1,
   "source": "frontend/"
 }

--- a/docs/approved/model-supplier-source-management.md
+++ b/docs/approved/model-supplier-source-management.md
@@ -25,9 +25,10 @@ related_stories: ["US-048"]
 account.priority = source.base_priority + discount_priority
 ```
 
-所有新供应源默认 `base_priority=100`。采购比例固定分六档，分别增加 `1..6`；`ratio=1.00` 和空值
-均进入档位 6。同一供应源、同一档位的模型合并为一个账号，每个供应源最多六个受管账号。
-`base_priority` 必须保证再加最大档位值 6 后仍可写入 PostgreSQL `INTEGER`。
+所有新供应源默认 `base_priority=100`。采购比例固定分六档，`discount_priority` 分别为
+`10, 20, …, 60`（相邻档位增量 10）；`ratio=1.00` 和空值均进入档位 6。同一供应源、同一档位的
+模型合并为一个账号，每个供应源最多六个受管账号。`base_priority` 必须保证再加最大档位贡献 60
+后仍可写入 PostgreSQL `INTEGER`。
 
 原生 OAuth、普通账号和供应账号没有额外调度层。它们的相对顺序完全由各自现有 priority 决定；
 供应源不读取或修改原生 OAuth priority。

--- a/frontend/e2e/us048-supplier-source-management.e2e.ts
+++ b/frontend/e2e/us048-supplier-source-management.e2e.ts
@@ -223,8 +223,8 @@ test('US048 Jiajie saves facts previews priority and syncs one band account', as
           supplier_name: '佳杰',
           channel_name: 'first-batch-lowest-ratio',
           discount_band: 3,
-          discount_priority: 3,
-          priority: 103,
+          discount_priority: 30,
+          priority: 130,
           client_model_ids: ['deepseek-v4-pro', 'qwen-3.7-max'],
         }],
         warnings: [],
@@ -259,7 +259,7 @@ test('US048 Jiajie saves facts previews priority and syncs one band account', as
           action: 'created',
           added_models: ['deepseek-v4-pro', 'qwen-3.7-max'],
           removed_models: [],
-          priority_after: 103,
+          priority_after: 130,
           schedulable_after: true,
         }],
       })
@@ -312,7 +312,7 @@ test('US048 Jiajie saves facts previews priority and syncs one band account', as
   await page.locator('[data-test="priority-preview-button"]').click()
   const preview = page.locator('[data-test="priority-preview"]')
   await expect(preview).toContainText('佳杰/first-batch-lowest-ratio')
-  await expect(preview).toContainText('103')
+  await expect(preview).toContainText('130')
   await expect(preview).toContainText('deepseek-v4-pro, qwen-3.7-max')
 
   await page.locator('[data-test="notes"]').fill('尚未保存的运营修改')
@@ -328,7 +328,7 @@ test('US048 Jiajie saves facts previews priority and syncs one band account', as
   await expect(result).toContainText('deepseek-v4-pro → deepseek-v4-pro')
   await expect(result).toContainText('qwen-3.7-max → qwen-3.7-max')
   await expect(result).toContainText('#101 · created · band 3')
-  await expect(result).toContainText('priority — → 103')
+  await expect(result).toContainText('priority — → 130')
   expect(syncRequests).toBe(1)
   await expect(page.getByRole('button', { name: /激活|暂停/ })).toHaveCount(0)
 })
@@ -401,7 +401,7 @@ test('US048 accounts UI marks supplier-managed accounts and allows ordinary edit
           channel_type: 1,
           status: 'active',
           schedulable: true,
-          priority: 103,
+          priority: 130,
           concurrency: 1,
           group_ids: [],
           supported_protocols: ['chat_completions'],

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -381,7 +381,7 @@ describe('EditAccountModal', () => {
     const account = {
       ...buildAccount(),
       extra: { supplier_source_id: '7' },
-      priority: 103,
+      priority: 130,
       group_ids: []
     }
     const wrapper = mountModal(account)

--- a/frontend/src/constants/supplierSource.tk.ts
+++ b/frontend/src/constants/supplierSource.tk.ts
@@ -1,0 +1,5 @@
+/**
+ * Supplier-source discount band → priority contribution step.
+ * Must match backend `service.SupplierDiscountPriorityStep`.
+ */
+export const SUPPLIER_DISCOUNT_PRIORITY_STEP = 10

--- a/frontend/src/views/admin/SupplierSourcesView.vue
+++ b/frontend/src/views/admin/SupplierSourcesView.vue
@@ -737,9 +737,11 @@ function discountBand(rawRatio: number | null): number {
   return 5
 }
 
+const DISCOUNT_PRIORITY_STEP = 10
+
 function modelPriority(ratio: number | null): number {
   const basePriority = Number.isFinite(Number(form.base_priority)) ? Number(form.base_priority) : 100
-  return basePriority + discountBand(ratio)
+  return basePriority + discountBand(ratio) * DISCOUNT_PRIORITY_STEP
 }
 
 function buildInput(): SupplierSourceInput {

--- a/frontend/src/views/admin/SupplierSourcesView.vue
+++ b/frontend/src/views/admin/SupplierSourcesView.vue
@@ -489,6 +489,7 @@ import {
 } from '@/api/admin'
 import { useNewApiChannelTypes } from '@/composables/useNewApiChannelTypes'
 import { isNewApiUpstreamFetchableChannelType } from '@/constants/newApiUpstreamFetchableChannelTypes'
+import { SUPPLIER_DISCOUNT_PRIORITY_STEP } from '@/constants/supplierSource.tk'
 
 const { t } = useI18n()
 const route = useRoute()
@@ -737,11 +738,9 @@ function discountBand(rawRatio: number | null): number {
   return 5
 }
 
-const DISCOUNT_PRIORITY_STEP = 10
-
 function modelPriority(ratio: number | null): number {
   const basePriority = Number.isFinite(Number(form.base_priority)) ? Number(form.base_priority) : 100
-  return basePriority + discountBand(ratio) * DISCOUNT_PRIORITY_STEP
+  return basePriority + discountBand(ratio) * SUPPLIER_DISCOUNT_PRIORITY_STEP
 }
 
 function buildInput(): SupplierSourceInput {

--- a/frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts
@@ -122,7 +122,7 @@ const managedAccount = {
   type: 'apikey',
   status: 'active',
   schedulable: true,
-  priority: 103,
+  priority: 130,
   concurrency: 1,
   group_ids: [],
   extra: { supplier_source_id: 7, supplier_discount_band: 3 },

--- a/frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts
+++ b/frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts
@@ -133,12 +133,12 @@ describe('SupplierSourcesView', () => {
     expect(wrapper.find('[data-test="sync-save-first"]').exists()).toBe(false)
   })
 
-  it('shows blank purchase ratio as band 6 and priority base plus 6', async () => {
+  it('shows blank purchase ratio as band 6 and priority base plus 60', async () => {
     const wrapper = mount(SupplierSourcesView)
     await flushPromises()
 
     expect(wrapper.get('[data-test="model-band-0"]').text()).toContain('6')
-    expect(wrapper.get('[data-test="model-priority-0"]').text()).toContain('106')
+    expect(wrapper.get('[data-test="model-priority-0"]').text()).toContain('160')
   })
 
   it('selects the supplier source requested by source_id after loading the list', async () => {
@@ -471,7 +471,7 @@ describe('SupplierSourcesView', () => {
       changes: [{
         account_id: 101, discount_band: 3, action: 'created',
         added_models: ['deepseek-v4-pro', 'qwen-3.7-max'], removed_models: [],
-        priority_after: 103, schedulable_after: true,
+        priority_after: 130, schedulable_after: true,
       }],
     })
     const wrapper = mount(SupplierSourcesView)


### PR DESCRIPTION
## 摘要
- 供应源六档 `discount_priority` 由 `1..6` 改为 `10/20/…/60`（相邻档位增量 10），账号 `priority = base_priority + discount_priority`。
- 同步 Admin 表单预览、审批基线 `docs/approved/model-supplier-source-management.md`、US-048 AC 与相关前后端断言。
- FE live priority 步进抽到 `supplierSource.tk.ts`；Go 测试从 Getwd 定位 monorepo root 钉齐（抗 CI `-trimpath`）。

## 风险
- 高风险：调度用账号 priority 语义与审批基线变更；已绑定 `docs/approved/model-supplier-source-management.md`。
- 已有受管账号需再跑「校验并同步」才会把 priority 收敛到新公式；未同步前仍保持旧数值。

## 验证
- `go test -tags=unit -count=1 ./internal/service/ -run 'TestUS048_DiscountPriorityStepMatchesFrontendConstant|TestUS048_SupplierPriorityIsBasePlusBandTimesStep'` 通过（含 `GOFLAGS=-trimpath`）
- `pnpm test:run src/views/admin/__tests__/SupplierSourcesView.spec.ts` 通过
- `./scripts/preflight.sh` 通过（rebase 后重跑）

## 提交
```
8682675bc fix(supplier): address R-001 — FE sync 测试用 Getwd 抗 trimpath
ad44f81b6 fix(supplier): address R-001 — FE step 与后端 SSOT 机械对齐
80ba336bf fix(supplier): address R-001..R-003 — preview 走统一 API，刷新 dist 戳
2a094dd41 fix(supplier): 供应源档位 discount_priority 相邻增量改为 10
```
- 最新提交：`8682675bc`

upstream-touch-trivial
sentinel-registry-reviewed