### PR TITLE
fix(ops): 供应源托管账号豁免 model_mapping floor 收敛

### DIFF
--- a/docs/approved/model-supplier-source-management.md
+++ b/docs/approved/model-supplier-source-management.md
@@ -3,7 +3,7 @@ title: TokenKey Model Supplier Source Management
 status: approved
 approved_by: "xuejiao (operator directives through 2026-08-28)"
 approved_at: 2026-08-27
-updated: 2026-08-31
+updated: 2026-09-01
 created: 2026-08-27
 owners: [tk-platform]
 scope: "supplier facts, admin API/UI, credential isolation, account projection, probe gate; managed accounts behave like ordinary accounts after create, with sync overwriting projection fields"
@@ -122,6 +122,11 @@ supplier_discount_band
 仅在供应源点击「同步账号」时，通过专用窄写命令覆盖供应源投影字段（名称、凭证含
 `model_mapping`、priority、concurrency、status/schedulable、transport 等），不读取或写入账号组，
 也不携带 `rate_multiplier`。供应投影更新不能回退到通用账号 Update。
+
+`model_mapping` 所有权：带 `extra.supplier_source_id` 的账号由供应源 Sync 拥有（采购投影的精确
+集合）。`ops/pricing/manage-account-model-mapping-runtime.py` 的 `check-accounts` /
+`apply-accounts` / `release-gate` **不得**用平台/渠道 serving floor 去扩写或判缺这些账号；
+floor 收敛只作用于非供应源托管账号。否则会出现 Sync 子集 ↔ floor 全量的乒乓。
 
 账号列表显示徽标：
 

--- a/ops/pricing/manage-account-model-mapping-runtime.py
+++ b/ops/pricing/manage-account-model-mapping-runtime.py
@@ -23,6 +23,12 @@ surface bundle, then
 ``apply-accounts --confirm ...`` when an operator has reviewed the diff and
 wants to overwrite persisted mappings.
 
+Supplier-source managed accounts (``extra.supplier_source_id`` present) are
+exempt from floor convergence in ``check-accounts`` / ``apply-accounts`` /
+``release-gate``. Their ``model_mapping`` is owned by supplier Sync as a
+procurement projection (exact client→upstream set), not the platform/channel
+serving floor. Applying the floor would fight the next Sync.
+
 ``release-gate`` is an explicit, **prod-only** modelops/model-activation floor
 check. It compares live prod account mappings to the selected release bundle's
 required floor and fails closed when prod is behind that model surface. It is not a
@@ -104,7 +110,8 @@ SELECT jsonb_build_object(
       'mirror_platform', a.credentials->>'mirror_platform',
       'base_url', a.credentials->>'base_url',
       'auth_mode', a.credentials->>'auth_mode',
-      'vertex_capability_profile', a.credentials->>'vertex_capability_profile'
+      'vertex_capability_profile', a.credentials->>'vertex_capability_profile',
+      'supplier_source_id', a.extra->>'supplier_source_id'
     ) ORDER BY a.platform, a.id)
     FROM accounts a
     WHERE a.deleted_at IS NULL
@@ -679,10 +686,26 @@ def _vertex_profile_issue(row: dict[str, Any], floor: dict[str, Any]) -> str | N
     return None
 
 
+def _is_supplier_managed_account(row: dict[str, Any]) -> bool:
+    """True when Extra.supplier_source_id marks supplier Sync as mapping owner.
+
+    Presence of a non-empty value is enough (matches Go IsSupplierManagedAccount).
+    Floor check/apply must not expand these rows to a platform/channel floor.
+    """
+    raw = (row or {}).get("supplier_source_id")
+    if raw is None:
+        return False
+    if isinstance(raw, str):
+        return bool(raw.strip())
+    return True
+
+
 def _account_plan(
     row: dict[str, Any],
     floor: dict[str, Any],
 ) -> dict[str, Any] | None:
+    if _is_supplier_managed_account(row):
+        return None
     want, scope = _desired_mapping_for_account(row, floor)
     if not want:
         return None
@@ -917,6 +940,10 @@ def _collect_apply_plan(
             plan["observed_model_mapping"] = _canonicalize_observed_mapping(row)
             account_changes.append(plan)
         elif account_ids is not None:
+            # Supplier Sync owns mapping; floor apply must not rewrite these rows.
+            if _is_supplier_managed_account(row):
+                skipped_ids.append(int(row.get("id") or 0))
+                continue
             # Distinguish skipped (no desired mapping / no scope match) from already-compliant.
             want, _scope = _desired_mapping_for_account(row, floor)
             if want:
@@ -2036,6 +2063,54 @@ def cmd_selftest(_args) -> int:
         floor,
     )
     assert openai_plan and openai_plan["diff"]["missing_keys"] == ["gpt-5.6-sol"]
+    # Supplier Sync owns model_mapping: subset vs channel floor must not violate or apply.
+    supplier_subset = {
+        "id": 104,
+        "platform": "newapi",
+        "type": "apikey",
+        "channel_type": 45,
+        "base_url": "https://qianfan.baidubce.com",
+        "supplier_source_id": "7",
+        "model_mapping": {
+            "deepseek-v4-flash": "deepseek-v4-flash",
+            "deepseek-v4-pro": "deepseek-v4-pro",
+        },
+    }
+    assert _is_supplier_managed_account(supplier_subset)
+    assert not _is_supplier_managed_account({**supplier_subset, "supplier_source_id": None})
+    assert not _is_supplier_managed_account({**supplier_subset, "supplier_source_id": ""})
+    assert _account_plan(supplier_subset, floor) is None
+    assert _account_plan({**supplier_subset, "supplier_source_id": None}, floor) is not None
+    original_run_check_sql_json = globals()["_run_check_sql_json"]
+    original_load_effective_floor = globals()["_load_effective_floor"]
+    globals()["_run_check_sql_json"] = lambda _region, _instance_id, _label: {
+        "runtime_setting": None,
+        "accounts": [supplier_subset, {
+            "id": 2,
+            "platform": "openai",
+            "type": "oauth",
+            "model_mapping": {
+                "gpt-5.6": "gpt-5.6",
+                "gpt-5.6-luna": "gpt-5.6-luna",
+                "gpt-5.6-terra": "gpt-5.6-terra",
+            },
+        }],
+        "antigravity_groups": [],
+    }
+    globals()["_load_effective_floor"] = lambda _raw: floor
+    try:
+        check_violations, _, _ = _check_target("prod", "test-region", "i-test")
+        assert all(int(v.get("id") or 0) != 104 for v in check_violations)
+        assert any(int(v.get("id") or 0) == 2 for v in check_violations)
+        apply_plan = _collect_apply_plan(
+            "prod", "test-region", "i-test", account_ids=[104, 2],
+        )
+        assert 104 in apply_plan["skipped_ids"]
+        assert 104 not in apply_plan["changed_ids"]
+        assert 2 in apply_plan["changed_ids"]
+    finally:
+        globals()["_run_check_sql_json"] = original_run_check_sql_json
+        globals()["_load_effective_floor"] = original_load_effective_floor
     account_override_row = {
         "id": 12345,
         "platform": "newapi",

--- a/ops/pricing/manage-account-model-mapping-runtime.py
+++ b/ops/pricing/manage-account-model-mapping-runtime.py
@@ -111,7 +111,7 @@ SELECT jsonb_build_object(
       'base_url', a.credentials->>'base_url',
       'auth_mode', a.credentials->>'auth_mode',
       'vertex_capability_profile', a.credentials->>'vertex_capability_profile',
-      'supplier_source_id', a.extra->>'supplier_source_id'
+      'supplier_source_id_present', COALESCE(a.extra ? 'supplier_source_id', false)
     ) ORDER BY a.platform, a.id)
     FROM accounts a
     WHERE a.deleted_at IS NULL
@@ -689,15 +689,11 @@ def _vertex_profile_issue(row: dict[str, Any], floor: dict[str, Any]) -> str | N
 def _is_supplier_managed_account(row: dict[str, Any]) -> bool:
     """True when Extra.supplier_source_id marks supplier Sync as mapping owner.
 
-    Presence of a non-empty value is enough (matches Go IsSupplierManagedAccount).
+    SQL projects JSONB key presence so even a malformed JSON null value matches
+    Go IsSupplierManagedAccount's fail-closed ownership rule.
     Floor check/apply must not expand these rows to a platform/channel floor.
     """
-    raw = (row or {}).get("supplier_source_id")
-    if raw is None:
-        return False
-    if isinstance(raw, str):
-        return bool(raw.strip())
-    return True
+    return (row or {}).get("supplier_source_id_present") is True
 
 
 def _account_plan(
@@ -848,6 +844,8 @@ def _check_target(
         return violations, [], runtime_present
     floor = _load_effective_floor(runtime_raw)
     for row in bundle.get("accounts") or []:
+        if _is_supplier_managed_account(row):
+            continue
         plan = _account_plan(row, floor)
         if plan:
             plan["target"] = label
@@ -2070,22 +2068,30 @@ def cmd_selftest(_args) -> int:
         "type": "apikey",
         "channel_type": 45,
         "base_url": "https://qianfan.baidubce.com",
-        "supplier_source_id": "7",
+        "supplier_source_id_present": True,
         "model_mapping": {
             "deepseek-v4-flash": "deepseek-v4-flash",
             "deepseek-v4-pro": "deepseek-v4-pro",
         },
     }
     assert _is_supplier_managed_account(supplier_subset)
-    assert not _is_supplier_managed_account({**supplier_subset, "supplier_source_id": None})
-    assert not _is_supplier_managed_account({**supplier_subset, "supplier_source_id": ""})
+    # SQL key-presence projection stays true even when the JSON value is null.
+    assert _is_supplier_managed_account({**supplier_subset, "supplier_source_id_present": True})
+    assert not _is_supplier_managed_account({**supplier_subset, "supplier_source_id_present": False})
+    assert "COALESCE(a.extra ? 'supplier_source_id', false)" in ACCOUNT_MODEL_MAPPING_CHECK_SQL
     assert _account_plan(supplier_subset, floor) is None
-    assert _account_plan({**supplier_subset, "supplier_source_id": None}, floor) is not None
+    assert _account_plan({**supplier_subset, "supplier_source_id_present": False}, floor) is not None
+    supplier_vertex = {
+        **supplier_subset,
+        "id": 105,
+        "channel_type": 41,
+        "vertex_capability_profile": "",
+    }
     original_run_check_sql_json = globals()["_run_check_sql_json"]
     original_load_effective_floor = globals()["_load_effective_floor"]
     globals()["_run_check_sql_json"] = lambda _region, _instance_id, _label: {
         "runtime_setting": None,
-        "accounts": [supplier_subset, {
+        "accounts": [supplier_subset, supplier_vertex, {
             "id": 2,
             "platform": "openai",
             "type": "oauth",
@@ -2101,12 +2107,15 @@ def cmd_selftest(_args) -> int:
     try:
         check_violations, _, _ = _check_target("prod", "test-region", "i-test")
         assert all(int(v.get("id") or 0) != 104 for v in check_violations)
+        assert all(int(v.get("id") or 0) != 105 for v in check_violations)
         assert any(int(v.get("id") or 0) == 2 for v in check_violations)
         apply_plan = _collect_apply_plan(
-            "prod", "test-region", "i-test", account_ids=[104, 2],
+            "prod", "test-region", "i-test", account_ids=[104, 105, 2],
         )
         assert 104 in apply_plan["skipped_ids"]
+        assert 105 in apply_plan["skipped_ids"]
         assert 104 not in apply_plan["changed_ids"]
+        assert 105 not in apply_plan["changed_ids"]
         assert 2 in apply_plan["changed_ids"]
     finally:
         globals()["_run_check_sql_json"] = original_run_check_sql_json

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2766,7 +2766,7 @@
         "\"account_bulk_changed\"",
         "\"group_changed\"",
         "def _is_supplier_managed_account(",
-        "'supplier_source_id', a.extra->>'supplier_source_id'",
+        "'supplier_source_id_present', COALESCE(a.extra ? 'supplier_source_id', false)",
         "if _is_supplier_managed_account(row):"
       ],
       "must_not_contain": [

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2764,14 +2764,17 @@
         "forbidden_model_mapping_keys",
         "_BUNDLE.account_override_scope",
         "\"account_bulk_changed\"",
-        "\"group_changed\""
+        "\"group_changed\"",
+        "def _is_supplier_managed_account(",
+        "'supplier_source_id', a.extra->>'supplier_source_id'",
+        "if _is_supplier_managed_account(row):"
       ],
       "must_not_contain": [
         "GO_HELPER",
         "--ssot-repo-root",
         "--allow-extra-model-mapping"
       ],
-      "rationale": "Explicit ops check/apply surfaces for account model_mapping. The script must consume the checksummed bundle without Go/source discovery, prioritize property-selected account overrides over shared platform/channel floors, select VolcEngine Agent Plan by platform/channel/base_url rather than account ID, use one required-floor + forbidden-policy rule, preserve compatible extras, keep check-accounts read-only, scope release-gate to explicit model activation, require confirmation before writes, update only model_mapping/group scopes, and enqueue scheduler outbox events. Activation pins the resolved prod instance and rechecks runtime-shadow absence under a settings-table lock before writes. Generic deploy wiring is prohibited by the workflow sentinel above, while direct Edge diagnostics/apply remain available."
+      "rationale": "Explicit ops check/apply surfaces for account model_mapping. The script must consume the checksummed bundle without Go/source discovery, prioritize property-selected account overrides over shared platform/channel floors, select VolcEngine Agent Plan by platform/channel/base_url rather than account ID, use one required-floor + forbidden-policy rule, preserve compatible extras, keep check-accounts read-only, scope release-gate to explicit model activation, require confirmation before writes, update only model_mapping/group scopes, and enqueue scheduler outbox events. Accounts with Extra.supplier_source_id are owned by supplier Sync (exact procurement subset) and must be exempt from floor check/apply/release-gate convergence. Activation pins the resolved prod instance and rechecks runtime-shadow absence under a settings-table lock before writes. Generic deploy wiring is prohibited by the workflow sentinel above, while direct Edge diagnostics/apply remain available."
     },
     {
       "path": "backend/cmd/account-model-mapping/main.go",


### PR DESCRIPTION
## 摘要
- 供应源 Sync 拥有带 `extra.supplier_source_id` 账号的 `model_mapping`（采购投影精确集合）。
- `check-accounts` / `apply-accounts` / `release-gate` 对这些账号跳过全部平台/渠道 floor 检查，包含 Vertex profile 门禁。
- SQL 以 JSONB 键存在性对齐 Go 的 fail-closed ownership，`supplier_source_id: null` 仍视为托管。
- 审批基线与 sentinel 锚定所有权边界及 SQL 投影。

## 风险
- 常规：仅 ops 工具、sentinel 与 approved 文档；不改网关运行时、不改线上账号 credentials。
- 非托管账号仍按原平台/渠道 floor 检查；供应源托管账号继续由 Sync 精确投影 mapping。

## 验证
- `python3 ops/pricing/manage-account-model-mapping-runtime.py --selftest` → ok（覆盖 ch41、JSON-null presence、正负向豁免）
- `python3 scripts/sentinels/check-gateway-tk.py` → PASS（822/822）
- `./scripts/preflight.sh` → PASS

## 提交
- a6f6d1423 fix(ops): 供应源托管账号豁免 model_mapping floor 收敛
- e7ed67eab fix(ops): anchor supplier mapping floor exemption in sentinel
- ad8aa49ff fix(ops): address R-002 R-003 — 收紧供应源 floor 豁免 (no-web-impact)
- 最新提交：ad8aa49ff