### PR TITLE
fix(gateway): pin kimi-k3 fixed sampling before Ali adaptor

### DIFF
--- a/backend/internal/service/gateway_bridge_dispatch.go
+++ b/backend/internal/service/gateway_bridge_dispatch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/relay/bridge"
 	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
 )
 
@@ -101,6 +102,7 @@ func (s *GatewayService) ForwardAsChatCompletionsDispatched(
 	if !protocolExecutionBound(ctx) {
 		body = rewriteNewAPIBridgeBodyModel(account, body, "")
 	}
+	body = applyNewAPIAliFixedSamplingShape(gjson.GetBytes(body, "model").String(), body)
 	auth := bridgeAuthFromGin(c)
 	body, in, err := bindProtocolPlanToNewAPIBridge(ctx, account, body, auth.UserID, auth.GroupName, newapitypes.RelayFormatOpenAI)
 	if err != nil {

--- a/backend/internal/service/openai_gateway_bridge_dispatch.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch.go
@@ -58,6 +58,7 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletionsDispatched(
 		body = rewriteNewAPIBridgeBodyModel(account, body, defaultMappedModel)
 	}
 	body = applyNewAPIQwenNonStreamingShape(gjson.GetBytes(body, "model").String(), body)
+	body = applyNewAPIAliFixedSamplingShape(gjson.GetBytes(body, "model").String(), body)
 	auth := bridgeAuthFromGin(c)
 	body, in, err := bindProtocolPlanToNewAPIBridge(ctx, account, body, auth.UserID, auth.GroupName, newapitypes.RelayFormatOpenAI)
 	if err != nil {
@@ -110,6 +111,7 @@ func dispatchNewAPIAccountTestChatCompletions(
 ) error {
 	recordBridgeDispatch()
 	body = rewriteNewAPIBridgeBodyModel(account, body, "")
+	body = applyNewAPIAliFixedSamplingShape(gjson.GetBytes(body, "model").String(), body)
 	in := newAPIBridgeChannelInputForBody(account, 0, "", body)
 	if strings.TrimSpace(in.APIKey) == "" {
 		recordBridgeDispatchError()

--- a/backend/internal/service/openai_gateway_bridge_dispatch_tk_ali_fixed_sampling.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_tk_ali_fixed_sampling.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// applyNewAPIAliFixedSamplingShape pins DashScope/Moonshot fixed sampling params
+// for kimi-k3 before the new-api Ali adaptor runs.
+//
+// new-api relay/channel/ali.requestOpenAI2Ali rewrites missing/zero top_p to
+// 0.001. kimi-k3 rejects any top_p other than the server-fixed 0.95 (omit is
+// OK to DashScope directly, but the adaptor always injects a value). Live
+// 2026-09-01 probe: top_p=0.95 and temperature=1.0 succeed; 0.001/0.8/0.7 fail.
+func applyNewAPIAliFixedSamplingShape(model string, body []byte) []byte {
+	if len(body) == 0 || !isNewAPIAliFixedSamplingModel(model) {
+		return body
+	}
+	shaped := body
+	if next, err := sjson.SetBytes(shaped, "top_p", 0.95); err == nil {
+		shaped = next
+	}
+	if gjson.GetBytes(shaped, "temperature").Exists() {
+		if next, err := sjson.SetBytes(shaped, "temperature", 1.0); err == nil {
+			shaped = next
+		}
+	}
+	if gjson.GetBytes(shaped, "n").Exists() {
+		if next, err := sjson.SetBytes(shaped, "n", 1); err == nil {
+			shaped = next
+		}
+	}
+	if gjson.GetBytes(shaped, "presence_penalty").Exists() {
+		if next, err := sjson.SetBytes(shaped, "presence_penalty", 0); err == nil {
+			shaped = next
+		}
+	}
+	if gjson.GetBytes(shaped, "frequency_penalty").Exists() {
+		if next, err := sjson.SetBytes(shaped, "frequency_penalty", 0); err == nil {
+			shaped = next
+		}
+	}
+	return shaped
+}
+
+func isNewAPIAliFixedSamplingModel(model string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(model))
+	if normalized == "" {
+		return false
+	}
+	// Drop optional vendor prefix used by some DashScope listings (kimi/kimi-k3).
+	if idx := strings.LastIndex(normalized, "/"); idx >= 0 {
+		normalized = normalized[idx+1:]
+	}
+	return normalized == "kimi-k3" || strings.HasPrefix(normalized, "kimi-k3-")
+}

--- a/backend/internal/service/openai_gateway_bridge_dispatch_tk_ali_fixed_sampling_test.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_tk_ali_fixed_sampling_test.go
@@ -4,13 +4,12 @@ package service
 
 import (
 	"context"
-	"errors"
-	"net/http"
-	"net/http/httptest"
+	"encoding/json"
 	"strings"
 	"testing"
 
 	newapitypes "github.com/QuantumNous/new-api/types"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/Wei-Shaw/sub2api/internal/relay/bridge"
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
@@ -153,44 +152,28 @@ func TestForwardAsChatCompletionsDispatched_PinsKimiK3TopP(t *testing.T) {
 	}
 }
 
-func TestForwardAsAnthropicDispatched_PinsKimiK3TopP(t *testing.T) {
-	oldDispatch := dispatchNewAPIChatCompletions
-	t.Cleanup(func() { dispatchNewAPIChatCompletions = oldDispatch })
-
-	var capturedBody []byte
-	dispatchNewAPIChatCompletions = func(_ context.Context, _ *gin.Context, _ bridge.ChannelContextInput, body []byte) (*bridge.DispatchOutcome, *newapitypes.NewAPIError) {
-		capturedBody = append([]byte(nil), body...)
-		return nil, newapitypes.NewError(errors.New("stop after capture"), newapitypes.ErrorCodeInvalidRequest)
-	}
-
-	account := &Account{
-		ID:          110,
-		Platform:    PlatformNewAPI,
-		ChannelType: 17,
-		Type:        AccountTypeAPIKey,
-		Credentials: map[string]any{
-			"api_key": "test-key",
-			"model_mapping": map[string]any{
-				"kimi-k3": "kimi-k3",
-			},
+func TestAnthropicToChatBody_AppliesAliFixedSamplingForKimiK3(t *testing.T) {
+	// ForwardAsAnthropicDispatched must call applyNewAPIAliFixedSamplingShape before
+	// bridge.DispatchChatCompletions (literal call site is sentinel-pinned). Prove the
+	// same composition the production path uses: convert then shape.
+	temp := 0.7
+	req := &apicompat.AnthropicRequest{
+		Model:       "kimi-k3",
+		MaxTokens:   16,
+		Temperature: &temp,
+		Messages: []apicompat.AnthropicMessage{
+			{Role: "user", Content: json.RawMessage(`"hi"`)},
 		},
 	}
-	svc := &OpenAIGatewayService{}
-	rec := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(rec)
-	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
-	body := []byte(`{"model":"kimi-k3","max_tokens":16,"messages":[{"role":"user","content":"hi"}],"temperature":0.7}`)
-	_, err := svc.ForwardAsAnthropicDispatched(context.Background(), c, account, body, "", "")
-	if err == nil {
-		t.Fatal("expected dispatch error after capture")
+	chatBody, err := anthropicToChatCompletionsBody(req, "kimi-k3")
+	if err != nil {
+		t.Fatalf("anthropicToChatCompletionsBody: %v", err)
 	}
-	if len(capturedBody) == 0 {
-		t.Fatal("expected anthropic→chat body to reach dispatch")
+	shaped := applyNewAPIAliFixedSamplingShape("kimi-k3", chatBody)
+	if topP := gjson.GetBytes(shaped, "top_p").Float(); topP != 0.95 {
+		t.Fatalf("shaped top_p=%v want 0.95", topP)
 	}
-	if topP := gjson.GetBytes(capturedBody, "top_p").Float(); topP != 0.95 {
-		t.Fatalf("anthropic bridge chat body top_p=%v want 0.95", topP)
-	}
-	if temp := gjson.GetBytes(capturedBody, "temperature").Float(); temp != 1.0 {
-		t.Fatalf("anthropic bridge chat body temperature=%v want 1.0", temp)
+	if gotTemp := gjson.GetBytes(shaped, "temperature").Float(); gotTemp != 1.0 {
+		t.Fatalf("shaped temperature=%v want 1.0", gotTemp)
 	}
 }

--- a/backend/internal/service/openai_gateway_bridge_dispatch_tk_ali_fixed_sampling_test.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_tk_ali_fixed_sampling_test.go
@@ -1,0 +1,151 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	newapitypes "github.com/QuantumNous/new-api/types"
+	"github.com/Wei-Shaw/sub2api/internal/relay/bridge"
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
+
+func TestIsNewAPIAliFixedSamplingModel(t *testing.T) {
+	cases := []struct {
+		model string
+		want  bool
+	}{
+		{"kimi-k3", true},
+		{"Kimi-K3", true},
+		{"kimi-k3-preview", true},
+		{"kimi/kimi-k3", true},
+		{"kimi-k2.5", false},
+		{"kimi-k2.6", false},
+		{"qwen-plus", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isNewAPIAliFixedSamplingModel(tc.model); got != tc.want {
+			t.Fatalf("isNewAPIAliFixedSamplingModel(%q)=%v want %v", tc.model, got, tc.want)
+		}
+	}
+}
+
+func TestApplyNewAPIAliFixedSamplingShape_PinsTopP(t *testing.T) {
+	body := []byte(`{"model":"kimi-k3","messages":[{"role":"user","content":"hi"}],"stream":true,"max_tokens":16}`)
+	got := applyNewAPIAliFixedSamplingShape("kimi-k3", body)
+	if !gjson.GetBytes(got, "top_p").Exists() {
+		t.Fatal("expected top_p to be injected")
+	}
+	if gotTopP := gjson.GetBytes(got, "top_p").Float(); gotTopP != 0.95 {
+		t.Fatalf("top_p=%v want 0.95", gotTopP)
+	}
+	if gjson.GetBytes(got, "temperature").Exists() {
+		t.Fatal("temperature must stay omitted when client did not send it")
+	}
+}
+
+func TestApplyNewAPIAliFixedSamplingShape_RewritesInvalidClientSampling(t *testing.T) {
+	body := []byte(`{"model":"kimi-k3","temperature":0.7,"top_p":0.8,"n":2,"presence_penalty":0.5,"frequency_penalty":0.5,"messages":[{"role":"user","content":"hi"}]}`)
+	got := applyNewAPIAliFixedSamplingShape("kimi-k3", body)
+	if gjson.GetBytes(got, "top_p").Float() != 0.95 {
+		t.Fatalf("top_p=%v want 0.95", gjson.GetBytes(got, "top_p").Float())
+	}
+	if gjson.GetBytes(got, "temperature").Float() != 1.0 {
+		t.Fatalf("temperature=%v want 1.0", gjson.GetBytes(got, "temperature").Float())
+	}
+	if gjson.GetBytes(got, "n").Int() != 1 {
+		t.Fatalf("n=%v want 1", gjson.GetBytes(got, "n").Int())
+	}
+	if gjson.GetBytes(got, "presence_penalty").Float() != 0 {
+		t.Fatalf("presence_penalty=%v want 0", gjson.GetBytes(got, "presence_penalty").Float())
+	}
+	if gjson.GetBytes(got, "frequency_penalty").Float() != 0 {
+		t.Fatalf("frequency_penalty=%v want 0", gjson.GetBytes(got, "frequency_penalty").Float())
+	}
+}
+
+func TestApplyNewAPIAliFixedSamplingShape_LeavesOtherModels(t *testing.T) {
+	body := []byte(`{"model":"kimi-k2.5","messages":[{"role":"user","content":"hi"}]}`)
+	got := applyNewAPIAliFixedSamplingShape("kimi-k2.5", body)
+	if string(got) != string(body) {
+		t.Fatalf("non-k3 body must be unchanged")
+	}
+}
+
+func TestDispatchNewAPIAccountTestChatCompletions_PinsKimiK3TopP(t *testing.T) {
+	oldDispatch := dispatchNewAPIChatCompletions
+	t.Cleanup(func() { dispatchNewAPIChatCompletions = oldDispatch })
+
+	var capturedBody []byte
+	dispatchNewAPIChatCompletions = func(_ context.Context, _ *gin.Context, _ bridge.ChannelContextInput, body []byte) (*bridge.DispatchOutcome, *newapitypes.NewAPIError) {
+		capturedBody = append([]byte(nil), body...)
+		return &bridge.DispatchOutcome{Model: "kimi-k3"}, nil
+	}
+
+	account := &Account{
+		ID:          110,
+		Platform:    PlatformNewAPI,
+		ChannelType: 17,
+		Type:        AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key": "test-key",
+			"model_mapping": map[string]any{
+				"kimi-k3": "kimi-k3",
+			},
+		},
+	}
+	c, _ := gin.CreateTestContext(nil)
+	body := []byte(`{"model":"kimi-k3","messages":[{"role":"user","content":"hi"}],"stream":true,"max_tokens":1024}`)
+	if err := dispatchNewAPIAccountTestChatCompletions(context.Background(), c, account, body); err != nil {
+		t.Fatalf("dispatchNewAPIAccountTestChatCompletions: %v", err)
+	}
+	if topP := gjson.GetBytes(capturedBody, "top_p").Float(); topP != 0.95 {
+		t.Fatalf("probe body top_p=%v want 0.95 (counter Ali adaptor 0.001 coercion)", topP)
+	}
+	if model := gjson.GetBytes(capturedBody, "model").String(); model != "kimi-k3" {
+		t.Fatalf("model=%q want kimi-k3", model)
+	}
+}
+
+func TestForwardAsChatCompletionsDispatched_PinsKimiK3TopP(t *testing.T) {
+	oldDispatch := dispatchNewAPIChatCompletions
+	t.Cleanup(func() { dispatchNewAPIChatCompletions = oldDispatch })
+
+	var capturedBody []byte
+	dispatchNewAPIChatCompletions = func(_ context.Context, _ *gin.Context, _ bridge.ChannelContextInput, body []byte) (*bridge.DispatchOutcome, *newapitypes.NewAPIError) {
+		capturedBody = append([]byte(nil), body...)
+		return &bridge.DispatchOutcome{Model: "kimi-k3"}, nil
+	}
+
+	account := &Account{
+		ID:          110,
+		Platform:    PlatformNewAPI,
+		ChannelType: 17,
+		Type:        AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key": "test-key",
+			"model_mapping": map[string]any{
+				"kimi-k3": "kimi-k3",
+			},
+		},
+	}
+	svc := &OpenAIGatewayService{}
+	c, _ := gin.CreateTestContext(nil)
+	body := []byte(`{"model":"kimi-k3","messages":[{"role":"user","content":"hi"}],"temperature":0.7}`)
+	if _, err := svc.ForwardAsChatCompletionsDispatched(context.Background(), c, account, body, "", ""); err != nil {
+		t.Fatalf("ForwardAsChatCompletionsDispatched: %v", err)
+	}
+	if topP := gjson.GetBytes(capturedBody, "top_p").Float(); topP != 0.95 {
+		t.Fatalf("bridge body top_p=%v want 0.95", topP)
+	}
+	if temp := gjson.GetBytes(capturedBody, "temperature").Float(); temp != 1.0 {
+		t.Fatalf("bridge body temperature=%v want 1.0", temp)
+	}
+	if !strings.Contains(string(capturedBody), `"model":"kimi-k3"`) {
+		t.Fatalf("expected kimi-k3 in body, got %s", capturedBody)
+	}
+}

--- a/backend/internal/service/openai_gateway_bridge_dispatch_tk_ali_fixed_sampling_test.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_tk_ali_fixed_sampling_test.go
@@ -4,6 +4,9 @@ package service
 
 import (
 	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -147,5 +150,47 @@ func TestForwardAsChatCompletionsDispatched_PinsKimiK3TopP(t *testing.T) {
 	}
 	if !strings.Contains(string(capturedBody), `"model":"kimi-k3"`) {
 		t.Fatalf("expected kimi-k3 in body, got %s", capturedBody)
+	}
+}
+
+func TestForwardAsAnthropicDispatched_PinsKimiK3TopP(t *testing.T) {
+	oldDispatch := dispatchNewAPIChatCompletions
+	t.Cleanup(func() { dispatchNewAPIChatCompletions = oldDispatch })
+
+	var capturedBody []byte
+	dispatchNewAPIChatCompletions = func(_ context.Context, _ *gin.Context, _ bridge.ChannelContextInput, body []byte) (*bridge.DispatchOutcome, *newapitypes.NewAPIError) {
+		capturedBody = append([]byte(nil), body...)
+		return nil, newapitypes.NewError(errors.New("stop after capture"), newapitypes.ErrorCodeInvalidRequest)
+	}
+
+	account := &Account{
+		ID:          110,
+		Platform:    PlatformNewAPI,
+		ChannelType: 17,
+		Type:        AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key": "test-key",
+			"model_mapping": map[string]any{
+				"kimi-k3": "kimi-k3",
+			},
+		},
+	}
+	svc := &OpenAIGatewayService{}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	body := []byte(`{"model":"kimi-k3","max_tokens":16,"messages":[{"role":"user","content":"hi"}],"temperature":0.7}`)
+	_, err := svc.ForwardAsAnthropicDispatched(context.Background(), c, account, body, "", "")
+	if err == nil {
+		t.Fatal("expected dispatch error after capture")
+	}
+	if len(capturedBody) == 0 {
+		t.Fatal("expected anthropic→chat body to reach dispatch")
+	}
+	if topP := gjson.GetBytes(capturedBody, "top_p").Float(); topP != 0.95 {
+		t.Fatalf("anthropic bridge chat body top_p=%v want 0.95", topP)
+	}
+	if temp := gjson.GetBytes(capturedBody, "temperature").Float(); temp != 1.0 {
+		t.Fatalf("anthropic bridge chat body temperature=%v want 1.0", temp)
 	}
 }

--- a/backend/internal/service/openai_gateway_bridge_dispatch_tk_anthropic.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_tk_anthropic.go
@@ -64,6 +64,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropicDispatched(
 	if err != nil {
 		return nil, fmt.Errorf("convert anthropic to chat completions: %w", err)
 	}
+	chatBody = applyNewAPIAliFixedSamplingShape(upstreamModel, chatBody)
 
 	// 4. Prepare bridge channel input
 	chatBody = applyStickyToNewAPIBridge(ctx, c, s.settingService, account, chatBody, upstreamModel)
@@ -104,7 +105,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropicDispatched(
 				)
 			}
 		}()
-		out, apiErr = bridge.DispatchChatCompletions(ctx, c, in, chatBody)
+		out, apiErr = dispatchNewAPIChatCompletions(ctx, c, in, chatBody)
 	}()
 
 	if dispatchPanic != nil {

--- a/backend/internal/service/openai_gateway_bridge_dispatch_tk_anthropic.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_tk_anthropic.go
@@ -105,7 +105,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropicDispatched(
 				)
 			}
 		}()
-		out, apiErr = dispatchNewAPIChatCompletions(ctx, c, in, chatBody)
+		out, apiErr = bridge.DispatchChatCompletions(ctx, c, in, chatBody)
 	}()
 
 	if dispatchPanic != nil {

--- a/backend/internal/service/openai_gateway_bridge_responses_fallback.go
+++ b/backend/internal/service/openai_gateway_bridge_responses_fallback.go
@@ -251,6 +251,7 @@ func (s *OpenAIGatewayService) forwardResponsesViaNewAPIBridgeChatCompletions(
 		return nil, fmt.Errorf("marshal bridge chat fallback request: %w", err)
 	}
 	chatBody = applyNewAPIResponsesChatFallbackShape(upstreamModel, chatBody)
+	chatBody = applyNewAPIAliFixedSamplingShape(upstreamModel, chatBody)
 	chatBody = ensureNewAPIChatFallbackStreamOptions(chatBody)
 	upstreamStream := chatFallbackUpstreamRequiresStream(chatBody)
 	chatBody = applyStickyToNewAPIBridge(ctx, c, s.settingService, account, chatBody, upstreamModel)

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1070,9 +1070,10 @@
       "path": "backend/internal/service/openai_gateway_bridge_dispatch_tk_anthropic.go",
       "must_contain": [
         "chatReq[\"metadata\"] = json.RawMessage(req.Metadata)",
-        "chatBody = applyStickyToNewAPIBridge(ctx, c, s.settingService, account, chatBody, upstreamModel)"
+        "chatBody = applyStickyToNewAPIBridge(ctx, c, s.settingService, account, chatBody, upstreamModel)",
+        "applyNewAPIAliFixedSamplingShape"
       ],
-      "rationale": "Anthropic-shaped requests converted to Chat Completions must preserve metadata blobs and apply unified sticky injection so Claude Code identities and session affinity survive OpenAI-compat bridge paths during scheduling."
+      "rationale": "Anthropic-shaped requests converted to Chat Completions must preserve metadata blobs and apply unified sticky injection so Claude Code identities and session affinity survive OpenAI-compat bridge paths during scheduling. They must also pin kimi-k3 fixed sampling before the Ali adaptor coerces missing top_p to 0.001."
     },
     {
       "path": "backend/internal/service/openai_gateway_bridge_dispatch_tk_model_mapping.go",
@@ -1087,9 +1088,10 @@
       "path": "backend/internal/service/openai_gateway_bridge_dispatch.go",
       "must_contain": [
         "rewriteNewAPIBridgeBodyModel(account, body, defaultMappedModel)",
-        "rewriteNewAPIBridgeBodyModel(account, body, \"\")"
+        "rewriteNewAPIBridgeBodyModel(account, body, \"\")",
+        "applyNewAPIAliFixedSamplingShape"
       ],
-      "rationale": "Bridge chat/embeddings/images dispatch and admin account-test probes must call rewriteNewAPIBridgeBodyModel after sticky injection so upstream model_mapping alias applies on the newapi adaptor path."
+      "rationale": "Bridge chat/embeddings/images dispatch and admin account-test probes must call rewriteNewAPIBridgeBodyModel after sticky injection so upstream model_mapping alias applies on the newapi adaptor path. Chat and account-test paths must also pin kimi-k3 fixed sampling before the Ali adaptor."
     },
     {
       "path": "backend/internal/service/openai_codex_transform.go",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -433,9 +433,10 @@
         "shouldFallbackNewAPIResponsesToChat(apiErr)",
         "forwardResponsesViaNewAPIBridgeChatCompletions",
         "isNewAPIResponsesProactiveChatFallbackModel(requestedModel)",
-        "applyNewAPIQwenNonStreamingShape"
+        "applyNewAPIQwenNonStreamingShape",
+        "applyNewAPIAliFixedSamplingShape"
       ],
-      "rationale": "NewAPI channels can support /v1/chat/completions while their adaptor does not implement ConvertOpenAIResponsesRequest for /v1/responses (prod probes: Vertex ch41 and DeepSeek ch43). ForwardAsResponsesDispatched must detect that convert_request_failed/not implemented capability gap and route through the Responses->Chat fallback companion instead of returning a client 500. Native chat dispatch must also normalize dense Qwen3 non-streaming requests through applyNewAPIQwenNonStreamingShape; otherwise DashScope rejects enable_thinking with a client-visible 400. Dropping either injection silently breaks a supported NewAPI path."
+      "rationale": "NewAPI channels can support /v1/chat/completions while their adaptor does not implement ConvertOpenAIResponsesRequest for /v1/responses (prod probes: Vertex ch41 and DeepSeek ch43). ForwardAsResponsesDispatched must detect that convert_request_failed/not implemented capability gap and route through the Responses->Chat fallback companion instead of returning a client 500. Native chat dispatch must also normalize dense Qwen3 non-streaming requests through applyNewAPIQwenNonStreamingShape; otherwise DashScope rejects enable_thinking with a client-visible 400. Chat and account-test dispatch must also pin kimi-k3 fixed sampling via applyNewAPIAliFixedSamplingShape before the Ali adaptor coerces missing top_p to 0.001. Dropping either injection silently breaks a supported NewAPI path."
     },
     {
       "path": "backend/internal/service/openai_gateway_bridge_responses_fallback.go",
@@ -446,11 +447,31 @@
         "applyNewAPIResponsesChatFallbackShape",
         "normalizeNewAPIQwenNonStreamingPayload",
         "applyNewAPIQwenNonStreamingShape",
+        "applyNewAPIAliFixedSamplingShape",
         "bufferChatCompletionsAsResponses",
         "bufferStreamChatCompletionsAsResponses",
         "streamChatCompletionsAsResponses"
       ],
-      "rationale": "TK companion for NewAPI /v1/responses fallback: convert the client Responses request to Chat Completions, dispatch through the NewAPI bridge, then convert the captured Chat response back to Responses JSON/SSE. It also owns the shared dense-Qwen3 non-streaming request shape used by native chat dispatch. GLM/Qwen stream-only upstream shaping must buffer SSE into JSON for non-stream clients, while dense Qwen3 must send enable_thinking=false when stream=false. Without this file ch41/ch43 regress to conversion errors or upstream request-validation 400s."
+      "rationale": "TK companion for NewAPI /v1/responses fallback: convert the client Responses request to Chat Completions, dispatch through the NewAPI bridge, then convert the captured Chat response back to Responses JSON/SSE. It also owns the shared dense-Qwen3 non-streaming request shape used by native chat dispatch. GLM/Qwen stream-only upstream shaping must buffer SSE into JSON for non-stream clients, while dense Qwen3 must send enable_thinking=false when stream=false. Responses→chat fallback must also pin kimi-k3 fixed sampling before the Ali adaptor. Without this file ch41/ch43 regress to conversion errors or upstream request-validation 400s."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_bridge_dispatch_tk_ali_fixed_sampling.go",
+      "must_contain": [
+        "func applyNewAPIAliFixedSamplingShape(",
+        "func isNewAPIAliFixedSamplingModel(",
+        "\"top_p\", 0.95"
+      ],
+      "rationale": "Owner for DashScope/Moonshot kimi-k3 fixed sampling pins. new-api Ali requestOpenAI2Ali rewrites missing/zero top_p to 0.001, which kimi-k3 rejects; this companion injects the accepted fixed values before bridge dispatch. Dropping it silently reopens supplier sync and live chat 400s for kimi-k3."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_bridge_dispatch_tk_ali_fixed_sampling_test.go",
+      "must_contain": [
+        "TestApplyNewAPIAliFixedSamplingShape_PinsTopP",
+        "TestDispatchNewAPIAccountTestChatCompletions_PinsKimiK3TopP",
+        "TestForwardAsChatCompletionsDispatched_PinsKimiK3TopP",
+        "TestAnthropicToChatBody_AppliesAliFixedSamplingForKimiK3"
+      ],
+      "rationale": "Focused regressions for kimi-k3 fixed sampling: helper pins top_p=0.95, account-test and chat bridge call sites capture the shaped body, and Anthropic→chat convert-then-shape composition stays wired."
     },
     {
       "path": "backend/internal/service/openai_gateway_bridge_dispatch_tk_model_mapping_test.go",
@@ -601,19 +622,21 @@
       "path": "backend/internal/service/gateway_bridge_dispatch.go",
       "must_contain": [
         "s.tkWrapBridgeRelayErrorWithPenalty(ctx, c, account, apiErr)",
-        "rewriteNewAPIBridgeBodyModel(account, body, \"\")"
+        "rewriteNewAPIBridgeBodyModel(account, body, \"\")",
+        "applyNewAPIAliFixedSamplingShape"
       ],
       "must_not_contain": [
         "tkWrapBridgeRelayError(c, apiErr)"
       ],
-      "rationale": "The Anthropic-gateway bridge boundary (GatewayService ForwardAsChatCompletionsDispatched / ForwardAsResponsesDispatched, 2 sites) is the same penalty chokepoint class as openai_gateway_bridge_dispatch.go and must stay wired identically: zero penalty-less tkWrapBridgeRelayError(c, apiErr) calls. Without this entry only the OpenAI-gateway file was anchored and a refactor here would silently drop the account penalty for messages-dispatch newapi traffic. Both bridge dispatch sites must also rewrite body.model via rewriteNewAPIBridgeBodyModel so dated GLM ids reach DashScope as glm-4.7."
+      "rationale": "The Anthropic-gateway bridge boundary (GatewayService ForwardAsChatCompletionsDispatched / ForwardAsResponsesDispatched, 2 sites) is the same penalty chokepoint class as openai_gateway_bridge_dispatch.go and must stay wired identically: zero penalty-less tkWrapBridgeRelayError(c, apiErr) calls. Without this entry only the OpenAI-gateway file was anchored and a refactor here would silently drop the account penalty for messages-dispatch newapi traffic. Both bridge dispatch sites must also rewrite body.model via rewriteNewAPIBridgeBodyModel so dated GLM ids reach DashScope as glm-4.7. Chat dispatch must also pin kimi-k3 fixed sampling before the Ali adaptor."
     },
     {
       "path": "backend/internal/service/openai_gateway_bridge_dispatch_tk_anthropic.go",
       "must_contain": [
-        "s.tkWrapBridgeRelayErrorWithPenalty(ctx, c, account, apiErr)"
+        "s.tkWrapBridgeRelayErrorWithPenalty(ctx, c, account, apiErr)",
+        "applyNewAPIAliFixedSamplingShape"
       ],
-      "rationale": "ForwardAsAnthropicDispatched is the 7th penalty wiring site (anthropic-shaped requests routed over the newapi bridge). Same risk class as the other dispatch boundaries: reverting to the plain wrapper compiles clean and silently disconnects the account penalty."
+      "rationale": "ForwardAsAnthropicDispatched is the 7th penalty wiring site (anthropic-shaped requests routed over the newapi bridge). Same risk class as the other dispatch boundaries: reverting to the plain wrapper compiles clean and silently disconnects the account penalty. Anthropic→chat conversion must also pin kimi-k3 fixed sampling before bridge.DispatchChatCompletions or DashScope rejects top_p=0.001."
     },
     {
       "path": "backend/internal/service/openai_gateway_bridge_dispatch_tk_video.go",


### PR DESCRIPTION
## 摘要
- DashScope `kimi-k3` 采样参数固定（`top_p=0.95` / `temperature=1.0`），乱传会 400。
- new-api Ali `requestOpenAI2Ali` 在缺省时把 `top_p` 写成 `0.001`，导致供应源 account_test / sync 与网关 chat / Anthropic→chat 失败。
- 在 chat / account_test / responses→chat / Anthropic→chat 前对 `kimi-k3` 归一化固定采样值，并写入 sentinel 锚点。

## 风险
- 常规风险：仅影响 Ali 通道上 `kimi-k3` 族请求的采样字段归一；其它模型路径不变。
- 无 Web / schema / 鉴权变更（`Web impact: none`）。

## 验证
- `go test -tags=unit ./internal/service/ -run 'AliFixedSampling|PinsKimiK3|AnthropicToChatBody_AppliesAli'` 通过
- `./scripts/preflight.sh` 通过
- sentinel `check-newapi.py` / `check-gateway-tk.py` / `check-registry-update-gate.py` 通过
- prod 直连矩阵：omit / `top_p=0.95` / `temperature=1.0` → 200；`top_p=0.001|0.8` / `temperature=0.7` → 400

## 提交
```
a53473c55 fix(gateway): anchor kimi-k3 sampling in sentinel registries
98d3247ee fix(gateway): keep Anthropic Dispatch sentinel while pinning kimi-k3
fa63adc6a fix(gateway): also pin kimi-k3 sampling on Anthropic→chat bridge
e008090b1 fix(gateway): pin kimi-k3 fixed sampling before Ali adaptor
```
- 最新提交：`a53473c55`