### PR TITLE
fix(gateway): prevent false done on Claude Code fallback

### DIFF
--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -54,8 +54,14 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 		}
 	}
 
-	if result, routed, err := s.tkTryRouteForwardAsAnthropic(ctx, c, account, body, defaultMappedModel); routed {
-		return result, err
+	// A bound protocol plan is immutable. In particular, a Responses plan must
+	// not be reclassified by the legacy TokenKey account flags below: doing so
+	// pairs a Chat Completions converter with the plan-selected /v1/responses
+	// endpoint and can synthesize an empty Anthropic end_turn response.
+	if !protocolExecutionBound(ctx) {
+		if result, routed, err := s.tkTryRouteForwardAsAnthropic(ctx, c, account, body, defaultMappedModel); routed {
+			return result, err
+		}
 	}
 
 	startTime := time.Now()

--- a/backend/internal/service/protocol_execution_target_test.go
+++ b/backend/internal/service/protocol_execution_target_test.go
@@ -369,6 +369,76 @@ func TestProtocolExecutionPlanOverridesLegacyMessagesRouting(t *testing.T) {
 	}
 }
 
+func TestProtocolResponsesPlanOverridesLegacyDualStackMessagesRouting(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, stream := range []bool{false, true} {
+		stream := stream
+		t.Run(map[bool]string{false: "non_stream", true: "stream"}[stream], func(t *testing.T) {
+			body := []byte(`{"model":"gpt-5.4","max_tokens":8,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+			if stream {
+				body = []byte(`{"model":"gpt-5.4","max_tokens":8,"messages":[{"role":"user","content":"hello"}],"stream":true}`)
+			}
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+			upstream := &protocolTargetHTTPUpstream{responses: []*http.Response{
+				protocolRouteContractResponse(protocolRouteSpecByAdapter(t, protocolrouter.AdapterMessagesToResponses)),
+			}}
+			svc := protocolTargetTestService(upstream)
+			account := protocolTargetTestAccount(
+				protocolrouter.ProtocolMessages,
+				protocolrouter.ProtocolChatCompletions,
+				protocolrouter.ProtocolResponses,
+			)
+			account.Name = "openai-us4"
+			account.Extra[openai_compat.ExtraKeyResponsesSupported] = true
+			account.Extra[openai_compat.ExtraKeyNativeMessagesSupported] = true
+
+			value, err := protocolTargetTestExecution(t, protocolrouter.ProtocolMessages, body, account, func(
+				executionCtx context.Context,
+				account *Account,
+				plan protocolrouter.Plan,
+				request protocolrouter.CanonicalRequest,
+			) (any, error) {
+				if plan.TargetProtocol() != protocolrouter.ProtocolResponses || plan.AdapterID() != protocolrouter.AdapterMessagesToResponses {
+					t.Fatalf("plan target/adapter = %q/%q, want responses/%s", plan.TargetProtocol(), plan.AdapterID(), protocolrouter.AdapterMessagesToResponses)
+				}
+				return svc.ForwardAsAnthropic(executionCtx, c, account, request.Body(), "", "")
+			})
+			if err != nil {
+				t.Fatalf("ExecuteSelectedProtocol: %v", err)
+			}
+			result, ok := value.(*OpenAIForwardResult)
+			if !ok || result == nil {
+				t.Fatalf("result type = %T, want *OpenAIForwardResult", value)
+			}
+			if len(upstream.requests) != 1 {
+				t.Fatalf("upstream requests = %d, want 1", len(upstream.requests))
+			}
+			request := upstream.requests[0]
+			if got := request.URL.String(); got != "http://upstream.example/v1/responses" {
+				t.Fatalf("upstream URL = %q, want plan-selected Responses endpoint", got)
+			}
+			wireBody := readProtocolTargetRequestBody(t, request)
+			if !gjson.GetBytes(wireBody, "input").Exists() || gjson.GetBytes(wireBody, "messages").Exists() {
+				t.Fatalf("upstream body is not Responses-shaped: %s", wireBody)
+			}
+			if stream {
+				if !strings.Contains(recorder.Body.String(), `"text":"ok"`) || !strings.Contains(recorder.Body.String(), "event: message_stop") {
+					t.Fatalf("streaming Anthropic response lost Responses output: %s", recorder.Body.String())
+				}
+			} else {
+				if got := gjson.Get(recorder.Body.String(), "content.0.text").String(); got != "ok" {
+					t.Fatalf("buffered Anthropic response text = %q, want ok; body=%s", got, recorder.Body.String())
+				}
+				if got := gjson.Get(recorder.Body.String(), "usage.output_tokens").Int(); got != 1 {
+					t.Fatalf("buffered Anthropic output_tokens = %d, want 1; body=%s", got, recorder.Body.String())
+				}
+			}
+		})
+	}
+}
+
 func TestProtocolMessagesIdentityUsesNativeAnthropicCredentialContractForCNAccount(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	body := []byte(`{"model":"claude-client","max_tokens":8,"messages":[{"role":"user","content":"hello"}],"stream":false}`)

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1175,6 +1175,25 @@
       "rationale": "TK /v1/messages entry routing (tokensea native /v1/messages, CC fallback, CN providers) and OAuth prompt-cache conversation_id cleanup extracted to companion. OpenAI APIKey dual-stack relays (tokensea/cloudwise) branch to native /v1/messages passthrough for claude-* models; tokensea #92 must do this even when extra.openai_native_messages_supported is a false-negative (GPT probe timeout). Non-Claude models (MiniMax-M3, glm-5) must fall back to raw chat completions like /v1/responses. The newAPIBridgeOwnsAnthropicMessages guard MUST stay the FIRST branch: inbound /v1/messages reaches ForwardAsAnthropic directly from the handler, so without it a bridge-eligible newapi account falls through the last predicate into the OpenAI-shaped CC fallback, whose base URL resolves to \"\" for platform=newapi and defaults to api.openai.com while still sending the real channel key (Qwen/Qwen-2/Qwen-4, 2026-08-24). Dropping it compiles clean and silently re-leaks the credential."
     },
     {
+      "path": "backend/internal/service/openai_gateway_messages.go",
+      "must_contain": [
+        "if !protocolExecutionBound(ctx) {",
+        "if result, routed, err := s.tkTryRouteForwardAsAnthropic(ctx, c, account, body, defaultMappedModel); routed {"
+      ],
+      "rationale": "A scheduler-bound ProtocolResponses plan is immutable and must bypass legacy TokenKey Messages account-flag routing. If this guard is removed, dual-stack OpenAI mirror accounts can pair the Chat Completions converter with the plan-selected /v1/responses endpoint: streaming requests fail as empty Chat streams, while Claude Code's non-streaming fallback can be synthesized into an empty Anthropic end_turn and report false success."
+    },
+    {
+      "path": "backend/internal/service/protocol_execution_target_test.go",
+      "must_contain": [
+        "func TestProtocolResponsesPlanOverridesLegacyDualStackMessagesRouting(t *testing.T) {",
+        "protocolrouter.AdapterMessagesToResponses",
+        "account.Extra[openai_compat.ExtraKeyNativeMessagesSupported] = true",
+        "upstream body is not Responses-shaped",
+        "buffered Anthropic response text = %q, want ok"
+      ],
+      "rationale": "Incident-shaped regression for Claude Code on an OpenAI mirror account advertising messages, chat_completions, and responses while both native-Messages and Responses legacy flags are true. Both client stream modes must keep the planned Responses endpoint/body and preserve semantic text plus usage; otherwise streaming failure followed by Claude Code non-stream fallback can regress to false done."
+    },
+    {
       "path": "backend/internal/service/openai_gateway_messages_native.go",
       "must_contain": [
         "func (s *OpenAIGatewayService) forwardAnthropicViaNativeMessages(",


### PR DESCRIPTION
## 摘要

- 已绑定的 `ProtocolResponses` 计划不再进入旧 TokenKey Messages 路由，避免 Chat Completions 转换器与 `/v1/responses` 端点错配。
- 覆盖线上双栈镜像账号形状：同时支持 `messages`、`chat_completions`、`responses`，且 native Messages 与 Responses 能力均开启。
- 新增客户端 `stream=true` 与 `stream=false` 回归，验证 Responses 请求体、端点、文本及 usage 均不丢失，不再合成空 `end_turn`。
- xj-review 补充 gateway sentinel，机械锚定不可变计划 guard 与事故形状回归测试，防止后续 upstream merge 静默覆盖。

## 风险

- 仅影响已经由协议路由器绑定不可变执行计划的 `/v1/messages` 请求；未治理账号继续沿用原有 TokenKey 兼容路由。
- Web impact: none
- sentinel registry 已更新，锚定实现调用点与聚焦回归测试。

## 验证

- `go test ./internal/service -run "TestProtocolResponsesPlanOverridesLegacyDualStackMessagesRouting|TestProtocolExecutionPlanOverridesLegacyMessagesRouting|TestForwardAsAnthropic_ResponsesSupportedAccountStillUsesResponsesEndpoint" -count=1`
- `go test ./internal/service ./internal/pkg/apicompat -count=1`
- `python3 ./scripts/sentinels/check-gateway-tk.py`
- `./scripts/preflight.sh`

## 提交

- `bc73276af fix(gateway): keep planned responses routing immutable (no-web-impact)`
- `7bbf9c1d1 fix(review): anchor immutable messages routing regression (no-web-impact)`
- 最新提交：`7bbf9c1d1`