### PR TITLE
fix(gateway): 修复 Kiro 镜像兼容入口空密钥 502

### DIFF
--- a/backend/internal/service/account_supported_protocols.go
+++ b/backend/internal/service/account_supported_protocols.go
@@ -162,11 +162,14 @@ func SeedOfficialSupportedProtocols(account *Account) bool {
 }
 
 // routingSupportedProtocols is the Plan() view of capability.supported_protocols.
-// Prod OpenAI edge-mirror stubs (api-*.tokenkey.dev) accept /v1/messages as
-// TokenKey ingress and convert simple probes, but the next hop's OpenAI OAuth
-// pool only speaks responses. Treating probe-positive messages as identity
-// dumps Claude Code bodies onto the edge, which then fail-closes to 503/502.
+// Kiro mirror stubs expose only their native Messages hop; public ingress
+// compatibility is handled by protocol conversion before prod calls edge.
+// OpenAI mirror stubs similarly hide their compatibility-only Messages ingress.
+// The stored capability remains untouched as probe evidence.
 func routingSupportedProtocols(account *Account) []protocolrouter.Protocol {
+	if account.IsKiroMirrorStub() {
+		return []protocolrouter.Protocol{protocolrouter.ProtocolMessages}
+	}
 	protocols := account.SupportedProtocols()
 	if !tkIsOpenAIEdgeMirrorStub(account) {
 		return protocols

--- a/backend/internal/service/account_supported_protocols_test.go
+++ b/backend/internal/service/account_supported_protocols_test.go
@@ -882,3 +882,30 @@ func TestRoutingSupportedProtocolsStripsMessagesOnOpenAIEdgeMirror(t *testing.T)
 		t.Fatalf("messages-only stub fallback = %v, want messages kept", got)
 	}
 }
+
+func TestRoutingSupportedProtocolsClampsKiroMirrorToMessages(t *testing.T) {
+	stub := &Account{
+		ID:       66,
+		Name:     "kiro-us6",
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":         "secret",
+			"base_url":        "https://api-us6.tokenkey.dev",
+			"mirror_platform": PlatformKiro,
+		},
+	}
+	stored := []protocolrouter.Protocol{
+		protocolrouter.ProtocolMessages,
+		protocolrouter.ProtocolChatCompletions,
+		protocolrouter.ProtocolResponses,
+	}
+	attachTestProtocolCapability(stub, stored...)
+
+	if got, want := routingSupportedProtocols(stub), []protocolrouter.Protocol{protocolrouter.ProtocolMessages}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("routingSupportedProtocols(Kiro stub) = %v, want %v", got, want)
+	}
+	if got := stub.SupportedProtocols(); !reflect.DeepEqual(got, stored) {
+		t.Fatalf("capability owner list was rewritten: %v", got)
+	}
+}

--- a/backend/internal/service/openai_gateway_chat_completions_anthropic_native.go
+++ b/backend/internal/service/openai_gateway_chat_completions_anthropic_native.go
@@ -97,7 +97,7 @@ func (s *OpenAIGatewayService) forwardChatCompletionsViaNativeAnthropic(
 	anthropicBody = FilterWebSearchHistoryBlocks(anthropicBody, upstreamModel)
 	anthropicBody = enforceCacheControlLimit(anthropicBody)
 
-	apiKey := strings.TrimSpace(account.GetOpenAIProtocolAPIKey())
+	apiKey := nativeAnthropicAPIKeyForAccount(account)
 	if apiKey == "" {
 		return nil, fmt.Errorf("account %d missing api_key", account.ID)
 	}

--- a/backend/internal/service/openai_gateway_messages_anthropic_native_tk.go
+++ b/backend/internal/service/openai_gateway_messages_anthropic_native_tk.go
@@ -76,7 +76,7 @@ func (s *OpenAIGatewayService) forwardAnthropicViaNativeAnthropicEndpoint(
 	logger.LegacyPrintf("service.gateway", "[CN Anthropic 直通] account=%d(%s) platform=%s model=%s upstream=%s stream=%v",
 		account.ID, account.Name, account.Platform, originalModel, upstreamModel, clientStream)
 
-	apiKey := strings.TrimSpace(account.GetOpenAIProtocolAPIKey())
+	apiKey := nativeAnthropicAPIKeyForAccount(account)
 	if apiKey == "" {
 		return nil, fmt.Errorf("account %d missing api_key", account.ID)
 	}
@@ -119,6 +119,17 @@ func (s *OpenAIGatewayService) forwardAnthropicViaNativeAnthropicEndpoint(
 		return s.handleNativeAnthropicStreamingResponse(ctx, resp, c, account, originalModel, billingModel, upstreamModel, reasoningEffort, startTime)
 	}
 	return s.handleNativeAnthropicBufferedResponse(ctx, resp, c, account, originalModel, billingModel, upstreamModel, reasoningEffort, startTime)
+}
+
+// nativeAnthropicAPIKeyForAccount returns the credential for a request whose
+// selected wire protocol is Anthropic Messages. The selected protocol, not the
+// account's platform label, owns this choice: edge mirror stubs remain
+// platform=anthropic while OpenAI-compatible ingress reaches this transport.
+func nativeAnthropicAPIKeyForAccount(account *Account) string {
+	if account == nil || account.Type != AccountTypeAPIKey {
+		return ""
+	}
+	return strings.TrimSpace(account.GetCredential("api_key"))
 }
 
 // nativeAnthropicTargetURL 组装国产供应商原生 Anthropic messages 端点。

--- a/backend/internal/service/openai_gateway_messages_anthropic_native_tk.go
+++ b/backend/internal/service/openai_gateway_messages_anthropic_native_tk.go
@@ -129,7 +129,7 @@ func nativeAnthropicAPIKeyForAccount(account *Account) string {
 	if account == nil || account.Type != AccountTypeAPIKey {
 		return ""
 	}
-	return strings.TrimSpace(account.GetCredential("api_key"))
+	return strings.TrimSpace(protocolAuthorizationToken(account))
 }
 
 // nativeAnthropicTargetURL 组装国产供应商原生 Anthropic messages 端点。

--- a/backend/internal/service/openai_gateway_responses_anthropic_native.go
+++ b/backend/internal/service/openai_gateway_responses_anthropic_native.go
@@ -102,7 +102,7 @@ func (s *OpenAIGatewayService) forwardResponsesViaNativeAnthropic(
 	anthropicBody = FilterWebSearchHistoryBlocks(anthropicBody, upstreamModel)
 	anthropicBody = enforceCacheControlLimit(anthropicBody)
 
-	apiKey := strings.TrimSpace(account.GetOpenAIProtocolAPIKey())
+	apiKey := nativeAnthropicAPIKeyForAccount(account)
 	if apiKey == "" {
 		return nil, fmt.Errorf("account %d missing api_key", account.ID)
 	}

--- a/backend/internal/service/protocol_capability_probe.go
+++ b/backend/internal/service/protocol_capability_probe.go
@@ -528,6 +528,9 @@ func ProtocolProbeCandidates(account *Account) []protocolrouter.Protocol {
 	if !protocolRoutingGovernsAccount(account) || len(officialSupportedProtocols(account)) > 0 {
 		return nil
 	}
+	if account.IsKiroMirrorStub() {
+		return []protocolrouter.Protocol{protocolrouter.ProtocolMessages}
+	}
 	if protocolGeminiEndpointProfile(account).Valid() {
 		return []protocolrouter.Protocol{protocolrouter.ProtocolGeminiGenerateContent}
 	}

--- a/backend/internal/service/protocol_capability_probe_test.go
+++ b/backend/internal/service/protocol_capability_probe_test.go
@@ -726,6 +726,13 @@ func TestProtocolProbeCandidatesCoverGovernedCustomAccountsOnly(t *testing.T) {
 			},
 		},
 		{
+			name: "kiro edge mirror probes only its native messages hop",
+			account: &Account{Platform: PlatformAnthropic, Type: AccountTypeAPIKey, Credentials: map[string]any{
+				"api_key": "secret", "base_url": "https://api-us6.tokenkey.dev", "mirror_platform": PlatformKiro,
+			}},
+			want: []protocolrouter.Protocol{protocolrouter.ProtocolMessages},
+		},
+		{
 			name: "antigravity edge relay probes its configurable text endpoints",
 			account: &Account{Platform: PlatformAntigravity, Type: AccountTypeAPIKey, Credentials: map[string]any{
 				"api_key": "secret", "base_url": "https://api-us3.tokenkey.dev",

--- a/backend/internal/service/protocol_execution_target_test.go
+++ b/backend/internal/service/protocol_execution_target_test.go
@@ -407,6 +407,42 @@ func TestProtocolMessagesIdentityUsesNativeAnthropicCredentialContractForCNAccou
 	}
 }
 
+func TestProtocolChatToMessagesUsesNativeAnthropicCredentialForKiroMirror(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"claude-opus-4-8","messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	route := protocolRouteSpecByAdapter(t, protocolrouter.AdapterChatToMessages)
+	upstream := &protocolTargetHTTPUpstream{responses: []*http.Response{protocolRouteContractResponse(route)}}
+	svc := protocolTargetTestService(upstream)
+	account := protocolTargetTestAccount(protocolrouter.ProtocolMessages)
+	account.Name = "kiro-us6"
+	account.Platform = PlatformAnthropic
+	account.Credentials["model_mapping"] = map[string]any{"claude-opus-4-8": "claude-opus-4-8"}
+
+	_, err := protocolTargetTestExecution(t, protocolrouter.ProtocolChatCompletions, body, account, func(
+		executionCtx context.Context,
+		account *Account,
+		_ protocolrouter.Plan,
+		request protocolrouter.CanonicalRequest,
+	) (any, error) {
+		return svc.ForwardAsChatCompletions(executionCtx, c, account, request.Body(), "", "")
+	})
+	if err != nil {
+		t.Fatalf("ExecuteSelectedProtocol: %v", err)
+	}
+	if len(upstream.requests) != 1 {
+		t.Fatalf("upstream requests = %d, want 1", len(upstream.requests))
+	}
+	request := upstream.requests[0]
+	if got := request.Header.Get("x-api-key"); got != "sk-protocol-target" {
+		t.Fatalf("x-api-key = %q, want Kiro mirror credential", got)
+	}
+	if got := request.Header.Get("Authorization"); got != "" {
+		t.Fatalf("authorization = %q, want no OpenAI bearer credential", got)
+	}
+}
+
 func TestProtocolMessagesIdentityUsesNewAPIProtocolCredential(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	body := []byte(`{"model":"client-model","max_tokens":8,"messages":[{"role":"user","content":"hello"}],"stream":false}`)

--- a/backend/internal/service/protocol_execution_target_test.go
+++ b/backend/internal/service/protocol_execution_target_test.go
@@ -415,9 +415,14 @@ func TestProtocolChatToMessagesUsesNativeAnthropicCredentialForKiroMirror(t *tes
 	route := protocolRouteSpecByAdapter(t, protocolrouter.AdapterChatToMessages)
 	upstream := &protocolTargetHTTPUpstream{responses: []*http.Response{protocolRouteContractResponse(route)}}
 	svc := protocolTargetTestService(upstream)
-	account := protocolTargetTestAccount(protocolrouter.ProtocolMessages)
+	account := protocolTargetTestAccount(
+		protocolrouter.ProtocolMessages,
+		protocolrouter.ProtocolChatCompletions,
+		protocolrouter.ProtocolResponses,
+	)
 	account.Name = "kiro-us6"
 	account.Platform = PlatformAnthropic
+	account.Credentials["mirror_platform"] = PlatformKiro
 	account.Credentials["model_mapping"] = map[string]any{"claude-opus-4-8": "claude-opus-4-8"}
 
 	_, err := protocolTargetTestExecution(t, protocolrouter.ProtocolChatCompletions, body, account, func(
@@ -435,6 +440,9 @@ func TestProtocolChatToMessagesUsesNativeAnthropicCredentialForKiroMirror(t *tes
 		t.Fatalf("upstream requests = %d, want 1", len(upstream.requests))
 	}
 	request := upstream.requests[0]
+	if got, want := request.URL.String(), "http://upstream.example/v1/messages"; got != want {
+		t.Fatalf("upstream URL = %q, want Kiro native messages hop %q", got, want)
+	}
 	if got := request.Header.Get("x-api-key"); got != "sk-protocol-target" {
 		t.Fatalf("x-api-key = %q, want Kiro mirror credential", got)
 	}

--- a/backend/internal/service/protocol_execution_target_test.go
+++ b/backend/internal/service/protocol_execution_target_test.go
@@ -443,6 +443,51 @@ func TestProtocolChatToMessagesUsesNativeAnthropicCredentialForKiroMirror(t *tes
 	}
 }
 
+func TestNativeAnthropicAPIKeyForAccountUsesProtocolCredentialOwner(t *testing.T) {
+	tests := []struct {
+		name    string
+		account *Account
+		want    string
+	}{
+		{name: "nil account", account: nil, want: ""},
+		{
+			name: "anthropic api key",
+			account: &Account{
+				Platform:    PlatformAnthropic,
+				Type:        AccountTypeAPIKey,
+				Credentials: map[string]any{"api_key": "  sk-kiro  "},
+			},
+			want: "sk-kiro",
+		},
+		{
+			name: "oauth token is rejected",
+			account: &Account{
+				Platform:    PlatformAnthropic,
+				Type:        AccountTypeOAuth,
+				Credentials: map[string]any{"access_token": "oauth-token", "api_key": "stale-key"},
+			},
+			want: "",
+		},
+		{
+			name: "blank api key",
+			account: &Account{
+				Platform:    PlatformAnthropic,
+				Type:        AccountTypeAPIKey,
+				Credentials: map[string]any{"api_key": "   "},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nativeAnthropicAPIKeyForAccount(tt.account); got != tt.want {
+				t.Fatalf("nativeAnthropicAPIKeyForAccount() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestProtocolMessagesIdentityUsesNewAPIProtocolCredential(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	body := []byte(`{"model":"client-model","max_tokens":8,"messages":[{"role":"user","content":"hello"}],"stream":false}`)

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7234,6 +7234,7 @@
     {
       "path": "backend/internal/service/openai_gateway_chat_completions_anthropic_native.go",
       "must_contain": [
+        "apiKey := nativeAnthropicAPIKeyForAccount(account)",
         "if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), s.cfg); ok {",
         "if tkAnthropicBufferedEventCompletesMessage(&event) {",
         "streamCompleted = true\n\t\t\tbreak",
@@ -7246,6 +7247,7 @@
     {
       "path": "backend/internal/service/openai_gateway_responses_anthropic_native.go",
       "must_contain": [
+        "apiKey := nativeAnthropicAPIKeyForAccount(account)",
         "if parsed, ok := tkParseAnthropicBufferedSSEError([]byte(payload), s.cfg); ok {",
         "if tkAnthropicBufferedEventCompletesMessage(&event) {",
         "streamCompleted = true\n\t\t\tbreak",
@@ -7254,6 +7256,26 @@
         "tkAnthropicBufferedPartialFailure(c, account, requestID, upstreamErr)"
       ],
       "rationale": "Native-Anthropic Responses buffered path shares the same completion, failover-before-write, and partial-truncation contract, including idle timeout handling."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_messages_anthropic_native_tk.go",
+      "must_contain": [
+        "apiKey := nativeAnthropicAPIKeyForAccount(account)",
+        "func nativeAnthropicAPIKeyForAccount(account *Account) string {",
+        "account.Type != AccountTypeAPIKey",
+        "account.GetCredential(\"api_key\")"
+      ],
+      "rationale": "Single credential owner for every native Anthropic Messages transport reached through the OpenAI-compatible protocol router. The selected wire protocol owns the credential shape; platform=anthropic Kiro mirror stubs must read their API-key credential instead of passing through the OpenAI-platform getter and failing locally before HTTP dispatch."
+    },
+    {
+      "path": "backend/internal/service/protocol_execution_target_test.go",
+      "must_contain": [
+        "func TestProtocolChatToMessagesUsesNativeAnthropicCredentialForKiroMirror(",
+        "account.Name = \"kiro-us6\"",
+        "account.Platform = PlatformAnthropic",
+        "x-api-key = %q, want Kiro mirror credential"
+      ],
+      "rationale": "Incident-shaped regression for default/composite OpenAI Chat Completions routing to a platform=anthropic Kiro API-key mirror. It must issue exactly one Messages request with x-api-key and no OpenAI Authorization bearer header."
     },
     {
       "path": "backend/internal/handler/gateway_anthropic_buffered_failover_tk_test.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7263,9 +7263,9 @@
         "apiKey := nativeAnthropicAPIKeyForAccount(account)",
         "func nativeAnthropicAPIKeyForAccount(account *Account) string {",
         "account.Type != AccountTypeAPIKey",
-        "account.GetCredential(\"api_key\")"
+        "protocolAuthorizationToken(account)"
       ],
-      "rationale": "Single credential owner for every native Anthropic Messages transport reached through the OpenAI-compatible protocol router. The selected wire protocol owns the credential shape; platform=anthropic Kiro mirror stubs must read their API-key credential instead of passing through the OpenAI-platform getter and failing locally before HTTP dispatch."
+      "rationale": "Native Anthropic Messages transports reached through the OpenAI-compatible protocol router enforce their API-key-only boundary, then delegate credential binding to protocolAuthorizationToken, the shared protocol-routing owner. The selected wire protocol owns the credential shape; platform=anthropic Kiro mirror stubs must not pass through the OpenAI-platform getter and fail locally before HTTP dispatch."
     },
     {
       "path": "backend/internal/service/protocol_execution_target_test.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7273,9 +7273,48 @@
         "func TestProtocolChatToMessagesUsesNativeAnthropicCredentialForKiroMirror(",
         "account.Name = \"kiro-us6\"",
         "account.Platform = PlatformAnthropic",
+        "account.Credentials[\"mirror_platform\"] = PlatformKiro",
+        "http://upstream.example/v1/messages",
         "x-api-key = %q, want Kiro mirror credential"
       ],
-      "rationale": "Incident-shaped regression for default/composite OpenAI Chat Completions routing to a platform=anthropic Kiro API-key mirror. It must issue exactly one Messages request with x-api-key and no OpenAI Authorization bearer header."
+      "rationale": "Incident-shaped regression for default/composite OpenAI Chat Completions routing to a mirror_platform=kiro Anthropic API-key stub whose stored evidence also claims Chat and Responses. Planning must still convert to exactly one edge /v1/messages request with x-api-key and no OpenAI Authorization bearer header."
+    },
+    {
+      "path": "backend/internal/service/account_supported_protocols.go",
+      "must_contain": [
+        "func routingSupportedProtocols(account *Account) []protocolrouter.Protocol {",
+        "if account.IsKiroMirrorStub() {",
+        "return []protocolrouter.Protocol{protocolrouter.ProtocolMessages}"
+      ],
+      "rationale": "The Plan-facing protocol projection is the execution SSOT for Kiro mirror stubs. Stored probe evidence may include compatibility endpoints, but mirror_platform=kiro must expose only native Messages so Chat/Responses ingress converts before the prod-to-edge hop."
+    },
+    {
+      "path": "backend/internal/service/account_supported_protocols_test.go",
+      "must_contain": [
+        "func TestRoutingSupportedProtocolsClampsKiroMirrorToMessages(",
+        "protocolrouter.ProtocolChatCompletions",
+        "protocolrouter.ProtocolResponses",
+        "capability owner list was rewritten"
+      ],
+      "rationale": "Regression pins the separation between stored protocol evidence and the effective Kiro execution projection: stale or probe-positive Chat/Responses remain observable but cannot become planner targets."
+    },
+    {
+      "path": "backend/internal/service/protocol_capability_probe.go",
+      "must_contain": [
+        "func ProtocolProbeCandidates(account *Account) []protocolrouter.Protocol {",
+        "if account.IsKiroMirrorStub() {",
+        "return []protocolrouter.Protocol{protocolrouter.ProtocolMessages}"
+      ],
+      "rationale": "Generic endpoint discovery must not promote edge Chat/Responses compatibility ingress into native Kiro execution capability. Kiro mirror probing is restricted to the prod-to-edge Messages hop."
+    },
+    {
+      "path": "backend/internal/service/protocol_capability_probe_test.go",
+      "must_contain": [
+        "kiro edge mirror probes only its native messages hop",
+        "\"mirror_platform\": PlatformKiro",
+        "want: []protocolrouter.Protocol{protocolrouter.ProtocolMessages}"
+      ],
+      "rationale": "Regression pins the Kiro probe candidate set to Messages even though the edge gateway also accepts selected compatibility endpoints."
     },
     {
       "path": "backend/internal/handler/gateway_anthropic_buffered_failover_tk_test.go",


### PR DESCRIPTION
## 摘要

- 修复默认组通过 OpenAI 兼容 `/v1/chat/completions` 调度到 Anthropic/Kiro 镜像时，在发起上游 HTTP 请求前因空 API key 返回 502 的问题。
- 根因是 Kiro mirror stub 的兼容入口被当成原生 Chat 能力，计划选择 `ChatIdentity`；随后 OpenAI 凭据读取无法从 `platform=anthropic` 账号取得 key。
- 不新增 `execution_profile` 或第二套协议实体：沿用 `credentials.mirror_platform=kiro` 作为 Kiro mirror 判别，Plan-facing 协议固定投影为 `messages`，Chat/Responses 公网入口在 prod 内转换后再通过 edge `/v1/messages` 执行。
- 通用协议探测对 Kiro mirror 也只探测 Messages，避免 edge 的兼容入口再次污染原生执行能力；数据库中已有能力证据不需要迁移，运行时会确定性夹紧。
- Native Anthropic transport 统一按已选 wire protocol 读取 API Key，并复用 `protocolAuthorizationToken()` 凭据 SSOT。
- 增加事故形状回归测试和 gateway sentinel，覆盖能力记录残留 `messages/chat/responses` 时仍必须走 `/v1/messages`、`x-api-key` 且不能发送 OpenAI Bearer。

Web impact: none

## 风险

- 改动收敛 Kiro mirror stub 的有效执行协议；普通 Anthropic、OpenAI、新 API 账号及 edge Kiro OAuth 真账号不改变。
- 不新增 schema、配置项或维护实体，不修改已存 `supported_protocols`；回滚只需回滚代码。
- 当前线上只保留 Messages 的热修与本实现方向一致；本 PR 尚未部署，也未执行任何线上配置、数据或服务操作。

## 验证

- `go test -tags=unit ./internal/service -run 'Test(RoutingSupportedProtocols|ProtocolProbeCandidates|ProtocolChatToMessages)' -count=1`：通过
- `go test -tags=unit ./internal/service -count=1`：通过
- `python3 ./scripts/sentinels/check-gateway-tk.py --quiet`：通过
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：通过
- `git diff --check origin/main...HEAD`：通过
- `$xj-review #1915`：`risk_level=normal`，`review_mode=concise`，0 findings，0 warn candidates

## 提交

- `edb75d856 fix(gateway): 修复 Kiro 镜像兼容入口空密钥 502`
- `3ed57ec0e fix(gateway): address R-001 credential owner`
- `2af174ee9 fix(gateway): clamp Kiro mirror routing to Messages`
- 最新提交：`2af174ee9`
