### PR TITLE
fix(protocol): fail over empty messages-chat streams

### DIFF
--- a/backend/internal/service/openai_gateway_messages_chat_fallback.go
+++ b/backend/internal/service/openai_gateway_messages_chat_fallback.go
@@ -127,7 +127,7 @@ func (s *OpenAIGatewayService) forwardAnthropicViaRawChatCompletions(
 
 	// 5. Convert response
 	if clientStream {
-		return s.streamChatCompletionsAsAnthropic(c, resp, originalModel, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime)
+		return s.streamChatCompletionsAsAnthropic(c, resp, account, originalModel, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime)
 	}
 	return s.bufferChatCompletionsAsAnthropic(c, resp, originalModel, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime)
 }
@@ -171,6 +171,7 @@ func (s *OpenAIGatewayService) bufferChatCompletionsAsAnthropic(
 func (s *OpenAIGatewayService) streamChatCompletionsAsAnthropic(
 	c *gin.Context,
 	resp *http.Response,
+	account *Account,
 	originalModel string,
 	billingModel string,
 	upstreamModel string,
@@ -179,33 +180,16 @@ func (s *OpenAIGatewayService) streamChatCompletionsAsAnthropic(
 	startTime time.Time,
 ) (*OpenAIForwardResult, error) {
 	requestID := resp.Header.Get("x-request-id")
-	writeStreamHeaders := s.newStreamHeaderWriter(c, resp.Header)
 
 	anthropicState := apicompat.NewChatCompletionsToAnthropicStreamState(originalModel)
-	clientDisconnected := false
+	outputStage := newMessagesChatAnthropicOutputStage(s, c, resp.Header)
 
 	// 与 responses 兄弟不同：客户端断开后仍继续做事件转换（喂 anthropicState），
 	// 仅跳过写出，保证 finalize 阶段的 usage 汇总不受断开影响。
 	emitChunk := func(chunk *apicompat.ChatCompletionsChunk) {
 		// CC chunk → Anthropic events (direct, single state machine)
 		anthropicEvents := apicompat.ChatCompletionsChunkToAnthropicEvents(chunk, anthropicState)
-		if clientDisconnected {
-			return
-		}
-		for _, aEvt := range anthropicEvents {
-			sse, err := apicompat.ResponsesAnthropicEventToSSE(aEvt)
-			if err != nil {
-				continue
-			}
-			writeStreamHeaders()
-			if _, err := fmt.Fprint(c.Writer, sse); err != nil {
-				clientDisconnected = true
-				break
-			}
-		}
-		if !clientDisconnected && len(anthropicEvents) > 0 {
-			c.Writer.Flush()
-		}
+		outputStage.Emit(anthropicEvents)
 	}
 
 	scan := s.scanCCStream(resp, "openai messages chat fallback", requestID, startTime, emitChunk)
@@ -226,25 +210,12 @@ func (s *OpenAIGatewayService) streamChatCompletionsAsAnthropic(
 			Stream:           true,
 			Duration:         time.Since(startTime),
 			FirstTokenMs:     scan.FirstTokenMs,
-			ClientDisconnect: clientDisconnected,
+			ClientDisconnect: outputStage.ClientDisconnected(),
 		}, fmt.Errorf("stream usage incomplete: %w", scan.Err)
 	}
 
-	// Finalize: close open blocks + emit message_delta/message_stop.
-	finalEvents := apicompat.FinalizeChatCompletionsAnthropicStream(anthropicState)
-	if !clientDisconnected {
-		for _, aEvt := range finalEvents {
-			sse, err := apicompat.ResponsesAnthropicEventToSSE(aEvt)
-			if err != nil {
-				continue
-			}
-			writeStreamHeaders()
-			if _, err := fmt.Fprint(c.Writer, sse); err != nil {
-				clientDisconnected = true
-				break
-			}
-		}
-		c.Writer.Flush()
+	if failoverErr := outputStage.Finalize(anthropicState, usage, account, requestID); failoverErr != nil {
+		return nil, failoverErr
 	}
 	if !scan.SawDone {
 		logCCStreamMissingDoneSentinel("openai messages chat fallback", requestID)
@@ -261,6 +232,6 @@ func (s *OpenAIGatewayService) streamChatCompletionsAsAnthropic(
 		Stream:           true,
 		Duration:         time.Since(startTime),
 		FirstTokenMs:     scan.FirstTokenMs,
-		ClientDisconnect: clientDisconnected,
+		ClientDisconnect: outputStage.ClientDisconnected(),
 	}, nil
 }

--- a/backend/internal/service/openai_gateway_messages_chat_fallback_test.go
+++ b/backend/internal/service/openai_gateway_messages_chat_fallback_test.go
@@ -313,9 +313,9 @@ func TestForwardAsAnthropic_ForceChatCompletionsStreamingLengthMapsToMaxTokens(t
 	require.Contains(t, out, "event: message_stop")
 }
 
-// An upstream that ends immediately with [DONE] must still produce a fully
-// framed (message_start → message_delta → message_stop) Anthropic stream.
-func TestForwardAsAnthropic_ForceChatCompletionsEmptyStreamStillFramesMessage(t *testing.T) {
+// An upstream that ends immediately with [DONE] must fail over without
+// synthesizing a successful Anthropic end_turn.
+func TestForwardAsAnthropic_ForceChatCompletionsEmptyStreamFailsOver(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	body := []byte(`{"model":"gpt-5.4","max_tokens":8,"messages":[{"role":"user","content":"hello"}],"stream":true}`)
@@ -335,13 +335,14 @@ func TestForwardAsAnthropic_ForceChatCompletionsEmptyStreamStillFramesMessage(t 
 	}
 
 	result, err := svc.ForwardAsAnthropic(context.Background(), c, forceChatMessagesFallbackAccount(), body, "", "")
-	require.NoError(t, err)
-	require.NotNil(t, result)
-
-	out := rec.Body.String()
-	require.Contains(t, out, "event: message_start")
-	require.Contains(t, out, "event: message_delta")
-	require.Contains(t, out, "event: message_stop")
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr))
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.True(t, failoverErr.SafeToFailoverAfterWrite)
+	require.True(t, IsOpenAISilentRefusalErrorBody(failoverErr.ResponseBody))
+	require.False(t, c.Writer.Written(), "empty attempt must remain replayable")
+	require.Empty(t, rec.Body.String(), "empty attempt must not synthesize end_turn")
 }
 
 // Non-failover 4xx responses must go through the shared compat error handler:

--- a/backend/internal/service/openai_gateway_messages_chat_fallback_test.go
+++ b/backend/internal/service/openai_gateway_messages_chat_fallback_test.go
@@ -339,7 +339,7 @@ func TestForwardAsAnthropic_ForceChatCompletionsEmptyStreamFailsOver(t *testing.
 	var failoverErr *UpstreamFailoverError
 	require.True(t, errors.As(err, &failoverErr))
 	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
-	require.True(t, failoverErr.SafeToFailoverAfterWrite)
+	require.False(t, failoverErr.SafeToFailoverAfterWrite, "no-write failure must retain the full failover budget")
 	require.True(t, IsOpenAISilentRefusalErrorBody(failoverErr.ResponseBody))
 	require.False(t, c.Writer.Written(), "empty attempt must remain replayable")
 	require.Empty(t, rec.Body.String(), "empty attempt must not synthesize end_turn")

--- a/backend/internal/service/openai_gateway_messages_chat_silent_refusal_tk.go
+++ b/backend/internal/service/openai_gateway_messages_chat_silent_refusal_tk.go
@@ -1,0 +1,115 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+	"github.com/gin-gonic/gin"
+)
+
+// messagesChatAnthropicOutputStage keeps converter-generated protocol preamble
+// attempt-local until text, thinking, or tool output proves that the upstream
+// produced a real answer. This preserves account failover for empty streams.
+type messagesChatAnthropicOutputStage struct {
+	c                      *gin.Context
+	writeStreamHeaders     func()
+	clientDisconnected     bool
+	semanticOutputReleased bool
+	pendingSSE             []string
+}
+
+func newMessagesChatAnthropicOutputStage(s *OpenAIGatewayService, c *gin.Context, upstreamHeaders http.Header) *messagesChatAnthropicOutputStage {
+	return &messagesChatAnthropicOutputStage{
+		c:                  c,
+		writeStreamHeaders: s.newStreamHeaderWriter(c, upstreamHeaders),
+		pendingSSE:         make([]string, 0, 4),
+	}
+}
+
+func (s *messagesChatAnthropicOutputStage) Emit(events []apicompat.AnthropicStreamEvent) {
+	s.emit(events, messagesChatAnthropicEventsHaveSemanticOutput(events))
+}
+
+func (s *messagesChatAnthropicOutputStage) Finalize(
+	state *apicompat.ChatCompletionsToAnthropicStreamState,
+	usage OpenAIUsage,
+	account *Account,
+	requestID string,
+) *UpstreamFailoverError {
+	finalEvents := apicompat.FinalizeChatCompletionsAnthropicStream(state)
+	finalHasSemanticOutput := messagesChatAnthropicEventsHaveSemanticOutput(finalEvents)
+	if !s.semanticOutputReleased && !finalHasSemanticOutput &&
+		!openAIUsageHasTokens(&usage) && messagesChatEmptyFinishIsSilentRefusal(state.FinishReason) {
+		failoverErr := newOpenAISilentRefusalFailoverError(s.c, account, requestID)
+		// Every bridge event is still staged. Bytes already written can only be
+		// header-wait pings, so the OpenAI handler may safely switch accounts on
+		// the same client stream.
+		failoverErr.SafeToFailoverAfterWrite = true
+		return failoverErr
+	}
+	s.emit(finalEvents, true)
+	return nil
+}
+
+func (s *messagesChatAnthropicOutputStage) ClientDisconnected() bool {
+	return s != nil && s.clientDisconnected
+}
+
+func (s *messagesChatAnthropicOutputStage) emit(events []apicompat.AnthropicStreamEvent, release bool) {
+	if s == nil || s.clientDisconnected {
+		return
+	}
+
+	serialized := make([]string, 0, len(events))
+	for _, event := range events {
+		value, err := apicompat.ResponsesAnthropicEventToSSE(event)
+		if err == nil {
+			serialized = append(serialized, value)
+		}
+	}
+
+	if !s.semanticOutputReleased {
+		s.pendingSSE = append(s.pendingSSE, serialized...)
+		if !release {
+			return
+		}
+		s.semanticOutputReleased = true
+		serialized = s.pendingSSE
+		s.pendingSSE = nil
+	}
+
+	if len(serialized) == 0 {
+		return
+	}
+	s.writeStreamHeaders()
+	for _, value := range serialized {
+		if _, err := fmt.Fprint(s.c.Writer, value); err != nil {
+			s.clientDisconnected = true
+			break
+		}
+	}
+	if !s.clientDisconnected {
+		s.c.Writer.Flush()
+	}
+}
+
+func messagesChatAnthropicEventsHaveSemanticOutput(events []apicompat.AnthropicStreamEvent) bool {
+	for _, event := range events {
+		switch event.Type {
+		case "content_block_start", "content_block_delta":
+			return true
+		}
+	}
+	return false
+}
+
+func messagesChatEmptyFinishIsSilentRefusal(finishReason string) bool {
+	switch strings.TrimSpace(finishReason) {
+	case "", "stop":
+		return true
+	default:
+		return false
+	}
+}

--- a/backend/internal/service/openai_gateway_messages_chat_silent_refusal_tk.go
+++ b/backend/internal/service/openai_gateway_messages_chat_silent_refusal_tk.go
@@ -43,10 +43,13 @@ func (s *messagesChatAnthropicOutputStage) Finalize(
 	if !s.semanticOutputReleased && !finalHasSemanticOutput &&
 		!openAIUsageHasTokens(&usage) && messagesChatEmptyFinishIsSilentRefusal(state.FinishReason) {
 		failoverErr := newOpenAISilentRefusalFailoverError(s.c, account, requestID)
-		// Every bridge event is still staged. Bytes already written can only be
-		// header-wait pings, so the OpenAI handler may safely switch accounts on
-		// the same client stream.
-		failoverErr.SafeToFailoverAfterWrite = true
+		// Every bridge event is still staged. If bytes were written, they can only
+		// be header-wait pings, so the handler may safely switch accounts on the
+		// same client stream. Leave the marker false before any write so ordinary
+		// empty attempts retain the full account-failover budget.
+		if s.c.Writer.Written() {
+			failoverErr.SafeToFailoverAfterWrite = true
+		}
 		return failoverErr
 	}
 	s.emit(finalEvents, true)

--- a/backend/internal/service/openai_gateway_messages_chat_silent_refusal_tk_test.go
+++ b/backend/internal/service/openai_gateway_messages_chat_silent_refusal_tk_test.go
@@ -45,7 +45,7 @@ func TestMessagesChatSilentRefusal_RoleOnlyStopFailsOver(t *testing.T) {
 	require.Nil(t, result)
 	var failoverErr *UpstreamFailoverError
 	require.True(t, errors.As(err, &failoverErr))
-	require.True(t, failoverErr.SafeToFailoverAfterWrite)
+	require.False(t, failoverErr.SafeToFailoverAfterWrite, "no-write failure must retain the full failover budget")
 	require.True(t, IsOpenAISilentRefusalErrorBody(failoverErr.ResponseBody))
 	require.False(t, c.Writer.Written())
 	require.Empty(t, rec.Body.String())
@@ -81,6 +81,39 @@ func TestMessagesChatSilentRefusal_UsageOnlyStreamSucceeds(t *testing.T) {
 	require.Equal(t, 4, result.Usage.InputTokens)
 	require.Zero(t, result.Usage.OutputTokens)
 	require.Contains(t, rec.Body.String(), `"input_tokens":4`)
+	require.Contains(t, rec.Body.String(), "event: message_stop")
+}
+
+func TestMessagesChatSilentRefusal_EmptyLengthStreamSucceeds(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.4","max_tokens":8,"messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`data: {"id":"chatcmpl_length","object":"chat.completion.chunk","model":"gpt-5.4","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		"",
+		`data: {"id":"chatcmpl_length","object":"chat.completion.chunk","model":"gpt-5.4","choices":[{"index":0,"delta":{},"finish_reason":"length"}]}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_msg_chat_length"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{cfg: rawChatCompletionsTestConfig(), httpUpstream: upstream}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, forceChatMessagesFallbackAccount(), body, "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Zero(t, result.Usage.InputTokens)
+	require.Zero(t, result.Usage.OutputTokens)
+	require.Contains(t, rec.Body.String(), `"stop_reason":"max_tokens"`)
 	require.Contains(t, rec.Body.String(), "event: message_stop")
 }
 

--- a/backend/internal/service/openai_gateway_messages_chat_silent_refusal_tk_test.go
+++ b/backend/internal/service/openai_gateway_messages_chat_silent_refusal_tk_test.go
@@ -1,0 +1,119 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessagesChatSilentRefusal_RoleOnlyStopFailsOver(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.4","max_tokens":8,"messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`data: {"id":"chatcmpl_empty","object":"chat.completion.chunk","model":"gpt-5.4","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		"",
+		`data: {"id":"chatcmpl_empty","object":"chat.completion.chunk","model":"gpt-5.4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_msg_chat_role_only"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{cfg: rawChatCompletionsTestConfig(), httpUpstream: upstream}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, forceChatMessagesFallbackAccount(), body, "", "")
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr))
+	require.True(t, failoverErr.SafeToFailoverAfterWrite)
+	require.True(t, IsOpenAISilentRefusalErrorBody(failoverErr.ResponseBody))
+	require.False(t, c.Writer.Written())
+	require.Empty(t, rec.Body.String())
+}
+
+func TestMessagesChatSilentRefusal_UsageOnlyStreamSucceeds(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.4","max_tokens":8,"messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`data: {"id":"chatcmpl_usage","object":"chat.completion.chunk","model":"gpt-5.4","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		"",
+		`data: {"id":"chatcmpl_usage","object":"chat.completion.chunk","model":"gpt-5.4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":0,"total_tokens":4}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_msg_chat_usage"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{cfg: rawChatCompletionsTestConfig(), httpUpstream: upstream}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, forceChatMessagesFallbackAccount(), body, "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 4, result.Usage.InputTokens)
+	require.Zero(t, result.Usage.OutputTokens)
+	require.Contains(t, rec.Body.String(), `"input_tokens":4`)
+	require.Contains(t, rec.Body.String(), "event: message_stop")
+}
+
+func TestMessagesChatSilentRefusal_AfterPingDoesNotEndTurn(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.4","max_tokens":8,"messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	inner := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_msg_chat_empty_ping"}},
+		Body:       io.NopCloser(strings.NewReader("data: [DONE]\n\n")),
+	}}
+	cfg := rawChatCompletionsTestConfig()
+	cfg.Gateway.StreamKeepaliveInterval = 1
+	svc := &OpenAIGatewayService{
+		cfg:          cfg,
+		httpUpstream: &delayingHTTPUpstream{delay: 1100 * time.Millisecond, inner: inner},
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, forceChatMessagesFallbackAccount(), body, "", "")
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr))
+	require.True(t, failoverErr.SafeToFailoverAfterWrite)
+	require.True(t, c.Writer.Written())
+	out := rec.Body.String()
+	require.Contains(t, out, "event: ping")
+	require.NotContains(t, out, "event: message_start")
+	require.NotContains(t, out, "event: message_delta")
+	require.NotContains(t, out, "event: message_stop")
+}

--- a/docs/approved/protocol-routing-ssot.md
+++ b/docs/approved/protocol-routing-ssot.md
@@ -4,7 +4,7 @@ status: approved
 approved_by: "feng (conversation approval, 2026-08-27)"
 authors: [codex]
 created: 2026-08-24
-revised: 2026-08-30
+revised: 2026-09-01
 revision_note: >
   Plans and Execute no longer compare account or capability revision tokens.
   Send-time freshness is authoritative reload plus route-fact equivalence.
@@ -15,7 +15,9 @@ revision_note: >
   from both exact endpoints and the Plan-facing supported set.
   On a non-OfficialEndpointAnthropic identity, native messages is legal only
   for a Claude-family resolved model; dual-stack OpenAI relays convert
-  inbound /v1/messages for GPT and other non-Claude models.
+  inbound /v1/messages for GPT and other non-Claude models. Conversation
+  approval on 2026-09-01 also requires conversion adapters to fail over an
+  empty zero-usage terminal attempt instead of synthesizing protocol success.
 related_stories: []
 ---
 
@@ -363,6 +365,16 @@ Execution invariants:
 - transports cannot change protocol or endpoint;
 - no handler or transport retries another protocol on the same account;
 - usage, billing, QA, and error records use the actual plan facts.
+
+Conversion adapters must also preserve failure semantics. A streaming attempt
+that reaches a terminal marker with no text, reasoning, tool call, error, or
+token usage is not a successful empty answer. Before semantic output is
+committed, the adapter keeps protocol preamble frames attempt-local and returns
+the existing silent-refusal failover error. If a keepalive has already committed
+the downstream stream, the terminal result is a protocol-shaped error; the
+adapter must never synthesize `end_turn` or an equivalent success terminal.
+Non-zero usage and explicit non-stop terminal reasons remain valid evidence and
+are not classified as this empty-attempt failure.
 
 Planning and pre-send validation failures perform no network I/O. Upstream
 failures retain existing cooldown and account-failover classification.

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7767,9 +7767,10 @@
         "type messagesChatAnthropicOutputStage struct",
         "messagesChatAnthropicEventsHaveSemanticOutput",
         "messagesChatEmptyFinishIsSilentRefusal",
+        "if s.c.Writer.Written()",
         "failoverErr.SafeToFailoverAfterWrite = true"
       ],
-      "rationale": "The TokenKey companion must stage synthetic Anthropic preamble frames until real text/thinking/tool output exists. Empty zero-usage upstream attempts must enter the shared silent-refusal failover path instead of synthesizing message_start -> end_turn and making Claude Code report a false successful completion. The safe-after-write marker applies only because this path leaves at most header-wait pings on the client stream."
+      "rationale": "The TokenKey companion must stage synthetic Anthropic preamble frames until real text/thinking/tool output exists. Empty zero-usage upstream attempts must enter the shared silent-refusal failover path instead of synthesizing message_start -> end_turn and making Claude Code report a false successful completion. The safe-after-write marker applies only when header-wait pings actually committed; no-write attempts must retain the full account-failover budget."
     },
     {
       "path": "backend/internal/service/openai_gateway_messages_chat_fallback_test.go",
@@ -7783,9 +7784,10 @@
       "must_contain": [
         "TestMessagesChatSilentRefusal_RoleOnlyStopFailsOver",
         "TestMessagesChatSilentRefusal_UsageOnlyStreamSucceeds",
+        "TestMessagesChatSilentRefusal_EmptyLengthStreamSucceeds",
         "TestMessagesChatSilentRefusal_AfterPingDoesNotEndTurn"
       ],
-      "rationale": "Focused companion regressions pin the production role-only false-success shape, the non-zero usage exemption, and the late header-wait ping case so an upstream merge cannot restore empty end_turn framing while ordinary text/tool tests remain green."
+      "rationale": "Focused companion regressions pin the production role-only false-success shape, the non-zero usage and explicit non-stop terminal exemptions, and the late header-wait ping case so an upstream merge cannot restore empty end_turn framing or shrink ordinary no-write account failover while text/tool tests remain green."
     }
   ]
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7751,6 +7751,41 @@
         "FinalizeAccountCredentials(credentials, 0)"
       ],
       "rationale": "Every CRS create/update path must go through the credential SSOT so rotating base_url/api_key cannot retain stale exclusive supplier endpoints."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_messages_chat_fallback.go",
+      "must_contain": [
+        "newMessagesChatAnthropicOutputStage",
+        "outputStage.Emit(",
+        "outputStage.Finalize("
+      ],
+      "rationale": "The upstream-shaped messages-to-chat forwarder must retain the TokenKey output stage call sites so upstream merges cannot bypass empty-stream refusal detection while leaving the companion implementation and tests intact."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_messages_chat_silent_refusal_tk.go",
+      "must_contain": [
+        "type messagesChatAnthropicOutputStage struct",
+        "messagesChatAnthropicEventsHaveSemanticOutput",
+        "messagesChatEmptyFinishIsSilentRefusal",
+        "failoverErr.SafeToFailoverAfterWrite = true"
+      ],
+      "rationale": "The TokenKey companion must stage synthetic Anthropic preamble frames until real text/thinking/tool output exists. Empty zero-usage upstream attempts must enter the shared silent-refusal failover path instead of synthesizing message_start -> end_turn and making Claude Code report a false successful completion. The safe-after-write marker applies only because this path leaves at most header-wait pings on the client stream."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_messages_chat_fallback_test.go",
+      "must_contain": [
+        "TestForwardAsAnthropic_ForceChatCompletionsEmptyStreamFailsOver"
+      ],
+      "rationale": "The upstream-shaped fallback suite must keep a focused end-to-end regression proving that a DONE-only Chat Completions stream cannot become a synthetic Anthropic success."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_messages_chat_silent_refusal_tk_test.go",
+      "must_contain": [
+        "TestMessagesChatSilentRefusal_RoleOnlyStopFailsOver",
+        "TestMessagesChatSilentRefusal_UsageOnlyStreamSucceeds",
+        "TestMessagesChatSilentRefusal_AfterPingDoesNotEndTurn"
+      ],
+      "rationale": "Focused companion regressions pin the production role-only false-success shape, the non-zero usage exemption, and the late header-wait ping case so an upstream merge cannot restore empty end_turn framing while ordinary text/tool tests remain green."
     }
   ]
 }


### PR DESCRIPTION
## 摘要

- 修复 `claude --model gpt-5.4` 经 TokenKey `messages → chat_completions` 适配器时的假成功：上游只返回 role/终止帧且 usage 为 0 时，不再合成 `message_start → end_turn → message_stop`，而是进入现有 silent-refusal account failover。
- 线上证据对应 user_id=1 在 2026-09-01 10:37（Asia/Shanghai）的请求 `efc30689-7205-45ea-9706-2802b3bf64a9`、`77003c67-0de0-4668-9ec8-620f6b4cac99`。PR #1896 / #1897 已覆盖其他空响应路径，但遗漏了 `messages → chat` bridge。
- 协议前导帧在出现真实 text / thinking / tool 输出前保持 attempt-local；即使 header-wait keepalive 已写出，也不会追加伪造的成功终止帧。
- 仅在 keepalive 确实提交后设置 `SafeToFailoverAfterWrite`；普通未写出的空尝试保留完整账号切换预算，不会因首输出保护上限而跳过后续健康账号。
- 将 TokenKey 状态机放入 `*_tk.go` companion，主转发文件仅保留构造、emit、finalize 三个接线点；增加 gateway sentinel，防止后续 upstream merge 静默冲掉行为。
- Web impact: none（`no-web-impact`，仅改变后端流式协议失败语义）。

## 风险

- 高风险公共协议行为变化：此前被误判为成功的空、零 usage、`stop`/无 finish reason 流现在会 failover；所有账号均失败时将向客户端返回错误，而不是空成功。
- 非零 usage、真实 text / thinking / tool 输出，以及 `length` 等显式非 stop 终止原因保持原行为。
- keepalive 已提交的空尝试仍受首输出保护预算约束；未写出任何字节的空尝试走普通完整账号 failover。
- 主转发文件仍需一个必要调用点，因此相对当前 `upstream/main` 新增 1 个冲突文件；companion 已把函数体插入从 7 处降到 1 处，并显式接受该最小冲突面：`upstream-conflict-surface-accepted`。

## 验证

- `go test -tags=unit ./internal/service -run 'TestForwardAsAnthropic_ForceChatCompletions|TestMessagesChatSilentRefusal' -count=1`
- `go test -tags=unit ./internal/service -count=1`（PASS，111.805s）
- `go test -tags=unit ./internal/pkg/apicompat -count=1`（PASS）
- `python3 scripts/sentinels/check-gateway-tk.py --quiet`（PASS）
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`（整体 PASS；上述 upstream conflict 由本 PR marker 显式接受）

## 设计

- 不改转换器公共 API，也不增加配置开关。适配层只延迟下游 preamble 的提交；检测到语义输出后按原顺序一次性释放，空终止则复用现有 `UpstreamFailoverError`。
- `SafeToFailoverAfterWrite=true` 仅在所有 bridge 事件仍在 staging、且 header-wait ping 确实已经写出时设置；未写出任何字节的空尝试保持该标志为 false，以使用完整账号 failover 预算。

## 契约

- 审批锚点：`docs/approved/protocol-routing-ssot.md`。
- 新增约束：空、零 usage 的 terminal attempt 不是成功；不得合成 `end_turn`。非零 usage 与显式非 stop terminal reason 仍是有效成功证据。

## 提交

- `26308c813 fix(protocol): fail over empty messages-chat streams`
- `7d6e917d3 fix(protocol): preserve full empty-stream failover budget`

最新提交：`7d6e917d3`
