### PR TITLE
fix(gateway): Agent luna chat 带 tools 可 failover 到 OAuth responses 与 tokensea

### DIFF
--- a/backend/internal/engine/protocolrouter/registry.go
+++ b/backend/internal/engine/protocolrouter/registry.go
@@ -191,7 +191,11 @@ func preservesMessagesToChat(req CanonicalRequest) bool {
 }
 
 func preservesChatToResponses(req CanonicalRequest) bool {
-	return preservesTextOnlyWithoutTools(req) &&
+	// ChatCompletionsToResponses already preserves function tools, images, and
+	// tool_call / tool result turns. Text-only-without-tools was fail-closing
+	// Agent /v1/chat/completions onto identity chat, which TokenKey edge
+	// ChatGPT OAuth pools cannot serve (supported_protocols=[responses]).
+	return preservesMessagesToResponsesContent(req) &&
 		req.profile.Continuation == ContinuationNone
 }
 

--- a/backend/internal/engine/protocolrouter/router_test.go
+++ b/backend/internal/engine/protocolrouter/router_test.go
@@ -389,6 +389,38 @@ func TestPlanMessagesToResponsesPreservesClaudeCodeTools(t *testing.T) {
 	}
 }
 
+func TestPlanChatToResponsesPreservesTools(t *testing.T) {
+	router := New(allTestAdapters())
+	account := testAccount(t, ProtocolResponses)
+	for _, profile := range []RequestProfile{
+		{Tools: true, ToolChoice: ToolChoiceAuto, ContentKinds: ContentText},
+		{Tools: true, ContentKinds: ContentText | ContentImage},
+		{Tools: true, ContentKinds: ContentText | ContentUnknown},
+	} {
+		plan, err := router.Plan(testRequest(t, ProtocolChatCompletions, profile), account)
+		if err != nil {
+			t.Fatalf("Plan profile=%+v: %v", profile, err)
+		}
+		if plan.TargetProtocol() != ProtocolResponses || plan.AdapterID() != AdapterChatToResponses {
+			t.Fatalf("plan target/adapter = %q/%q, want responses/%s",
+				plan.TargetProtocol(), plan.AdapterID(), AdapterChatToResponses)
+		}
+	}
+}
+
+func TestPlanChatToResponsesStillRejectsContinuation(t *testing.T) {
+	router := New(allTestAdapters())
+	account := testAccount(t, ProtocolResponses)
+	_, err := router.Plan(testRequest(t, ProtocolChatCompletions, RequestProfile{
+		Tools:        true,
+		ContentKinds: ContentText,
+		Continuation: ContinuationPreviousResponse,
+	}), account)
+	if !errors.Is(err, ErrNoLegalRoute) {
+		t.Fatalf("Plan error = %v, want ErrNoLegalRoute", err)
+	}
+}
+
 func TestRouteRegistryRejectsIncompleteExecutionPolicy(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/backend/internal/service/account_model_mapping_ssot_tk.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk.go
@@ -487,9 +487,6 @@ var tokenseaRelaySharedExtraSSOTIDs = []string{
 	"codex-auto-review",
 	"gpt-5.3-codex-spark",
 	"gpt-5.6",
-	"gpt-5.6-luna",
-	"gpt-5.6-sol",
-	"gpt-5.6-terra",
 }
 
 func tokenseaRelaySupportsRequestedModel(requestedModel string) bool {

--- a/backend/internal/service/account_model_mapping_ssot_tk.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk.go
@@ -487,6 +487,9 @@ var tokenseaRelaySharedExtraSSOTIDs = []string{
 	"codex-auto-review",
 	"gpt-5.3-codex-spark",
 	"gpt-5.6",
+	"gpt-5.6-luna",
+	"gpt-5.6-sol",
+	"gpt-5.6-terra",
 }
 
 func tokenseaRelaySupportsRequestedModel(requestedModel string) bool {

--- a/backend/internal/service/account_model_mapping_ssot_tk_test.go
+++ b/backend/internal/service/account_model_mapping_ssot_tk_test.go
@@ -110,6 +110,9 @@ func TestOpenAITokenseaRelayFloorIsProbeCuratedOnly(t *testing.T) {
 	require.Contains(t, mapping, "gpt-5.4")
 	require.Contains(t, mapping, "claude-sonnet-4-6")
 	require.Contains(t, mapping, "gpt-5.6")
+	require.Contains(t, mapping, "gpt-5.6-luna")
+	require.Contains(t, mapping, "gpt-5.6-sol")
+	require.Contains(t, mapping, "gpt-5.6-terra")
 	require.NotContains(t, mapping, "byteplus/dreamina-seedance-2-0-260128", "non-SSOT upstream id is a boundary sample, not an owner copy")
 	// Live 2026-08-20 account 92 raw chat: listed DeepSeek/Qwen/GLM/Kimi IDs
 	// returned 400 openai_error; dated flash-0731 is not even listed.

--- a/backend/internal/service/gateway_scheduling.go
+++ b/backend/internal/service/gateway_scheduling.go
@@ -2308,6 +2308,13 @@ func accountAdmitsRequestedModel(account *Account, requestedModel string, thinki
 	if account.IsAnthropicTokenseaRelay() {
 		return account.IsModelSupported(requestedModel)
 	}
+	// OpenAI tokensea leftover model_mapping is a passthrough whitelist in the
+	// block below. Floor IDs such as gpt-5.6-luna must still admit even when
+	// that leftover snapshot omitted them — otherwise Plan returns
+	// model_not_supported and failover never reaches account 92's chat hop.
+	if account.IsOpenAITokenseaRelay() && tokenseaRelaySupportsRequestedModel(requestedModel) {
+		return true
+	}
 	if account.Platform == PlatformAntigravity {
 		if strings.TrimSpace(requestedModel) == "" {
 			return true

--- a/backend/internal/service/protocol_routing_context_test.go
+++ b/backend/internal/service/protocol_routing_context_test.go
@@ -809,3 +809,25 @@ func TestTokenseaOpenAIRelayAdmitsLunaChatDespiteLeftoverMapping(t *testing.T) {
 			plan.TargetProtocol(), plan.AdapterID(), protocolrouter.AdapterChatIdentity)
 	}
 }
+
+func TestTokenseaOpenAIRelayLeftoverMappingStillRejectsNonFloorID(t *testing.T) {
+	// Boundary sample: leftover passthrough whitelist must still hide IDs that
+	// are not on the tokensea public floor. A too-wide IsOpenAITokenseaRelay
+	// admit-all would fail this and still pass the luna floor case above.
+	const unknownID = "not-a-tokensea-floor-model"
+	account := protocolRoutingRelinkedOpenAIAccount(92, "https://agent.tokensea.ai/v1", "messages", "chat_completions")
+	account.Extra["openai_passthrough"] = true
+	account.Credentials["model_mapping"] = map[string]any{"gpt-5.4": "gpt-5.4"}
+	if tokenseaRelaySupportsRequestedModel(unknownID) {
+		t.Fatal("test precondition: unknownID is a boundary sample, not a floor owner copy")
+	}
+	ctx := WithProtocolRouting(
+		context.Background(),
+		protocolRoutingTestRouter(),
+		protocolRoutingChatCompletionsToolsRequest(t, unknownID),
+	)
+	eligible, reason := protocolRequestEligibilityReason(ctx, account, unknownID)
+	if eligible || reason != "model_not_supported" {
+		t.Fatalf("eligibility = %v/%q, want false/model_not_supported for leftover non-floor ID", eligible, reason)
+	}
+}

--- a/backend/internal/service/protocol_routing_context_test.go
+++ b/backend/internal/service/protocol_routing_context_test.go
@@ -745,3 +745,67 @@ func TestSelectionFailsClosedAndReleasesAcquiredSlotWhenHydratedPlanIsIllegal(t 
 		t.Fatalf("expected acquired account slot release once after protocol re-plan failure, got %d", releaseCalls)
 	}
 }
+
+func protocolRoutingChatCompletionsToolsRequest(t *testing.T, model string) protocolrouter.CanonicalRequest {
+	t.Helper()
+	req, err := protocolrouter.NewCanonicalRequest(protocolrouter.CanonicalRequestInput{
+		InboundProtocol: protocolrouter.ProtocolChatCompletions,
+		RequestedModel:  model,
+		Profile: protocolrouter.RequestProfile{
+			Tools:        true,
+			ToolChoice:   protocolrouter.ToolChoiceAuto,
+			ContentKinds: protocolrouter.ContentText,
+		},
+		Body: []byte(`{"model":"` + model + `","tools":[{"type":"function","function":{"name":"lookup"}}],"messages":[{"role":"user","content":"hi"}]}`),
+	})
+	if err != nil {
+		t.Fatalf("NewCanonicalRequest: %v", err)
+	}
+	return req
+}
+
+func TestOfficialOpenAIOAuthChatWithToolsPlansResponses(t *testing.T) {
+	account := officialOpenAIOAuthAccount(81)
+	ctx := WithProtocolRouting(
+		context.Background(),
+		protocolRoutingTestRouter(),
+		protocolRoutingChatCompletionsToolsRequest(t, "gpt-5.6-luna"),
+	)
+	eligible, reason := protocolRequestEligibilityReason(ctx, account, "gpt-5.6-luna")
+	if !eligible || reason != "" {
+		t.Fatalf("eligibility = %v/%q, want true for official OAuth chat+tools luna", eligible, reason)
+	}
+	plan, governed, err := protocolPlanForAccount(ctx, account, "gpt-5.6-luna")
+	if !governed || err != nil {
+		t.Fatalf("protocolPlanForAccount: governed=%v err=%v", governed, err)
+	}
+	if plan.TargetProtocol() != protocolrouter.ProtocolResponses ||
+		plan.AdapterID() != protocolrouter.AdapterChatToResponses {
+		t.Fatalf("plan target/adapter = %q/%q, want responses/%s",
+			plan.TargetProtocol(), plan.AdapterID(), protocolrouter.AdapterChatToResponses)
+	}
+}
+
+func TestTokenseaOpenAIRelayAdmitsLunaChatDespiteLeftoverMapping(t *testing.T) {
+	account := protocolRoutingRelinkedOpenAIAccount(92, "https://agent.tokensea.ai/v1", "messages", "chat_completions")
+	account.Extra["openai_passthrough"] = true
+	account.Credentials["model_mapping"] = map[string]any{"gpt-5.4": "gpt-5.4"}
+	ctx := WithProtocolRouting(
+		context.Background(),
+		protocolRoutingTestRouter(),
+		protocolRoutingChatCompletionsToolsRequest(t, "gpt-5.6-luna"),
+	)
+	eligible, reason := protocolRequestEligibilityReason(ctx, account, "gpt-5.6-luna")
+	if !eligible || reason != "" {
+		t.Fatalf("eligibility = %v/%q, want true so leftover mapping cannot hide tokensea floor luna", eligible, reason)
+	}
+	plan, governed, err := protocolPlanForAccount(ctx, account, "gpt-5.6-luna")
+	if !governed || err != nil {
+		t.Fatalf("protocolPlanForAccount: governed=%v err=%v", governed, err)
+	}
+	if plan.TargetProtocol() != protocolrouter.ProtocolChatCompletions ||
+		plan.AdapterID() != protocolrouter.AdapterChatIdentity {
+		t.Fatalf("plan target/adapter = %q/%q, want chat_completions/%s",
+			plan.TargetProtocol(), plan.AdapterID(), protocolrouter.AdapterChatIdentity)
+	}
+}


### PR DESCRIPTION
## 摘要

user16 的 `gpt-5.6-luna` 走 `/v1/chat/completions` 且带 tools 时，edge OpenAI OAuth 账号只有 `supported_protocols=["responses"]`，`preservesChatToResponses` 却只放行纯文本无 tools，路由在 14ms 内以 `no_legal_protocol_route` 本地 429。组 2 唯一带 `chat_completions` 的 tokensea 账号 92 又被 leftover `model_mapping` 白名单漏掉 floor ID，选号记成 `model_unsupported`。

本 PR 做两件事：

1. 将 `preservesChatToResponses` 与 messages→responses 对齐，允许 tools / image / unknown，仍拒绝 continuation。
2. OpenAI tokensea 在 leftover mapping 拦截之前放行 **已有 catalog floor ID**（luna/sol/terra 已在 `supportedOpenAITokenseaRelayCatalogModels`，不再写入 extras 副本）。

Web impact: none
sentinel-registry-reviewed

## 风险

常规风险：网关协议路由与账号准入，不改公共 API 字段、schema、鉴权或计费公式。回滚即 revert。上线前 user16 luna Agent chat 仍会 429。

审查已处理：去掉与 catalog owner 重复的 extras；补 leftover 对非 floor ID 仍拒绝的负向断言。gateway_scheduling 为纯插入；未改 sentinel 字面量。

## 验证

```
cd backend && go test -tags=unit ./internal/engine/protocolrouter/ ./internal/service/ \
  -run 'TestPlanChatToResponses|TestOfficialOpenAIOAuthChatWithTools|TestTokenseaOpenAIRelay|TestOpenAITokenseaRelayFloorIsProbeCuratedOnly'
```

已绿。preflight（`PREFLIGHT_BASE=origin/main`）已绿。

新增断言：

- `TestPlanChatToResponsesPreservesTools` / `TestPlanChatToResponsesStillRejectsContinuation`
- `TestOfficialOpenAIOAuthChatWithToolsPlansResponses`
- `TestTokenseaOpenAIRelayAdmitsLunaChatDespiteLeftoverMapping`
- `TestTokenseaOpenAIRelayLeftoverMappingStillRejectsNonFloorID`

## 提交

- `4036979d4` fix(gateway): address R-001..R-002 — drop redundant extras, add leftover negative
- `129ebc45b` fix(gateway): let Agent luna chat with tools failover onto OAuth and tokensea

最新提交：`4036979d4`