### PR TITLE
fix(supplier): 按飞秒官方指南改 FMGo 视频方言

### DIFF
--- a/.testing/user-stories/stories/US-048-model-supplier-source-management.md
+++ b/.testing/user-stories/stories/US-048-model-supplier-source-management.md
@@ -103,7 +103,9 @@
 - `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_FMGoSeedanceSyncProjectsOfficialClientsOnly`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_DoubaoVideoChannelProbesVideoPathNotChat`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_VideoProbeFailToFetchTaskDoesNotPass`
-- `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_FMGoVideoProbeURLUsesVideoGenerations`
+- `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_FMGoVideoProbeURLUsesChatCompletions`
+- `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_FMGoChatProbeBodyMatchesOfficialDialect`
+- `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_VideoProbeAcceptsHTTP202`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_SupplierManagedAccountDeclaresOnlyChatProtocol`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_SupplierManagedQianfanDeclaresBaiduV2ChatProtocol`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_UnmanagedQianfanIdentityKeyStaysStable`

--- a/backend/internal/handler/openai_gateway_tk_video.go
+++ b/backend/internal/handler/openai_gateway_tk_video.go
@@ -127,18 +127,7 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 	}
 	subscription, _ := middleware2.GetSubscriptionFromContext(c)
 
-	// TK: pre-flight balance hold (concurrent-overdraft fix; see
-	// openai_gateway_handler_tk_hold.go). Video reserves the exact submit-time
-	// cost (same request-derived seconds the billing path uses); refund
-	// ownership is handed to the usage-record task at submit time. Balance
-	// users only.
 	videoBilling := service.VideoSubmitBillingParamsFromBody(body)
-	hold, holdReject := h.tkApplyVideoHold(c, apiKey, reqModel, videoRequestedSeconds(body), videoBilling)
-	if holdReject {
-		h.errorResponse(c, http.StatusForbidden, "insufficient_balance", tkInsufficientBalanceForHoldMsg)
-		return
-	}
-	defer hold.ReleaseUnlessSettling()
 
 	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
 	routingStart := time.Now()
@@ -199,6 +188,19 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 	openAIMarkAffinitySelected(c, groupName, account.ID)
 
 	service.SetOpsLatencyMs(c, service.OpsRoutingLatencyMsKey, time.Since(routingStart).Milliseconds())
+
+	// The public Seedance IDs can route to several ch54 providers, whose omitted
+	// duration defaults differ. Resolve the billing duration only after account
+	// selection, then reserve before any paid upstream request. The same value is
+	// handed to settlement below so hold, generation, and recorded usage agree.
+	videoSeconds := videoBillingSecondsForAccount(account, body)
+	hold, holdReject := h.tkApplyVideoHold(c, apiKey, reqModel, videoSeconds, videoBilling)
+	if holdReject {
+		h.errorResponse(c, http.StatusForbidden, "insufficient_balance", tkInsufficientBalanceForHoldMsg)
+		return
+	}
+	defer hold.ReleaseUnlessSettling()
+
 	forwardStart := time.Now()
 
 	// Generate the public task id BEFORE dispatch so the bridge can stamp it
@@ -278,11 +280,8 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 
 	userAgent := c.GetHeader("User-Agent")
 	clientIP := ip.GetClientIP(c)
-	// Per-second video billing (veo etc.): we record at submit using the requested
-	// duration (default 8s) rather than at fetch — the submit path already holds the
-	// full billing context (apiKey/user/account/subscription), and 8s is veo's
-	// conservative max so we never under-charge when the field is omitted.
-	videoSeconds := videoRequestedSeconds(body)
+	// Per-second video billing is recorded at submit rather than fetch. The
+	// account-resolved duration above is also what the pre-flight hold reserved.
 	tkHoldRequestID := hold.HandOffToSettlement()
 	gatewayLatencyMs := tkSnapshotGatewayTransferLatencyMs(c)
 	h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
@@ -529,6 +528,17 @@ func generateVideoTaskID() string {
 // conservative 8s (veo's max) so per-second billing never under-charges when the client
 // omits the field; clamped to a sane [1,60] range.
 func videoRequestedSeconds(body []byte) int64 {
+	return videoRequestedSecondsOrDefault(body, 8)
+}
+
+func videoBillingSecondsForAccount(account *service.Account, body []byte) int64 {
+	if account != nil && newapiintegration.IsFMGoBaseURL(account.ChannelType, account.GetBaseURL()) {
+		return videoRequestedSecondsOrDefault(body, int64(newapiintegration.FMGoDefaultDuration))
+	}
+	return videoRequestedSeconds(body)
+}
+
+func videoRequestedSecondsOrDefault(body []byte, defaultSeconds int64) int64 {
 	for _, key := range []string{"seconds", "duration_seconds", "duration"} {
 		r := gjson.GetBytes(body, key)
 		if !r.Exists() {
@@ -544,7 +554,7 @@ func videoRequestedSeconds(body []byte) int64 {
 			return n
 		}
 	}
-	return 8
+	return defaultSeconds
 }
 
 // videoSubmitHasVideoInput reports whether a video submit body carries a

--- a/backend/internal/handler/openai_gateway_tk_video_test.go
+++ b/backend/internal/handler/openai_gateway_tk_video_test.go
@@ -260,6 +260,26 @@ func TestVideoRequestedSeconds(t *testing.T) {
 	}
 }
 
+func TestVideoBillingSecondsForAccount(t *testing.T) {
+	fmgo := &service.Account{
+		Platform:    service.PlatformNewAPI,
+		Type:        service.AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeDoubaoVideo,
+		Credentials: map[string]any{"base_url": newapiintegration.FMGoBaseURL},
+	}
+	ark := &service.Account{
+		Platform:    service.PlatformNewAPI,
+		Type:        service.AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeDoubaoVideo,
+		Credentials: map[string]any{"base_url": "https://ark.cn-beijing.volces.com"},
+	}
+
+	require.Equal(t, int64(newapiintegration.FMGoDefaultDuration), videoBillingSecondsForAccount(fmgo, []byte(`{"model":"doubao-seedance-2-0-260128"}`)))
+	require.Equal(t, int64(8), videoBillingSecondsForAccount(ark, []byte(`{"model":"doubao-seedance-2-0-260128"}`)))
+	require.Equal(t, int64(6), videoBillingSecondsForAccount(fmgo, []byte(`{"duration":6}`)))
+	require.Equal(t, int64(newapiintegration.FMGoDefaultDuration), videoBillingSecondsForAccount(fmgo, []byte(`{"duration":0}`)))
+}
+
 func TestVideoSubmitHasVideoInput(t *testing.T) {
 	cases := []struct {
 		name string

--- a/backend/internal/integration/newapi/fmgo.go
+++ b/backend/internal/integration/newapi/fmgo.go
@@ -9,8 +9,14 @@ import (
 	newapiconstant "github.com/QuantumNous/new-api/constant"
 )
 
-// FMGoBaseURL is the canonical FMGo (feimiao) API root.
-const FMGoBaseURL = "https://www.fmgo.top"
+// FMGoBaseURL is the canonical FMGo (feimiao) API root from the vendor guide.
+const FMGoBaseURL = "https://api.fmgo.top"
+
+// FMGo chat-completions video dialect (feimiao-v2 / feimiao-v2-fast).
+const (
+	FMGoChatCompletionsPath = "/v1/chat/completions"
+	FMGoTaskPathPrefix      = "/v1/tasks"
+)
 
 // Official Seedance 2.0 client ids TokenKey exposes. Runtime rewrite on the
 // FMGo video adaptor turns these into feimiao-v2[-fast]-{res}-{dur}s SKUs.
@@ -32,7 +38,10 @@ var (
 		"720p": {},
 	}
 	fmgoDurations = map[int]struct{}{
-		8: {}, 10: {}, 12: {}, 15: {},
+		6: {}, 8: {}, 10: {}, 12: {}, 15: {},
+	}
+	fmgoAspectRatios = map[string]struct{}{
+		"16:9": {}, "9:16": {}, "1:1": {}, "2:3": {}, "3:2": {},
 	}
 )
 
@@ -46,7 +55,7 @@ func IsFMGoBaseURL(channelType int, base string) bool {
 }
 
 // NormalizeFMGoBaseURL collapses accepted FMGo spellings to the canonical root.
-// Accepts www.fmgo.top and fmgo.top, with or without a trailing /v1.
+// Accepts api.fmgo.top, www.fmgo.top, and fmgo.top, with or without a trailing /v1.
 // Non-FMGo hosts pass through unchanged.
 func NormalizeFMGoBaseURL(base string) string {
 	base = strings.TrimRight(strings.TrimSpace(base), "/")
@@ -73,7 +82,16 @@ func isFMGoHost(host string) bool {
 	host = strings.TrimPrefix(host, "https://")
 	host = strings.TrimPrefix(host, "http://")
 	host = strings.TrimSuffix(host, "/")
-	return host == "www.fmgo.top" || host == "fmgo.top"
+	return host == "api.fmgo.top" || host == "www.fmgo.top" || host == "fmgo.top"
+}
+
+// NormalizeFMGoAspectRatio returns a vendor-legal ratio, or 16:9 when absent/unknown.
+func NormalizeFMGoAspectRatio(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if _, ok := fmgoAspectRatios[raw]; ok {
+		return raw
+	}
+	return "16:9"
 }
 
 // IsFMGoSeedanceClient reports a TokenKey-facing official Seedance 2.0 id.

--- a/backend/internal/integration/newapi/fmgo_test.go
+++ b/backend/internal/integration/newapi/fmgo_test.go
@@ -14,10 +14,12 @@ func TestIsFMGoBaseURL(t *testing.T) {
 		base        string
 		want        bool
 	}{
+		{"ch54 api", newapiconstant.ChannelTypeDoubaoVideo, "https://api.fmgo.top", true},
 		{"ch54 www", newapiconstant.ChannelTypeDoubaoVideo, "https://www.fmgo.top", true},
 		{"ch54 www /v1", newapiconstant.ChannelTypeDoubaoVideo, "https://www.fmgo.top/v1", true},
 		{"ch54 apex", newapiconstant.ChannelTypeDoubaoVideo, "https://fmgo.top", true},
 		{"ch1 www", 1, "https://www.fmgo.top", false},
+		{"ch1 api", 1, "https://api.fmgo.top", false},
 		{"ch54 ark", newapiconstant.ChannelTypeDoubaoVideo, "https://ark.cn-beijing.volces.com", false},
 		{"empty", newapiconstant.ChannelTypeDoubaoVideo, "", false},
 	}
@@ -45,6 +47,7 @@ func TestFMGoSeedanceUpstreamSKU(t *testing.T) {
 		{"fast defaults", FMGoSeedanceFastClientID, "", 0, "feimiao-v2-fast-720p-15s", false},
 		{"explicit", FMGoSeedanceClientID, "720p", 10, "feimiao-v2-720p-10s", false},
 		{"480p 8s", FMGoSeedanceClientID, "480p", 8, "feimiao-v2-480p-8s", false},
+		{"6s", FMGoSeedanceClientID, "720p", 6, "feimiao-v2-720p-6s", false},
 		{"fast 12s", FMGoSeedanceFastClientID, "720p", 12, "feimiao-v2-fast-720p-12s", false},
 		{"reject 1080p", FMGoSeedanceClientID, "1080p", 10, "", true},
 		{"reject 4k", FMGoSeedanceClientID, "4k", 10, "", true},
@@ -69,6 +72,37 @@ func TestFMGoSeedanceUpstreamSKU(t *testing.T) {
 				t.Fatalf("sku = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestNormalizeFMGoBaseURL(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []string{
+		"https://api.fmgo.top",
+		"https://api.fmgo.top/v1",
+		"https://www.fmgo.top",
+		"https://www.fmgo.top/v1/",
+		"https://fmgo.top",
+	} {
+		if got := NormalizeFMGoBaseURL(raw); got != FMGoBaseURL {
+			t.Fatalf("NormalizeFMGoBaseURL(%q) = %q, want %q", raw, got, FMGoBaseURL)
+		}
+	}
+	if got := NormalizeFMGoBaseURL("https://ark.cn-beijing.volces.com"); got != "https://ark.cn-beijing.volces.com" {
+		t.Fatalf("non-FMGo host must pass through, got %q", got)
+	}
+}
+
+func TestNormalizeFMGoAspectRatio(t *testing.T) {
+	t.Parallel()
+	if got := NormalizeFMGoAspectRatio("9:16"); got != "9:16" {
+		t.Fatalf("legal ratio = %q", got)
+	}
+	if got := NormalizeFMGoAspectRatio(""); got != "16:9" {
+		t.Fatalf("empty ratio must default to 16:9, got %q", got)
+	}
+	if got := NormalizeFMGoAspectRatio("21:9"); got != "16:9" {
+		t.Fatalf("unknown ratio must default to 16:9, got %q", got)
 	}
 }
 

--- a/backend/internal/relay/bridge/video_relay_tk_fmgo.go
+++ b/backend/internal/relay/bridge/video_relay_tk_fmgo.go
@@ -2,12 +2,14 @@ package bridge
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/model"
 	newapichannel "github.com/QuantumNous/new-api/relay/channel"
 	taskdoubao "github.com/QuantumNous/new-api/relay/channel/task/doubao"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
@@ -21,10 +23,10 @@ import (
 
 // TokenKey: FMGo (feimiao) video task adaptor.
 //
-// FMGo resells Seedance as baked SKUs (feimiao-v2[-fast]-{res}-{dur}s) behind a
-// NewAPI-shaped surface. TokenKey clients send official Ark ids plus
-// resolution/duration. Identification is channel_type + base_url only — never
-// supplier_source_id. Capability set is pinned in newapiintegration.
+// Official feimiao-v2 / feimiao-v2-fast dialect is async chat completions
+// (POST /v1/chat/completions + GET /v1/tasks/{id}), not OpenAI /v1/videos.
+// TokenKey clients still send official Ark ids plus resolution/duration.
+// Identification is channel_type + base_url only — never supplier_source_id.
 type fmgoTaskAdaptor struct {
 	*taskdoubao.TaskAdaptor
 	baseURL string
@@ -45,11 +47,28 @@ func (a *fmgoTaskAdaptor) BuildRequestURL(_ *relaycommon.RelayInfo) (string, err
 	if a.baseURL == "" {
 		return "", fmt.Errorf("fmgo video submit: empty base_url")
 	}
-	return fmt.Sprintf("%s/v1/video/generations", a.baseURL), nil
+	return a.baseURL + newapiintegration.FMGoChatCompletionsPath, nil
+}
+
+func (a *fmgoTaskAdaptor) BuildRequestHeader(c *gin.Context, req *http.Request, info *relaycommon.RelayInfo) error {
+	if err := a.TaskAdaptor.BuildRequestHeader(c, req, info); err != nil {
+		return err
+	}
+	req.Header.Set("Prefer", "respond-async")
+	return nil
 }
 
 func (a *fmgoTaskAdaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, requestBody io.Reader) (*http.Response, error) {
-	return newapichannel.DoTaskApiRequest(a, c, info, requestBody)
+	resp, err := newapichannel.DoTaskApiRequest(a, c, info, requestBody)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	// Vendor guide: create returns HTTP 202. DispatchVideoSubmit only accepts 200.
+	if resp.StatusCode == http.StatusAccepted {
+		resp.StatusCode = http.StatusOK
+		resp.Status = http.StatusText(http.StatusOK)
+	}
+	return resp, nil
 }
 
 func (a *fmgoTaskAdaptor) FetchTask(baseUrl, key string, body map[string]any, proxy string) (*http.Response, error) {
@@ -61,13 +80,12 @@ func (a *fmgoTaskAdaptor) FetchTask(baseUrl, key string, body map[string]any, pr
 	if base == "" {
 		return nil, fmt.Errorf("fmgo video fetch: empty base_url")
 	}
-	uri := fmt.Sprintf("%s/v1/videos/%s", base, taskID)
+	uri := fmt.Sprintf("%s%s/%s", base, newapiintegration.FMGoTaskPathPrefix, taskID)
 	req, err := http.NewRequest(http.MethodGet, uri, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+key)
 	client, err := newapiservice.GetHttpClientWithProxy(proxy)
 	if err != nil {
@@ -77,19 +95,13 @@ func (a *fmgoTaskAdaptor) FetchTask(baseUrl, key string, body map[string]any, pr
 }
 
 func (a *fmgoTaskAdaptor) BuildRequestBody(c *gin.Context, info *relaycommon.RelayInfo) (io.Reader, error) {
-	inner, err := a.TaskAdaptor.BuildRequestBody(c, info)
-	if err != nil {
-		return nil, err
+	orig := fmgoOriginalSubmitBody(c)
+	wireModel := gjson.GetBytes(orig, "model").String()
+	if wireModel == "" && info != nil {
+		wireModel = info.OriginModelName
 	}
-	if inner == nil {
-		return nil, fmt.Errorf("fmgo video submit: embedded adaptor produced no body")
-	}
-	raw, err := io.ReadAll(inner)
-	if err != nil {
-		return nil, fmt.Errorf("fmgo video submit: read embedded body: %w", err)
-	}
-	client := fmgoSeedanceClientFromRelay(info, gjson.GetBytes(raw, "model").String())
-	resolution, duration, durErr := fmgoVideoParamsFromSubmit(c, raw)
+	client := fmgoSeedanceClientFromRelay(info, wireModel)
+	resolution, duration, durErr := fmgoVideoParamsFromSubmit(c, orig)
 	if durErr != nil {
 		return nil, durErr
 	}
@@ -97,17 +109,81 @@ func (a *fmgoTaskAdaptor) BuildRequestBody(c *gin.Context, info *relaycommon.Rel
 	if skuErr != nil {
 		return nil, skuErr
 	}
-	if upstream == gjson.GetBytes(raw, "model").String() {
-		return bytes.NewReader(raw), nil
-	}
-	rewritten, err := sjson.SetBytes(raw, "model", upstream)
-	if err != nil {
-		return nil, fmt.Errorf("fmgo video submit: rewrite model to %q: %w", upstream, err)
-	}
 	if info != nil {
 		info.UpstreamModelName = upstream
 	}
-	return bytes.NewReader(rewritten), nil
+	if resolution == "" {
+		resolution = newapiintegration.FMGoDefaultResolution
+	}
+	if duration == 0 {
+		duration = newapiintegration.FMGoDefaultDuration
+	}
+	payload, err := fmgoChatCompletionsBody(upstream, fmgoPromptFromSubmit(c, orig), fmgoImagesFromSubmit(c, orig), resolution, duration, fmgoAspectRatioFromSubmit(c, orig))
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(payload), nil
+}
+
+func (a *fmgoTaskAdaptor) ParseTaskResult(respBody []byte) (*relaycommon.TaskInfo, error) {
+	info := &relaycommon.TaskInfo{Code: 0}
+	status := strings.ToLower(firstNonEmptyJSONString(respBody, "status", "task.status"))
+	videoURL := firstNonEmptyJSONString(respBody, "result.url", "content.video_url")
+	reason := firstNonEmptyJSONString(respBody, "error.message", "task.error", "message")
+	switch status {
+	case "queued", "pending":
+		info.Status = model.TaskStatusQueued
+		info.Progress = "10%"
+	case "in_progress", "processing", "running":
+		info.Status = model.TaskStatusInProgress
+		info.Progress = "50%"
+	case "completed", "succeeded", "success":
+		info.Status = model.TaskStatusSuccess
+		info.Progress = "100%"
+		info.Url = videoURL
+	case "failed", "failure", "error":
+		info.Status = model.TaskStatusFailure
+		info.Progress = "100%"
+		info.Reason = reason
+	default:
+		info.Status = model.TaskStatusInProgress
+		info.Progress = "30%"
+	}
+	return info, nil
+}
+
+func fmgoChatCompletionsBody(model, prompt string, images []string, resolution string, duration int, aspectRatio string) ([]byte, error) {
+	message := map[string]any{"role": "user"}
+	if len(images) == 0 {
+		message["content"] = prompt
+	} else {
+		parts := []map[string]any{{"type": "text", "text": prompt}}
+		for _, imageURL := range images {
+			imageURL = strings.TrimSpace(imageURL)
+			if imageURL == "" {
+				continue
+			}
+			parts = append(parts, map[string]any{
+				"type":      "image_url",
+				"image_url": map[string]any{"url": imageURL},
+			})
+		}
+		message["content"] = parts
+	}
+	return json.Marshal(map[string]any{
+		"model": model,
+		"messages": []map[string]any{
+			message,
+		},
+		"generationConfig": map[string]any{
+			"videoConfig": map[string]any{
+				"duration":    duration,
+				"aspectRatio": aspectRatio,
+				"resolution":  resolution,
+			},
+		},
+		"async": true,
+	})
 }
 
 // fmgoSeedanceClientFromRelay prefers OriginModelName: production mapping remaps
@@ -231,6 +307,67 @@ func parseFMGoDurationValue(value any) (int, error) {
 	default:
 		return 0, fmt.Errorf("fmgo seedance: duration has unsupported type %T", value)
 	}
+}
+
+func fmgoPromptFromSubmit(c *gin.Context, raw []byte) string {
+	if c != nil {
+		if req, err := relaycommon.GetTaskRequest(c); err == nil {
+			if prompt := strings.TrimSpace(req.Prompt); prompt != "" {
+				return prompt
+			}
+		}
+	}
+	if prompt := firstNonEmptyJSONString(raw, "prompt", "input"); prompt != "" {
+		return prompt
+	}
+	return "probe"
+}
+
+func fmgoImagesFromSubmit(c *gin.Context, raw []byte) []string {
+	images := make([]string, 0, 4)
+	if c != nil {
+		if req, err := relaycommon.GetTaskRequest(c); err == nil {
+			images = append(images, req.Images...)
+			if trimmed := strings.TrimSpace(req.Image); trimmed != "" {
+				images = append(images, trimmed)
+			}
+			if trimmed := strings.TrimSpace(req.InputReference); trimmed != "" {
+				images = append(images, trimmed)
+			}
+		}
+	}
+	for _, path := range []string{"image", "input_reference"} {
+		if value := firstNonEmptyJSONString(raw, path); value != "" {
+			images = append(images, value)
+		}
+	}
+	seen := make(map[string]struct{}, len(images))
+	out := make([]string, 0, len(images))
+	for _, image := range images {
+		image = strings.TrimSpace(image)
+		if image == "" {
+			continue
+		}
+		if _, ok := seen[image]; ok {
+			continue
+		}
+		seen[image] = struct{}{}
+		out = append(out, image)
+	}
+	return out
+}
+
+func fmgoAspectRatioFromSubmit(c *gin.Context, raw []byte) string {
+	if c != nil {
+		if req, err := relaycommon.GetTaskRequest(c); err == nil && req.Metadata != nil {
+			for _, key := range []string{"aspect_ratio", "aspectRatio", "ratio"} {
+				if value, ok := req.Metadata[key].(string); ok {
+					return newapiintegration.NormalizeFMGoAspectRatio(value)
+				}
+			}
+		}
+	}
+	return newapiintegration.NormalizeFMGoAspectRatio(firstNonEmptyJSONString(raw, "aspect_ratio", "aspectRatio", "ratio", "metadata.aspect_ratio", "metadata.aspectRatio", "metadata.ratio"))
 }
 
 func fmgoVideoParamsFromBody(raw []byte) (string, int, error) {

--- a/backend/internal/relay/bridge/video_relay_tk_fmgo_test.go
+++ b/backend/internal/relay/bridge/video_relay_tk_fmgo_test.go
@@ -22,11 +22,12 @@ import (
 
 func TestFMGoTaskAdaptor_BuildRequestURL(t *testing.T) {
 	t.Parallel()
-	want := newapiintegration.FMGoBaseURL + "/v1/video/generations"
+	want := newapiintegration.FMGoBaseURL + newapiintegration.FMGoChatCompletionsPath
 	for _, base := range []string{
 		newapiintegration.FMGoBaseURL,
 		newapiintegration.FMGoBaseURL + "/v1",
 		"https://fmgo.top",
+		"https://www.fmgo.top",
 	} {
 		a := newFMGoTaskAdaptor()
 		a.baseURL = newapiintegration.NormalizeFMGoBaseURL(base)
@@ -45,6 +46,10 @@ func TestTaskAdaptorForChannel_SelectsFMGo(t *testing.T) {
 	got := taskAdaptorForChannel(newapiconstant.ChannelTypeDoubaoVideo, newapiintegration.FMGoBaseURL)
 	if _, ok := got.(*fmgoTaskAdaptor); !ok {
 		t.Fatalf("ch54+fmgo host must select fmgo adaptor, got %T", got)
+	}
+	got = taskAdaptorForChannel(newapiconstant.ChannelTypeDoubaoVideo, "https://www.fmgo.top")
+	if _, ok := got.(*fmgoTaskAdaptor); !ok {
+		t.Fatalf("legacy www.fmgo.top must still select fmgo adaptor, got %T", got)
 	}
 	got = taskAdaptorForChannel(newapiconstant.ChannelTypeDoubaoVideo, "https://ark.cn-beijing.volces.com")
 	if _, ok := got.(*fmgoTaskAdaptor); ok {
@@ -119,6 +124,18 @@ func TestFMGoTaskAdaptor_RewritesOfficialSeedanceSKU(t *testing.T) {
 	want := "feimiao-v2-720p-10s"
 	if got := gjson.GetBytes(wire, "model").String(); got != want {
 		t.Fatalf("wire model = %q, want %q", got, want)
+	}
+	if !gjson.GetBytes(wire, "async").Bool() {
+		t.Fatal("official feimiao-v2 submit must set async=true")
+	}
+	if gjson.GetBytes(wire, "generationConfig.videoConfig.duration").Int() != 10 {
+		t.Fatalf("videoConfig.duration = %s", gjson.GetBytes(wire, "generationConfig.videoConfig.duration").Raw)
+	}
+	if gjson.GetBytes(wire, "generationConfig.videoConfig.resolution").String() != "720p" {
+		t.Fatalf("videoConfig.resolution = %q", gjson.GetBytes(wire, "generationConfig.videoConfig.resolution").String())
+	}
+	if gjson.GetBytes(wire, "messages.0.content").String() != "a cat playing piano" {
+		t.Fatalf("chat prompt = %q", gjson.GetBytes(wire, "messages.0.content").String())
 	}
 	if info.UpstreamModelName != want {
 		t.Fatalf("UpstreamModelName = %q, want %q", info.UpstreamModelName, want)
@@ -228,12 +245,14 @@ func TestFMGoTaskAdaptor_SanitizeFetchResponse(t *testing.T) {
 	}
 }
 
-func TestFMGoTaskAdaptor_DoRequest_HitsVideoGenerations(t *testing.T) {
+func TestFMGoTaskAdaptor_DoRequest_HitsChatCompletions(t *testing.T) {
 	ensureNewAPIDeps()
-	var gotPath string
+	var gotPath, gotPrefer string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
+		gotPrefer = r.Header.Get("Prefer")
 		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
 		_, _ = w.Write([]byte(`{"id":"task-fmgo-1"}`))
 	}))
 	defer srv.Close()
@@ -250,12 +269,70 @@ func TestFMGoTaskAdaptor_DoRequest_HitsVideoGenerations(t *testing.T) {
 	a := newFMGoTaskAdaptor()
 	a.baseURL = srv.URL
 	a.TaskAdaptor.Init(info)
-	resp, err := a.DoRequest(c, info, bytes.NewReader([]byte(`{"model":"feimiao-v2-720p-15s"}`)))
+	resp, err := a.DoRequest(c, info, bytes.NewReader([]byte(`{"model":"feimiao-v2-720p-15s","async":true}`)))
 	if err != nil {
 		t.Fatalf("DoRequest: %v", err)
 	}
 	_ = resp.Body.Close()
-	if gotPath != "/v1/video/generations" {
-		t.Fatalf("path = %q, want /v1/video/generations (not Ark /api/v3)", gotPath)
+	if gotPath != newapiintegration.FMGoChatCompletionsPath {
+		t.Fatalf("path = %q, want %s (not /v1/video/generations)", gotPath, newapiintegration.FMGoChatCompletionsPath)
+	}
+	if gotPrefer != "respond-async" {
+		t.Fatalf("Prefer = %q, want respond-async", gotPrefer)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("FMGo 202 must be rewritten to 200 for DispatchVideoSubmit, got %d", resp.StatusCode)
+	}
+}
+
+func TestFMGoTaskAdaptor_FetchTask_HitsTasksPath(t *testing.T) {
+	t.Parallel()
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"task-1","status":"completed","result":{"url":"https://static.fmgo.top/v.mp4"}}`))
+	}))
+	defer srv.Close()
+	a := newFMGoTaskAdaptor()
+	resp, err := a.FetchTask(srv.URL, "k", map[string]any{"task_id": "task-1"}, "")
+	if err != nil {
+		t.Fatalf("FetchTask: %v", err)
+	}
+	_ = resp.Body.Close()
+	if gotPath != "/v1/tasks/task-1" {
+		t.Fatalf("fetch path = %q, want /v1/tasks/task-1", gotPath)
+	}
+}
+
+func TestFMGoTaskAdaptor_ParseTaskResult_Completed(t *testing.T) {
+	t.Parallel()
+	a := newFMGoTaskAdaptor()
+	info, err := a.ParseTaskResult([]byte(`{"id":"task-1","status":"completed","result":{"url":"https://static.fmgo.top/v.mp4"}}`))
+	if err != nil {
+		t.Fatalf("ParseTaskResult: %v", err)
+	}
+	if info.Url != "https://static.fmgo.top/v.mp4" {
+		t.Fatalf("completed url = %q status=%q", info.Url, info.Status)
+	}
+	if string(info.Status) != "SUCCESS" {
+		t.Fatalf("completed status = %q, want SUCCESS", info.Status)
+	}
+}
+
+func TestFMGoTaskAdaptor_Accepts6s(t *testing.T) {
+	client := newapiintegration.FMGoSeedanceClientID
+	wire, _, err := buildFMGoSubmitBody(t, client, `{"`+client+`":"`+client+`"}`, map[string]any{
+		"resolution": "720p",
+		"duration":   6,
+	})
+	if err != nil {
+		t.Fatalf("BuildRequestBody: %v", err)
+	}
+	if got := gjson.GetBytes(wire, "model").String(); got != "feimiao-v2-720p-6s" {
+		t.Fatalf("6s sku = %q", got)
+	}
+	if gjson.GetBytes(wire, "generationConfig.videoConfig.duration").Int() != 6 {
+		t.Fatalf("videoConfig.duration = %s", gjson.GetBytes(wire, "generationConfig.videoConfig.duration").Raw)
 	}
 }

--- a/backend/internal/service/account_test_service_supplier_probe.go
+++ b/backend/internal/service/account_test_service_supplier_probe.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"time"
 
@@ -74,6 +75,10 @@ func (s *AccountTestService) probeSupplierVideoModel(
 	}
 	submitURL := supplierVideoProbeURL(account.ChannelType, baseURL)
 	body := []byte(fmt.Sprintf(`{"model":%q,"prompt":"probe"}`, baseResult.UpstreamModelID))
+	fmgo := newapiintegration.IsFMGoBaseURL(account.ChannelType, baseURL)
+	if fmgo {
+		body = supplierFMGoChatProbeBody(baseResult.UpstreamModelID)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, submitURL, bytes.NewReader(body))
 	if err != nil {
 		baseResult.Status = SupplierProbeStatusFailed
@@ -82,6 +87,9 @@ func (s *AccountTestService) probeSupplierVideoModel(
 	}
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
+	if fmgo {
+		req.Header.Set("Prefer", "respond-async")
+	}
 	client := &http.Client{Timeout: 20 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -94,7 +102,11 @@ func (s *AccountTestService) probeSupplierVideoModel(
 	status := supplierVideoProbeStatus(resp.StatusCode, raw)
 	baseResult.Status = status
 	if status == SupplierProbeStatusPassed {
-		baseResult.Protocol = "openai_video"
+		if fmgo {
+			baseResult.Protocol = "fmgo_chat_completions"
+		} else {
+			baseResult.Protocol = "openai_video"
+		}
 	}
 	baseResult.Detail = supplierProbeSafeDetail(status)
 	return baseResult
@@ -104,12 +116,48 @@ func supplierVideoProbeURL(channelType int, baseURL string) string {
 	baseURL = strings.TrimRight(baseURL, "/")
 	switch {
 	case newapiintegration.IsFMGoBaseURL(channelType, baseURL):
-		return newapiintegration.NormalizeFMGoBaseURL(baseURL) + "/v1/video/generations"
+		return newapiintegration.NormalizeFMGoBaseURL(baseURL) + newapiintegration.FMGoChatCompletionsPath
 	case newapiintegration.IsXRTokenBaseURL(channelType, baseURL):
 		return newapiintegration.NormalizeXRTokenBaseURL(baseURL) + "/v1/contents/generations/tasks"
 	default:
 		return baseURL + "/api/v3/contents/generations/tasks"
 	}
+}
+
+func supplierFMGoChatProbeBody(upstreamModelID string) []byte {
+	resolution := newapiintegration.FMGoDefaultResolution
+	duration := newapiintegration.FMGoDefaultDuration
+	model := strings.TrimSpace(upstreamModelID)
+	for _, res := range []string{"720p", "480p"} {
+		if strings.Contains(model, "-"+res+"-") {
+			resolution = res
+			break
+		}
+	}
+	for _, seconds := range []int{15, 12, 10, 8, 6} {
+		if strings.HasSuffix(model, fmt.Sprintf("-%ds", seconds)) {
+			duration = seconds
+			break
+		}
+	}
+	body, err := json.Marshal(map[string]any{
+		"model": model,
+		"messages": []map[string]any{
+			{"role": "user", "content": "probe"},
+		},
+		"generationConfig": map[string]any{
+			"videoConfig": map[string]any{
+				"duration":    duration,
+				"aspectRatio": "16:9",
+				"resolution":  resolution,
+			},
+		},
+		"async": true,
+	})
+	if err != nil {
+		return []byte(`{"model":` + strconv.Quote(model) + `,"async":true}`)
+	}
+	return body
 }
 
 func supplierVideoProbeStatus(statusCode int, body []byte) SupplierProbeStatus {

--- a/backend/internal/service/account_test_service_supplier_probe_test.go
+++ b/backend/internal/service/account_test_service_supplier_probe_test.go
@@ -107,11 +107,28 @@ func TestUS048_VideoProbeFailToFetchTaskDoesNotPass(t *testing.T) {
 	}
 }
 
-func TestUS048_FMGoVideoProbeURLUsesVideoGenerations(t *testing.T) {
+func TestUS048_FMGoVideoProbeURLUsesChatCompletions(t *testing.T) {
 	got := supplierVideoProbeURL(newapiconstant.ChannelTypeDoubaoVideo, newapiintegration.FMGoBaseURL)
-	require.Equal(t, newapiintegration.FMGoBaseURL+"/v1/video/generations", got)
+	require.Equal(t, newapiintegration.FMGoBaseURL+newapiintegration.FMGoChatCompletionsPath, got)
+	got = supplierVideoProbeURL(newapiconstant.ChannelTypeDoubaoVideo, "https://www.fmgo.top")
+	require.Equal(t, newapiintegration.FMGoBaseURL+newapiintegration.FMGoChatCompletionsPath, got)
 	got = supplierVideoProbeURL(newapiconstant.ChannelTypeDoubaoVideo, "https://ark.cn-beijing.volces.com")
 	require.Equal(t, "https://ark.cn-beijing.volces.com/api/v3/contents/generations/tasks", got)
+}
+
+func TestUS048_VideoProbeAcceptsHTTP202(t *testing.T) {
+	require.Equal(t, SupplierProbeStatusPassed, supplierVideoProbeStatus(http.StatusAccepted, []byte(`{"id":"task-1"}`)))
+}
+
+func TestUS048_FMGoChatProbeBodyMatchesOfficialDialect(t *testing.T) {
+	body := supplierFMGoChatProbeBody("feimiao-v2-fast-720p-15s")
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(body, &payload))
+	require.Equal(t, "feimiao-v2-fast-720p-15s", payload["model"])
+	require.Equal(t, true, payload["async"])
+	video := payload["generationConfig"].(map[string]any)["videoConfig"].(map[string]any)
+	require.Equal(t, "720p", video["resolution"])
+	require.Equal(t, float64(15), video["duration"])
 }
 
 func TestUS048_SupplierManagedAccountDeclaresOnlyChatProtocol(t *testing.T) {

--- a/backend/internal/service/account_test_service_supplier_probe_test.go
+++ b/backend/internal/service/account_test_service_supplier_probe_test.go
@@ -126,7 +126,10 @@ func TestUS048_FMGoChatProbeBodyMatchesOfficialDialect(t *testing.T) {
 	require.NoError(t, json.Unmarshal(body, &payload))
 	require.Equal(t, "feimiao-v2-fast-720p-15s", payload["model"])
 	require.Equal(t, true, payload["async"])
-	video := payload["generationConfig"].(map[string]any)["videoConfig"].(map[string]any)
+	gen, ok := payload["generationConfig"].(map[string]any)
+	require.True(t, ok)
+	video, ok := gen["videoConfig"].(map[string]any)
+	require.True(t, ok)
 	require.Equal(t, "720p", video["resolution"])
 	require.Equal(t, float64(15), video["duration"])
 }

--- a/docs/approved/model-supplier-source-fmgo-seedance-account-rewrite.md
+++ b/docs/approved/model-supplier-source-fmgo-seedance-account-rewrite.md
@@ -34,11 +34,11 @@ operator_locks: "2026-09-01: models exactly 2 official remaps; 16 SKUs notes-onl
 识别 FMGo dialect：账号上的 `channel_type` + `base_url`（类比 XRToken ch54）。  
 **禁止**读 `supplier_source_id`。
 
-`{480p,720p} × {6,8,10,12,15}` **钉在 FMGo 账号通道 adaptor 里**。  
+`{480p,720p} × {6,8,10,12,15}` **钉在 FMGo 账号通道 adaptor 里**。
 不读供应源表，不从 notes 解析，不读账号 Extra 里的供应源字段。
 
-上游方言（飞秒使用指南）：`feimiao-v2` / `feimiao-v2-fast` 走  
-`https://api.fmgo.top` 的 `POST /v1/chat/completions`（`Prefer: respond-async`、`async: true`、`generationConfig.videoConfig`），轮询 `GET /v1/tasks/{task_id}`。  
+上游方言（飞秒使用指南）：`feimiao-v2` / `feimiao-v2-fast` 走
+`https://api.fmgo.top` 的 `POST /v1/chat/completions`（`Prefer: respond-async`、`async: true`、`generationConfig.videoConfig`），轮询 `GET /v1/tasks/{task_id}`。
 不是 `/v1/video/generations`，也不是通用 Chat 伪成功。
 
 ## 已拍板

--- a/docs/approved/model-supplier-source-fmgo-seedance-account-rewrite.md
+++ b/docs/approved/model-supplier-source-fmgo-seedance-account-rewrite.md
@@ -34,8 +34,12 @@ operator_locks: "2026-09-01: models exactly 2 official remaps; 16 SKUs notes-onl
 识别 FMGo dialect：账号上的 `channel_type` + `base_url`（类比 XRToken ch54）。  
 **禁止**读 `supplier_source_id`。
 
-`{480p,720p} × {8,10,12,15}` **钉在 FMGo 账号通道 adaptor 里**。  
+`{480p,720p} × {6,8,10,12,15}` **钉在 FMGo 账号通道 adaptor 里**。  
 不读供应源表，不从 notes 解析，不读账号 Extra 里的供应源字段。
+
+上游方言（飞秒使用指南）：`feimiao-v2` / `feimiao-v2-fast` 走  
+`https://api.fmgo.top` 的 `POST /v1/chat/completions`（`Prefer: respond-async`、`async: true`、`generationConfig.videoConfig`），轮询 `GET /v1/tasks/{task_id}`。  
+不是 `/v1/video/generations`，也不是通用 Chat 伪成功。
 
 ## 已拍板
 
@@ -58,9 +62,12 @@ operator_locks: "2026-09-01: models exactly 2 official remaps; 16 SKUs notes-onl
 ## 上游能力集合（adaptor 内钉死）
 
 ```text
+host       ∈ {api.fmgo.top, www.fmgo.top, fmgo.top} → canonical https://api.fmgo.top
 resolution ∈ {480p, 720p}
-duration   ∈ {8, 10, 12, 15}
+duration   ∈ {6, 8, 10, 12, 15}
 SKU        = feimiao-v2[-fast]-{resolution}-{duration}s
+submit     = POST /v1/chat/completions
+poll       = GET /v1/tasks/{id}
 ```
 
 ## 供应源唯一存法
@@ -79,13 +86,14 @@ SKU        = feimiao-v2[-fast]-{resolution}-{duration}s
 1. fast 与否 → `feimiao-v2-fast-*` / `feimiao-v2-*`
 2. resolution：缺省 → `720p`；∈ 集合 → 用其值；否则明确拒绝
 3. duration：缺省 → `15`；∈ 集合 → 用其值；否则明确拒绝
-4. 拼出唯一上游 SKU 再提交 FMGo 视频 API
+4. 拼出唯一上游 SKU，按官方 chat-completions 视频方言提交
 
 ## 探测
 
-- `channel_type=54` → 视频协议，与账号通道同一路径。
+- `channel_type=54` → 与账号通道同一上游方言。
+- FMGo：官方 `POST /v1/chat/completions` 视频体（不是「hi」Chat 伪成功）。
 - 只探两行锚点：`feimiao-v2-720p-15s`、`feimiao-v2-fast-720p-15s`。
-- 失败不写账号。禁止 Chat 伪成功。
+- 失败不写账号。禁止用普通 Chat Completions 探测冒充视频可服务。
 
 ## Scenarios
 

--- a/docs/approved/model-supplier-source-probe-sync-split.md
+++ b/docs/approved/model-supplier-source-probe-sync-split.md
@@ -90,7 +90,8 @@ POST /admin/supplier-sources/:id/sync
 ### MODIFIED — 探测协议
 
 - 默认：Chat Completions 正向证据。
-- 通道能力为视频（DoubaoVideo / 54）→ 视频协议真实探测，不得用 Chat 伪成功。
+- 通道能力为视频（DoubaoVideo / 54）→ 该通道真实视频方言，不得用「hi」Chat 伪成功。
+- FMGo `feimiao-v2` 的真实视频方言就是官方异步 `POST /v1/chat/completions`；Ark / XRToken 仍走各自视频口。
 - 每一行用该行 `upstream_model_id` 探测；失败封闭，不写账号。
 - 不按 client 名字开协议例外。
 

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2923,6 +2923,7 @@
       "path": "backend/internal/handler/openai_gateway_tk_video.go",
       "must_contain": [
         "videoRequestedSeconds",
+        "videoBillingSecondsForAccount",
         "VideoSubmitBillingParamsFromBody",
         "VideoDurationSeconds",
         "VideoResolution:      videoBilling.Resolution",
@@ -2934,7 +2935,16 @@
         "TkVideoModelUnpriced",
         "videoDurationBelowProviderMinimum"
       ],
-      "rationale": "Per-second video billing: VideoSubmitBillingParamsFromBody resolves resolution/audio/image-input once and the explicit ForwardResult assignments carry those exact dimensions into settlement; dropping any one silently flattens tier billing even when submit still succeeds. videoRequestedSeconds anchors duration, RefundVideoUsageOnFailure anchors terminal-failed refund, and videoSubmitHasVideoInput anchors the unpriced video-input reject guard. videoDurationBelowProviderMinimum keeps XRToken's four-second floor local and before paid upstream dispatch."
+      "rationale": "Per-second video billing: VideoSubmitBillingParamsFromBody resolves resolution/audio/image-input once and the explicit ForwardResult assignments carry those exact dimensions into settlement; dropping any one silently flattens tier billing even when submit still succeeds. videoBillingSecondsForAccount resolves provider-specific omitted-duration semantics after account selection and before the hold, while videoRequestedSeconds anchors the shared explicit-duration parser. RefundVideoUsageOnFailure anchors terminal-failed refund, videoSubmitHasVideoInput anchors the unpriced video-input reject guard, and videoDurationBelowProviderMinimum keeps XRToken's four-second floor local and before paid upstream dispatch."
+    },
+    {
+      "path": "backend/internal/handler/openai_gateway_tk_video_test.go",
+      "must_contain": [
+        "TestVideoBillingSecondsForAccount",
+        "FMGoDefaultDuration",
+        "https://ark.cn-beijing.volces.com"
+      ],
+      "rationale": "The same public Seedance model can route to FMGo or official Ark. This regression locks FMGo's omitted duration to the adaptor-owned 15 seconds while preserving the shared 8-second default for Ark, and proves explicit durations still win."
     },
     {
       "path": "backend/internal/service/billing_service_tk_video_test.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7602,9 +7602,13 @@
         "protocol != \"account_test\" && protocol != \"openai_chat_completions\"",
         "SupplierProbeStatusProtocolUnsupported",
         "return \"openai_responses\"",
-        "return \"anthropic_messages\""
+        "return \"anthropic_messages\"",
+        "supplierFMGoChatProbeBody",
+        "fmgo_chat_completions",
+        "respond-async",
+        "FMGoChatCompletionsPath"
       ],
-      "rationale": "Version-one supplier probing is intentionally fixed to OpenAI Chat. Even successful Responses or Anthropic Messages evidence must fail closed as protocol_unsupported instead of silently expanding the production transport surface."
+      "rationale": "Version-one supplier probing is intentionally fixed to OpenAI Chat. Even successful Responses or Anthropic Messages evidence must fail closed as protocol_unsupported instead of silently expanding the production transport surface. FMGo ch54 is the exception that still uses official async chat-completions video dialect (not hi-Chat fake success, not /v1/video/generations)."
     },
     {
       "path": "backend/internal/service/account_test_service_supplier_probe_test.go",
@@ -7614,9 +7618,12 @@
         "TestUS048_SupplierManagedOpenAIEndpointDoesNotDuplicateV1",
         "TestUS048_SupplierProbeDoesNotLogRawUpstreamError",
         "TestUS048_SupplierProbeClassifiesEventsWithoutPersistingUpstreamDetail",
-        "successful non-chat protocol remains unsupported"
+        "successful non-chat protocol remains unsupported",
+        "TestUS048_FMGoVideoProbeURLUsesChatCompletions",
+        "TestUS048_FMGoChatProbeBodyMatchesOfficialDialect",
+        "TestUS048_VideoProbeAcceptsHTTP202"
       ],
-      "rationale": "Probe regressions pin in-memory execution, the managed identity's single Chat capability, supplier-only trailing-/v1 normalization, raw-upstream log redaction, fixed public result details, and non-Chat failure closure without persisting an account or upstream response body."
+      "rationale": "Probe regressions pin in-memory execution, the managed identity's single Chat capability, supplier-only trailing-/v1 normalization, raw-upstream log redaction, fixed public result details, and non-Chat failure closure without persisting an account or upstream response body. FMGo video probe must hit official chat completions, carry the vendor video body, and accept HTTP 202."
     },
     {
       "path": "backend/internal/service/supplier_managed_account_guard.go",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -779,14 +779,17 @@
         "FMGoSeedanceUpstreamSKU",
         "FMGoSeedanceClientID",
         "FMGoSeedanceFastClientID",
+        "FMGoChatCompletionsPath",
+        "api.fmgo.top",
         "ChannelTypeDoubaoVideo"
       ],
-      "rationale": "FMGo (feimiao) host detection and pinned Seedance capability set. Identification is channel_type + base_url only; scheduler/gateway must never read supplier_source_id. FMGoSeedanceUpstreamSKU is the only owner of {480p,720p} x {8,10,12,15} and the feimiao-v2[-fast]-{res}-{dur}s formula. Dropping it freezes probe-anchor SKUs or leaks inventory ids as clients."
+      "rationale": "FMGo (feimiao) host detection and pinned Seedance capability set. Identification is channel_type + base_url only; scheduler/gateway must never read supplier_source_id. Canonical host is api.fmgo.top. FMGoSeedanceUpstreamSKU is the only owner of {480p,720p} x {6,8,10,12,15} and the feimiao-v2[-fast]-{res}-{dur}s formula. Dropping it freezes probe-anchor SKUs or leaks inventory ids as clients."
     },
     {
       "path": "backend/internal/integration/newapi/fmgo_test.go",
       "must_contain": [
         "TestIsFMGoBaseURL",
+        "TestNormalizeFMGoBaseURL",
         "TestFMGoSeedanceUpstreamSKU",
         "TestParseFMGoVideoDuration"
       ],
@@ -797,13 +800,15 @@
       "must_contain": [
         "fmgoTaskAdaptor",
         "newFMGoTaskAdaptor",
-        "/v1/video/generations",
+        "/v1/chat/completions",
+        "/v1/tasks",
+        "respond-async",
         "fmgoSeedanceClientFromRelay",
         "fmgoVideoParamsFromSubmit",
         "FMGoSeedanceUpstreamSKU",
         "duration_seconds"
       ],
-      "rationale": "TK companion task adaptor for FMGo video. Must submit /v1/video/generations, rewrite official Seedance clients from OriginModelName plus request params, and ignore probe-anchor mapping as a frozen SKU. Capability set stays in newapiintegration, never notes or supplier Extra."
+      "rationale": "TK companion task adaptor for official FMGo feimiao-v2 dialect: async POST /v1/chat/completions plus GET /v1/tasks/{id}. Must rewrite official Seedance clients from OriginModelName plus request params, ignore probe-anchor mapping as a frozen SKU, and not fall back to /v1/video/generations. Capability set stays in newapiintegration, never notes or supplier Extra."
     },
     {
       "path": "backend/internal/relay/bridge/video_relay_tk_fmgo_test.go",
@@ -816,7 +821,10 @@
         "TestFMGoTaskAdaptor_RejectsUnsupportedResolution",
         "TestFMGoTaskAdaptor_RejectsUnsupportedDuration",
         "TestFMGoTaskAdaptor_ReadsDurationSecondsAlias",
-        "TestFMGoTaskAdaptor_SanitizeFetchResponse"
+        "TestFMGoTaskAdaptor_SanitizeFetchResponse",
+        "TestFMGoTaskAdaptor_DoRequest_HitsChatCompletions",
+        "TestFMGoTaskAdaptor_FetchTask_HitsTasksPath",
+        "TestFMGoTaskAdaptor_ParseTaskResult_Completed"
       ],
       "rationale": "Focused FMGo video regressions: host selection, official + probe-anchor rewrite, defaults, and illegal param rejection."
     },


### PR DESCRIPTION
## 摘要

- 现网对飞秒 `feimiao-v2` 探测失败：`www.fmgo.top` 的 `/v1/video/generations` 返回 404。官方指南要求 `https://api.fmgo.top` 的异步 `POST /v1/chat/completions`（`Prefer: respond-async`、`async:true`、`generationConfig.videoConfig`），轮询 `GET /v1/tasks/{id}`。
- 探测与账号视频 adaptor 统一走同一方言；创建 202 改写成 200；时长集合补上 6s。客户端对外仍是 `POST /v1/video/generations` + 两个官方 Seedance id。
- 计费在账户选定后解析供应商缺省时长：FMGo 为 15s，官方 Ark 等其他通道保持 8s；余额 hold 与最终结算复用同一时长。
- 无管理面/用户面改动（no-web-impact）。

## 风险

常规风险：变更触达上游协议、探测门禁与视频计费默认值。供应商识别同时依赖 `channel_type` 与 `base_url`，避免同一公开模型路由到非 FMGo 通道时被多计费；hold 仍发生在任何付费上游请求前。现网尚无 fmgo 受管账号，爆炸半径有限。发版前再 sync 仍会 422；上线后再对供应源 10 做探测/同步。

## 验证

- `go test -tags=unit ./internal/handler/ ./internal/relay/bridge/ ./internal/integration/newapi/` 通过
- `python3 ./scripts/sentinels/check-newapi.py` 通过
- `python3 ./scripts/sentinels/check-gateway-tk.py` 通过（821/821）
- `python3 ./scripts/sentinels/check-registry-update-gate.py` 通过
- `./scripts/preflight.sh` 通过

## 提交

- `df9b9a774` fix(supplier): 按飞秒官方指南改 FMGo 视频方言 (no-web-impact)
- `df5f9c61b` fix(supplier): 对齐 US-048 探测测试名并消除 type-assert lint (no-web-impact)
- `358c40624` fix(supplier): address R-001 — 给 FMGo 探测方言补 gateway-tk 锚点 (no-web-impact)
- `e250db590` fix(billing): address R-001 — 对齐 FMGo 缺省视频时长 (no-web-impact)
- `9151d879b` fix(docs): address R-002 — 清理 FMGo 规范行尾空格 (no-web-impact)

最新提交：`9151d879b`