### PR TITLE
fix(pricing): 供应源缺价模型写入完整 registry

### DIFF
--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -7,6 +7,7 @@
   },
   "_aliases": {
     "deepseek-v4-flash-0731": "deepseek-v4-flash",
+    "deepseek-v4-pro-0813": "deepseek-v4-pro",
     "gpt-5.5-pro": "gpt-5.5"
   },
   "_config": {
@@ -10046,5 +10047,76 @@
     "output_cost_per_token": 0.00000417910447761194,
     "cache_read_input_token_cost": 0.00000029850746268656716,
     "source": "BigModel official pricing https://bigmodel.cn/pricing, captured 2026-08-19: GLM-5.3 input ¥8/Mtok, output ¥28/Mtok, cache-hit ¥2/Mtok, 1M context, no input-tier split; CNY/USD=6.7. Cross-checked Z.AI international https://docs.z.ai/guides/overview/pricing same day: GLM-5.3 $1.4/$0.26/$4.4 per 1M tokens (USD list; TokenKey GLM owner remains BigModel CNY÷6.7, matching glm-5.2). LiteLLM has no glm-5.3 row (lookup 2026-08-19). Pricing source only: serving remains the configured OpenAI-compat / DashScope path (runtime DB/config, not pricing truth), not BigModel/Zhipu direct. Overlay stores pre-tax official list rates; TokenKey applies the official_list_base_tax zhipu multiplier at resolution/catalog time. Cache storage is listed as limited-time free."
+  },
+  "glm-5.3-flash": {
+    "litellm_provider": "zhipu",
+    "mode": "chat",
+    "input_cost_per_token": 0.00000015,
+    "output_cost_per_token": 0.0000005,
+    "cache_read_input_token_cost": 0.00000003,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 128000,
+    "supports_prompt_caching": true,
+    "supports_function_calling": true,
+    "supports_tool_choice": true,
+    "supports_vision": true,
+    "supports_reasoning": true,
+    "source": "Z.AI official https://docs.z.ai/guides/overview/pricing captured 2026-09-01 via litellm zai/glm-5.3-flash: GLM-5.3-Flash $0.15/$0.03/$0.50 per 1M tokens (input/cache-hit/output). TokenKey glm-5.3 owner remains BigModel CNY÷6.7; flash SKU priced from Z.AI USD list until BigModel flash row is captured. Overlay stores pre-tax official list rates; official_list_base_tax zhipu multiplier applies at resolution."
+  },
+  "hy3": {
+    "litellm_provider": "tencent",
+    "mode": "chat",
+    "input_cost_per_token": 0.000000132,
+    "output_cost_per_token": 0.000000528,
+    "cache_read_input_token_cost": 0.000000033,
+    "source": "Tencent Cloud TokenHub international model pricing https://www-sg.tencentcloud.com/document/product/1300/78937 captured 2026-09-01: Hy3 $0.132/$0.528/$0.033 per 1M tokens (input/output/cache). Served via supplier OpenAI-compat path (cloudwise account mapping), not Tencent direct."
+  },
+  "qwen3.6-plus": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 0.00000029850746268656716,
+    "output_cost_per_token": 0.0000011940298507462686,
+    "cache_read_input_token_cost": 0.00000029850746268656716,
+    "source": "TEMPORARY owner cloned from qwen3.7-plus DashScope CNY÷6.7 (2026-09-01 supplier hotfix). Replace with Alibaba DashScope official qwen3.6-plus China-mainland list when captured. LiteLLM also lists openrouter/qwen/qwen3.6-plus at $0.325/$1.95 per 1M (not used; keep DashScope family consistency)."
+  },
+  "qwen3.6-35b-a3b": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 0.00000005970149253731344,
+    "output_cost_per_token": 0.0000004776119402985075,
+    "supports_vision": true,
+    "supports_reasoning": false,
+    "source": "TEMPORARY owner cloned from qwen3.5-35b-a3b (same size class) for 2026-09-01 supplier hotfix. Replace with DashScope official qwen3.6-35b-a3b list when captured."
+  },
+  "qwen3.6-max-preview": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 0.0000017910447761194032,
+    "output_cost_per_token": 0.000005373134328358209,
+    "cache_read_input_token_cost": 0.0000017910447761194032,
+    "source": "TEMPORARY owner cloned from qwen3.8-max DashScope CNY÷6.7 for 2026-09-01 supplier hotfix (max-tier preview). Replace with DashScope official qwen3.6-max-preview list when captured."
+  },
+  "qwen3.8-27b": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 0.0000004,
+    "output_cost_per_token": 0.000003,
+    "cache_read_input_token_cost": 0.00000004,
+    "max_input_tokens": 262144,
+    "max_tokens": 262144,
+    "supports_prompt_caching": true,
+    "supports_function_calling": true,
+    "supports_tool_choice": true,
+    "supports_vision": true,
+    "supports_reasoning": true,
+    "source": "Sensor consensus 2026-09-01: litellm deepinfra/Qwen/Qwen3.8-27B and wandb/Qwen/Qwen3.8-27B both $0.40/$3.00 per 1M (cache-read deepinfra $0.04/M). No DashScope official row captured yet; provider tag kept dashscope for qwen tax rule. Replace with Alibaba DashScope official list when available."
+  },
+  "qwen3.8-flash": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 0.0000001791044776119403,
+    "output_cost_per_token": 0.0000010746268656716418,
+    "cache_read_input_token_cost": 0.0000001791044776119403,
+    "source": "TEMPORARY owner cloned from qwen3.6-flash DashScope CNY÷6.7 for 2026-09-01 supplier hotfix (flash-tier). Replace with DashScope official qwen3.8-flash list when captured."
   }
 }


### PR DESCRIPTION
## 摘要
- 将本会话发现的供应源 mapping 缺价 client id 写入 `tk_pricing_overlay.json` 完整 registry（`glm-5.3-flash`、`hy3`、`qwen3.6-plus`、`qwen3.6-35b-a3b`、`qwen3.6-max-preview`、`qwen3.8-27b`、`qwen3.8-flash`）
- `deepseek-v4-pro-0813` → `_aliases` 指向已有 `deepseek-v4-pro` owner
- 合并后可用 `manage-overlay-runtime.py sync-runtime` 热发布，替换 prod channel `#2 tk-supplier-price-hotfix` 临时价

## 风险
- 常规：全局计价 owner 变更；若干 qwen 条目为 TEMPORARY sibling clone，需后续换 DashScope 官方表
- 不覆盖：`tk_served_models` 公开展示、`hy3` Unsupported（非缺价）

## 验证
- `python3 scripts/checks/pricing-overlay.py` PASS
- `./scripts/preflight.sh` PASS
- prod 已用 channel 热更验证 china/universal 对多数缺价模型 200（`hy3` 仍 400 Unsupported）

## 提交
- `2d7ebddb1` fix(pricing): 供应源缺价模型写入完整 registry 并加 dated SKU alias
- 最新提交：`2d7ebddb1`

Made with [Cursor](https://cursor.com)