### PR TITLE
fix(account): vstecscloud 预付额度错误接入欠费告警 SSOT

### DIFF
--- a/backend/internal/service/newapi_bridge_arrears_tk.go
+++ b/backend/internal/service/newapi_bridge_arrears_tk.go
@@ -124,7 +124,7 @@ func tkIsBridgeUpstreamArrears(apiErr *newapitypes.NewAPIError) bool {
 	// matcher. Keep bridge-only Arrearage metadata above, but do not duplicate
 	// provider phrases here (vstecscloud insufficient_user_quota is one such
 	// 403 shape).
-	return tkIsAccountStandingBillingFailure(msg, nil)
+	return tkIsAccountStandingBillingFailure("", body)
 }
 
 // tkIsBridgeUpstreamArrearsBillingMessage is the 429-safe standing-failure set.

--- a/backend/internal/service/newapi_bridge_arrears_tk.go
+++ b/backend/internal/service/newapi_bridge_arrears_tk.go
@@ -120,7 +120,11 @@ func tkIsBridgeUpstreamArrears(apiErr *newapitypes.NewAPIError) bool {
 			return true
 		}
 	}
-	return tkIsBridgeUpstreamArrearsBillingMessage(msg)
+	// 400/403 account-standing balance/quota text is owned by the shared
+	// matcher. Keep bridge-only Arrearage metadata above, but do not duplicate
+	// provider phrases here (vstecscloud insufficient_user_quota is one such
+	// 403 shape).
+	return tkIsAccountStandingBillingFailure(msg, nil)
 }
 
 // tkIsBridgeUpstreamArrearsBillingMessage is the 429-safe standing-failure set.
@@ -168,13 +172,21 @@ func tkBridgeArrearsDetail(apiErr *newapitypes.NewAPIError) string {
 }
 
 // tkHandleBridgeArrearsPenalty applies the account-level penalty for an upstream
-// arrears 400 and emits the immediate P0 Feishu alert. Returns true when it
-// handled the error (caller must NOT then run the generic status-allowlist
-// penalty). The account-state write survives client cancellation via
-// openAIAccountStateContext (context.WithoutCancel), like the sibling penalty.
+// standing-billing failure and emits the immediate P0 Feishu alert. Shared
+// prepaid/balance text delegates to tkTryHandleStandingBilling; bridge-only
+// Arrearage and billing-429 shapes retain the compatibility fallback below.
+// Returns true when handled (caller must not run the generic status allowlist).
 func tkHandleBridgeArrearsPenalty(ctx context.Context, rls *RateLimitService, account *Account, apiErr *newapitypes.NewAPIError) bool {
 	if rls == nil || account == nil || apiErr == nil {
 		return false
+	}
+	body := tkBridgeUpstreamErrorBody(apiErr)
+	// Balance/prepaid standing failures use the same owner as native gateway
+	// errors: one matcher, SetError policy, incident reason and Feishu P0 path.
+	// Bridge-only Arrearage metadata and the deliberately narrow billing 429
+	// compatibility remain below.
+	if rls.tkTryHandleStandingBilling(ctx, account, apiErr.StatusCode, body) {
+		return true
 	}
 	if !tkIsBridgeUpstreamArrears(apiErr) {
 		return false

--- a/backend/internal/service/newapi_bridge_arrears_tk_test.go
+++ b/backend/internal/service/newapi_bridge_arrears_tk_test.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 
@@ -24,6 +25,8 @@ func arrearsBridgeError(statusCode int, msg, typ, code string) *newapitypes.NewA
 }
 
 const dashscopeArrearsMessage = "Access denied, please make sure your account is in good standing. For details, see: https://help.aliyun.com/zh/model-studio/error-code#overdue-payment"
+
+const vstecscloudPrepaidQuotaMessage = "预扣费额度失败, 用户剩余额度: ¥0.031624, 需要预扣费额度: ¥0.470498 (request id: test-request)"
 
 func newQwenArrearsAccount() *Account {
 	// Mirrors prod account 60 "Qwen": fifth-platform newapi apikey account on
@@ -58,11 +61,42 @@ func TestTkIsBridgeUpstreamArrears_MessageAndCaseVariants(t *testing.T) {
 		{"overdue phrase", arrearsBridgeError(400, "Your payment is overdue, please recharge.", "billing_error", "billing")},
 		{"arrear phrase", arrearsBridgeError(400, "Account in arrears.", "", "")},
 		{"403 arrears", arrearsBridgeError(403, "x", "Arrearage", "Arrearage")},
+		{"vstecscloud prepaid quota 403", arrearsBridgeError(403, vstecscloudPrepaidQuotaMessage, "insufficient_user_quota", "insufficient_user_quota")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require.True(t, tkIsBridgeUpstreamArrears(tc.err))
 		})
 	}
+}
+
+func TestTkHandleBridgeArrearsPenalty_VstecscloudPrepaidQuotaUsesStandingBillingSSOT(t *testing.T) {
+	svc, repo, blocker, incidents := newBridgePenaltyTestService()
+	account := &Account{
+		ID:          101,
+		Name:        "佳杰-stbl-5",
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: 1,
+	}
+	apiErr := arrearsBridgeError(
+		http.StatusForbidden,
+		vstecscloudPrepaidQuotaMessage,
+		"insufficient_user_quota",
+		"insufficient_user_quota",
+	)
+
+	handled := tkHandleBridgeArrearsPenalty(context.Background(), svc, account, apiErr)
+
+	require.True(t, handled)
+	require.Equal(t, 1, repo.setErrorCalls, "prepaid quota exhaustion must permanently stop scheduling")
+	require.Zero(t, repo.tempCalls)
+	require.Contains(t, repo.lastErrorMsg, "Account billing standing (403)")
+	require.Contains(t, repo.lastErrorMsg, "预扣费额度失败")
+	require.Equal(t, []string{tkStandingBillingIncidentReason}, blocker.reasons)
+	require.Equal(t, []string{tkStandingBillingIncidentReason}, incidents.reasons)
+	require.Len(t, incidents.details, 1)
+	require.Contains(t, incidents.details[0], "用户剩余额度")
+	require.True(t, tkBridgeUpstreamShouldFailoverAfterPenalty(apiErr))
 }
 
 // Part A NEGATIVE: genuine client / validation / oversize 400s, model-not-found

--- a/backend/internal/service/newapi_bridge_arrears_tk_test.go
+++ b/backend/internal/service/newapi_bridge_arrears_tk_test.go
@@ -99,6 +99,32 @@ func TestTkHandleBridgeArrearsPenalty_VstecscloudPrepaidQuotaUsesStandingBilling
 	require.True(t, tkBridgeUpstreamShouldFailoverAfterPenalty(apiErr))
 }
 
+func TestTkHandleBridgeArrearsPenalty_StandingBillingMarkerOutsideMessageStillFailsOver(t *testing.T) {
+	svc, repo, blocker, incidents := newBridgePenaltyTestService()
+	account := &Account{
+		ID:          102,
+		Name:        "newapi-billing-code-only",
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: 1,
+	}
+	apiErr := arrearsBridgeError(
+		http.StatusForbidden,
+		"billing rejected",
+		"credit balance exhausted",
+		"billing_error",
+	)
+
+	handled := tkHandleBridgeArrearsPenalty(context.Background(), svc, account, apiErr)
+
+	require.True(t, handled)
+	require.Equal(t, 1, repo.setErrorCalls)
+	require.Equal(t, []string{tkStandingBillingIncidentReason}, blocker.reasons)
+	require.Equal(t, []string{tkStandingBillingIncidentReason}, incidents.reasons)
+	require.True(t, tkBridgeUpstreamShouldFailoverAfterPenalty(apiErr),
+		"penalty and failover must classify the same complete upstream envelope")
+}
+
 // Part A NEGATIVE: genuine client / validation / oversize 400s, model-not-found
 // 404s, rate-limit 429s (including quota-type 429s without billing text) and 5xx
 // outages must NEVER be classified as arrears — they carry no account-standing

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -557,10 +557,10 @@
     {
       "path": "backend/internal/service/newapi_bridge_arrears_tk.go",
       "must_contain": [
-        "tkIsAccountStandingBillingFailure(msg, nil)",
+        "tkIsAccountStandingBillingFailure(\"\", body)",
         "rls.tkTryHandleStandingBilling"
       ],
-      "rationale": "The newapi bridge must delegate 400/403 prepaid-balance messages to the account-standing billing SSOT. Prod 2026-09-01 vstecscloud returned 403 insufficient_user_quota with '预扣费额度失败'; using the 429-only narrow matcher skipped SetError and the immediate newapi_arrears Feishu P0. Bridge-only Arrearage metadata and narrow billing 429 handling remain compatibility fallbacks."
+      "rationale": "The newapi bridge must delegate the complete 400/403 upstream envelope to the account-standing billing SSOT for both penalty and failover classification. Prod 2026-09-01 vstecscloud returned 403 insufficient_user_quota with '预扣费额度失败'; using the 429-only narrow matcher skipped SetError and the immediate newapi_arrears Feishu P0. Passing message-only here can still split penalty from failover when the billing marker lives in error.code/type. Bridge-only Arrearage metadata and narrow billing 429 handling remain compatibility fallbacks."
     },
     {
       "path": "backend/internal/service/account_standing_billing_tk_test.go",
@@ -575,9 +575,10 @@
       "path": "backend/internal/service/newapi_bridge_arrears_tk_test.go",
       "must_contain": [
         "TestTkHandleBridgeArrearsPenalty_VstecscloudPrepaidQuotaUsesStandingBillingSSOT",
+        "TestTkHandleBridgeArrearsPenalty_StandingBillingMarkerOutsideMessageStillFailsOver",
         "vstecscloudPrepaidQuotaMessage"
       ],
-      "rationale": "Regression for the real vstecscloud 403 insufficient_user_quota response shape: the bridge must SetError, emit newapi_arrears through the account incident notifier, preserve the upstream detail, and fail over."
+      "rationale": "Regression for the real vstecscloud 403 insufficient_user_quota response shape plus a marker-outside-message boundary: the bridge must SetError, emit newapi_arrears through the account incident notifier, preserve the upstream detail, and make the same failover decision from the complete envelope."
     },
     {
       "path": "backend/internal/service/ratelimit_service.go",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -555,6 +555,14 @@
       "rationale": "SSOT for account-standing billing / prepaid quota death across 400/402/403. Prod 2026-08-30 tokensea-cc #93 returned 403 '用户额度不足' and only failovers (no SetError, no account-incident P0). This file owns the shared phrase list and the SetError + newapi_arrears Feishu path. 'weekly usage quota' is the negative marker so recoverable windows (account 88) must not permanently disable. Dropping the file or the tokensea phrase re-opens the prepaid-dead account staying schedulable."
     },
     {
+      "path": "backend/internal/service/newapi_bridge_arrears_tk.go",
+      "must_contain": [
+        "tkIsAccountStandingBillingFailure(msg, nil)",
+        "rls.tkTryHandleStandingBilling"
+      ],
+      "rationale": "The newapi bridge must delegate 400/403 prepaid-balance messages to the account-standing billing SSOT. Prod 2026-09-01 vstecscloud returned 403 insufficient_user_quota with '预扣费额度失败'; using the 429-only narrow matcher skipped SetError and the immediate newapi_arrears Feishu P0. Bridge-only Arrearage metadata and narrow billing 429 handling remain compatibility fallbacks."
+    },
+    {
       "path": "backend/internal/service/account_standing_billing_tk_test.go",
       "must_contain": [
         "TestTkTryHandleStandingBilling_Tokensea403DisablesAndAlerts",
@@ -562,6 +570,14 @@
         "tokenseaQuota403Body"
       ],
       "rationale": "Regression for prepaid 额度不足 403 (prod 2026-08-30 account 93) and the weekly-quota negative. Dropping these tests lets handle403 stub-saturation failover stay green while a dead prepaid account remains schedulable."
+    },
+    {
+      "path": "backend/internal/service/newapi_bridge_arrears_tk_test.go",
+      "must_contain": [
+        "TestTkHandleBridgeArrearsPenalty_VstecscloudPrepaidQuotaUsesStandingBillingSSOT",
+        "vstecscloudPrepaidQuotaMessage"
+      ],
+      "rationale": "Regression for the real vstecscloud 403 insufficient_user_quota response shape: the bridge must SetError, emit newapi_arrears through the account incident notifier, preserve the upstream detail, and fail over."
     },
     {
       "path": "backend/internal/service/ratelimit_service.go",


### PR DESCRIPTION
## 摘要

- 修复 vstecscloud 上游用户预付额度不足时，newapi bridge 未进入账号欠费统一处理的问题。
- 400/403 的账号级余额/预付额度错误现在把完整 upstream error envelope 交给 `account_standing_billing` SSOT：处罚与 failover 使用同一分类真值，执行 `SetError` 停止调度、切换兄弟账号，并通过 `newapi_arrears` 发送即时飞书 P0 告警。
- 保留 bridge 专属 DashScope `Arrearage` 与 Moonshot billing 429 兼容；普通客户端 400、普通限流 429 不扩面。
- 增加真实 vstecscloud `403 insufficient_user_quota` 响应与 billing marker 仅位于 `error.type/code` 的边界回归，并更新 newapi sentinel 防止上游合并静默删掉 SSOT 调用点。

Web impact: none

## 线上证据

- target: prod
- time window: 2026-09-01 12:39–12:51 UTC / 20:39–20:51 Asia/Shanghai
- `ops_error_logs` 共 84 条 HTTP 403，provider code=`insufficient_user_quota`
- 上游原文：`预扣费额度失败, 用户剩余额度: ¥0.031624–¥0.437200, 需要预扣费额度: ¥0.466060–¥0.475090`
- 根因：bridge 的 400/403 分支末端误用了仅供 429 的窄 billing matcher，导致未执行 `SetError + newapi_arrears + 飞书 P0`

## 风险

- 仅扩展已有 400/403 account-standing envelope 进入既有 SSOT，不新增 schema、配置或告警通道。
- 429 继续使用窄 marker，避免把 RPM/普通 quota 限流误判为欠费并永久停号。
- 回滚只需回滚本 PR 提交；尚未部署或修改线上状态。

## 验证

- `go test -tags unit ./internal/service -count=1`：通过
- vstecscloud 与 marker-outside-message 聚焦回归：通过
- `python3 ./scripts/sentinels/check-newapi.py --quiet`：通过
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：通过
- `git diff --check origin/main...HEAD`：通过
- `$xj-review #1926`：`risk_level=normal`，`review_mode=concise`；R-001 已修复，复审 0 findings
- 新 HEAD `58548f06a`：GitHub CI 全绿（21 checks success/skipped，0 failed/pending）

## 提交

- `d9c8a9bf3 fix(account): vstecscloud 预付额度错误复用欠费告警 SSOT`
- `58548f06a fix(account): address R-001 standing billing envelope SSOT`
- 最新提交：`58548f06a`
