### PR TITLE
fix(lifecycle): edge 热库保留与 prod 对齐（90/30/7）

### DIFF
--- a/backend/internal/service/data_lifecycle_policy_tk.go
+++ b/backend/internal/service/data_lifecycle_policy_tk.go
@@ -6,9 +6,12 @@ const (
 	prodUsageLogRetentionDays  = 90
 	prodErrorLogRetentionDays  = 30
 	prodSystemLogRetentionDays = 7
-	edgeUsageLogRetentionDays  = 7
-	edgeErrorLogRetentionDays  = 14
-	edgeSystemLogRetentionDays = 3
+	// Edge hot-layer retention matches prod: usage 90d / error 30d / system 7d.
+	// (Previously capped at 7/14/3 for small Lightsail disks; current ~60GiB
+	// edges have headroom, and short windows broke cross-edge billing audits.)
+	edgeUsageLogRetentionDays  = 90
+	edgeErrorLogRetentionDays  = 30
+	edgeSystemLogRetentionDays = 7
 	billingDedupRetentionDays  = 365
 )
 
@@ -48,7 +51,7 @@ func capLifecycleRetention(configured, upperBound int) int {
 }
 
 // UsageLogRetentionDays 返回当前节点 usage_logs 的有效保留天数。
-// prod 上限 90，edge 上限 7；配置更短时用配置值。展示用，0 或负值回落到 prod 默认。
+// prod/edge 上限均为 90；配置更短时用配置值。展示用，0 或负值回落到 prod 默认。
 func UsageLogRetentionDays(cfg *config.Config) int {
 	days := resolveDataLifecyclePolicy(cfg, config.OpsCleanupConfig{}).usageLogRetentionDays
 	if days <= 0 {

--- a/backend/internal/service/data_lifecycle_policy_tk_test.go
+++ b/backend/internal/service/data_lifecycle_policy_tk_test.go
@@ -38,9 +38,9 @@ func TestResolveDataLifecyclePolicyRoleLimits(t *testing.T) {
 		},
 	}, cleanup)
 	require.Equal(t, "edge", edge.role)
-	require.Equal(t, 7, edge.usageLogRetentionDays)
-	require.Equal(t, 14, edge.errorLogRetentionDays)
-	require.Equal(t, 3, edge.systemLogRetentionDays)
+	require.Equal(t, 90, edge.usageLogRetentionDays)
+	require.Equal(t, 30, edge.errorLogRetentionDays)
+	require.Equal(t, 7, edge.systemLogRetentionDays)
 	require.Equal(t, 365, edge.billingDedupRetentionDays)
 }
 
@@ -86,7 +86,7 @@ func TestUsageLogRetentionDaysUsesResolvedPolicy(t *testing.T) {
 			Retention: config.DashboardAggregationRetentionConfig{UsageLogsDays: 180},
 		},
 	}))
-	require.Equal(t, 7, UsageLogRetentionDays(&config.Config{
+	require.Equal(t, 90, UsageLogRetentionDays(&config.Config{
 		Server: config.ServerConfig{FrontendURL: "https://api-us1.tokenkey.dev"},
 		DashboardAgg: config.DashboardAggregationConfig{
 			Retention: config.DashboardAggregationRetentionConfig{UsageLogsDays: 90},

--- a/backend/internal/service/ops_cleanup_service_test.go
+++ b/backend/internal/service/ops_cleanup_service_test.go
@@ -150,8 +150,8 @@ func TestOpsCleanupServiceRunCleanupOnceUsageFailureStopsBeforeOpsTables(t *test
 	if dashboardRepo.cleanupUsageCalls != 1 || dashboardRepo.cleanupDedupCalls != 0 {
 		t.Fatalf("usage lifecycle calls = usage:%d dedup:%d", dashboardRepo.cleanupUsageCalls, dashboardRepo.cleanupDedupCalls)
 	}
-	if !cutoffMatchesDays(dashboardRepo.lastUsageCutoff, 7) {
-		t.Fatalf("edge usage cutoff = %s, want 7 days", dashboardRepo.lastUsageCutoff)
+	if !cutoffMatchesDays(dashboardRepo.lastUsageCutoff, 90) {
+		t.Fatalf("edge usage cutoff = %s, want 90 days", dashboardRepo.lastUsageCutoff)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unexpected ops table cleanup: %v", err)

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6821,9 +6821,9 @@
         "prodUsageLogRetentionDays  = 90",
         "prodErrorLogRetentionDays  = 30",
         "prodSystemLogRetentionDays = 7",
-        "edgeUsageLogRetentionDays  = 7",
-        "edgeErrorLogRetentionDays  = 14",
-        "edgeSystemLogRetentionDays = 3",
+        "edgeUsageLogRetentionDays  = 90",
+        "edgeErrorLogRetentionDays  = 30",
+        "edgeSystemLogRetentionDays = 7",
         "billingDedupRetentionDays  = 365",
         "func resolveDataLifecyclePolicy(",
         "billingDedupRetentionDays: billingDedupRetentionDays",
@@ -6839,7 +6839,7 @@
         "func IsEdgeFrontendURL(frontendURL string) bool {",
         "strings.HasSuffix(strings.ToLower(parsed.Hostname()), \".tokenkey.dev\")"
       ],
-      "rationale": "The lifecycle policy now connects this shared role helper to destructive retention cutoffs. Edge classification must require the canonical TokenKey domain; otherwise a custom prod host such as api-us1.example.com silently receives the shorter edge windows while cleanup still reports success."
+      "rationale": "The lifecycle policy connects this shared role helper to destructive retention cutoffs. Edge classification must require the canonical TokenKey domain; otherwise a custom prod host such as api-us1.example.com is treated as an unknown/non-edge role and may apply the wrong role policy while cleanup still reports success."
     },
     {
       "path": "backend/internal/service/data_lifecycle_policy_tk_test.go",


### PR DESCRIPTION
## 摘要
- Edge `data_lifecycle` 硬上限从 usage **7d** / error **14d** / system **3d** 提升为与 prod 一致：usage **90** / error **30** / system **7**。
- 根因：配置即使设更长也会被 cap；叠加 8/29 左右 restore 后，deployable edges 热库仅剩约 3 天可查。
- 同步更新 `scripts/sentinels/gateway-tk.json` 锚点，避免上游 merge 静默冲回旧天花板。
- `tokenkey-pgdump.timer` 已在 us3/us4/us5/us6 线下恢复（不在本 PR）；热保留需带本改动的镜像滚到 edge 后生效。

## 风险
- 常规风险：仅放宽 edge 热层保留上限，不改对外 API / Web / schema。
- 磁盘：四边合计热库按当前流量估约 6–8 GiB，空闲约 53 GiB，余量充足。
- 生效依赖后续 edge 发版；合并 alone 不会立刻拉长线上热库。

## 验证
- `go test -tags=unit ./internal/service/ -run 'TestResolveDataLifecyclePolicy|TestUsageLogRetentionDays|TestOpsCleanupServiceRunCleanupOnceUsageFailure'` 已绿。
- `python3 ./scripts/sentinels/check-gateway-tk.py` 已绿；registry update gate 识别到 `gateway-tk.json`。
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh` exit 0。

## 提交
- `394c30c35` fix(lifecycle): align edge hot retention with prod (90/30/7)
- `fde471033` fix(lifecycle): sync gateway-tk sentinel to edge 90/30/7
- 最新提交：`fde471033`