### PR TITLE
fix(supplier): FMGo Seedance 改走现网 v2.5/431/mini videos 方言

### DIFF
--- a/.testing/user-stories/stories/US-048-model-supplier-source-management.md
+++ b/.testing/user-stories/stories/US-048-model-supplier-source-management.md
@@ -103,8 +103,10 @@
 - `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_FMGoSeedanceSyncProjectsOfficialClientsOnly`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_DoubaoVideoChannelProbesVideoPathNotChat`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_VideoProbeFailToFetchTaskDoesNotPass`
-- `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_FMGoVideoProbeURLUsesChatCompletions`
+- `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_FMGoVideoProbeURLUsesVideosForLiveFamilies`
+- `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_FMGoVideosProbeBodyMatchesOfficialDialect`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_FMGoChatProbeBodyMatchesOfficialDialect`
+- `backend/internal/service/supplier_source_probe_test.go`::`TestUS048_FMGoProbeSkipsNonVideoInventory`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_VideoProbeAcceptsHTTP202`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_SupplierManagedAccountDeclaresOnlyChatProtocol`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_SupplierManagedQianfanDeclaresBaiduV2ChatProtocol`

--- a/backend/internal/integration/newapi/fmgo.go
+++ b/backend/internal/integration/newapi/fmgo.go
@@ -12,14 +12,17 @@ import (
 // FMGoBaseURL is the canonical FMGo (feimiao) API root from the vendor guide.
 const FMGoBaseURL = "https://api.fmgo.top"
 
-// FMGo chat-completions video dialect (feimiao-v2 / feimiao-v2-fast).
+// FMGo chat-completions video dialect (legacy feimiao-v2 / feimiao-v2-fast).
+// Current default Seedance inventory (v2.5 / 431 / mini) uses /v1/videos.
 const (
 	FMGoChatCompletionsPath = "/v1/chat/completions"
 	FMGoTaskPathPrefix      = "/v1/tasks"
+	FMGoVideosPath          = "/v1/videos"
 )
 
 // Official Seedance 2.0 client ids TokenKey exposes. Runtime rewrite on the
-// FMGo video adaptor turns these into feimiao-v2[-fast]-{res}-{dur}s SKUs.
+// FMGo video adaptor turns these into catalog families that the live default
+// group actually serves: 431 / 431-fast (FMGo aliases seedance-2.0).
 const (
 	FMGoSeedanceClientID     = "doubao-seedance-2-0-260128"
 	FMGoSeedanceFastClientID = "doubao-seedance-2-0-fast-260128"
@@ -28,6 +31,12 @@ const (
 const (
 	FMGoDefaultResolution = "720p"
 	FMGoDefaultDuration   = 15
+	FMGoFamilyV25         = "v2.5"
+	FMGoFamily431         = "v2-431"
+	FMGoFamily431Fast     = "v2-431-fast"
+	FMGoFamilyMini        = "v2-mini"
+	FMGoFamilyV2          = "v2"
+	FMGoFamilyV2Fast      = "v2-fast"
 )
 
 // FMGo capability set is pinned in this adaptor. Do not read supplier sources
@@ -37,11 +46,22 @@ var (
 		"480p": {},
 		"720p": {},
 	}
-	fmgoDurations = map[int]struct{}{
+	fmgoChatDurations = map[int]struct{}{
 		6: {}, 8: {}, 10: {}, 12: {}, 15: {},
+	}
+	fmgo431Durations = map[int]struct{}{
+		10: {}, 15: {},
 	}
 	fmgoAspectRatios = map[string]struct{}{
 		"16:9": {}, "9:16": {}, "1:1": {}, "2:3": {}, "3:2": {},
+	}
+	fmgoV25Combos = map[string]map[int]struct{}{
+		"480p": {5: {}, 10: {}, 15: {}, 30: {}},
+		"720p": {10: {}, 15: {}, 30: {}},
+	}
+	fmgoMiniCombos = map[string]int{
+		"720p": 10,
+		"480p": 15,
 	}
 )
 
@@ -104,17 +124,98 @@ func IsFMGoSeedanceClient(model string) bool {
 	}
 }
 
+// FMGoModelFamily classifies a client or upstream id onto a pinned FMGo family.
+// Official Seedance clients map to 431 / 431-fast (live default-group inventory).
+func FMGoModelFamily(model string) string {
+	model = strings.ToLower(strings.TrimSpace(model))
+	switch {
+	case model == "":
+		return ""
+	case model == FMGoSeedanceFastClientID || strings.HasPrefix(model, "feimiao-v2-431-fast"):
+		return FMGoFamily431Fast
+	case model == FMGoSeedanceClientID || strings.HasPrefix(model, "feimiao-v2-431"):
+		return FMGoFamily431
+	case strings.HasPrefix(model, "feimiao-v2.5"):
+		return FMGoFamilyV25
+	case strings.HasPrefix(model, "feimiao-v2-mini"):
+		return FMGoFamilyMini
+	case strings.HasPrefix(model, "feimiao-v2-fast-"):
+		return FMGoFamilyV2Fast
+	case strings.HasPrefix(model, "feimiao-v2-"):
+		return FMGoFamilyV2
+	default:
+		return ""
+	}
+}
+
+// FMGoUsesVideosDialect is the official /v1/videos families plus official Seedance clients.
+func FMGoUsesVideosDialect(model string) bool {
+	switch FMGoModelFamily(model) {
+	case FMGoFamilyV25, FMGoFamily431, FMGoFamily431Fast, FMGoFamilyMini:
+		return true
+	default:
+		return false
+	}
+}
+
+// FMGoSubmitPath is the vendor create path for this model. Seedance clients
+// follow the videos dialect of the live default group.
+func FMGoSubmitPath(model string) string {
+	if FMGoUsesVideosDialect(model) {
+		return FMGoVideosPath
+	}
+	return FMGoChatCompletionsPath
+}
+
+// FMGoFetchPath is the vendor poll path for a previously created task.
+// Empty model defaults to /v1/videos (live Seedance inventory).
+func FMGoFetchPath(model string) string {
+	switch FMGoModelFamily(model) {
+	case FMGoFamilyV2, FMGoFamilyV2Fast:
+		return FMGoTaskPathPrefix
+	default:
+		return FMGoVideosPath
+	}
+}
+
+// IsFMGoVideoInventoryID reports catalog ids that are real FMGo video SKUs.
+// Used to keep ch54 candidate probes off Claude/GPT chat rows in a mixed group.
+func IsFMGoVideoInventoryID(model string) bool {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if FMGoModelFamily(model) != "" {
+		return true
+	}
+	switch {
+	case strings.HasPrefix(model, "veo-"),
+		strings.HasPrefix(model, "sora-"),
+		strings.HasPrefix(model, "grok-video"),
+		strings.HasPrefix(model, "gemini-omni"),
+		model == "omni":
+		return true
+	default:
+		return false
+	}
+}
+
 // FMGoSeedanceUpstreamSKU maps an official Seedance client + request params
-// onto one FMGo inventory SKU. Empty resolution/duration take the set maximum.
-// Values outside the pinned set are rejected; nothing is clamped or downgraded.
+// onto one live-group inventory SKU. Empty resolution/duration take the
+// family default. Values outside the pinned family set are rejected.
 func FMGoSeedanceUpstreamSKU(client, resolution string, duration int) (string, error) {
 	client = strings.TrimSpace(client)
 	if client == "" {
 		return "", fmt.Errorf("fmgo seedance: empty model")
 	}
+	family := FMGoModelFamily(client)
+	if family == "" {
+		return client, nil
+	}
 	if !IsFMGoSeedanceClient(client) {
 		return client, nil
 	}
+	return fmgoFormatFamilySKU(family, resolution, duration)
+}
+
+func fmgoFormatFamilySKU(family, resolution string, duration int) (string, error) {
 	resolution = strings.ToLower(strings.TrimSpace(resolution))
 	if resolution == "" {
 		resolution = FMGoDefaultResolution
@@ -124,14 +225,64 @@ func FMGoSeedanceUpstreamSKU(client, resolution string, duration int) (string, e
 	}
 	if duration == 0 {
 		duration = FMGoDefaultDuration
+		if family == FMGoFamilyMini && resolution == "720p" {
+			duration = 10
+		}
 	}
-	if _, ok := fmgoDurations[duration]; !ok {
-		return "", fmt.Errorf("fmgo seedance: unsupported duration %d", duration)
+	switch family {
+	case FMGoFamily431, FMGoFamily431Fast:
+		if _, ok := fmgo431Durations[duration]; !ok {
+			return "", fmt.Errorf("fmgo seedance: unsupported duration %d", duration)
+		}
+		if family == FMGoFamily431Fast {
+			return fmt.Sprintf("feimiao-v2-431-fast-%s-%ds", resolution, duration), nil
+		}
+		return fmt.Sprintf("feimiao-v2-431-%s-%ds", resolution, duration), nil
+	case FMGoFamilyV25:
+		allowed, ok := fmgoV25Combos[resolution]
+		if !ok {
+			return "", fmt.Errorf("fmgo seedance: unsupported resolution %q", resolution)
+		}
+		if _, ok = allowed[duration]; !ok {
+			return "", fmt.Errorf("fmgo seedance: unsupported duration %d", duration)
+		}
+		return fmt.Sprintf("feimiao-v2.5-%s-%ds", resolution, duration), nil
+	case FMGoFamilyMini:
+		want, ok := fmgoMiniCombos[resolution]
+		if !ok || want != duration {
+			return "", fmt.Errorf("fmgo seedance: unsupported mini combo %s/%ds", resolution, duration)
+		}
+		return fmt.Sprintf("feimiao-v2-mini-%s-%ds", resolution, duration), nil
+	case FMGoFamilyV2, FMGoFamilyV2Fast:
+		if _, ok := fmgoChatDurations[duration]; !ok {
+			return "", fmt.Errorf("fmgo seedance: unsupported duration %d", duration)
+		}
+		if family == FMGoFamilyV2Fast {
+			return fmt.Sprintf("feimiao-v2-fast-%s-%ds", resolution, duration), nil
+		}
+		return fmt.Sprintf("feimiao-v2-%s-%ds", resolution, duration), nil
+	default:
+		return "", fmt.Errorf("fmgo seedance: unknown family %q", family)
 	}
-	if client == FMGoSeedanceFastClientID {
-		return fmt.Sprintf("feimiao-v2-fast-%s-%ds", resolution, duration), nil
+}
+
+// FMGoClientForUpstreamSKU rewrites a vendor inventory or echo id back to the
+// TokenKey-facing official Seedance client. Unknown ids pass through.
+func FMGoClientForUpstreamSKU(model string) string {
+	switch strings.ToLower(strings.TrimSpace(model)) {
+	case "seedance-2.0-fast", "seeddance-2.0-min", "seedance-2.0-min":
+		return FMGoSeedanceFastClientID
+	case "seedance-2.0":
+		return FMGoSeedanceClientID
 	}
-	return fmt.Sprintf("feimiao-v2-%s-%ds", resolution, duration), nil
+	switch FMGoModelFamily(model) {
+	case FMGoFamily431Fast, FMGoFamilyV2Fast, FMGoFamilyMini:
+		return FMGoSeedanceFastClientID
+	case FMGoFamily431, FMGoFamilyV25, FMGoFamilyV2:
+		return FMGoSeedanceClientID
+	default:
+		return strings.TrimSpace(model)
+	}
 }
 
 // ParseFMGoVideoDuration accepts a JSON number or numeric string. Zero means absent.

--- a/backend/internal/integration/newapi/fmgo.go
+++ b/backend/internal/integration/newapi/fmgo.go
@@ -178,23 +178,12 @@ func FMGoFetchPath(model string) string {
 	}
 }
 
-// IsFMGoVideoInventoryID reports catalog ids that are real FMGo video SKUs.
-// Used to keep ch54 candidate probes off Claude/GPT chat rows in a mixed group.
+// IsFMGoVideoInventoryID reports catalog ids this adaptor can actually speak:
+// v2.5 / 431 / mini / legacy v2, plus official Seedance clients.
+// Other video-looking rows (veo/sora/grok-video/omni) stay out so ch54
+// candidate probes do not hit them with the Seedance or legacy-v2 dialect.
 func IsFMGoVideoInventoryID(model string) bool {
-	model = strings.ToLower(strings.TrimSpace(model))
-	if FMGoModelFamily(model) != "" {
-		return true
-	}
-	switch {
-	case strings.HasPrefix(model, "veo-"),
-		strings.HasPrefix(model, "sora-"),
-		strings.HasPrefix(model, "grok-video"),
-		strings.HasPrefix(model, "gemini-omni"),
-		model == "omni":
-		return true
-	default:
-		return false
-	}
+	return FMGoModelFamily(model) != ""
 }
 
 // FMGoSeedanceUpstreamSKU maps an official Seedance client + request params

--- a/backend/internal/integration/newapi/fmgo_test.go
+++ b/backend/internal/integration/newapi/fmgo_test.go
@@ -99,6 +99,9 @@ func TestFMGoUsesVideosDialect(t *testing.T) {
 	if !IsFMGoVideoInventoryID("feimiao-v2.5-720p-15s") || IsFMGoVideoInventoryID("claude-opus-4-8") {
 		t.Fatal("video inventory classifier drifted")
 	}
+	if IsFMGoVideoInventoryID("veo-3-fast-4k-8s") || IsFMGoVideoInventoryID("grok-video-3") {
+		t.Fatal("unsupported video families must not look probeable")
+	}
 }
 
 func TestNormalizeFMGoBaseURL(t *testing.T) {

--- a/backend/internal/integration/newapi/fmgo_test.go
+++ b/backend/internal/integration/newapi/fmgo_test.go
@@ -43,17 +43,18 @@ func TestFMGoSeedanceUpstreamSKU(t *testing.T) {
 		want       string
 		wantErr    bool
 	}{
-		{"defaults", FMGoSeedanceClientID, "", 0, "feimiao-v2-720p-15s", false},
-		{"fast defaults", FMGoSeedanceFastClientID, "", 0, "feimiao-v2-fast-720p-15s", false},
-		{"explicit", FMGoSeedanceClientID, "720p", 10, "feimiao-v2-720p-10s", false},
-		{"480p 8s", FMGoSeedanceClientID, "480p", 8, "feimiao-v2-480p-8s", false},
-		{"6s", FMGoSeedanceClientID, "720p", 6, "feimiao-v2-720p-6s", false},
-		{"fast 12s", FMGoSeedanceFastClientID, "720p", 12, "feimiao-v2-fast-720p-12s", false},
+		{"defaults", FMGoSeedanceClientID, "", 0, "feimiao-v2-431-720p-15s", false},
+		{"fast defaults", FMGoSeedanceFastClientID, "", 0, "feimiao-v2-431-fast-720p-15s", false},
+		{"explicit", FMGoSeedanceClientID, "720p", 10, "feimiao-v2-431-720p-10s", false},
+		{"480p 15s", FMGoSeedanceClientID, "480p", 15, "feimiao-v2-431-480p-15s", false},
+		{"reject 6s", FMGoSeedanceClientID, "720p", 6, "", true},
+		{"reject 8s", FMGoSeedanceClientID, "480p", 8, "", true},
+		{"reject 12s", FMGoSeedanceFastClientID, "720p", 12, "", true},
 		{"reject 1080p", FMGoSeedanceClientID, "1080p", 10, "", true},
 		{"reject 4k", FMGoSeedanceClientID, "4k", 10, "", true},
 		{"reject 9s", FMGoSeedanceClientID, "720p", 9, "", true},
 		{"passthrough other", "doubao-seedance-2-5-260628", "1080p", 5, "doubao-seedance-2-5-260628", false},
-		{"passthrough already sku", "feimiao-v2-720p-10s", "720p", 10, "feimiao-v2-720p-10s", false},
+		{"passthrough already sku", "feimiao-v2.5-720p-10s", "720p", 10, "feimiao-v2.5-720p-10s", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -72,6 +73,31 @@ func TestFMGoSeedanceUpstreamSKU(t *testing.T) {
 				t.Fatalf("sku = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestFMGoUsesVideosDialect(t *testing.T) {
+	t.Parallel()
+	for _, model := range []string{
+		FMGoSeedanceClientID,
+		FMGoSeedanceFastClientID,
+		"feimiao-v2.5-720p-15s",
+		"feimiao-v2-431-720p-15s",
+		"feimiao-v2-431-fast-480p-10s",
+		"feimiao-v2-mini-720p-10s",
+	} {
+		if !FMGoUsesVideosDialect(model) {
+			t.Fatalf("%q must use /v1/videos", model)
+		}
+	}
+	if FMGoUsesVideosDialect("feimiao-v2-720p-15s") {
+		t.Fatal("legacy v2 SKU must stay on chat completions")
+	}
+	if got := FMGoSubmitPath(FMGoSeedanceClientID); got != FMGoVideosPath {
+		t.Fatalf("seedance submit path = %q", got)
+	}
+	if !IsFMGoVideoInventoryID("feimiao-v2.5-720p-15s") || IsFMGoVideoInventoryID("claude-opus-4-8") {
+		t.Fatal("video inventory classifier drifted")
 	}
 }
 

--- a/backend/internal/relay/bridge/video_relay_tk_fmgo.go
+++ b/backend/internal/relay/bridge/video_relay_tk_fmgo.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/QuantumNous/new-api/common"
@@ -23,13 +24,14 @@ import (
 
 // TokenKey: FMGo (feimiao) video task adaptor.
 //
-// Official feimiao-v2 / feimiao-v2-fast dialect is async chat completions
-// (POST /v1/chat/completions + GET /v1/tasks/{id}), not OpenAI /v1/videos.
-// TokenKey clients still send official Ark ids plus resolution/duration.
-// Identification is channel_type + base_url only — never supplier_source_id.
+// Official Seedance clients rewrite to live-group /v1/videos families
+// (v2.5 / 431 / mini). Legacy feimiao-v2[-fast] still uses async chat
+// completions. Identification is channel_type + base_url only — never
+// supplier_source_id.
 type fmgoTaskAdaptor struct {
 	*taskdoubao.TaskAdaptor
 	baseURL string
+	family  string
 }
 
 func newFMGoTaskAdaptor() *fmgoTaskAdaptor {
@@ -43,18 +45,20 @@ func (a *fmgoTaskAdaptor) Init(info *relaycommon.RelayInfo) {
 	a.TaskAdaptor.Init(info)
 }
 
-func (a *fmgoTaskAdaptor) BuildRequestURL(_ *relaycommon.RelayInfo) (string, error) {
+func (a *fmgoTaskAdaptor) BuildRequestURL(info *relaycommon.RelayInfo) (string, error) {
 	if a.baseURL == "" {
 		return "", fmt.Errorf("fmgo video submit: empty base_url")
 	}
-	return a.baseURL + newapiintegration.FMGoChatCompletionsPath, nil
+	return a.baseURL + newapiintegration.FMGoSubmitPath(fmgoRelayModel(info, a.family)), nil
 }
 
 func (a *fmgoTaskAdaptor) BuildRequestHeader(c *gin.Context, req *http.Request, info *relaycommon.RelayInfo) error {
 	if err := a.TaskAdaptor.BuildRequestHeader(c, req, info); err != nil {
 		return err
 	}
-	req.Header.Set("Prefer", "respond-async")
+	if !newapiintegration.FMGoUsesVideosDialect(fmgoRelayModel(info, a.family)) {
+		req.Header.Set("Prefer", "respond-async")
+	}
 	return nil
 }
 
@@ -80,7 +84,7 @@ func (a *fmgoTaskAdaptor) FetchTask(baseUrl, key string, body map[string]any, pr
 	if base == "" {
 		return nil, fmt.Errorf("fmgo video fetch: empty base_url")
 	}
-	uri := fmt.Sprintf("%s%s/%s", base, newapiintegration.FMGoTaskPathPrefix, taskID)
+	uri := fmt.Sprintf("%s%s/%s", base, newapiintegration.FMGoFetchPath(a.family), taskID)
 	req, err := http.NewRequest(http.MethodGet, uri, nil)
 	if err != nil {
 		return nil, err
@@ -112,13 +116,26 @@ func (a *fmgoTaskAdaptor) BuildRequestBody(c *gin.Context, info *relaycommon.Rel
 	if info != nil {
 		info.UpstreamModelName = upstream
 	}
+	a.family = newapiintegration.FMGoModelFamily(upstream)
+	if a.family == "" {
+		a.family = newapiintegration.FMGoModelFamily(client)
+	}
 	if resolution == "" {
 		resolution = newapiintegration.FMGoDefaultResolution
 	}
 	if duration == 0 {
 		duration = newapiintegration.FMGoDefaultDuration
 	}
-	payload, err := fmgoChatCompletionsBody(upstream, fmgoPromptFromSubmit(c, orig), fmgoImagesFromSubmit(c, orig), resolution, duration, fmgoAspectRatioFromSubmit(c, orig))
+	aspect := fmgoAspectRatioFromSubmit(c, orig)
+	prompt := fmgoPromptFromSubmit(c, orig)
+	images := fmgoImagesFromSubmit(c, orig)
+	var payload []byte
+	var err error
+	if newapiintegration.FMGoUsesVideosDialect(upstream) || newapiintegration.FMGoUsesVideosDialect(client) {
+		payload, err = fmgoVideosBody(upstream, prompt, images, resolution, duration, aspect)
+	} else {
+		payload, err = fmgoChatCompletionsBody(upstream, prompt, images, resolution, duration, aspect)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +145,7 @@ func (a *fmgoTaskAdaptor) BuildRequestBody(c *gin.Context, info *relaycommon.Rel
 func (a *fmgoTaskAdaptor) ParseTaskResult(respBody []byte) (*relaycommon.TaskInfo, error) {
 	info := &relaycommon.TaskInfo{Code: 0}
 	status := strings.ToLower(firstNonEmptyJSONString(respBody, "status", "task.status"))
-	videoURL := firstNonEmptyJSONString(respBody, "result.url", "content.video_url")
+	videoURL := firstNonEmptyJSONString(respBody, "result.url", "result_url", "content.video_url")
 	reason := firstNonEmptyJSONString(respBody, "error.message", "task.error", "message")
 	switch status {
 	case "queued", "pending":
@@ -150,6 +167,48 @@ func (a *fmgoTaskAdaptor) ParseTaskResult(respBody []byte) (*relaycommon.TaskInf
 		info.Progress = "30%"
 	}
 	return info, nil
+}
+
+func fmgoVideosBody(model, prompt string, images []string, resolution string, duration int, aspectRatio string) ([]byte, error) {
+	body := map[string]any{
+		"model":        model,
+		"prompt":       prompt,
+		"aspect_ratio": aspectRatio,
+		"resolution":   resolution,
+		"seconds":      strconv.Itoa(duration),
+	}
+	if len(images) > 0 {
+		cleaned := make([]string, 0, len(images))
+		for _, imageURL := range images {
+			imageURL = strings.TrimSpace(imageURL)
+			if imageURL != "" {
+				cleaned = append(cleaned, imageURL)
+			}
+		}
+		if len(cleaned) > 0 {
+			body["images"] = cleaned
+		}
+	}
+	return json.Marshal(body)
+}
+
+func fmgoRelayModel(info *relaycommon.RelayInfo, family string) string {
+	if info != nil {
+		if name := strings.TrimSpace(info.UpstreamModelName); name != "" {
+			return name
+		}
+		if name := strings.TrimSpace(info.OriginModelName); name != "" {
+			return name
+		}
+	}
+	switch family {
+	case newapiintegration.FMGoFamily431Fast, newapiintegration.FMGoFamilyV2Fast, newapiintegration.FMGoFamilyMini:
+		return newapiintegration.FMGoSeedanceFastClientID
+	case newapiintegration.FMGoFamily431, newapiintegration.FMGoFamilyV25, newapiintegration.FMGoFamilyV2:
+		return newapiintegration.FMGoSeedanceClientID
+	default:
+		return newapiintegration.FMGoSeedanceClientID
+	}
 }
 
 func fmgoChatCompletionsBody(model, prompt string, images []string, resolution string, duration int, aspectRatio string) ([]byte, error) {
@@ -210,12 +269,9 @@ func (a *fmgoTaskAdaptor) sanitizeFetchResponse(body []byte) []byte {
 		return body
 	}
 	model := current.String()
-	if !strings.HasPrefix(model, "feimiao-v2-") {
+	client := newapiintegration.FMGoClientForUpstreamSKU(model)
+	if client == "" || client == strings.TrimSpace(model) {
 		return body
-	}
-	client := newapiintegration.FMGoSeedanceClientID
-	if strings.Contains(model, "-fast-") {
-		client = newapiintegration.FMGoSeedanceFastClientID
 	}
 	rewritten, err := sjson.SetBytes(body, "model", client)
 	if err != nil {

--- a/backend/internal/relay/bridge/video_relay_tk_fmgo_test.go
+++ b/backend/internal/relay/bridge/video_relay_tk_fmgo_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestFMGoTaskAdaptor_BuildRequestURL(t *testing.T) {
 	t.Parallel()
-	want := newapiintegration.FMGoBaseURL + newapiintegration.FMGoChatCompletionsPath
+	want := newapiintegration.FMGoBaseURL + newapiintegration.FMGoVideosPath
 	for _, base := range []string{
 		newapiintegration.FMGoBaseURL,
 		newapiintegration.FMGoBaseURL + "/v1",
@@ -121,21 +121,21 @@ func TestFMGoTaskAdaptor_RewritesOfficialSeedanceSKU(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildRequestBody: %v", err)
 	}
-	want := "feimiao-v2-720p-10s"
+	want := "feimiao-v2-431-720p-10s"
 	if got := gjson.GetBytes(wire, "model").String(); got != want {
 		t.Fatalf("wire model = %q, want %q", got, want)
 	}
-	if !gjson.GetBytes(wire, "async").Bool() {
-		t.Fatal("official feimiao-v2 submit must set async=true")
+	if gjson.GetBytes(wire, "async").Exists() {
+		t.Fatal("/v1/videos body must not set async")
 	}
-	if gjson.GetBytes(wire, "generationConfig.videoConfig.duration").Int() != 10 {
-		t.Fatalf("videoConfig.duration = %s", gjson.GetBytes(wire, "generationConfig.videoConfig.duration").Raw)
+	if gjson.GetBytes(wire, "seconds").String() != "10" {
+		t.Fatalf("seconds = %s", gjson.GetBytes(wire, "seconds").Raw)
 	}
-	if gjson.GetBytes(wire, "generationConfig.videoConfig.resolution").String() != "720p" {
-		t.Fatalf("videoConfig.resolution = %q", gjson.GetBytes(wire, "generationConfig.videoConfig.resolution").String())
+	if gjson.GetBytes(wire, "resolution").String() != "720p" {
+		t.Fatalf("resolution = %q", gjson.GetBytes(wire, "resolution").String())
 	}
-	if gjson.GetBytes(wire, "messages.0.content").String() != "a cat playing piano" {
-		t.Fatalf("chat prompt = %q", gjson.GetBytes(wire, "messages.0.content").String())
+	if gjson.GetBytes(wire, "prompt").String() != "a cat playing piano" {
+		t.Fatalf("prompt = %q", gjson.GetBytes(wire, "prompt").String())
 	}
 	if info.UpstreamModelName != want {
 		t.Fatalf("UpstreamModelName = %q, want %q", info.UpstreamModelName, want)
@@ -147,15 +147,15 @@ func TestFMGoTaskAdaptor_RewritesOfficialSeedanceSKU(t *testing.T) {
 
 func TestFMGoTaskAdaptor_RewritesPastProbeAnchorMapping(t *testing.T) {
 	client := newapiintegration.FMGoSeedanceClientID
-	anchor := "feimiao-v2-720p-15s"
+	anchor := "feimiao-v2-431-720p-15s"
 	wire, info, err := buildFMGoSubmitBody(t, client, `{"`+client+`":"`+anchor+`"}`, map[string]any{
 		"resolution": "480p",
-		"duration":   8,
+		"duration":   10,
 	})
 	if err != nil {
 		t.Fatalf("BuildRequestBody: %v", err)
 	}
-	want := "feimiao-v2-480p-8s"
+	want := "feimiao-v2-431-480p-10s"
 	if got := gjson.GetBytes(wire, "model").String(); got != want {
 		t.Fatalf("wire model = %q, want %q — probe-anchor mapping must not freeze the SKU", got, want)
 	}
@@ -173,7 +173,7 @@ func TestFMGoTaskAdaptor_DefaultsToMaxResolutionAndDuration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildRequestBody: %v", err)
 	}
-	if got := gjson.GetBytes(wire, "model").String(); got != "feimiao-v2-fast-720p-15s" {
+	if got := gjson.GetBytes(wire, "model").String(); got != "feimiao-v2-431-fast-720p-15s" {
 		t.Fatalf("default sku = %q", got)
 	}
 }
@@ -209,15 +209,15 @@ func TestFMGoTaskAdaptor_ReadsDurationSecondsAlias(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildRequestBody: %v", err)
 	}
-	if got := gjson.GetBytes(wire, "model").String(); got != "feimiao-v2-720p-10s" {
-		t.Fatalf("duration_seconds=10 must rewrite to feimiao-v2-720p-10s, got %q", got)
+	if got := gjson.GetBytes(wire, "model").String(); got != "feimiao-v2-431-720p-10s" {
+		t.Fatalf("duration_seconds=10 must rewrite to feimiao-v2-431-720p-10s, got %q", got)
 	}
 }
 
 func TestFMGoTaskAdaptor_SanitizeFetchResponse(t *testing.T) {
 	t.Parallel()
 	adaptor := newFMGoTaskAdaptor()
-	got := adaptor.sanitizeFetchResponse([]byte(`{"id":"t1","model":"feimiao-v2-720p-10s","status":"succeeded"}`))
+	got := adaptor.sanitizeFetchResponse([]byte(`{"id":"t1","model":"feimiao-v2-431-720p-10s","status":"succeeded"}`))
 	if gjson.GetBytes(got, "model").String() != newapiintegration.FMGoSeedanceClientID {
 		t.Fatalf("non-fast sku model = %q", gjson.GetBytes(got, "model").String())
 	}
@@ -245,14 +245,14 @@ func TestFMGoTaskAdaptor_SanitizeFetchResponse(t *testing.T) {
 	}
 }
 
-func TestFMGoTaskAdaptor_DoRequest_HitsChatCompletions(t *testing.T) {
+func TestFMGoTaskAdaptor_DoRequest_HitsVideos(t *testing.T) {
 	ensureNewAPIDeps()
 	var gotPath, gotPrefer string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		gotPrefer = r.Header.Get("Prefer")
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusAccepted)
+		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"id":"task-fmgo-1"}`))
 	}))
 	defer srv.Close()
@@ -265,27 +265,28 @@ func TestFMGoTaskAdaptor_DoRequest_HitsChatCompletions(t *testing.T) {
 			ChannelBaseUrl: srv.URL,
 			ApiKey:         "fmgo-key",
 		},
+		OriginModelName: newapiintegration.FMGoSeedanceClientID,
 	}
 	a := newFMGoTaskAdaptor()
 	a.baseURL = srv.URL
 	a.TaskAdaptor.Init(info)
-	resp, err := a.DoRequest(c, info, bytes.NewReader([]byte(`{"model":"feimiao-v2-720p-15s","async":true}`)))
+	resp, err := a.DoRequest(c, info, bytes.NewReader([]byte(`{"model":"feimiao-v2-431-720p-15s","prompt":"probe"}`)))
 	if err != nil {
 		t.Fatalf("DoRequest: %v", err)
 	}
 	_ = resp.Body.Close()
-	if gotPath != newapiintegration.FMGoChatCompletionsPath {
-		t.Fatalf("path = %q, want %s (not /v1/video/generations)", gotPath, newapiintegration.FMGoChatCompletionsPath)
+	if gotPath != newapiintegration.FMGoVideosPath {
+		t.Fatalf("path = %q, want %s", gotPath, newapiintegration.FMGoVideosPath)
 	}
-	if gotPrefer != "respond-async" {
-		t.Fatalf("Prefer = %q, want respond-async", gotPrefer)
+	if gotPrefer != "" {
+		t.Fatalf("videos dialect must not send Prefer, got %q", gotPrefer)
 	}
 	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("FMGo 202 must be rewritten to 200 for DispatchVideoSubmit, got %d", resp.StatusCode)
+		t.Fatalf("videos create is already 200, got %d", resp.StatusCode)
 	}
 }
 
-func TestFMGoTaskAdaptor_FetchTask_HitsTasksPath(t *testing.T) {
+func TestFMGoTaskAdaptor_FetchTask_HitsVideosPath(t *testing.T) {
 	t.Parallel()
 	var gotPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -300,8 +301,8 @@ func TestFMGoTaskAdaptor_FetchTask_HitsTasksPath(t *testing.T) {
 		t.Fatalf("FetchTask: %v", err)
 	}
 	_ = resp.Body.Close()
-	if gotPath != "/v1/tasks/task-1" {
-		t.Fatalf("fetch path = %q, want /v1/tasks/task-1", gotPath)
+	if gotPath != "/v1/videos/task-1" {
+		t.Fatalf("fetch path = %q, want /v1/videos/task-1", gotPath)
 	}
 }
 
@@ -320,19 +321,25 @@ func TestFMGoTaskAdaptor_ParseTaskResult_Completed(t *testing.T) {
 	}
 }
 
-func TestFMGoTaskAdaptor_Accepts6s(t *testing.T) {
+func TestFMGoTaskAdaptor_RejectsLegacy6sOnVideosFamily(t *testing.T) {
 	client := newapiintegration.FMGoSeedanceClientID
-	wire, _, err := buildFMGoSubmitBody(t, client, `{"`+client+`":"`+client+`"}`, map[string]any{
+	_, _, err := buildFMGoSubmitBody(t, client, `{"`+client+`":"`+client+`"}`, map[string]any{
 		"resolution": "720p",
 		"duration":   6,
 	})
+	if err == nil {
+		t.Fatal("431 family must reject 6s")
+	}
+}
+
+func TestFMGoTaskAdaptor_ParseTaskResult_VideosResultURL(t *testing.T) {
+	t.Parallel()
+	a := newFMGoTaskAdaptor()
+	info, err := a.ParseTaskResult([]byte(`{"id":"task-1","status":"completed","result_url":"https://static.fmgo.top/v.mp4"}`))
 	if err != nil {
-		t.Fatalf("BuildRequestBody: %v", err)
+		t.Fatalf("ParseTaskResult: %v", err)
 	}
-	if got := gjson.GetBytes(wire, "model").String(); got != "feimiao-v2-720p-6s" {
-		t.Fatalf("6s sku = %q", got)
-	}
-	if gjson.GetBytes(wire, "generationConfig.videoConfig.duration").Int() != 6 {
-		t.Fatalf("videoConfig.duration = %s", gjson.GetBytes(wire, "generationConfig.videoConfig.duration").Raw)
+	if info.Url != "https://static.fmgo.top/v.mp4" {
+		t.Fatalf("result_url = %q", info.Url)
 	}
 }

--- a/backend/internal/service/account_test_service_supplier_probe.go
+++ b/backend/internal/service/account_test_service_supplier_probe.go
@@ -73,10 +73,13 @@ func (s *AccountTestService) probeSupplierVideoModel(
 		baseResult.Detail = supplierProbeSafeDetail(SupplierProbeStatusFailed)
 		return baseResult
 	}
-	submitURL := supplierVideoProbeURL(account.ChannelType, baseURL)
+	submitURL := supplierVideoProbeURL(account.ChannelType, baseURL, baseResult.UpstreamModelID)
 	body := []byte(fmt.Sprintf(`{"model":%q,"prompt":"probe"}`, baseResult.UpstreamModelID))
 	fmgo := newapiintegration.IsFMGoBaseURL(account.ChannelType, baseURL)
-	if fmgo {
+	fmgoVideos := fmgo && newapiintegration.FMGoUsesVideosDialect(baseResult.UpstreamModelID)
+	if fmgoVideos {
+		body = supplierFMGoVideosProbeBody(baseResult.UpstreamModelID)
+	} else if fmgo {
 		body = supplierFMGoChatProbeBody(baseResult.UpstreamModelID)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, submitURL, bytes.NewReader(body))
@@ -87,7 +90,7 @@ func (s *AccountTestService) probeSupplierVideoModel(
 	}
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
-	if fmgo {
+	if fmgo && !fmgoVideos {
 		req.Header.Set("Prefer", "respond-async")
 	}
 	client := &http.Client{Timeout: 20 * time.Second}
@@ -102,7 +105,9 @@ func (s *AccountTestService) probeSupplierVideoModel(
 	status := supplierVideoProbeStatus(resp.StatusCode, raw)
 	baseResult.Status = status
 	if status == SupplierProbeStatusPassed {
-		if fmgo {
+		if fmgoVideos {
+			baseResult.Protocol = "fmgo_videos"
+		} else if fmgo {
 			baseResult.Protocol = "fmgo_chat_completions"
 		} else {
 			baseResult.Protocol = "openai_video"
@@ -112,16 +117,48 @@ func (s *AccountTestService) probeSupplierVideoModel(
 	return baseResult
 }
 
-func supplierVideoProbeURL(channelType int, baseURL string) string {
+func supplierVideoProbeURL(channelType int, baseURL, upstreamModelID string) string {
 	baseURL = strings.TrimRight(baseURL, "/")
 	switch {
 	case newapiintegration.IsFMGoBaseURL(channelType, baseURL):
-		return newapiintegration.NormalizeFMGoBaseURL(baseURL) + newapiintegration.FMGoChatCompletionsPath
+		return newapiintegration.NormalizeFMGoBaseURL(baseURL) + newapiintegration.FMGoSubmitPath(upstreamModelID)
 	case newapiintegration.IsXRTokenBaseURL(channelType, baseURL):
 		return newapiintegration.NormalizeXRTokenBaseURL(baseURL) + "/v1/contents/generations/tasks"
 	default:
 		return baseURL + "/api/v3/contents/generations/tasks"
 	}
+}
+
+func supplierFMGoVideosProbeBody(upstreamModelID string) []byte {
+	resolution := newapiintegration.FMGoDefaultResolution
+	duration := newapiintegration.FMGoDefaultDuration
+	model := strings.TrimSpace(upstreamModelID)
+	for _, res := range []string{"720p", "480p"} {
+		if strings.Contains(model, "-"+res+"-") {
+			resolution = res
+			break
+		}
+	}
+	for _, seconds := range []int{30, 15, 12, 10, 8, 6, 5} {
+		if strings.HasSuffix(model, fmt.Sprintf("-%ds", seconds)) {
+			duration = seconds
+			break
+		}
+	}
+	if newapiintegration.FMGoModelFamily(model) == newapiintegration.FMGoFamilyMini && resolution == "720p" && duration == 15 {
+		duration = 10
+	}
+	body, err := json.Marshal(map[string]any{
+		"model":        model,
+		"prompt":       "probe",
+		"aspect_ratio": "16:9",
+		"resolution":   resolution,
+		"seconds":      strconv.Itoa(duration),
+	})
+	if err != nil {
+		return []byte(`{"model":` + strconv.Quote(model) + `,"prompt":"probe"}`)
+	}
+	return body
 }
 
 func supplierFMGoChatProbeBody(upstreamModelID string) []byte {

--- a/backend/internal/service/account_test_service_supplier_probe_test.go
+++ b/backend/internal/service/account_test_service_supplier_probe_test.go
@@ -107,17 +107,30 @@ func TestUS048_VideoProbeFailToFetchTaskDoesNotPass(t *testing.T) {
 	}
 }
 
-func TestUS048_FMGoVideoProbeURLUsesChatCompletions(t *testing.T) {
-	got := supplierVideoProbeURL(newapiconstant.ChannelTypeDoubaoVideo, newapiintegration.FMGoBaseURL)
+func TestUS048_FMGoVideoProbeURLUsesVideosForLiveFamilies(t *testing.T) {
+	got := supplierVideoProbeURL(newapiconstant.ChannelTypeDoubaoVideo, newapiintegration.FMGoBaseURL, "feimiao-v2.5-720p-15s")
+	require.Equal(t, newapiintegration.FMGoBaseURL+newapiintegration.FMGoVideosPath, got)
+	got = supplierVideoProbeURL(newapiconstant.ChannelTypeDoubaoVideo, "https://www.fmgo.top", "feimiao-v2-431-fast-720p-15s")
+	require.Equal(t, newapiintegration.FMGoBaseURL+newapiintegration.FMGoVideosPath, got)
+	got = supplierVideoProbeURL(newapiconstant.ChannelTypeDoubaoVideo, newapiintegration.FMGoBaseURL, "feimiao-v2-720p-15s")
 	require.Equal(t, newapiintegration.FMGoBaseURL+newapiintegration.FMGoChatCompletionsPath, got)
-	got = supplierVideoProbeURL(newapiconstant.ChannelTypeDoubaoVideo, "https://www.fmgo.top")
-	require.Equal(t, newapiintegration.FMGoBaseURL+newapiintegration.FMGoChatCompletionsPath, got)
-	got = supplierVideoProbeURL(newapiconstant.ChannelTypeDoubaoVideo, "https://ark.cn-beijing.volces.com")
+	got = supplierVideoProbeURL(newapiconstant.ChannelTypeDoubaoVideo, "https://ark.cn-beijing.volces.com", "feimiao-v2-431-720p-15s")
 	require.Equal(t, "https://ark.cn-beijing.volces.com/api/v3/contents/generations/tasks", got)
 }
 
 func TestUS048_VideoProbeAcceptsHTTP202(t *testing.T) {
 	require.Equal(t, SupplierProbeStatusPassed, supplierVideoProbeStatus(http.StatusAccepted, []byte(`{"id":"task-1"}`)))
+}
+
+func TestUS048_FMGoVideosProbeBodyMatchesOfficialDialect(t *testing.T) {
+	body := supplierFMGoVideosProbeBody("feimiao-v2-431-fast-720p-15s")
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(body, &payload))
+	require.Equal(t, "feimiao-v2-431-fast-720p-15s", payload["model"])
+	require.Equal(t, "probe", payload["prompt"])
+	require.Equal(t, "16:9", payload["aspect_ratio"])
+	require.Equal(t, "720p", payload["resolution"])
+	require.Equal(t, "15", payload["seconds"])
 }
 
 func TestUS048_FMGoChatProbeBodyMatchesOfficialDialect(t *testing.T) {

--- a/backend/internal/service/supplier_source_probe.go
+++ b/backend/internal/service/supplier_source_probe.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
 )
 
 const (
@@ -276,6 +278,13 @@ func (s *SupplierSourceService) StartSupplierProbeJob(ctx context.Context, sourc
 		if !supplierUpstreamTypeProbeable(entry.Type, source.ChannelType) {
 			result.RejectedCandidates = append(result.RejectedCandidates, SupplierProbeRejectedCandidate{
 				UpstreamModelID: entry.ID, Type: entry.Type, Reason: "non_chat_type",
+			})
+			continue
+		}
+		if newapiintegration.IsFMGoBaseURL(source.ChannelType, source.Endpoint) &&
+			!newapiintegration.IsFMGoVideoInventoryID(entry.ID) {
+			result.RejectedCandidates = append(result.RejectedCandidates, SupplierProbeRejectedCandidate{
+				UpstreamModelID: entry.ID, Type: entry.Type, Reason: "non_video_inventory",
 			})
 			continue
 		}

--- a/backend/internal/service/supplier_source_probe_test.go
+++ b/backend/internal/service/supplier_source_probe_test.go
@@ -252,6 +252,43 @@ func TestUS048_StartSupplierProbeJobProbesAllCandidatesAsynchronously(t *testing
 	require.Len(t, result.SuggestedAppends, 12)
 }
 
+func TestUS048_FMGoProbeSkipsNonVideoInventory(t *testing.T) {
+	source := &SupplierSource{
+		ID: 10, SupplierName: "feimiao", ChannelName: "default",
+		ChannelType:         newapiconstant.ChannelTypeDoubaoVideo,
+		Endpoint:            "https://www.fmgo.top",
+		EncryptedCredential: "enc:secret",
+		BasePriority:        100,
+	}
+	repo := &supplierSourceRepoFake{stored: cloneSupplierSourceForTest(source)}
+	lister := &supplierProbeFake{
+		entries: []SupplierUpstreamModelEntry{
+			{ID: "claude-opus-4-8"},
+			{ID: "feimiao-v2-431-720p-15s"},
+			{ID: "gpt-5.4"},
+			{ID: "feimiao-v2.5-720p-15s"},
+		},
+		probeStatus: map[string]SupplierProbeStatus{
+			"feimiao-v2-431-720p-15s": SupplierProbeStatusPassed,
+			"feimiao-v2.5-720p-15s":   SupplierProbeStatusPassed,
+		},
+	}
+	svc := NewSupplierSourceService(repo, nil, lister, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{})
+
+	result, err := svc.ProbeUntilComplete(context.Background(), 10)
+	require.NoError(t, err)
+	rejected := map[string]string{}
+	for _, item := range result.RejectedCandidates {
+		rejected[item.UpstreamModelID] = item.Reason
+	}
+	require.Equal(t, "non_video_inventory", rejected["claude-opus-4-8"])
+	require.Equal(t, "non_video_inventory", rejected["gpt-5.4"])
+	require.NotContains(t, rejected, "feimiao-v2-431-720p-15s")
+	require.NotContains(t, rejected, "feimiao-v2.5-720p-15s")
+	require.Equal(t, int64(2), lister.probeCalls.Load())
+	require.Len(t, result.SuggestedAppends, 2)
+}
+
 func TestUS048_ExtractSupplierUpstreamModelEntriesKeepsType(t *testing.T) {
 	entries, err := extractSupplierUpstreamModelEntries([]byte(`{
 		"data": [

--- a/backend/internal/service/supplier_source_probe_test.go
+++ b/backend/internal/service/supplier_source_probe_test.go
@@ -266,6 +266,7 @@ func TestUS048_FMGoProbeSkipsNonVideoInventory(t *testing.T) {
 			{ID: "claude-opus-4-8"},
 			{ID: "feimiao-v2-431-720p-15s"},
 			{ID: "gpt-5.4"},
+			{ID: "veo-3-fast-4k-8s"},
 			{ID: "feimiao-v2.5-720p-15s"},
 		},
 		probeStatus: map[string]SupplierProbeStatus{
@@ -283,6 +284,7 @@ func TestUS048_FMGoProbeSkipsNonVideoInventory(t *testing.T) {
 	}
 	require.Equal(t, "non_video_inventory", rejected["claude-opus-4-8"])
 	require.Equal(t, "non_video_inventory", rejected["gpt-5.4"])
+	require.Equal(t, "non_video_inventory", rejected["veo-3-fast-4k-8s"])
 	require.NotContains(t, rejected, "feimiao-v2-431-720p-15s")
 	require.NotContains(t, rejected, "feimiao-v2.5-720p-15s")
 	require.Equal(t, int64(2), lister.probeCalls.Load())

--- a/backend/internal/service/supplier_source_sync_test.go
+++ b/backend/internal/service/supplier_source_sync_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestUS048_FMGoSeedanceSyncProjectsOfficialClientsOnly(t *testing.T) {
 	ratio := 0.5
-	notes := "inventory: feimiao-v2-480p-8s feimiao-v2-720p-15s feimiao-v2-fast-720p-10s"
+	notes := "inventory: feimiao-v2.5-720p-15s feimiao-v2-431-720p-15s feimiao-v2-mini-720p-10s"
 	repo := &supplierSourceRepoFake{stored: &SupplierSource{
 		ID: 10, SupplierName: "feimiao", ChannelName: "feimiao-svip",
 		ChannelType:         newapiconstant.ChannelTypeDoubaoVideo,
@@ -20,8 +20,8 @@ func TestUS048_FMGoSeedanceSyncProjectsOfficialClientsOnly(t *testing.T) {
 		EncryptedCredential: "enc:secret", CredentialFingerprint: "fp:secret", BasePriority: 100,
 		Notes: notes,
 		Models: []SupplierSourceModel{
-			{ClientModelID: "doubao-seedance-2-0-260128", UpstreamModelID: "feimiao-v2-720p-15s", PurchaseRatio: &ratio},
-			{ClientModelID: "doubao-seedance-2-0-fast-260128", UpstreamModelID: "feimiao-v2-fast-720p-15s", PurchaseRatio: &ratio},
+			{ClientModelID: "doubao-seedance-2-0-260128", UpstreamModelID: "feimiao-v2-431-720p-15s", PurchaseRatio: &ratio},
+			{ClientModelID: "doubao-seedance-2-0-fast-260128", UpstreamModelID: "feimiao-v2-431-fast-720p-15s", PurchaseRatio: &ratio},
 		},
 	}}
 	accounts := &supplierSyncAccountStoreFake{}
@@ -34,8 +34,8 @@ func TestUS048_FMGoSeedanceSyncProjectsOfficialClientsOnly(t *testing.T) {
 	require.NotNil(t, result)
 	require.NotEmpty(t, accounts.updated)
 	require.Equal(t, map[string]string{
-		"doubao-seedance-2-0-260128":      "feimiao-v2-720p-15s",
-		"doubao-seedance-2-0-fast-260128": "feimiao-v2-fast-720p-15s",
+		"doubao-seedance-2-0-260128":      "feimiao-v2-431-720p-15s",
+		"doubao-seedance-2-0-fast-260128": "feimiao-v2-431-fast-720p-15s",
 	}, accounts.updated[0].ModelMapping)
 	for clientID := range accounts.updated[0].ModelMapping {
 		require.False(t, strings.HasPrefix(clientID, "feimiao-v2-"), "SKU %q leaked as client", clientID)

--- a/docs/approved/model-supplier-source-fmgo-seedance-account-rewrite.md
+++ b/docs/approved/model-supplier-source-fmgo-seedance-account-rewrite.md
@@ -1,23 +1,23 @@
 ---
 title: FMGo Seedance — account/relay SKU rewrite (not supplier runtime)
 status: approved
-approved_by: "xuejiao (operator directives 2026-09-01)"
+approved_by: "xuejiao (operator directives 2026-09-01; live-group override 2026-09-01)"
 approved_at: 2026-09-01
 updated: 2026-09-01
 created: 2026-09-01
 owners: [tk-platform]
-scope: "FMGo ch54: models are 2 official remaps; 16 SKUs live in notes; runtime rewrite on account video relay; capability set pinned in adaptor"
+scope: "FMGo ch54: models are 2 official remaps onto live 431 inventory; runtime rewrite on account video relay; capability set pinned in adaptor"
 related_stories: ["US-048"]
 related_design: ["docs/approved/model-supplier-source-probe-sync-split.md"]
 amends: ["docs/approved/model-supplier-source-management.md"]
-operator_locks: "2026-09-01: models exactly 2 official remaps; 16 SKUs notes-only not projected; capability set in FMGo adaptor; missing res/dur→max; illegal→reject; no supplier_source_id in gateway"
+operator_locks: "2026-09-01 live default group: official Seedance remaps to 431[-fast]; submit POST /v1/videos; v2.5/mini dialect supported as passthrough; capability set in FMGo adaptor; missing res/dur→family default; illegal→reject; no supplier_source_id in gateway"
 ---
 
 # FMGo Seedance：账号侧动态改写（审批草案）
 
 ## 一件事
 
-客户只打 2 个官方 Seedance 2.0 client id。线上由**账号视频通道**按请求参数改写为 FMGo SKU。
+客户只打 2 个官方 Seedance 2.0 client id。线上由**账号视频通道**按请求参数改写为飞秒现网目录里已有的 SKU。
 
 供应源不进入 scheduler / gateway。探测/同步按钮见  
 `docs/approved/model-supplier-source-probe-sync-split.md`（可并行，非实现前置）。
@@ -34,100 +34,114 @@ operator_locks: "2026-09-01: models exactly 2 official remaps; 16 SKUs notes-onl
 识别 FMGo dialect：账号上的 `channel_type` + `base_url`（类比 XRToken ch54）。  
 **禁止**读 `supplier_source_id`。
 
-`{480p,720p} × {6,8,10,12,15}` **钉在 FMGo 账号通道 adaptor 里**。
+能力集合**钉在 FMGo 账号通道 adaptor 里**。
 不读供应源表，不从 notes 解析，不读账号 Extra 里的供应源字段。
 
-上游方言（飞秒使用指南）：`feimiao-v2` / `feimiao-v2-fast` 走
-`https://api.fmgo.top` 的 `POST /v1/chat/completions`（`Prefer: respond-async`、`async: true`、`generationConfig.videoConfig`），轮询 `GET /v1/tasks/{task_id}`。
-不是 `/v1/video/generations`，也不是通用 Chat 伪成功。
+现网 default 组目录里没有 `feimiao-v2[-fast]-*`。Seedance 2.0 对应
+`feimiao-v2-431[-fast]-*`（上游回显 `seedance-2.0` / `seedance-2.0-fast`）。
+同组还有 `feimiao-v2.5-*`、`feimiao-v2-mini-*`，走同一套 `/v1/videos` 方言。
+
+| 族 | 提交 | 轮询 |
+|---|---|---|
+| 官方 Seedance / 431 / v2.5 / mini | `POST /v1/videos` | `GET /v1/videos/{id}`（完成字段 `result_url`） |
+| legacy `feimiao-v2[-fast]` | `POST /v1/chat/completions` + `Prefer: respond-async` + `async:true` + `generationConfig.videoConfig` | `GET /v1/tasks/{id}` |
+
+都不是 `/v1/video/generations`，也不是通用 Chat 伪成功。
 
 ## 已拍板
 
 | 项 | 决定 |
 |---|---|
-| 对外 client | 仅 `doubao-seedance-2-0-260128`、`doubao-seedance-2-0-fast-260128` |
-| 供应源 `models` | **恰好 2 行官方 remap**，禁止再存 16 行 identity |
-| 16 条 `feimiao-v2-*` | 只写在 `notes`（采购备忘），**不进 models、不进账号 mapping、不进对外目录** |
-| 同步投影 | 投影这 2 行。不同步为 16 个 client。同步不靠「聪明过滤」 |
-| 探测 | `channel_type=54` → 视频门禁；只探这 2 行的锚点 upstream |
+| 对外 client | 仅 `doubao-seedance-2-0-260128`、`doubao-seedance-2-0-fast-260128`（Studio / 目录不暴露飞秒 SKU） |
+| 探测 | 列出 `/v1/models` 里**全部可探视频库存**（v2.5 / 431 / mini 网格，以及 veo / grok-video / omni 等）；跳过 Claude/GPT。结果应是很多行，不是 2 行 |
+| 供应源 `models` | 探测通过的建议追加是 opt-in。若只要承接官方 Seedance，保存 2 行 remap；若要把库存写进采购表，可加入全部通过的 identity 行 |
+| 同步投影 | 投影**当时已保存的** `models` 行。探测到很多 SKU ≠ 自动同步很多 client |
 | 非法 resolution / duration | **拒绝**，不降级、不钳制 |
-| 缺省 resolution | `720p`（集合最大） |
-| 缺省 duration | `15`（集合最大秒） |
+| 缺省 resolution | `720p` |
+| 缺省 duration | `15`（mini 720p 例外为 `10`） |
 | 运行时 SKU | 按参数动态拼；mapping 的 upstream 只是探测锚点，不是唯一永久上游 id |
 
 不设 `projectable` / `inventory_only` 标记。不设静态 fallback SKU。
 
-现网若仍是 16 行 identity：本实现 PR 先把该供应源收成 2 行再同步。
+1.8.193 只会走 chat completions，**发新版后才能探测/同步 videos 族**。
 
 ## 上游能力集合（adaptor 内钉死）
 
 ```text
 host       ∈ {api.fmgo.top, www.fmgo.top, fmgo.top} → canonical https://api.fmgo.top
+official   → feimiao-v2-431[-fast]-{resolution}-{duration}s
 resolution ∈ {480p, 720p}
-duration   ∈ {6, 8, 10, 12, 15}
-SKU        = feimiao-v2[-fast]-{resolution}-{duration}s
-submit     = POST /v1/chat/completions
-poll       = GET /v1/tasks/{id}
+431 dur    ∈ {10, 15}
+v2.5       透传目录组合（480p: 5/10/15/30；720p: 10/15/30）
+mini       仅 (720p,10) / (480p,15)
+legacy v2  {480p,720p} × {6,8,10,12,15}，仍走 chat completions
 ```
 
 ## 供应源唯一存法
 
 | client_model_id | upstream_model_id（探测锚点） | 同步进账号 mapping |
 |---|---|---|
-| `doubao-seedance-2-0-260128` | `feimiao-v2-720p-15s` | 是 |
-| `doubao-seedance-2-0-fast-260128` | `feimiao-v2-fast-720p-15s` | 是 |
+| `doubao-seedance-2-0-260128` | `feimiao-v2-431-720p-15s` | 是 |
+| `doubao-seedance-2-0-fast-260128` | `feimiao-v2-431-fast-720p-15s` | 是 |
 
-`notes` 可列出 16 个 SKU 备忘。运行时不读 notes。
+`notes` 可列出 v2.5 / 431 / mini 备忘。运行时不读 notes。
 
 ## 运行时改写（账号 / video relay）
 
 账号 mapping 表明本账号可承接该官方 client 后：
 
-1. fast 与否 → `feimiao-v2-fast-*` / `feimiao-v2-*`
+1. fast 与否 → `feimiao-v2-431-fast-*` / `feimiao-v2-431-*`
 2. resolution：缺省 → `720p`；∈ 集合 → 用其值；否则明确拒绝
-3. duration：缺省 → `15`；∈ 集合 → 用其值；否则明确拒绝
-4. 拼出唯一上游 SKU，按官方 chat-completions 视频方言提交
+3. duration：缺省 → `15`；∈ `{10,15}` → 用其值；`6/8/12` **拒绝**（相对旧 chat 族是行为变化）
+4. 拼出唯一上游 SKU，按 `/v1/videos` 提交（`seconds` 为字符串）
+
+已经是 `feimiao-v2.5-*` / `feimiao-v2-mini-*` / legacy `feimiao-v2-*` 的请求按族透传，不改写成官方 client。
 
 ## 探测
 
 - `channel_type=54` → 与账号通道同一上游方言。
-- FMGo：官方 `POST /v1/chat/completions` 视频体（不是「hi」Chat 伪成功）。
-- 只探两行锚点：`feimiao-v2-720p-15s`、`feimiao-v2-fast-720p-15s`。
+- 现网族：官方 `POST /v1/videos`（不是「hi」Chat 伪成功）。
+- legacy `feimiao-v2[-fast]`：官方 `POST /v1/chat/completions` 视频体。
+- **已配置行 + 全部未覆盖的视频候选都探**。default 组目录应出现 v2.5 / 431 / mini 多条 SKU（建议追加），不是只探两个锚点。
+- 目录混有 Claude/GPT 时，候选探测跳过非视频库存。
 - 失败不写账号。禁止用普通 Chat Completions 探测冒充视频可服务。
+- 「加入表单」才会把建议追加写进 `models`；探测本身不改供应源、不同步账号。
 
 ## Scenarios
 
 ### 正向
 
 1. 同步后账号 mapping 仅含 2 个官方 client。
-2. `…-260128` + `720p` + `10` → `feimiao-v2-720p-10s`。
-3. 省略 resolution/duration → `720p` + `15s` → `feimiao-v2-720p-15s`（或 fast 变体）。
+2. `…-260128` + `720p` + `10` → `feimiao-v2-431-720p-10s`。
+3. 省略 resolution/duration → `720p` + `15s` → `feimiao-v2-431-720p-15s`（或 fast 变体）。
 
 ### 负向
 
-1. `1080p` / `4k` / `9s` → 拒绝。
-2. 保存或同步把 `feimiao-v2-*` 写成 client → 缺陷；测试锁死不出现。
+1. `1080p` / `4k` / `9s` / `6s` / `8s` / `12s` → 拒绝。
+2. 保存或同步把 `feimiao-*` 写成 client → 缺陷；测试锁死不出现。
 3. 网关不查供应源表、不解析 notes。
+4. 探测候选不含 `claude-*` / `gpt-*`。
 
 ## Validation
 
-- 单测：缺省 → 最大；非法 → 拒绝；fast/非 fast 拼 SKU。
-- 单测：同步投影后 mapping 客户端集合 == 2 个官方 id。
+- 单测：缺省 → 431 最大；非法（含旧 6/8/12）→ 拒绝；fast/非 fast 拼 SKU。
+- 单测：同步投影后 mapping 客户端集合 == 2 个官方 id，锚点为 431。
 - 单测：adaptor 能力集合不从供应源/notes 读取。
+- 单测：live 族打 `/v1/videos`；legacy 族打 chat completions。
 - 上游视频 task 404 时探测失败，不写账号。
 
 ## 非目标
 
-- 不把 16 个 `feimiao-v2-*` 进 models / 目录 / 对外 client。
-- 不映射 2.5 / mini / 1.x。
+- 不把飞秒目录 SKU 进 models / 目录 / 对外 client。
+- 不把 v2.5 / mini 做成 TokenKey 对外 client（adaptor 只支持其 `/v1/videos` 方言与透传）。
 - 不在供应源服务内拼运行时 SKU。
 - 不实现探测/同步按钮拆分。
 - 不做 inventory 行标记。
 
 ## 审批检查清单
 
-- [x] models 恰好 2 行；16 条只在 notes
+- [x] 探测覆盖全部视频库存；官方 Seedance 对外仍是 2 个 client
 - [x] 能力集合钉在 adaptor
-- [x] 缺省取集合最大；非法拒绝
+- [x] 缺省取族默认；非法拒绝
 - [x] 改写在账号 relay；不读供应源
-- [x] 已批准（2026-09-01）
+- [x] 已批准（2026-09-01）；现网目录覆盖 431 / v2.5 / mini

--- a/docs/approved/model-supplier-source-fmgo-seedance-account-rewrite.md
+++ b/docs/approved/model-supplier-source-fmgo-seedance-account-rewrite.md
@@ -77,7 +77,9 @@ mini       仅 (720p,10) / (480p,15)
 legacy v2  {480p,720p} × {6,8,10,12,15}，仍走 chat completions
 ```
 
-## 供应源唯一存法
+## 官方 Seedance 承接时的存法
+
+只承接官方 Seedance 时保存这两行 remap。探测通过的 v2.5 / 431 / mini identity 行是 opt-in 采购事实，不是这张表的互斥条件。
 
 | client_model_id | upstream_model_id（探测锚点） | 同步进账号 mapping |
 |---|---|---|
@@ -111,14 +113,14 @@ legacy v2  {480p,720p} × {6,8,10,12,15}，仍走 chat completions
 
 ### 正向
 
-1. 同步后账号 mapping 仅含 2 个官方 client。
+1. 若只保存 2 行官方 remap，同步后账号 mapping 仅含 2 个官方 client。
 2. `…-260128` + `720p` + `10` → `feimiao-v2-431-720p-10s`。
 3. 省略 resolution/duration → `720p` + `15s` → `feimiao-v2-431-720p-15s`（或 fast 变体）。
 
 ### 负向
 
 1. `1080p` / `4k` / `9s` / `6s` / `8s` / `12s` → 拒绝。
-2. 保存或同步把 `feimiao-*` 写成 client → 缺陷；测试锁死不出现。
+2. 把飞秒 SKU 做成 TokenKey 对外 / Studio client 或写入对外目录 → 缺陷。供应源 `models` 可以有 identity 行，那是采购事实。
 3. 网关不查供应源表、不解析 notes。
 4. 探测候选不含 `claude-*` / `gpt-*` / `veo-*` / `grok-video*`。
 

--- a/docs/approved/model-supplier-source-fmgo-seedance-account-rewrite.md
+++ b/docs/approved/model-supplier-source-fmgo-seedance-account-rewrite.md
@@ -53,7 +53,7 @@ operator_locks: "2026-09-01 live default group: official Seedance remaps to 431[
 | 项 | 决定 |
 |---|---|
 | 对外 client | 仅 `doubao-seedance-2-0-260128`、`doubao-seedance-2-0-fast-260128`（Studio / 目录不暴露飞秒 SKU） |
-| 探测 | 列出 `/v1/models` 里**全部可探视频库存**（v2.5 / 431 / mini 网格，以及 veo / grok-video / omni 等）；跳过 Claude/GPT。结果应是很多行，不是 2 行 |
+| 探测 | 列出 `/v1/models` 里本 adaptor 能说的视频库存（v2.5 / 431 / mini / legacy v2）；跳过 Claude/GPT 以及 veo/sora/grok-video/omni。结果应是很多行，不是 2 行 |
 | 供应源 `models` | 探测通过的建议追加是 opt-in。若只要承接官方 Seedance，保存 2 行 remap；若要把库存写进采购表，可加入全部通过的 identity 行 |
 | 同步投影 | 投影**当时已保存的** `models` 行。探测到很多 SKU ≠ 自动同步很多 client |
 | 非法 resolution / duration | **拒绝**，不降级、不钳制 |
@@ -120,7 +120,7 @@ legacy v2  {480p,720p} × {6,8,10,12,15}，仍走 chat completions
 1. `1080p` / `4k` / `9s` / `6s` / `8s` / `12s` → 拒绝。
 2. 保存或同步把 `feimiao-*` 写成 client → 缺陷；测试锁死不出现。
 3. 网关不查供应源表、不解析 notes。
-4. 探测候选不含 `claude-*` / `gpt-*`。
+4. 探测候选不含 `claude-*` / `gpt-*` / `veo-*` / `grok-video*`。
 
 ## Validation
 
@@ -132,15 +132,15 @@ legacy v2  {480p,720p} × {6,8,10,12,15}，仍走 chat completions
 
 ## 非目标
 
-- 不把飞秒目录 SKU 进 models / 目录 / 对外 client。
-- 不把 v2.5 / mini 做成 TokenKey 对外 client（adaptor 只支持其 `/v1/videos` 方言与透传）。
+- 不把飞秒 SKU 做成 TokenKey 对外 / Studio client；供应源 `models` 可以 opt-in 保存探测通过的 identity 行，同步只投影已保存行。
+- 不实现 veo / sora / grok-video / omni 方言；这些目录行探测直接跳过。
 - 不在供应源服务内拼运行时 SKU。
 - 不实现探测/同步按钮拆分。
 - 不做 inventory 行标记。
 
 ## 审批检查清单
 
-- [x] 探测覆盖全部视频库存；官方 Seedance 对外仍是 2 个 client
+- [x] 探测覆盖 v2.5 / 431 / mini / legacy v2；官方 Seedance 对外仍是 2 个 client
 - [x] 能力集合钉在 adaptor
 - [x] 缺省取族默认；非法拒绝
 - [x] 改写在账号 relay；不读供应源

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7636,11 +7636,14 @@
         "return \"openai_responses\"",
         "return \"anthropic_messages\"",
         "supplierFMGoChatProbeBody",
+        "supplierFMGoVideosProbeBody",
         "fmgo_chat_completions",
+        "fmgo_videos",
         "respond-async",
-        "FMGoChatCompletionsPath"
+        "FMGoSubmitPath",
+        "FMGoUsesVideosDialect"
       ],
-      "rationale": "Version-one supplier probing is intentionally fixed to OpenAI Chat. Even successful Responses or Anthropic Messages evidence must fail closed as protocol_unsupported instead of silently expanding the production transport surface. FMGo ch54 is the exception that still uses official async chat-completions video dialect (not hi-Chat fake success, not /v1/video/generations)."
+      "rationale": "Version-one supplier probing is intentionally fixed to OpenAI Chat. Even successful Responses or Anthropic Messages evidence must fail closed as protocol_unsupported instead of silently expanding the production transport surface. FMGo ch54 live families (v2.5/431/mini) use official POST /v1/videos; legacy feimiao-v2 stays on async chat completions. Neither path is hi-Chat fake success or /v1/video/generations."
     },
     {
       "path": "backend/internal/service/account_test_service_supplier_probe_test.go",
@@ -7651,11 +7654,12 @@
         "TestUS048_SupplierProbeDoesNotLogRawUpstreamError",
         "TestUS048_SupplierProbeClassifiesEventsWithoutPersistingUpstreamDetail",
         "successful non-chat protocol remains unsupported",
-        "TestUS048_FMGoVideoProbeURLUsesChatCompletions",
+        "TestUS048_FMGoVideoProbeURLUsesVideosForLiveFamilies",
+        "TestUS048_FMGoVideosProbeBodyMatchesOfficialDialect",
         "TestUS048_FMGoChatProbeBodyMatchesOfficialDialect",
         "TestUS048_VideoProbeAcceptsHTTP202"
       ],
-      "rationale": "Probe regressions pin in-memory execution, the managed identity's single Chat capability, supplier-only trailing-/v1 normalization, raw-upstream log redaction, fixed public result details, and non-Chat failure closure without persisting an account or upstream response body. FMGo video probe must hit official chat completions, carry the vendor video body, and accept HTTP 202."
+      "rationale": "Probe regressions pin in-memory execution, the managed identity's single Chat capability, supplier-only trailing-/v1 normalization, raw-upstream log redaction, fixed public result details, and non-Chat failure closure without persisting an account or upstream response body. Live FMGo families probe POST /v1/videos; legacy feimiao-v2 still uses official chat-completions video dialect and HTTP 202."
     },
     {
       "path": "backend/internal/service/supplier_managed_account_guard.go",
@@ -7772,6 +7776,7 @@
       "must_contain": [
         "func TestUS048_StartSupplierProbeJobProbesAllCandidatesAsynchronously(",
         "func TestUS048_GetSupplierProbeJobMissingReturnsFailedSnapshot(",
+        "func TestUS048_FMGoProbeSkipsNonVideoInventory(",
         "require.Equal(t, int64(12), lister.probeCalls.Load())"
       ],
       "rationale": "Focused regressions pin full-candidate async probing without a budget cap, and prove missing/expired jobs return a failed snapshot rather than conflating with supplier-source-not-found."

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -780,10 +780,14 @@
         "FMGoSeedanceClientID",
         "FMGoSeedanceFastClientID",
         "FMGoChatCompletionsPath",
+        "FMGoVideosPath",
+        "FMGoUsesVideosDialect",
+        "IsFMGoVideoInventoryID",
+        "feimiao-v2-431",
         "api.fmgo.top",
         "ChannelTypeDoubaoVideo"
       ],
-      "rationale": "FMGo (feimiao) host detection and pinned Seedance capability set. Identification is channel_type + base_url only; scheduler/gateway must never read supplier_source_id. Canonical host is api.fmgo.top. FMGoSeedanceUpstreamSKU is the only owner of {480p,720p} x {6,8,10,12,15} and the feimiao-v2[-fast]-{res}-{dur}s formula. Dropping it freezes probe-anchor SKUs or leaks inventory ids as clients."
+      "rationale": "FMGo (feimiao) host detection and pinned Seedance capability set. Identification is channel_type + base_url only; scheduler/gateway must never read supplier_source_id. Canonical host is api.fmgo.top. Live default-group Seedance inventory is v2.5/431/mini on /v1/videos; FMGoSeedanceUpstreamSKU is the only owner of official client → 431[-fast] rewrite."
     },
     {
       "path": "backend/internal/integration/newapi/fmgo_test.go",
@@ -791,6 +795,7 @@
         "TestIsFMGoBaseURL",
         "TestNormalizeFMGoBaseURL",
         "TestFMGoSeedanceUpstreamSKU",
+        "TestFMGoUsesVideosDialect",
         "TestParseFMGoVideoDuration"
       ],
       "rationale": "Regressions for FMGo host detection, default-to-max SKU, illegal resolution/duration rejection, and passthrough of non-official clients."
@@ -800,15 +805,17 @@
       "must_contain": [
         "fmgoTaskAdaptor",
         "newFMGoTaskAdaptor",
-        "/v1/chat/completions",
-        "/v1/tasks",
-        "respond-async",
+        "/v1/videos",
+        "FMGoSubmitPath",
+        "FMGoFetchPath",
+        "fmgoVideosBody",
+        "fmgoChatCompletionsBody",
         "fmgoSeedanceClientFromRelay",
         "fmgoVideoParamsFromSubmit",
         "FMGoSeedanceUpstreamSKU",
         "duration_seconds"
       ],
-      "rationale": "TK companion task adaptor for official FMGo feimiao-v2 dialect: async POST /v1/chat/completions plus GET /v1/tasks/{id}. Must rewrite official Seedance clients from OriginModelName plus request params, ignore probe-anchor mapping as a frozen SKU, and not fall back to /v1/video/generations. Capability set stays in newapiintegration, never notes or supplier Extra."
+      "rationale": "TK companion task adaptor for live FMGo Seedance inventory: official clients rewrite to 431[-fast] and submit POST /v1/videos; legacy feimiao-v2 stays on chat completions. Must ignore probe-anchor mapping as a frozen SKU. Capability set stays in newapiintegration, never notes or supplier Extra."
     },
     {
       "path": "backend/internal/relay/bridge/video_relay_tk_fmgo_test.go",
@@ -822,8 +829,8 @@
         "TestFMGoTaskAdaptor_RejectsUnsupportedDuration",
         "TestFMGoTaskAdaptor_ReadsDurationSecondsAlias",
         "TestFMGoTaskAdaptor_SanitizeFetchResponse",
-        "TestFMGoTaskAdaptor_DoRequest_HitsChatCompletions",
-        "TestFMGoTaskAdaptor_FetchTask_HitsTasksPath",
+        "TestFMGoTaskAdaptor_DoRequest_HitsVideos",
+        "TestFMGoTaskAdaptor_FetchTask_HitsVideosPath",
         "TestFMGoTaskAdaptor_ParseTaskResult_Completed"
       ],
       "rationale": "Focused FMGo video regressions: host selection, official + probe-anchor rewrite, defaults, and illegal param rejection."


### PR DESCRIPTION
## 摘要

- 飞秒 default 组目录已没有 `feimiao-v2[-fast]`。官方 Seedance 运行时改写到现网 `431` / `431-fast`，提交走 `POST /v1/videos`。
- `v2.5` / `mini` 按目录 SKU 透传同一套 videos 方言；旧 `feimiao-v2` 仍走 chat completions。
- 探测覆盖本 adaptor 能说的视频库存（v2.5 / 431 / mini / legacy v2，很多行），跳过 Claude/GPT 以及 veo/sora/grok-video/omni。
- 「2 行 remap」只用于对外 Seedance client，不是探测上限。
- Web impact: none

## 风险

- 常规偏高：上游方言从 chat completions 换成 `/v1/videos`；官方 Seedance 不再接受 6/8/12 秒。
- 对外 client id 不变。网关仍禁止读 `supplier_source_id`。
- 现网 `1.8.193` 不会按 videos 族探测/转发，本 PR 发版后才能对供应源 10 做 probe。

## 验证

- `go test -tags=unit`：`internal/integration/newapi`、`internal/relay/bridge`、相关 `TestUS048_FMGo*` 通过。
- `./scripts/preflight.sh` 通过。
- 未对 prod 供应源 10 做 probe/sync。

## 提交

- `e737d264c` fix(supplier): FMGo Seedance 改走现网 v2.5/431/mini videos 方言 (no-web-impact)
- `6f4eb2fc2` fix(supplier): address R-001 R-002 — 收紧 FMGo 可探库存并消除文档分叉 (no-web-impact)
- `ce6bc1b3e` fix(docs): address R-001 — 对齐 FMGo 供应源 identity 与官方 remap 口径 (no-web-impact)
- 最新提交：`ce6bc1b3e`