### PR TITLE
fix(openai): Messages 续写识别 edge ownership 400 并剥离重试

### DIFF
--- a/backend/internal/service/openai_compat_model_test.go
+++ b/backend/internal/service/openai_compat_model_test.go
@@ -887,6 +887,53 @@ func TestForwardAsAnthropic_ReplaysWithoutContinuationWhenPreviousResponseMissin
 	require.Equal(t, "resp_replayed", gjson.GetBytes(upstream.bodies[2], "previous_response_id").String())
 }
 
+func TestForwardAsAnthropic_ReplaysWithoutContinuationWhenPreviousResponseOwnerMismatch(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	upstream := &httpUpstreamRecorder{}
+	svc := &OpenAIGatewayService{
+		httpUpstream: upstream,
+		cfg:          &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
+	}
+	account := &Account{
+		ID:          63,
+		Name:        "openai-us6",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-edge-relay",
+			"base_url": "https://api-us6.tokenkey.dev/v1",
+		},
+	}
+
+	svc.bindOpenAICompatSessionResponseID(context.Background(), nil, account, "stable-cache-key", "resp_owner_mismatch")
+	secondBody := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"first"},{"role":"assistant","content":"ok"},{"role":"user","content":"second"}],"stream":false}`)
+	upstream.responses = []*http.Response{
+		{
+			StatusCode: http.StatusBadRequest,
+			Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid_owner_mismatch"}},
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"invalid_request_error","message":"previous_response_id is not available for this user"}}`)),
+		},
+		openAICompatSSECompletedResponse("resp_owner_replayed", "gpt-5.4"),
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(secondBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, secondBody, "stable-cache-key", "gpt-5.4")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "resp_owner_replayed", result.ResponseID)
+	require.Len(t, upstream.requests, 2)
+	require.Equal(t, "resp_owner_mismatch", gjson.GetBytes(upstream.bodies[0], "previous_response_id").String())
+	require.False(t, gjson.GetBytes(upstream.bodies[1], "previous_response_id").Exists(),
+		"edge ownership 400 must strip previous_response_id and replay")
+}
+
 func TestForwardAsAnthropic_OAuthDisablesContinuationAfterPreviousResponseNotFound(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)

--- a/backend/internal/service/openai_messages_continuation.go
+++ b/backend/internal/service/openai_messages_continuation.go
@@ -112,7 +112,11 @@ func isOpenAICompatPreviousResponseNotFound(statusCode int, upstreamMsg string, 
 		lower := strings.ToLower(strings.TrimSpace(s))
 		return strings.Contains(lower, "previous_response_not_found") ||
 			(strings.Contains(lower, "previous response") && strings.Contains(lower, "not found")) ||
-			(strings.Contains(lower, "unsupported parameter") && strings.Contains(lower, "previous_response_id"))
+			(strings.Contains(lower, "unsupported parameter") && strings.Contains(lower, "previous_response_id")) ||
+			// TokenKey edge /v1/responses ownership gate: sticky resp_* survived a
+			// blue/green or account hop but is not bound for this user/key. Treat as
+			// not-found so Messages continuation strips previous_response_id and retries.
+			(strings.Contains(lower, "previous_response_id") && strings.Contains(lower, "not available for this user"))
 	}
 	if check(upstreamMsg) || check(string(upstreamBody)) {
 		return true

--- a/backend/internal/service/openai_messages_continuation_test.go
+++ b/backend/internal/service/openai_messages_continuation_test.go
@@ -3,10 +3,27 @@
 package service
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestIsOpenAICompatPreviousResponseNotFound_OwnerMismatch(t *testing.T) {
+	t.Parallel()
+
+	ownerMsg := "previous_response_id is not available for this user"
+	ownerBody := []byte(`{"error":{"type":"invalid_request_error","message":"previous_response_id is not available for this user"}}`)
+
+	assert.True(t, isOpenAICompatPreviousResponseNotFound(http.StatusBadRequest, ownerMsg, nil),
+		"edge ownership gate message must trigger Messages continuation fallback")
+	assert.True(t, isOpenAICompatPreviousResponseNotFound(http.StatusBadRequest, "", ownerBody),
+		"edge ownership gate JSON body must trigger Messages continuation fallback")
+	assert.False(t, isOpenAICompatPreviousResponseNotFound(http.StatusBadRequest, "invalid model", nil),
+		"unrelated 400 must not be treated as previous_response recovery")
+	assert.False(t, isOpenAICompatPreviousResponseUnsupported(http.StatusBadRequest, ownerMsg, ownerBody),
+		"ownership mismatch is not_found recovery, not unsupported-parameter disable")
+}
 
 func TestOpenAICompatContinuationEnabled(t *testing.T) {
 	cases := []struct {

--- a/scripts/sentinels/relay-invariants.json
+++ b/scripts/sentinels/relay-invariants.json
@@ -5,9 +5,17 @@
     {
       "path": "backend/internal/service/openai_compat_model_test.go",
       "must_contain": [
-        "func TestForwardAsAnthropic_DisablesAPIKeyContinuationWhenUpstreamRejectsHTTPContinuation("
+        "func TestForwardAsAnthropic_DisablesAPIKeyContinuationWhenUpstreamRejectsHTTPContinuation(",
+        "func TestForwardAsAnthropic_ReplaysWithoutContinuationWhenPreviousResponseOwnerMismatch("
       ],
-      "rationale": "OpenAI API-key relay HTTP continuation fallback. An API-key account can route through an OAuth-backed edge that rejects previous_response_id on HTTP; the gateway must replay full history once and disable continuation for the sticky window instead of returning repeated 400s. The characterization test pins both the exact relay error classification and the subsequent no-continuation behavior so an upstream rewrite cannot silently remove the recovery path together with its test."
+      "rationale": "OpenAI API-key relay HTTP continuation fallback. An API-key account can route through an OAuth-backed edge that rejects previous_response_id on HTTP; the gateway must replay full history once and disable continuation for the sticky window instead of returning repeated 400s. Owner-mismatch 400 from edge ownership gate (blue/green or sticky hop) must classify the same way: strip previous_response_id and replay. The characterization tests pin both the exact relay error classification and the subsequent no-continuation behavior so an upstream rewrite cannot silently remove the recovery path together with its test."
+    },
+    {
+      "path": "backend/internal/service/openai_messages_continuation.go",
+      "must_contain": [
+        "not available for this user"
+      ],
+      "rationale": "Messages continuation must treat TokenKey edge ownership 400 (previous_response_id is not available for this user) as not-found recovery, not a terminal client error. Without this anchor an upstream rewrite of isOpenAICompatPreviousResponseNotFound can drop the matcher while tests still pass on unrelated cases."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_model_cooldown_test.go",


### PR DESCRIPTION
## 摘要
- Claude Code `gpt-5.4` 多轮时，prod 注入的 `previous_response_id` 在 edge `/v1/responses` 触发 ownership 校验失败（`previous_response_id is not available for this user`），此前 Messages 续写 fallback 不识别该文案，400 直接透传给客户端。
- 将该文案纳入 `isOpenAICompatPreviousResponseNotFound`，按 not-found 剥离 `previous_response_id` 后全量重放。
- 在 `relay-invariants.json` 锚定 matcher 与 characterization test，防止 upstream merge 静默冲掉恢复路径。

## 风险
- 常规风险：仅扩大续写恢复匹配面，不改变 ownership 门禁本身。
- 误匹配面窄：要求同时含 `previous_response_id` 与 `not available for this user`。

## 验证
- `go test -tags=unit ./internal/service/ -run 'TestIsOpenAICompatPreviousResponseNotFound_OwnerMismatch|TestForwardAsAnthropic_ReplaysWithoutContinuationWhenPreviousResponseOwnerMismatch|TestForwardAsAnthropic_ReplaysWithoutContinuationWhenPreviousResponseMissing'` → PASS
- `./scripts/preflight.sh` → PASS

## 提交
- `41b489e58` fix(openai): recover Messages continuation on edge ownership 400
- `12fecf9f5` fix(openai): anchor edge ownership continuation recovery in relay sentinels
- 最新提交：`12fecf9f5`