### PR TITLE
fix(newapi): 调度缓存下 OpenAI base_url 规范化避免合成 503

### DIFF
--- a/backend/internal/service/newapi_bridge_openai_base_url_test.go
+++ b/backend/internal/service/newapi_bridge_openai_base_url_test.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"testing"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+	newapitypes "github.com/QuantumNous/new-api/types"
+	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
+	"github.com/Wei-Shaw/sub2api/internal/relay/bridge"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOpenAIChannelBaseURL_SchedulerCacheMatchesFreshReload pins the vstecs
+// gateway 503 shape: scheduler Extra drops supplier_source_id, so plan-time and
+// execution-time bridge BaseURL normalization must not depend on that marker.
+func TestOpenAIChannelBaseURL_SchedulerCacheMatchesFreshReload(t *testing.T) {
+	base := "https://token.vstecscloud.com/v1"
+	model := "MiniMax-M2.7"
+	creds := map[string]any{
+		"base_url": base,
+		"api_key":  "sk-test",
+		"api_base_urls": map[string]any{
+			APIProtocolChatCompletions: base,
+		},
+		ProtocolEndpointsExclusiveCredentialKey: true,
+		"model_mapping": map[string]any{
+			"MiniMax-M2.7": "MiniMax-M2.7",
+		},
+	}
+
+	sched := &Account{
+		ID:          101,
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeOpenAI,
+		Credentials: creds,
+		Extra:       map[string]any{}, // mirrors scheduler cache filter
+	}
+	fresh := &Account{
+		ID:          101,
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeOpenAI,
+		Credentials: creds,
+		Extra:       map[string]any{SupplierSourceIDExtraKey: int64(6)},
+	}
+
+	require.False(t, IsSupplierManagedAccount(sched))
+	require.True(t, IsSupplierManagedAccount(fresh))
+
+	schedIn := newAPIBridgeChannelInputForModel(sched, 0, "", model).WithoutModelMapping()
+	freshIn := newAPIBridgeChannelInputForModel(fresh, 0, "", model).WithoutModelMapping()
+	require.Equal(t, freshIn.BaseURL, schedIn.BaseURL,
+		"scheduler-shaped account must normalize OpenAI base_url the same as a fresh managed reload")
+	require.Equal(t, "https://token.vstecscloud.com", schedIn.BaseURL)
+
+	schedEP, err := bridge.ResolveTextEndpoint(schedIn, newapitypes.RelayFormatOpenAI, model)
+	require.NoError(t, err)
+	freshEP, err := bridge.ResolveTextEndpoint(freshIn, newapitypes.RelayFormatOpenAI, model)
+	require.NoError(t, err)
+	require.Equal(t, freshEP, schedEP)
+	require.Equal(t, "https://token.vstecscloud.com/v1/chat/completions", schedEP)
+	require.NotContains(t, schedEP, "/v1/v1/")
+
+	schedExact, err := protocolExactEndpoint(sched, protocolrouter.ProtocolChatCompletions, model)
+	require.NoError(t, err)
+	freshExact, err := protocolExactEndpoint(fresh, protocolrouter.ProtocolChatCompletions, model)
+	require.NoError(t, err)
+	require.Equal(t, freshExact, schedExact)
+	require.Equal(t, schedEP, schedExact)
+}

--- a/backend/internal/service/newapi_bridge_openai_base_url_test.go
+++ b/backend/internal/service/newapi_bridge_openai_base_url_test.go
@@ -12,7 +12,8 @@ import (
 
 // TestOpenAIChannelBaseURL_SchedulerCacheMatchesFreshReload pins the vstecs
 // gateway 503 shape: scheduler Extra drops supplier_source_id, so plan-time and
-// execution-time bridge BaseURL normalization must not depend on that marker.
+// execution-time bridge BaseURL normalization must use
+// HasSupplierManagedTransportIdentity (exclusive credential), not Extra alone.
 func TestOpenAIChannelBaseURL_SchedulerCacheMatchesFreshReload(t *testing.T) {
 	base := "https://token.vstecscloud.com/v1"
 	model := "MiniMax-M2.7"
@@ -47,8 +48,10 @@ func TestOpenAIChannelBaseURL_SchedulerCacheMatchesFreshReload(t *testing.T) {
 
 	require.False(t, IsSupplierManagedAccount(sched))
 	require.True(t, IsSupplierManagedAccount(fresh))
-	require.True(t, accountDeclaresExclusiveProtocolEndpoints(sched),
-		"exclusive credential must survive scheduler-shaped Extra filtering")
+	require.True(t, HasSupplierManagedTransportIdentity(sched))
+	require.True(t, HasSupplierManagedTransportIdentity(fresh))
+	require.True(t, shouldNormalizeNewAPIOpenAIChannelBaseURL(sched))
+	require.True(t, shouldNormalizeNewAPIOpenAIChannelBaseURL(fresh))
 
 	schedIn := newAPIBridgeChannelInputForModel(sched, 0, "", model).WithoutModelMapping()
 	freshIn := newAPIBridgeChannelInputForModel(fresh, 0, "", model).WithoutModelMapping()

--- a/backend/internal/service/newapi_bridge_openai_base_url_test.go
+++ b/backend/internal/service/newapi_bridge_openai_base_url_test.go
@@ -47,11 +47,13 @@ func TestOpenAIChannelBaseURL_SchedulerCacheMatchesFreshReload(t *testing.T) {
 
 	require.False(t, IsSupplierManagedAccount(sched))
 	require.True(t, IsSupplierManagedAccount(fresh))
+	require.True(t, accountDeclaresExclusiveProtocolEndpoints(sched),
+		"exclusive credential must survive scheduler-shaped Extra filtering")
 
 	schedIn := newAPIBridgeChannelInputForModel(sched, 0, "", model).WithoutModelMapping()
 	freshIn := newAPIBridgeChannelInputForModel(fresh, 0, "", model).WithoutModelMapping()
 	require.Equal(t, freshIn.BaseURL, schedIn.BaseURL,
-		"scheduler-shaped account must normalize OpenAI base_url the same as a fresh managed reload")
+		"scheduler-shaped exclusive account must normalize OpenAI base_url the same as a fresh managed reload")
 	require.Equal(t, "https://token.vstecscloud.com", schedIn.BaseURL)
 
 	schedEP, err := bridge.ResolveTextEndpoint(schedIn, newapitypes.RelayFormatOpenAI, model)

--- a/backend/internal/service/newapi_bridge_usage.go
+++ b/backend/internal/service/newapi_bridge_usage.go
@@ -77,16 +77,7 @@ func newAPIBridgeChannelInputForModel(account *Account, userID int64, groupLabel
 	}
 	baseURL := strings.TrimSpace(account.GetBaseURL())
 	baseURL = newapiintegration.NormalizeArkChannelBaseURL(account.ChannelType, baseURL)
-	// Trailing-/v1 strip for OpenAI channel adaptors. Prefer Extra.supplier_source_id
-	// when present, but also accept credentials.protocol_endpoints_exclusive — the
-	// marker scheduler cache keeps after intentionally dropping supplier Extra
-	// ("identity uses account credentials only"). Gating only on
-	// IsSupplierManagedAccount made plan-time ResolveTextEndpoint emit
-	// .../v1/v1/chat/completions while execution-time reload emitted
-	// .../v1/chat/completions → protocol_execution_stale → client 503. Ordinary
-	// OpenAI NewAPI accounts without exclusive keep their stored base URL.
-	if account.ChannelType == newapiconstant.ChannelTypeOpenAI &&
-		(IsSupplierManagedAccount(account) || accountDeclaresExclusiveProtocolEndpoints(account)) {
+	if shouldNormalizeNewAPIOpenAIChannelBaseURL(account) {
 		baseURL = normalizeNewAPIOpenAIChannelBaseURL(baseURL)
 	}
 	// Fifth platform `newapi`: OpenAI base URL fallback does not apply; credentials.base_url is required at create time.
@@ -134,6 +125,16 @@ func newAPIBridgeChannelInputForModel(account *Account, userID int64, groupLabel
 		VertexKeyType:         vertexKeyType,
 		VertexLocation:        vertexLocation,
 	}
+}
+
+// shouldNormalizeNewAPIOpenAIChannelBaseURL is the SSOT gate for stripping a
+// trailing /v1 before OpenAI-channel adaptors (they append /v1/... themselves).
+// Uses HasSupplierManagedTransportIdentity so scheduler-cache-shaped accounts
+// (no Extra.supplier_source_id) still match execution-time reloads.
+func shouldNormalizeNewAPIOpenAIChannelBaseURL(account *Account) bool {
+	return account != nil &&
+		account.ChannelType == newapiconstant.ChannelTypeOpenAI &&
+		HasSupplierManagedTransportIdentity(account)
 }
 
 func normalizeNewAPIOpenAIChannelBaseURL(baseURL string) string {

--- a/backend/internal/service/newapi_bridge_usage.go
+++ b/backend/internal/service/newapi_bridge_usage.go
@@ -77,14 +77,16 @@ func newAPIBridgeChannelInputForModel(account *Account, userID int64, groupLabel
 	}
 	baseURL := strings.TrimSpace(account.GetBaseURL())
 	baseURL = newapiintegration.NormalizeArkChannelBaseURL(account.ChannelType, baseURL)
-	// OpenAI channel adaptors append /v1/... themselves. Strip a trailing /v1
-	// from credentials.base_url for every OpenAI channel — not only when
-	// Extra.supplier_source_id is present. Scheduler cache intentionally omits
-	// that Extra key ("identity uses account credentials only"), so gating on
+	// Trailing-/v1 strip for OpenAI channel adaptors. Prefer Extra.supplier_source_id
+	// when present, but also accept credentials.protocol_endpoints_exclusive — the
+	// marker scheduler cache keeps after intentionally dropping supplier Extra
+	// ("identity uses account credentials only"). Gating only on
 	// IsSupplierManagedAccount made plan-time ResolveTextEndpoint emit
-	// .../v1/v1/chat/completions while execution-time reload (full Extra) emitted
-	// .../v1/chat/completions → protocol_execution_stale → client 503.
-	if account.ChannelType == newapiconstant.ChannelTypeOpenAI {
+	// .../v1/v1/chat/completions while execution-time reload emitted
+	// .../v1/chat/completions → protocol_execution_stale → client 503. Ordinary
+	// OpenAI NewAPI accounts without exclusive keep their stored base URL.
+	if account.ChannelType == newapiconstant.ChannelTypeOpenAI &&
+		(IsSupplierManagedAccount(account) || accountDeclaresExclusiveProtocolEndpoints(account)) {
 		baseURL = normalizeNewAPIOpenAIChannelBaseURL(baseURL)
 	}
 	// Fifth platform `newapi`: OpenAI base URL fallback does not apply; credentials.base_url is required at create time.

--- a/backend/internal/service/newapi_bridge_usage.go
+++ b/backend/internal/service/newapi_bridge_usage.go
@@ -77,7 +77,14 @@ func newAPIBridgeChannelInputForModel(account *Account, userID int64, groupLabel
 	}
 	baseURL := strings.TrimSpace(account.GetBaseURL())
 	baseURL = newapiintegration.NormalizeArkChannelBaseURL(account.ChannelType, baseURL)
-	if account.ChannelType == newapiconstant.ChannelTypeOpenAI && IsSupplierManagedAccount(account) {
+	// OpenAI channel adaptors append /v1/... themselves. Strip a trailing /v1
+	// from credentials.base_url for every OpenAI channel — not only when
+	// Extra.supplier_source_id is present. Scheduler cache intentionally omits
+	// that Extra key ("identity uses account credentials only"), so gating on
+	// IsSupplierManagedAccount made plan-time ResolveTextEndpoint emit
+	// .../v1/v1/chat/completions while execution-time reload (full Extra) emitted
+	// .../v1/chat/completions → protocol_execution_stale → client 503.
+	if account.ChannelType == newapiconstant.ChannelTypeOpenAI {
 		baseURL = normalizeNewAPIOpenAIChannelBaseURL(baseURL)
 	}
 	// Fifth platform `newapi`: OpenAI base URL fallback does not apply; credentials.base_url is required at create time.

--- a/backend/internal/service/supplier_managed_account_guard.go
+++ b/backend/internal/service/supplier_managed_account_guard.go
@@ -49,7 +49,6 @@ func ValidateSupplierReservedAccountExtra(extra map[string]any) error {
 	return nil
 }
 
-
 // StripSupplierReservedAccountExtra removes reserved ownership keys from an
 // incoming Extra map so ordinary edits can echo Extra without forging.
 func StripSupplierReservedAccountExtra(extra map[string]any) map[string]any {

--- a/backend/internal/service/supplier_managed_account_guard.go
+++ b/backend/internal/service/supplier_managed_account_guard.go
@@ -7,12 +7,30 @@ import (
 // IsSupplierManagedAccount reports whether Extra carries the supplier_source_id
 // marker used by supplier-source sync and admin UI badges. Presence alone is
 // enough (fail closed on malformed values).
+//
+// Do NOT use this alone on gateway/scheduler hot paths: scheduler Extra
+// intentionally omits supplier_source_id. Prefer
+// HasSupplierManagedTransportIdentity for transport exceptions that must also
+// work on scheduler-cache-shaped accounts.
 func IsSupplierManagedAccount(account *Account) bool {
 	if account == nil || account.Extra == nil {
 		return false
 	}
 	_, exists := account.Extra[SupplierSourceIDExtraKey]
 	return exists
+}
+
+// HasSupplierManagedTransportIdentity is the SSOT for supplier-managed
+// transport exceptions on gateway/scheduler hot paths.
+//
+// Primary signal: credentials.protocol_endpoints_exclusive (kept by scheduler
+// cache; identity uses account credentials, not Extra.supplier_source_id).
+// Fallback: Extra.supplier_source_id on full DB-loaded accounts.
+func HasSupplierManagedTransportIdentity(account *Account) bool {
+	if accountDeclaresExclusiveProtocolEndpoints(account) {
+		return true
+	}
+	return IsSupplierManagedAccount(account)
 }
 
 // ValidateSupplierReservedAccountExtra rejects forging supplier ownership keys
@@ -30,6 +48,7 @@ func ValidateSupplierReservedAccountExtra(extra map[string]any) error {
 	}
 	return nil
 }
+
 
 // StripSupplierReservedAccountExtra removes reserved ownership keys from an
 // incoming Extra map so ordinary edits can echo Extra without forging.

--- a/backend/internal/service/supplier_managed_account_guard_test.go
+++ b/backend/internal/service/supplier_managed_account_guard_test.go
@@ -14,6 +14,30 @@ func TestUS048_ManagedAccountUsesSupplierSourceIDAsOnlyMarker(t *testing.T) {
 	require.False(t, IsSupplierManagedAccount(&Account{}))
 }
 
+func TestHasSupplierManagedTransportIdentity_SchedulerSafeSSOT(t *testing.T) {
+	exclusiveOnly := &Account{
+		Credentials: map[string]any{ProtocolEndpointsExclusiveCredentialKey: true},
+	}
+	extraOnly := &Account{
+		Extra: map[string]any{SupplierSourceIDExtraKey: int64(7)},
+	}
+	neither := &Account{}
+	both := &Account{
+		Credentials: map[string]any{ProtocolEndpointsExclusiveCredentialKey: true},
+		Extra:       map[string]any{SupplierSourceIDExtraKey: int64(7)},
+	}
+
+	require.True(t, HasSupplierManagedTransportIdentity(exclusiveOnly),
+		"exclusive credential alone must light the hot-path transport identity (scheduler Extra omits supplier_source_id)")
+	require.False(t, IsSupplierManagedAccount(exclusiveOnly))
+	require.True(t, HasSupplierManagedTransportIdentity(extraOnly),
+		"full DB loads with Extra.supplier_source_id remain recognized")
+	require.False(t, accountDeclaresExclusiveProtocolEndpoints(extraOnly))
+	require.False(t, HasSupplierManagedTransportIdentity(neither))
+	require.True(t, HasSupplierManagedTransportIdentity(both))
+	require.False(t, HasSupplierManagedTransportIdentity(nil))
+}
+
 func TestUS048_OrdinaryCreateRejectsSupplierReservedExtra(t *testing.T) {
 	for _, key := range []string{SupplierSourceIDExtraKey, SupplierDiscountBandExtraKey} {
 		err := ValidateSupplierReservedAccountExtra(map[string]any{key: 7})

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7547,12 +7547,33 @@
       "rationale": "Probe regressions pin in-memory execution, the managed identity's single Chat capability, supplier-only trailing-/v1 normalization, raw-upstream log redaction, fixed public result details, and non-Chat failure closure without persisting an account or upstream response body."
     },
     {
+      "path": "backend/internal/service/supplier_managed_account_guard.go",
+      "must_contain": [
+        "func HasSupplierManagedTransportIdentity(account *Account) bool",
+        "accountDeclaresExclusiveProtocolEndpoints(account)",
+        "Do NOT use this alone on gateway/scheduler hot paths"
+      ],
+      "rationale": "SSOT for supplier transport exceptions on hot paths: credentials.protocol_endpoints_exclusive survives scheduler Extra filtering; Extra.supplier_source_id does not. Call sites must not re-invent IsSupplierManagedAccount || exclusive inline."
+    },
+    {
       "path": "backend/internal/service/newapi_bridge_usage.go",
       "must_contain": [
-        "IsSupplierManagedAccount(account) || accountDeclaresExclusiveProtocolEndpoints(account)",
+        "shouldNormalizeNewAPIOpenAIChannelBaseURL(account)",
+        "HasSupplierManagedTransportIdentity(account)",
         "baseURL = normalizeNewAPIOpenAIChannelBaseURL(baseURL)"
       ],
-      "rationale": "Trailing-/v1 normalization stays a supplier-transport exception, but the gate must also accept credentials.protocol_endpoints_exclusive. Scheduler cache drops Extra.supplier_source_id by design; exclusive is the credential-side ownership signal that keeps plan-time and execution-time ResolveTextEndpoint URLs identical. Ordinary unmanaged OpenAI NewAPI accounts without exclusive keep their stored base URL."
+      "must_not_contain": [
+        "IsSupplierManagedAccount(account) || accountDeclaresExclusiveProtocolEndpoints(account)"
+      ],
+      "rationale": "Trailing-/v1 normalization must go through shouldNormalizeNewAPIOpenAIChannelBaseURL → HasSupplierManagedTransportIdentity so plan-time scheduler accounts and execution-time reloads agree. Ordinary unmanaged OpenAI NewAPI accounts without exclusive keep their stored base URL."
+    },
+    {
+      "path": "backend/internal/service/supplier_managed_account_guard_test.go",
+      "must_contain": [
+        "TestHasSupplierManagedTransportIdentity_SchedulerSafeSSOT",
+        "exclusive credential alone must light the hot-path transport identity"
+      ],
+      "rationale": "Pins the SSOT matrix: exclusive-only (scheduler-shaped), Extra-only (full DB load), neither, and both."
     },
     {
       "path": "backend/internal/service/newapi_bridge_usage_test.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7549,10 +7549,10 @@
     {
       "path": "backend/internal/service/newapi_bridge_usage.go",
       "must_contain": [
-        "if account.ChannelType == newapiconstant.ChannelTypeOpenAI && IsSupplierManagedAccount(account) {",
+        "IsSupplierManagedAccount(account) || accountDeclaresExclusiveProtocolEndpoints(account)",
         "baseURL = normalizeNewAPIOpenAIChannelBaseURL(baseURL)"
       ],
-      "rationale": "Trailing-/v1 normalization is a supplier-managed transport exception, not a global NewAPI OpenAI behavior change. The supplier_source_id ownership marker must remain part of the condition so ordinary accounts keep their stored base URL untouched."
+      "rationale": "Trailing-/v1 normalization stays a supplier-transport exception, but the gate must also accept credentials.protocol_endpoints_exclusive. Scheduler cache drops Extra.supplier_source_id by design; exclusive is the credential-side ownership signal that keeps plan-time and execution-time ResolveTextEndpoint URLs identical. Ordinary unmanaged OpenAI NewAPI accounts without exclusive keep their stored base URL."
     },
     {
       "path": "backend/internal/service/newapi_bridge_usage_test.go",


### PR DESCRIPTION
## 摘要
- 根因：调度缓存故意省略 `Extra.supplier_source_id`，但 OpenAI channel 尾部 `/v1` 规范化只看 `IsSupplierManagedAccount` → plan/执行期 URL 不一致 → `protocol_execution_stale` 合成 503。
- 全库盘点：`IsSupplierManagedAccount` 其余调用均为 admin/sync/投影（DB 全量账号），**无第二处同类热路径 bug**。
- SSOT：新增 `HasSupplierManagedTransportIdentity`（`protocol_endpoints_exclusive` 优先，`supplier_source_id` 兜底）；`shouldNormalizeNewAPIOpenAIChannelBaseURL` 统一门控；sentinel 锁住调用形状。

## 风险
- 常规风险：仅 newapi OpenAI channel bridge BaseURL 规范化；公共 API 不变。
- 非受管、无 exclusive 账号仍保持原 base_url（US-048 负向测试保留）。

## 验证
- `go test -tags=unit -run 'TestHasSupplierManagedTransportIdentity_SchedulerSafeSSOT|TestOpenAIChannelBaseURL_SchedulerCacheMatchesFreshReload|TestUS048_UnmanagedNewAPIOpenAIBaseURLRemainsUntouched' ./internal/service/` — PASS
- `python3 scripts/sentinels/check-gateway-tk.py` — PASS (809/809)
- `./scripts/preflight.sh` — PASS

## 提交
```
fc90bde8e style: gofmt supplier_managed_account_guard
0d31777d5 fix(newapi): 供应源热路径门控收敛到 HasSupplierManagedTransportIdentity
361c9f5fa fix(newapi): 用 exclusive 凭证对齐 OpenAI base_url 规范化
c3d571246 fix(newapi): OpenAI channel base_url 规范化不依赖 supplier Extra
```
- 最新提交：`fc90bde8e`