### PR TITLE
fix(pricing): #1916 后续 — BigModel flash 价、qwen 分档与 hy3 调度

### DIFF
--- a/backend/internal/service/openai_cloudwise_relay_tk.go
+++ b/backend/internal/service/openai_cloudwise_relay_tk.go
@@ -10,6 +10,7 @@ var openAICloudwiseRelayAllowedModelPrefixes = []string{
 	"glm-",
 	"minimax-",
 	"deepseek-",
+	"hy3", // Tencent Hy3 on CloudWise MaaS (supplier account #114); no hyphen suffix.
 }
 
 func openAICloudwiseRelayWildcardModelMappingFloor() map[string]string {

--- a/backend/internal/service/openai_cloudwise_relay_tk_test.go
+++ b/backend/internal/service/openai_cloudwise_relay_tk_test.go
@@ -15,6 +15,7 @@ func TestOpenAICloudwiseRelayAllowedModelPrefixes(t *testing.T) {
 		"glm-",
 		"minimax-",
 		"deepseek-",
+		"hy3",
 	}, openAICloudwiseRelayAllowedModelPrefixes)
 }
 
@@ -26,6 +27,7 @@ func TestOpenAICloudwiseRelayWildcardModelMappingFloor(t *testing.T) {
 		"glm-*":      "glm-*",
 		"minimax-*":  "minimax-*",
 		"deepseek-*": "deepseek-*",
+		"hy3*":       "hy3*",
 	}, mapping)
 }
 
@@ -57,7 +59,7 @@ func TestCloudwiseRelayAccountSupportsPrefixFamiliesOnly(t *testing.T) {
 	}
 	require.True(t, account.IsOpenAICloudwiseRelay())
 
-	for _, model := range []string{"claude-opus-4-6", "kimi-k3", "glm-5", "MiniMax-M3", "deepseek-v4-flash"} {
+	for _, model := range []string{"claude-opus-4-6", "kimi-k3", "glm-5", "MiniMax-M3", "deepseek-v4-flash", "hy3"} {
 		require.True(t, account.IsModelSupported(model), model)
 		require.Equal(t, model, account.GetMappedModel(model), model)
 	}
@@ -88,7 +90,7 @@ func TestCloudwiseRelayEmptyMappingStillRejectsForeignFamilies(t *testing.T) {
 				},
 				Extra: map[string]any{"openai_passthrough": true},
 			}
-			for _, model := range []string{"claude-opus-4-8", "glm-5.3", "MiniMax-M3", "kimi-k3", "deepseek-v4-flash"} {
+			for _, model := range []string{"claude-opus-4-8", "glm-5.3", "MiniMax-M3", "kimi-k3", "deepseek-v4-flash", "hy3"} {
 				require.True(t, account.IsModelSupported(model), model)
 			}
 			for _, model := range []string{"gpt-5.4", "gpt-5.4-mini", "gemini-3-pro-preview"} {
@@ -148,7 +150,7 @@ func TestGatewayService_CloudwiseRelayPassthroughEmptyMappingUsesPrefixGate(t *t
 				},
 				Extra: map[string]any{"openai_passthrough": true},
 			}
-			for _, model := range []string{"claude-opus-4-8", "glm-5.3", "MiniMax-M3", "kimi-k3", "deepseek-v4-flash"} {
+			for _, model := range []string{"claude-opus-4-8", "glm-5.3", "MiniMax-M3", "kimi-k3", "deepseek-v4-flash", "hy3"} {
 				require.True(t, svc.isModelSupportedByAccount(account, model), model)
 			}
 			for _, model := range []string{"gpt-5.4", "gpt-5.4-mini", "gemini-3-pro-preview"} {

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -10051,9 +10051,9 @@
   "glm-5.3-flash": {
     "litellm_provider": "zhipu",
     "mode": "chat",
-    "input_cost_per_token": 0.00000015,
-    "output_cost_per_token": 0.0000005,
-    "cache_read_input_token_cost": 0.00000003,
+    "input_cost_per_token": 1.1940298507462686e-07,
+    "output_cost_per_token": 4.17910447761194e-07,
+    "cache_read_input_token_cost": 3.432835820895522e-08,
     "max_input_tokens": 1048576,
     "max_output_tokens": 128000,
     "supports_prompt_caching": true,
@@ -10061,7 +10061,7 @@
     "supports_tool_choice": true,
     "supports_vision": true,
     "supports_reasoning": true,
-    "source": "Z.AI official https://docs.z.ai/guides/overview/pricing captured 2026-09-01 via litellm zai/glm-5.3-flash: GLM-5.3-Flash $0.15/$0.03/$0.50 per 1M tokens (input/cache-hit/output). TokenKey glm-5.3 owner remains BigModel CNY÷6.7; flash SKU priced from Z.AI USD list until BigModel flash row is captured. Overlay stores pre-tax official list rates; official_list_base_tax zhipu multiplier applies at resolution."
+    "source": "BigModel official pricing https://bigmodel.cn/pricing, captured 2026-09-01: GLM-5.3-Flash standard list input ¥0.8/Mtok, output ¥2.8/Mtok, cache-hit ¥0.23/Mtok, 1M context; CNY/USD=6.7 (promo 50% row ignored — matches glm-5.3 BigModel list-price basis, not Z.AI USD). Overlay stores pre-tax official list rates; official_list_base_tax zhipu multiplier applies at resolution."
   },
   "hy3": {
     "litellm_provider": "tencent",
@@ -10077,7 +10077,23 @@
     "input_cost_per_token": 0.00000029850746268656716,
     "output_cost_per_token": 0.0000011940298507462686,
     "cache_read_input_token_cost": 0.00000029850746268656716,
-    "source": "TEMPORARY owner cloned from qwen3.7-plus DashScope CNY÷6.7 (2026-09-01 supplier hotfix). Replace with Alibaba DashScope official qwen3.6-plus China-mainland list when captured. LiteLLM also lists openrouter/qwen/qwen3.6-plus at $0.325/$1.95 per 1M (not used; keep DashScope family consistency)."
+    "intervals": [
+      {
+        "min_tokens": 0,
+        "max_tokens": 256000,
+        "input_cost_per_token": 0.00000029850746268656716,
+        "output_cost_per_token": 0.0000011940298507462686,
+        "cache_read_input_token_cost": 0.00000029850746268656716
+      },
+      {
+        "min_tokens": 256000,
+        "max_tokens": null,
+        "input_cost_per_token": 0.0000008955223880597015,
+        "output_cost_per_token": 0.000003582089552238806,
+        "cache_read_input_token_cost": 0.0000008955223880597015
+      }
+    ],
+    "source": "TEMPORARY owner cloned from qwen3.7-plus DashScope CNY÷6.7 incl. input-tier intervals (2026-09-01 supplier hotfix). Replace with Alibaba DashScope official qwen3.6-plus China-mainland list when captured. LiteLLM also lists openrouter/qwen/qwen3.6-plus at $0.325/$1.95 per 1M (not used; keep DashScope family consistency)."
   },
   "qwen3.6-35b-a3b": {
     "litellm_provider": "dashscope",
@@ -10086,7 +10102,21 @@
     "output_cost_per_token": 0.0000004776119402985075,
     "supports_vision": true,
     "supports_reasoning": false,
-    "source": "TEMPORARY owner cloned from qwen3.5-35b-a3b (same size class) for 2026-09-01 supplier hotfix. Replace with DashScope official qwen3.6-35b-a3b list when captured."
+    "intervals": [
+      {
+        "min_tokens": 0,
+        "max_tokens": 128000,
+        "input_cost_per_token": 0.00000005970149253731344,
+        "output_cost_per_token": 0.0000004776119402985075
+      },
+      {
+        "min_tokens": 128000,
+        "max_tokens": null,
+        "input_cost_per_token": 0.00000023880597014925373,
+        "output_cost_per_token": 0.00000191044776119403
+      }
+    ],
+    "source": "TEMPORARY owner cloned from qwen3.5-35b-a3b incl. input-tier intervals (same size class) for 2026-09-01 supplier hotfix. Replace with DashScope official qwen3.6-35b-a3b list when captured."
   },
   "qwen3.6-max-preview": {
     "litellm_provider": "dashscope",
@@ -10117,6 +10147,22 @@
     "input_cost_per_token": 0.0000001791044776119403,
     "output_cost_per_token": 0.0000010746268656716418,
     "cache_read_input_token_cost": 0.0000001791044776119403,
-    "source": "TEMPORARY owner cloned from qwen3.6-flash DashScope CNY÷6.7 for 2026-09-01 supplier hotfix (flash-tier). Replace with DashScope official qwen3.8-flash list when captured."
+    "intervals": [
+      {
+        "min_tokens": 0,
+        "max_tokens": 256000,
+        "input_cost_per_token": 0.0000001791044776119403,
+        "output_cost_per_token": 0.0000010746268656716418,
+        "cache_read_input_token_cost": 0.0000001791044776119403
+      },
+      {
+        "min_tokens": 256000,
+        "max_tokens": null,
+        "input_cost_per_token": 0.0000007164179104477612,
+        "output_cost_per_token": 0.000004298507462686567,
+        "cache_read_input_token_cost": 0.0000007164179104477612
+      }
+    ],
+    "source": "TEMPORARY owner cloned from qwen3.6-flash DashScope CNY÷6.7 incl. input-tier intervals for 2026-09-01 supplier hotfix (flash-tier). Replace with DashScope official qwen3.8-flash list when captured."
   }
 }

--- a/backend/internal/service/universal_routing_tk_serving.go
+++ b/backend/internal/service/universal_routing_tk_serving.go
@@ -242,7 +242,7 @@ func universalOpenAICompatMappingHonorsPlatformHint(account *Account, model stri
 	}
 	// Listing-only OpenAI relays (tokensea / ainzy / official GPT 专线 leftovers)
 	// must not steal curated newapi vendor models. CloudWise is the exception:
-	// its openai apikey floor is explicitly glm-*/deepseek-*/kimi-*/minimax-*.
+	// its openai apikey floor is explicitly glm-*/deepseek-*/kimi-*/minimax-*/hy3*.
 	if account.Platform == PlatformOpenAI && hint == PlatformNewAPI {
 		return isCloudwiseRelayAccount(account)
 	}

--- a/backend/migrations/tk_092_cloudwise_hy3_prefix_model_mapping.sql
+++ b/backend/migrations/tk_092_cloudwise_hy3_prefix_model_mapping.sql
@@ -1,0 +1,44 @@
+-- TokenKey: CloudWise relay model_mapping → add hy3* wildcard floor entry.
+--
+-- Runtime SSOT: backend/internal/service/openai_cloudwise_relay_tk.go
+-- (openAICloudwiseRelayAllowedModelPrefixes). Supplier account #114 serves hy3;
+-- legacy wildcard-floor CloudWise accounts need the matching mapping key.
+--
+-- Idempotent: re-running is a no-op when mapping already matches the floor.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+WITH want AS (
+    SELECT jsonb_build_object(
+        'kimi-*', 'kimi-*',
+        'claude-*', 'claude-*',
+        'glm-*', 'glm-*',
+        'minimax-*', 'minimax-*',
+        'deepseek-*', 'deepseek-*',
+        'hy3*', 'hy3*'
+    ) AS mapping
+),
+cloudwise AS (
+    SELECT a.id, w.mapping AS new_mapping
+    FROM accounts AS a
+    CROSS JOIN want AS w
+    WHERE a.deleted_at IS NULL
+      AND a.platform = 'openai'
+      AND a.type = 'apikey'
+      AND LOWER(TRIM(BOTH '/' FROM a.credentials->>'base_url')) IN (
+          'https://api.cloudwise.ai/api',
+          'https://api-us.cloudwise.ai/api'
+      )
+      AND COALESCE(a.credentials -> 'model_mapping', '{}'::jsonb) IS DISTINCT FROM w.mapping
+),
+upd AS (
+    UPDATE accounts AS a
+    SET credentials = jsonb_set(a.credentials, '{model_mapping}', c.new_mapping, true),
+        updated_at = NOW()
+    FROM cloudwise AS c
+    WHERE a.id = c.id
+    RETURNING a.id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'account_changed', id, NULL, NULL FROM upd;

--- a/ops/pricing/model-surface-bundle.json
+++ b/ops/pricing/model-surface-bundle.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 4,
-  "floor_sha256": "759afa7a3b6486ba260b26160109c56f7817fa10477b0cb82310f58afbee0d9c",
+  "floor_sha256": "0d13b7ea93c11fd6798ee557b511e6ab81c0a47623c2c1aca79cdd954b4545a8",
   "account_model_mapping": {
     "platforms": {
       "anthropic": {
@@ -217,6 +217,7 @@
         "claude-*": "claude-*",
         "deepseek-*": "deepseek-*",
         "glm-*": "glm-*",
+        "hy3*": "hy3*",
         "kimi-*": "kimi-*",
         "minimax-*": "minimax-*"
       },

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1202,9 +1202,10 @@
         "openAICloudwiseRelayWildcardModelMappingFloor(",
         "func isCloudwiseRelayAccount(",
         "func openAICloudwiseRelaySupportsRequestedModel(",
-        "if account == nil || !isCloudwiseRelayAccount(account)"
+        "if account == nil || !isCloudwiseRelayAccount(account)",
+        "\"hy3\""
       ],
-      "rationale": "Single SSOT for CloudWise MaaS relay supported model families (kimi/claude/glm/minimax/deepseek prefix policy). Adjust only openAICloudwiseRelayAllowedModelPrefixes; wildcard model_mapping floor derives from it. isCloudwiseRelayAccount + openAICloudwiseRelaySupportsRequestedModel are the dual-stack prefix hard gate used before passthrough / empty-mapping allow-all."
+      "rationale": "Single SSOT for CloudWise MaaS relay supported model families (kimi/claude/glm/minimax/deepseek/hy3 prefix policy). Adjust only openAICloudwiseRelayAllowedModelPrefixes; wildcard model_mapping floor derives from it. isCloudwiseRelayAccount + openAICloudwiseRelaySupportsRequestedModel are the dual-stack prefix hard gate used before passthrough / empty-mapping allow-all."
     },
     {
       "path": "backend/internal/service/account.go",
@@ -1251,9 +1252,19 @@
         "TestCloudwiseRelayEmptyMappingStillRejectsForeignFamilies",
         "TestCloudwiseRelayPrefixGateOverridesExplicitGPTMapping",
         "TestGatewayService_CloudwiseRelayPassthroughEmptyMappingUsesPrefixGate",
-        "TestApplyOpenAICloudwiseRelayUpstreamModelID_AnthropicAccount"
+        "TestApplyOpenAICloudwiseRelayUpstreamModelID_AnthropicAccount",
+        "\"hy3\""
       ],
       "rationale": "Focused regressions for the CloudWise prefix hard gate: empty mapping / leftover passthrough still reject gpt-* on both Account.IsModelSupported and GatewayService.isModelSupportedByAccount, and an explicit gpt mapping cannot override the family floor."
+    },
+    {
+      "path": "backend/internal/service/universal_routing_tk_serving.go",
+      "must_contain": [
+        "func universalOpenAICompatMappingHonorsPlatformHint(",
+        "isCloudwiseRelayAccount(account)",
+        "minimax-*/hy3*"
+      ],
+      "rationale": "Universal OpenAI-compat routing must keep CloudWise as the newapi-hint exception for curated prefix families including hy3; dropping the exception misroutes hy3 away from CloudWise supplier accounts."
     },
     {
       "path": "backend/internal/service/gateway_cloudwise_relay_test.go",

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -160,7 +160,9 @@
         "\"provider\": \"dashscope\"",
         "\"provider\": \"moonshot\"",
         "\"provider\": \"volcengine\"",
-        "\"provider\": \"zhipu\""
+        "\"provider\": \"zhipu\"",
+        "\"glm-5.3-flash\"",
+        "\"hy3\""
       ],
       "rationale": "Executable SSOT for all currently taxed official-list providers. The embedded registry is the last-known-good fallback and a valid protected-main envelope replaces the whole snapshot atomically. Pinning every behavior-preserving provider row and the multiplier prevents an upstream merge from silently dropping one tax family while model prices continue to parse. New providers are added here, not in Go."
     },


### PR DESCRIPTION
## 摘要

- **glm-5.3-flash**：定价来源从 Z.AI USD 改为与 `glm-5.3` 一致的 BigModel 标准价 CNY÷6.7（input ¥0.8/M、output ¥2.8/M、cache ¥0.23/M）
- **qwen TEMPORARY 条目**：`qwen3.6-plus` / `qwen3.8-flash` / `qwen3.6-35b-a3b` 从 sibling 复制 `intervals`，长上下文（>256k 或 >128k input）按高档计费，避免欠费
- **hy3 可服务**：CloudWise relay prefix gate 新增 `hy3`，legacy wildcard floor migration `tk_092` 补 `hy3*`；修复供应源账号 #114 有 mapping 但网关 400 Unsupported model 的问题
- **sentinel**：gateway-tk / pricing-availability 锚点同步 hy3 与 overlay 新 owner

## 风险

- 常规风险：overlay 价微调 + 调度 gate 扩展；hy3 需发版部署后生效，overlay 需 merge 后 `sync-runtime`
- glm-5.3-flash 单价略低于原 Z.AI USD 行（与 BigModel 标准价对齐）
- tk_092 migration：idempotent CloudWise wildcard floor 扩展（同 tk_082 模式）

## 验证

- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh` — PASS（本地）
- `go test -tags=unit ./internal/service/ -run CloudwiseRelay` — PASS
- `python3 scripts/checks/pricing-overlay.py --quiet` — PASS
- `go run ./cmd/account-model-mapping bundle --check ../ops/pricing/model-surface-bundle.json` — PASS

## 提交

- 2884e18de fix(pricing): #1916 后续 — BigModel flash 价、qwen 分档与 hy3 调度
- 60941dd79 chore(sentinel): anchor hy3 cloudwise gate 与 #1916 overlay 跟进

最新提交：60941dd79