### PR TITLE
fix(billing): 账号统计定价与用户 token 计费对齐（峰谷价 + SSOT 镜像）

### DIFF
--- a/backend/internal/service/account_stats_pricing.go
+++ b/backend/internal/service/account_stats_pricing.go
@@ -14,8 +14,9 @@ import (
 // 优先级（先命中为准）：
 //  1. 自定义规则（始终尝试，不依赖 ApplyPricingToAccountStats 开关）
 //  2. ApplyPricingToAccountStats 启用时，直接使用本次请求的客户计费（倍率前的 totalCost）
-//  3. 模型定价文件（LiteLLM）默认价格 — 经 calculateCostInternalWithPolicyAt / computeTokenBreakdown，与用户 token 计费同核
-//  4. nil → 走默认公式（total_cost × account_rate_multiplier）
+//  3. 镜像用户 token 计费（倍率=1，与用户 CalculateCostUnified 同路径）— 优先于文件价
+//  4. 模型定价文件（LiteLLM）默认价格 — 经 calculateCostInternalWithPolicyAt / computeTokenBreakdown
+//  5. nil → 走默认公式（total_cost × account_rate_multiplier）
 //
 // NOTE: 2026-09-02 之前 priority-3 路径未应用峰谷价，历史 usage_logs.account_stats_cost
 // 在峰时 DeepSeek 流量上可能约为 total_cost 的一半；不做 backfill，仅 forward-fix。
@@ -24,6 +25,7 @@ import (
 // totalCost 是本次请求的客户计费（倍率前），用于优先级 2。
 // serviceTier 是最终参与用户计费的 OpenAI 服务层级，用于优先级 3。
 // billingAt 与用户计费的 BillingAt 对齐（通常为 recordUsageBillingAt(pricingAt)）。
+// mirroredTokenCostAtMultOne 为用户 token 计费路径在倍率=1 下的 totalCost；非 nil 且 >0 时用于优先级 3。
 func resolveAccountStatsCost(
 	ctx context.Context,
 	channelService *ChannelService,
@@ -36,6 +38,7 @@ func resolveAccountStatsCost(
 	totalCost float64,
 	serviceTier string,
 	billingAt time.Time,
+	mirroredTokenCostAtMultOne *float64,
 ) *float64 {
 	if channelService == nil || upstreamModel == "" {
 		return nil
@@ -61,7 +64,13 @@ func resolveAccountStatsCost(
 		return &cost
 	}
 
-	// 优先级 3：模型定价文件（LiteLLM）— 与用户 total_cost 共用 computeTokenBreakdown
+	// 优先级 3：镜像用户 token 计费（倍率=1），与用户 CalculateCostUnified 同定价源
+	if mirroredTokenCostAtMultOne != nil && *mirroredTokenCostAtMultOne > 0 {
+		cost := *mirroredTokenCostAtMultOne
+		return &cost
+	}
+
+	// 优先级 4：模型定价文件（LiteLLM）— 与用户 total_cost 共用 computeTokenBreakdown
 	if billingService != nil {
 		return tryModelFilePricing(billingService, upstreamModel, tokens, serviceTier, billingAt)
 	}
@@ -254,6 +263,7 @@ func applyAccountStatsCost(
 	upstreamModel, requestedModel string,
 	totalCost float64,
 	billingAt time.Time,
+	mirroredTokenCostAtMultOne *float64,
 ) {
 	model := upstreamModel
 	if model == "" {
@@ -276,6 +286,6 @@ func applyAccountStatsCost(
 	}
 	usageLog.AccountStatsCost = resolveAccountStatsCost(
 		ctx, cs, bs, accountID, groupID, model, usageLogAccountStatsTokens(usageLog),
-		requestCount, totalCost, serviceTier, at,
+		requestCount, totalCost, serviceTier, at, mirroredTokenCostAtMultOne,
 	)
 }

--- a/backend/internal/service/account_stats_pricing.go
+++ b/backend/internal/service/account_stats_pricing.go
@@ -14,7 +14,7 @@ import (
 // 优先级（先命中为准）：
 //  1. 自定义规则（始终尝试，不依赖 ApplyPricingToAccountStats 开关）
 //  2. ApplyPricingToAccountStats 启用时，直接使用本次请求的客户计费（倍率前的 totalCost）
-//  3. 模型定价文件（LiteLLM）中上游模型的默认价格（含 DeepSeek 峰谷价，billingAt 与 usage_logs.created_at 对齐）
+//  3. 模型定价文件（LiteLLM）默认价格 — 经 calculateCostInternalWithPolicyAt / computeTokenBreakdown，与用户 token 计费同核
 //  4. nil → 走默认公式（total_cost × account_rate_multiplier）
 //
 // NOTE: 2026-09-02 之前 priority-3 路径未应用峰谷价，历史 usage_logs.account_stats_cost
@@ -23,7 +23,7 @@ import (
 // upstreamModel 是最终发往上游的模型 ID。
 // totalCost 是本次请求的客户计费（倍率前），用于优先级 2。
 // serviceTier 是最终参与用户计费的 OpenAI 服务层级，用于优先级 3。
-// billingAt 是请求落库时刻（usage_logs.created_at），用于峰谷价与用户计费对齐。
+// billingAt 与用户计费的 BillingAt 对齐（通常为 recordUsageBillingAt(pricingAt)）。
 func resolveAccountStatsCost(
 	ctx context.Context,
 	channelService *ChannelService,
@@ -61,7 +61,7 @@ func resolveAccountStatsCost(
 		return &cost
 	}
 
-	// 优先级 3：模型定价文件（LiteLLM）默认价格
+	// 优先级 3：模型定价文件（LiteLLM）— 与用户 total_cost 共用 computeTokenBreakdown
 	if billingService != nil {
 		return tryModelFilePricing(billingService, upstreamModel, tokens, serviceTier, billingAt)
 	}
@@ -69,42 +69,40 @@ func resolveAccountStatsCost(
 	return nil
 }
 
-// tryModelFilePricing 使用模型定价文件（LiteLLM/fallback）中的价格计算费用。
-// billingAt 与用户计费的峰谷时刻对齐（通常为 usageLog.CreatedAt）；零值回退到 timezone.Now()。
-// DeepSeek 等受 _config.deepseek_peak_valley 约束的模型在此与用户 total_cost 使用同一峰谷窗口。
+// usageLogAccountStatsTokens derives billing tokens from the persisted usage log
+// fields so account stats see the same token breakdown as user settlement.
+func usageLogAccountStatsTokens(log *UsageLog) UsageTokens {
+	if log == nil {
+		return UsageTokens{}
+	}
+	return UsageTokens{
+		InputTokens:           log.InputTokens,
+		OutputTokens:          log.OutputTokens,
+		CacheCreationTokens:   log.CacheCreationTokens,
+		CacheReadTokens:       log.CacheReadTokens,
+		CacheCreation5mTokens: log.CacheCreation5mTokens,
+		CacheCreation1hTokens: log.CacheCreation1hTokens,
+		ImageOutputTokens:     log.ImageOutputTokens,
+		ImageInputTokens:      log.ImageInputTokens,
+	}
+}
+
+// tryModelFilePricing prices account stats from the LiteLLM/fallback registry via
+// calculateCostInternalWithPolicyAt (computeTokenBreakdown SSOT).
 func tryModelFilePricing(billingService *BillingService, model string, tokens UsageTokens, serviceTier string, billingAt time.Time) *float64 {
 	pricing, err := billingService.GetModelPricing(model)
 	if err != nil || pricing == nil {
 		return nil
 	}
-	at := billingAt
-	if at.IsZero() {
-		at = timezone.Now()
-	}
-	normalizedTier := normalizeBillingServiceTier(serviceTier)
-	if normalizedTier == "priority" || normalizedTier == "fast" || normalizedTier == "flex" ||
-		billingService.shouldApplySessionLongContextPricing(tokens, pricing) {
-		breakdown, err := billingService.calculateCostInternalWithPolicyAt(
-			model, tokens, 1, normalizedTier, nil,
-			billingService.shouldApplySessionLongContextPricing(tokens, pricing),
-			at,
-		)
-		if err != nil || breakdown == nil || breakdown.TotalCost <= 0 {
-			return nil
-		}
-		return &breakdown.TotalCost
-	}
-	pricing = billingService.applyModelSpecificPricingPolicy(model, pricing)
-	pricing = tkApplyDeepSeekPeakValleyPricing(model, pricing, at, PricingSourceLiteLLM)
-	cost := float64(tokens.InputTokens)*pricing.InputPricePerToken +
-		float64(tokens.OutputTokens)*pricing.OutputPricePerToken +
-		float64(tokens.CacheCreationTokens)*pricing.CacheCreationPricePerToken +
-		float64(tokens.CacheReadTokens)*pricing.CacheReadPricePerToken +
-		float64(tokens.ImageOutputTokens)*pricing.ImageOutputPricePerToken
-	if cost <= 0 {
+	at := RecordUsageBillingAt(billingAt)
+	longCtx := billingService.shouldApplySessionLongContextPricing(tokens, pricing)
+	breakdown, err := billingService.calculateCostInternalWithPolicyAt(
+		model, tokens, 1, normalizeBillingServiceTier(serviceTier), nil, longCtx, at,
+	)
+	if err != nil || breakdown == nil || breakdown.TotalCost <= 0 {
 		return nil
 	}
-	return &cost
+	return &breakdown.TotalCost
 }
 
 // tryCustomRules 遍历自定义规则，按数组顺序先命中为准。
@@ -246,16 +244,16 @@ func calculateTokenStatsCost(pricing *ChannelModelPricing, tokens UsageTokens) *
 }
 
 // applyAccountStatsCost resolves the account stats cost for a usage log entry.
-// It resolves the upstream model (falling back to the requested model) and calls
-// the 4-level priority chain via resolveAccountStatsCost.
+// billingAt must match the BillingAt passed to user CalculateCostUnified on the
+// same record (typically RecordUsageBillingAt(pricingAt)).
 func applyAccountStatsCost(
 	ctx context.Context,
 	usageLog *UsageLog,
 	cs *ChannelService, bs *BillingService,
 	accountID int64, groupID int64,
 	upstreamModel, requestedModel string,
-	tokens UsageTokens,
 	totalCost float64,
+	billingAt time.Time,
 ) {
 	model := upstreamModel
 	if model == "" {
@@ -269,11 +267,15 @@ func applyAccountStatsCost(
 	if usageLog != nil && usageLog.ServiceTier != nil {
 		serviceTier = *usageLog.ServiceTier
 	}
-	billingAt := time.Time{}
-	if usageLog != nil {
-		billingAt = usageLog.CreatedAt
+	at := billingAt
+	if at.IsZero() && usageLog != nil && !usageLog.CreatedAt.IsZero() {
+		at = usageLog.CreatedAt
+	}
+	if at.IsZero() {
+		at = timezone.Now()
 	}
 	usageLog.AccountStatsCost = resolveAccountStatsCost(
-		ctx, cs, bs, accountID, groupID, model, tokens, requestCount, totalCost, serviceTier, billingAt,
+		ctx, cs, bs, accountID, groupID, model, usageLogAccountStatsTokens(usageLog),
+		requestCount, totalCost, serviceTier, at,
 	)
 }

--- a/backend/internal/service/account_stats_pricing.go
+++ b/backend/internal/service/account_stats_pricing.go
@@ -25,7 +25,7 @@ import (
 // totalCost 是本次请求的客户计费（倍率前），用于优先级 2。
 // serviceTier 是最终参与用户计费的 OpenAI 服务层级，用于优先级 3。
 // billingAt 与用户计费的 BillingAt 对齐（通常为 recordUsageBillingAt(pricingAt)）。
-// mirroredTokenCostAtMultOne 为用户 token 计费路径在倍率=1 下的 totalCost；非 nil 且 >0 时用于优先级 3。
+// mirroredTokenCostAtMultOne 为用户 token 计费路径在倍率=1 下的 totalCost；非 nil 时用于优先级 3（含明确零价）。
 func resolveAccountStatsCost(
 	ctx context.Context,
 	channelService *ChannelService,
@@ -65,7 +65,7 @@ func resolveAccountStatsCost(
 	}
 
 	// 优先级 3：镜像用户 token 计费（倍率=1），与用户 CalculateCostUnified 同定价源
-	if mirroredTokenCostAtMultOne != nil && *mirroredTokenCostAtMultOne > 0 {
+	if mirroredTokenCostAtMultOne != nil {
 		cost := *mirroredTokenCostAtMultOne
 		return &cost
 	}
@@ -76,6 +76,16 @@ func resolveAccountStatsCost(
 	}
 
 	return nil
+}
+
+// accountStatsTokenCostFromBreakdown preserves an authoritative zero-cost token
+// result so account stats do not fall through to a different pricing source.
+func accountStatsTokenCostFromBreakdown(breakdown *CostBreakdown) *float64 {
+	if breakdown == nil || breakdown.TotalCost < 0 {
+		return nil
+	}
+	cost := breakdown.TotalCost
+	return &cost
 }
 
 // usageLogAccountStatsTokens derives billing tokens from the persisted usage log

--- a/backend/internal/service/account_stats_pricing.go
+++ b/backend/internal/service/account_stats_pricing.go
@@ -3,6 +3,9 @@ package service
 import (
 	"context"
 	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 )
 
 // resolveAccountStatsCost 计算账号统计定价费用。
@@ -11,12 +14,16 @@ import (
 // 优先级（先命中为准）：
 //  1. 自定义规则（始终尝试，不依赖 ApplyPricingToAccountStats 开关）
 //  2. ApplyPricingToAccountStats 启用时，直接使用本次请求的客户计费（倍率前的 totalCost）
-//  3. 模型定价文件（LiteLLM）中上游模型的默认价格
+//  3. 模型定价文件（LiteLLM）中上游模型的默认价格（含 DeepSeek 峰谷价，billingAt 与 usage_logs.created_at 对齐）
 //  4. nil → 走默认公式（total_cost × account_rate_multiplier）
+//
+// NOTE: 2026-09-02 之前 priority-3 路径未应用峰谷价，历史 usage_logs.account_stats_cost
+// 在峰时 DeepSeek 流量上可能约为 total_cost 的一半；不做 backfill，仅 forward-fix。
 //
 // upstreamModel 是最终发往上游的模型 ID。
 // totalCost 是本次请求的客户计费（倍率前），用于优先级 2。
 // serviceTier 是最终参与用户计费的 OpenAI 服务层级，用于优先级 3。
+// billingAt 是请求落库时刻（usage_logs.created_at），用于峰谷价与用户计费对齐。
 func resolveAccountStatsCost(
 	ctx context.Context,
 	channelService *ChannelService,
@@ -28,6 +35,7 @@ func resolveAccountStatsCost(
 	requestCount int,
 	totalCost float64,
 	serviceTier string,
+	billingAt time.Time,
 ) *float64 {
 	if channelService == nil || upstreamModel == "" {
 		return nil
@@ -55,27 +63,39 @@ func resolveAccountStatsCost(
 
 	// 优先级 3：模型定价文件（LiteLLM）默认价格
 	if billingService != nil {
-		return tryModelFilePricing(billingService, upstreamModel, tokens, serviceTier)
+		return tryModelFilePricing(billingService, upstreamModel, tokens, serviceTier, billingAt)
 	}
 
 	return nil
 }
 
 // tryModelFilePricing 使用模型定价文件（LiteLLM/fallback）中的价格计算费用。
-func tryModelFilePricing(billingService *BillingService, model string, tokens UsageTokens, serviceTier string) *float64 {
+// billingAt 与用户计费的峰谷时刻对齐（通常为 usageLog.CreatedAt）；零值回退到 timezone.Now()。
+// DeepSeek 等受 _config.deepseek_peak_valley 约束的模型在此与用户 total_cost 使用同一峰谷窗口。
+func tryModelFilePricing(billingService *BillingService, model string, tokens UsageTokens, serviceTier string, billingAt time.Time) *float64 {
 	pricing, err := billingService.GetModelPricing(model)
 	if err != nil || pricing == nil {
 		return nil
 	}
+	at := billingAt
+	if at.IsZero() {
+		at = timezone.Now()
+	}
 	normalizedTier := normalizeBillingServiceTier(serviceTier)
 	if normalizedTier == "priority" || normalizedTier == "fast" || normalizedTier == "flex" ||
 		billingService.shouldApplySessionLongContextPricing(tokens, pricing) {
-		breakdown, err := billingService.CalculateCostWithServiceTier(model, tokens, 1, normalizedTier)
+		breakdown, err := billingService.calculateCostInternalWithPolicyAt(
+			model, tokens, 1, normalizedTier, nil,
+			billingService.shouldApplySessionLongContextPricing(tokens, pricing),
+			at,
+		)
 		if err != nil || breakdown == nil || breakdown.TotalCost <= 0 {
 			return nil
 		}
 		return &breakdown.TotalCost
 	}
+	pricing = billingService.applyModelSpecificPricingPolicy(model, pricing)
+	pricing = tkApplyDeepSeekPeakValleyPricing(model, pricing, at, PricingSourceLiteLLM)
 	cost := float64(tokens.InputTokens)*pricing.InputPricePerToken +
 		float64(tokens.OutputTokens)*pricing.OutputPricePerToken +
 		float64(tokens.CacheCreationTokens)*pricing.CacheCreationPricePerToken +
@@ -249,7 +269,11 @@ func applyAccountStatsCost(
 	if usageLog != nil && usageLog.ServiceTier != nil {
 		serviceTier = *usageLog.ServiceTier
 	}
+	billingAt := time.Time{}
+	if usageLog != nil {
+		billingAt = usageLog.CreatedAt
+	}
 	usageLog.AccountStatsCost = resolveAccountStatsCost(
-		ctx, cs, bs, accountID, groupID, model, tokens, requestCount, totalCost, serviceTier,
+		ctx, cs, bs, accountID, groupID, model, tokens, requestCount, totalCost, serviceTier, billingAt,
 	)
 }

--- a/backend/internal/service/account_stats_pricing_test.go
+++ b/backend/internal/service/account_stats_pricing_test.go
@@ -454,10 +454,47 @@ func TestTryModelFilePricing_Success(t *testing.T) {
 		},
 	})
 	tokens := UsageTokens{InputTokens: 100, OutputTokens: 50}
-	result := tryModelFilePricing(bs, "claude-sonnet-4", tokens, "")
+	result := tryModelFilePricing(bs, "claude-sonnet-4", tokens, "", time.Time{})
 	require.NotNil(t, result)
 	// 100*0.001 + 50*0.002 = 0.1 + 0.1 = 0.2
 	require.InDelta(t, 0.2, *result, 1e-12)
+}
+
+func TestTryModelFilePricing_AppliesDeepSeekPeakValleyAtBillingAt(t *testing.T) {
+	// Regression: priority-3 account_stats_cost must follow the same peak-valley policy as
+	// user total_cost (see resolveAccountStatsCost NOTE — pre-2026-09-02 rows are not backfilled).
+	policy := loadTkDeepSeekPeakValleyPolicy()
+	require.NotNil(t, policy)
+
+	bs := newTestBillingService()
+	tokens := UsageTokens{InputTokens: 1_000_000, OutputTokens: 1_000_000}
+
+	shanghai, err := time.LoadLocation("Asia/Shanghai")
+	require.NoError(t, err)
+	peakAt := time.Date(2026, 7, 21, 10, 0, 0, 0, shanghai)
+	offPeakAt := time.Date(2026, 7, 21, 13, 0, 0, 0, shanghai)
+
+	peakCost, err := bs.calculateCostInternalWithPolicyAt(
+		"deepseek-v4-pro", tokens, 1, "", nil, true, peakAt,
+	)
+	require.NoError(t, err)
+
+	offPeakCost, err := bs.calculateCostInternalWithPolicyAt(
+		"deepseek-v4-pro", tokens, 1, "", nil, true, offPeakAt,
+	)
+	require.NoError(t, err)
+
+	peakStats := tryModelFilePricing(bs, "deepseek-v4-pro", tokens, "", peakAt)
+	offPeakStats := tryModelFilePricing(bs, "deepseek-v4-pro", tokens, "", offPeakAt)
+	require.NotNil(t, peakStats)
+	require.NotNil(t, offPeakStats)
+
+	require.InDelta(t, peakCost.TotalCost, *peakStats, 1e-9,
+		"account stats must match user billing peak total at the same billing instant")
+	require.InDelta(t, offPeakCost.TotalCost, *offPeakStats, 1e-9,
+		"account stats must match user billing off-peak total at the same billing instant")
+	require.Greater(t, *peakStats, *offPeakStats)
+	require.InDelta(t, *offPeakStats*policy.PeakMultiplier, *peakStats, 1e-6)
 }
 
 func TestTryModelFilePricing_AppliesLongContextPricing(t *testing.T) {
@@ -473,7 +510,7 @@ func TestTryModelFilePricing_AppliesLongContextPricing(t *testing.T) {
 	})
 	tokens := UsageTokens{InputTokens: 101, OutputTokens: 10, CacheReadTokens: 5}
 
-	result := tryModelFilePricing(bs, "gpt-5.6-sol", tokens, "")
+	result := tryModelFilePricing(bs, "gpt-5.6-sol", tokens, "", time.Time{})
 
 	require.NotNil(t, result)
 	// Input and cache-read use the 2x input tier; output uses the 1.5x tier.
@@ -512,7 +549,7 @@ func TestTryModelFilePricing_AppliesServiceTierPricing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tryModelFilePricing(bs, "gpt-5.6-sol", tokens, tt.serviceTier)
+			result := tryModelFilePricing(bs, "gpt-5.6-sol", tokens, tt.serviceTier, time.Time{})
 			require.NotNil(t, result)
 			require.InDelta(t, tt.want, *result, 1e-12)
 		})
@@ -542,7 +579,7 @@ func TestTryModelFilePricing_CombinesPriorityAndLongContextPricing(t *testing.T)
 		CacheReadTokens:     5,
 	}
 
-	result := tryModelFilePricing(bs, "gpt-5.6-sol", tokens, "priority")
+	result := tryModelFilePricing(bs, "gpt-5.6-sol", tokens, "priority", time.Time{})
 
 	require.NotNil(t, result)
 	// priority 单价先应用，再叠加长上下文输入 2x、输出 1.5x。
@@ -553,7 +590,7 @@ func TestTryModelFilePricing_PricingNotFound(t *testing.T) {
 	// "nonexistent-model" does not match any fallback pattern
 	bs := newTestBillingServiceWithPrices(map[string]*ModelPricing{})
 	tokens := UsageTokens{InputTokens: 100, OutputTokens: 50}
-	result := tryModelFilePricing(bs, "nonexistent-model", tokens, "")
+	result := tryModelFilePricing(bs, "nonexistent-model", tokens, "", time.Time{})
 	require.Nil(t, result)
 }
 
@@ -563,7 +600,7 @@ func TestTryModelFilePricing_NilFallback(t *testing.T) {
 		"claude-sonnet-4": nil,
 	})
 	tokens := UsageTokens{InputTokens: 100}
-	result := tryModelFilePricing(bs, "claude-sonnet-4", tokens, "")
+	result := tryModelFilePricing(bs, "claude-sonnet-4", tokens, "", time.Time{})
 	require.Nil(t, result)
 }
 
@@ -575,7 +612,7 @@ func TestTryModelFilePricing_ZeroCost(t *testing.T) {
 		},
 	})
 	tokens := UsageTokens{} // all zero tokens → cost = 0 → nil
-	result := tryModelFilePricing(bs, "claude-sonnet-4", tokens, "")
+	result := tryModelFilePricing(bs, "claude-sonnet-4", tokens, "", time.Time{})
 	require.Nil(t, result)
 }
 
@@ -592,7 +629,7 @@ func TestTryModelFilePricing_WithImageOutput(t *testing.T) {
 		OutputTokens:      50,
 		ImageOutputTokens: 10,
 	}
-	result := tryModelFilePricing(bs, "claude-sonnet-4", tokens, "")
+	result := tryModelFilePricing(bs, "claude-sonnet-4", tokens, "", time.Time{})
 	require.NotNil(t, result)
 	// 100*0.001 + 50*0.002 + 10*0.01 = 0.1 + 0.1 + 0.1 = 0.3
 	require.InDelta(t, 0.3, *result, 1e-12)
@@ -613,7 +650,7 @@ func TestTryModelFilePricing_WithCacheTokens(t *testing.T) {
 		CacheCreationTokens: 200,
 		CacheReadTokens:     300,
 	}
-	result := tryModelFilePricing(bs, "claude-sonnet-4", tokens, "")
+	result := tryModelFilePricing(bs, "claude-sonnet-4", tokens, "", time.Time{})
 	require.NotNil(t, result)
 	// 100*0.001 + 50*0.002 + 200*0.003 + 300*0.0005
 	// = 0.1 + 0.1 + 0.6 + 0.15 = 0.95
@@ -630,7 +667,7 @@ func TestResolveAccountStatsCost_NilChannelService(t *testing.T) {
 		nil, // channelService is nil
 		newTestBillingServiceWithPrices(map[string]*ModelPricing{}),
 		1, 1, "claude-sonnet-4",
-		UsageTokens{InputTokens: 100}, 1, 0.5, "",
+		UsageTokens{InputTokens: 100}, 1, 0.5, "", time.Time{},
 	)
 	require.Nil(t, result)
 }
@@ -646,7 +683,7 @@ func TestResolveAccountStatsCost_EmptyUpstreamModel(t *testing.T) {
 		cs,
 		newTestBillingServiceWithPrices(map[string]*ModelPricing{}),
 		1, 1, "", // empty upstream model
-		UsageTokens{InputTokens: 100}, 1, 0.5, "",
+		UsageTokens{InputTokens: 100}, 1, 0.5, "", time.Time{},
 	)
 	require.Nil(t, result)
 }
@@ -663,7 +700,7 @@ func TestResolveAccountStatsCost_GetChannelForGroupReturnsNil(t *testing.T) {
 		cs,
 		newTestBillingServiceWithPrices(map[string]*ModelPricing{}),
 		1, 99, "claude-sonnet-4", // groupID 99 has no channel
-		UsageTokens{InputTokens: 100}, 1, 0.5, "",
+		UsageTokens{InputTokens: 100}, 1, 0.5, "", time.Time{},
 	)
 	require.Nil(t, result)
 }
@@ -694,7 +731,7 @@ func TestResolveAccountStatsCost_HitsCustomRule(t *testing.T) {
 		context.Background(),
 		cs, nil, // billingService not needed when custom rule hits
 		1, 10, "claude-sonnet-4",
-		tokens, 1, 999.0, "priority", // 自定义账号价格不叠加服务层级倍率
+		tokens, 1, 999.0, "priority", time.Time{}, // 自定义账号价格不叠加服务层级倍率
 	)
 	require.NotNil(t, result)
 	// 100*0.01 + 50*0.02 = 1.0 + 1.0 = 2.0
@@ -716,7 +753,7 @@ func TestResolveAccountStatsCost_ApplyPricingToAccountStats_UsesTotalCost(t *tes
 		context.Background(),
 		cs, nil,
 		1, 10, "claude-sonnet-4",
-		tokens, 1, 0.75, "priority", // 已完成用户计费，不再重复应用服务层级倍率
+		tokens, 1, 0.75, "priority", time.Time{}, // 已完成用户计费，不再重复应用服务层级倍率
 	)
 	require.NotNil(t, result)
 	require.InDelta(t, 0.75, *result, 1e-12)
@@ -734,7 +771,7 @@ func TestResolveAccountStatsCost_ApplyPricingToAccountStats_ZeroTotalCost_Return
 		context.Background(),
 		cs, nil,
 		1, 10, "claude-sonnet-4",
-		UsageTokens{}, 1, 0.0, "", // totalCost = 0
+		UsageTokens{}, 1, 0.0, "", time.Time{}, // totalCost = 0
 	)
 	require.Nil(t, result)
 }
@@ -761,7 +798,7 @@ func TestResolveAccountStatsCost_FallsBackToLiteLLM(t *testing.T) {
 		context.Background(),
 		cs, bs,
 		1, 10, "claude-sonnet-4",
-		tokens, 1, 999.0, "", // totalCost ignored
+		tokens, 1, 999.0, "", time.Time{}, // totalCost ignored
 	)
 	require.NotNil(t, result)
 	// 100*0.001 + 50*0.002 = 0.1 + 0.1 = 0.2
@@ -782,7 +819,7 @@ func TestResolveAccountStatsCost_FallbackHonorsAnthropicFast(t *testing.T) {
 		context.Background(), cs, bs,
 		1, 10, "claude-opus-5",
 		UsageTokens{InputTokens: 1_000_000, OutputTokens: 1_000_000},
-		1, 0, "fast",
+		1, 0, "fast", time.Time{},
 	)
 	require.NotNil(t, result)
 	require.InDelta(t, 60, *result, 1e-12)
@@ -801,7 +838,7 @@ func TestResolveAccountStatsCost_Gemini36FlashTierUsesFallbackPricing(t *testing
 		context.Background(),
 		cs, bs,
 		1, 10, "gemini-3.6-flash-low",
-		UsageTokens{InputTokens: 1_000_000, OutputTokens: 1_000_000, CacheReadTokens: 1_000_000}, 1, 0, "",
+		UsageTokens{InputTokens: 1_000_000, OutputTokens: 1_000_000, CacheReadTokens: 1_000_000}, 1, 0, "", time.Time{},
 	)
 	require.NotNil(t, result)
 	require.InDelta(t, 9.15, *result, 1e-12)
@@ -825,7 +862,7 @@ func TestResolveAccountStatsCost_AllMiss_ReturnsNil(t *testing.T) {
 		context.Background(),
 		cs, bs,
 		1, 10, "totally-unknown-model",
-		tokens, 1, 0.0, "",
+		tokens, 1, 0.0, "", time.Time{},
 	)
 	require.Nil(t, result)
 }
@@ -842,7 +879,7 @@ func TestResolveAccountStatsCost_NilBillingService_SkipsLiteLLM(t *testing.T) {
 		context.Background(),
 		cs, nil, // billingService is nil
 		1, 10, "claude-sonnet-4",
-		UsageTokens{InputTokens: 100}, 1, 0.0, "",
+		UsageTokens{InputTokens: 100}, 1, 0.0, "", time.Time{},
 	)
 	require.Nil(t, result)
 }
@@ -875,7 +912,7 @@ func TestResolveAccountStatsCost_CustomRulePriorityOverApplyPricing(t *testing.T
 		context.Background(),
 		cs, nil,
 		1, 10, "claude-sonnet-4",
-		tokens, 1, 99.0, "", // totalCost = 99.0 (would be used if ApplyPricing wins)
+		tokens, 1, 99.0, "", time.Time{}, // totalCost = 99.0 (would be used if ApplyPricing wins)
 	)
 	require.NotNil(t, result)
 	// Custom rule: 100*0.05 = 5.0 (NOT 99.0 from totalCost)

--- a/backend/internal/service/account_stats_pricing_test.go
+++ b/backend/internal/service/account_stats_pricing_test.go
@@ -699,7 +699,7 @@ func TestResolveAccountStatsCost_NilChannelService(t *testing.T) {
 		nil, // channelService is nil
 		newTestBillingServiceWithPrices(map[string]*ModelPricing{}),
 		1, 1, "claude-sonnet-4",
-		UsageTokens{InputTokens: 100}, 1, 0.5, "", time.Time{},
+		UsageTokens{InputTokens: 100}, 1, 0.5, "", time.Time{}, nil,
 	)
 	require.Nil(t, result)
 }
@@ -715,7 +715,7 @@ func TestResolveAccountStatsCost_EmptyUpstreamModel(t *testing.T) {
 		cs,
 		newTestBillingServiceWithPrices(map[string]*ModelPricing{}),
 		1, 1, "", // empty upstream model
-		UsageTokens{InputTokens: 100}, 1, 0.5, "", time.Time{},
+		UsageTokens{InputTokens: 100}, 1, 0.5, "", time.Time{}, nil,
 	)
 	require.Nil(t, result)
 }
@@ -732,7 +732,7 @@ func TestResolveAccountStatsCost_GetChannelForGroupReturnsNil(t *testing.T) {
 		cs,
 		newTestBillingServiceWithPrices(map[string]*ModelPricing{}),
 		1, 99, "claude-sonnet-4", // groupID 99 has no channel
-		UsageTokens{InputTokens: 100}, 1, 0.5, "", time.Time{},
+		UsageTokens{InputTokens: 100}, 1, 0.5, "", time.Time{}, nil,
 	)
 	require.Nil(t, result)
 }
@@ -763,7 +763,7 @@ func TestResolveAccountStatsCost_HitsCustomRule(t *testing.T) {
 		context.Background(),
 		cs, nil, // billingService not needed when custom rule hits
 		1, 10, "claude-sonnet-4",
-		tokens, 1, 999.0, "priority", time.Time{}, // 自定义账号价格不叠加服务层级倍率
+		tokens, 1, 999.0, "priority", time.Time{}, nil, // 自定义账号价格不叠加服务层级倍率
 	)
 	require.NotNil(t, result)
 	// 100*0.01 + 50*0.02 = 1.0 + 1.0 = 2.0
@@ -785,7 +785,7 @@ func TestResolveAccountStatsCost_ApplyPricingToAccountStats_UsesTotalCost(t *tes
 		context.Background(),
 		cs, nil,
 		1, 10, "claude-sonnet-4",
-		tokens, 1, 0.75, "priority", time.Time{}, // 已完成用户计费，不再重复应用服务层级倍率
+		tokens, 1, 0.75, "priority", time.Time{}, nil, // 已完成用户计费，不再重复应用服务层级倍率
 	)
 	require.NotNil(t, result)
 	require.InDelta(t, 0.75, *result, 1e-12)
@@ -803,7 +803,7 @@ func TestResolveAccountStatsCost_ApplyPricingToAccountStats_ZeroTotalCost_Return
 		context.Background(),
 		cs, nil,
 		1, 10, "claude-sonnet-4",
-		UsageTokens{}, 1, 0.0, "", time.Time{}, // totalCost = 0
+		UsageTokens{}, 1, 0.0, "", time.Time{}, nil, // totalCost = 0
 	)
 	require.Nil(t, result)
 }
@@ -830,7 +830,7 @@ func TestResolveAccountStatsCost_FallsBackToLiteLLM(t *testing.T) {
 		context.Background(),
 		cs, bs,
 		1, 10, "claude-sonnet-4",
-		tokens, 1, 999.0, "", time.Time{}, // totalCost ignored
+		tokens, 1, 999.0, "", time.Time{}, nil, // totalCost ignored
 	)
 	require.NotNil(t, result)
 	// 100*0.001 + 50*0.002 = 0.1 + 0.1 = 0.2
@@ -851,7 +851,7 @@ func TestResolveAccountStatsCost_FallbackHonorsAnthropicFast(t *testing.T) {
 		context.Background(), cs, bs,
 		1, 10, "claude-opus-5",
 		UsageTokens{InputTokens: 1_000_000, OutputTokens: 1_000_000},
-		1, 0, "fast", time.Time{},
+		1, 0, "fast", time.Time{}, nil,
 	)
 	require.NotNil(t, result)
 	require.InDelta(t, 60, *result, 1e-12)
@@ -870,7 +870,7 @@ func TestResolveAccountStatsCost_Gemini36FlashTierUsesFallbackPricing(t *testing
 		context.Background(),
 		cs, bs,
 		1, 10, "gemini-3.6-flash-low",
-		UsageTokens{InputTokens: 1_000_000, OutputTokens: 1_000_000, CacheReadTokens: 1_000_000}, 1, 0, "", time.Time{},
+		UsageTokens{InputTokens: 1_000_000, OutputTokens: 1_000_000, CacheReadTokens: 1_000_000}, 1, 0, "", time.Time{}, nil,
 	)
 	require.NotNil(t, result)
 	require.InDelta(t, 9.15, *result, 1e-12)
@@ -894,7 +894,7 @@ func TestResolveAccountStatsCost_AllMiss_ReturnsNil(t *testing.T) {
 		context.Background(),
 		cs, bs,
 		1, 10, "totally-unknown-model",
-		tokens, 1, 0.0, "", time.Time{},
+		tokens, 1, 0.0, "", time.Time{}, nil,
 	)
 	require.Nil(t, result)
 }
@@ -911,7 +911,7 @@ func TestResolveAccountStatsCost_NilBillingService_SkipsLiteLLM(t *testing.T) {
 		context.Background(),
 		cs, nil, // billingService is nil
 		1, 10, "claude-sonnet-4",
-		UsageTokens{InputTokens: 100}, 1, 0.0, "", time.Time{},
+		UsageTokens{InputTokens: 100}, 1, 0.0, "", time.Time{}, nil,
 	)
 	require.Nil(t, result)
 }
@@ -944,11 +944,37 @@ func TestResolveAccountStatsCost_CustomRulePriorityOverApplyPricing(t *testing.T
 		context.Background(),
 		cs, nil,
 		1, 10, "claude-sonnet-4",
-		tokens, 1, 99.0, "", time.Time{}, // totalCost = 99.0 (would be used if ApplyPricing wins)
+		tokens, 1, 99.0, "", time.Time{}, nil, // totalCost = 99.0 (would be used if ApplyPricing wins)
 	)
 	require.NotNil(t, result)
 	// Custom rule: 100*0.05 = 5.0 (NOT 99.0 from totalCost)
 	require.InDelta(t, 5.0, *result, 1e-12)
+}
+
+func TestResolveAccountStatsCost_MirroredTokenCostOverridesLiteLLM(t *testing.T) {
+	channel := &Channel{
+		ID:                         1,
+		Status:                     StatusActive,
+		ApplyPricingToAccountStats: false,
+	}
+	cs := newTestChannelServiceForStats(t, channel, 10, "openai")
+	bs := newTestBillingServiceWithPrices(map[string]*ModelPricing{
+		"custom-model": {
+			InputPricePerToken:  0.001,
+			OutputPricePerToken: 0.002,
+		},
+	})
+	tokens := UsageTokens{InputTokens: 100, OutputTokens: 50}
+	mirrored := 7.5
+
+	result := resolveAccountStatsCost(
+		context.Background(),
+		cs, bs,
+		1, 10, "custom-model",
+		tokens, 1, 99.0, "", time.Time{}, &mirrored,
+	)
+	require.NotNil(t, result)
+	require.InDelta(t, 7.5, *result, 1e-12)
 }
 
 func TestApplyAccountStatsCost_UsesUsageLogServiceTier(t *testing.T) {
@@ -976,7 +1002,7 @@ func TestApplyAccountStatsCost_UsesUsageLogServiceTier(t *testing.T) {
 	applyAccountStatsCost(
 		context.Background(), usageLog, cs, bs,
 		1, 10, "gpt-5.6-sol", "gpt-5.6-sol",
-		999, time.Time{},
+		999, time.Time{}, nil,
 	)
 
 	require.NotNil(t, usageLog.AccountStatsCost)

--- a/backend/internal/service/account_stats_pricing_test.go
+++ b/backend/internal/service/account_stats_pricing_test.go
@@ -977,6 +977,34 @@ func TestResolveAccountStatsCost_MirroredTokenCostOverridesLiteLLM(t *testing.T)
 	require.InDelta(t, 7.5, *result, 1e-12)
 }
 
+func TestResolveAccountStatsCost_ZeroMirroredTokenCostOverridesLiteLLM(t *testing.T) {
+	channel := &Channel{ID: 1, Status: StatusActive}
+	cs := newTestChannelServiceForStats(t, channel, 10, "openai")
+	bs := newTestBillingServiceWithPrices(map[string]*ModelPricing{
+		"explicit-free-via-channel": {
+			InputPricePerToken: 0.001,
+		},
+	})
+	zero := 0.0
+
+	result := resolveAccountStatsCost(
+		context.Background(), cs, bs,
+		1, 10, "explicit-free-via-channel",
+		UsageTokens{InputTokens: 100}, 1, 0, "", time.Time{}, &zero,
+	)
+
+	require.NotNil(t, result)
+	require.Zero(t, *result, "authoritative channel zero price must not fall through to LiteLLM")
+}
+
+func TestAccountStatsTokenCostFromBreakdown_PreservesZero(t *testing.T) {
+	result := accountStatsTokenCostFromBreakdown(&CostBreakdown{TotalCost: 0})
+	require.NotNil(t, result)
+	require.Zero(t, *result)
+	require.Nil(t, accountStatsTokenCostFromBreakdown(nil))
+	require.Nil(t, accountStatsTokenCostFromBreakdown(&CostBreakdown{TotalCost: -1}))
+}
+
 func TestApplyAccountStatsCost_UsesUsageLogServiceTier(t *testing.T) {
 	channel := &Channel{
 		ID:                         1,

--- a/backend/internal/service/account_stats_pricing_test.go
+++ b/backend/internal/service/account_stats_pricing_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 	"github.com/stretchr/testify/require"
 )
 
@@ -458,6 +459,36 @@ func TestTryModelFilePricing_Success(t *testing.T) {
 	require.NotNil(t, result)
 	// 100*0.001 + 50*0.002 = 0.1 + 0.1 = 0.2
 	require.InDelta(t, 0.2, *result, 1e-12)
+
+	expected, err := bs.calculateCostInternalWithPolicyAt(
+		"claude-sonnet-4", tokens, 1, "", nil, false, time.Time{},
+	)
+	require.NoError(t, err)
+	require.InDelta(t, expected.TotalCost, *result, 1e-12,
+		"priority-3 must delegate to computeTokenBreakdown SSOT")
+}
+
+func TestUsageLogAccountStatsTokens_IncludesCacheBreakdown(t *testing.T) {
+	log := &UsageLog{
+		InputTokens:           10,
+		OutputTokens:          20,
+		CacheCreation5mTokens: 30,
+		CacheCreation1hTokens: 40,
+		ImageInputTokens:      5,
+	}
+	tokens := usageLogAccountStatsTokens(log)
+	require.Equal(t, 10, tokens.InputTokens)
+	require.Equal(t, 20, tokens.OutputTokens)
+	require.Equal(t, 30, tokens.CacheCreation5mTokens)
+	require.Equal(t, 40, tokens.CacheCreation1hTokens)
+	require.Equal(t, 5, tokens.ImageInputTokens)
+}
+
+func TestRecordUsageBillingAt(t *testing.T) {
+	fixed := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+	require.Equal(t, fixed, RecordUsageBillingAt(fixed))
+	fallback := RecordUsageBillingAt(time.Time{})
+	require.WithinDuration(t, timezone.Now(), fallback, 2*time.Second)
 }
 
 func TestTryModelFilePricing_AppliesDeepSeekPeakValleyAtBillingAt(t *testing.T) {
@@ -631,8 +662,9 @@ func TestTryModelFilePricing_WithImageOutput(t *testing.T) {
 	}
 	result := tryModelFilePricing(bs, "claude-sonnet-4", tokens, "", time.Time{})
 	require.NotNil(t, result)
-	// 100*0.001 + 50*0.002 + 10*0.01 = 0.1 + 0.1 + 0.1 = 0.3
-	require.InDelta(t, 0.3, *result, 1e-12)
+	// computeTokenBreakdown: text output = 50-10, image output billed separately
+	// 100*0.001 + 40*0.002 + 10*0.01 = 0.28
+	require.InDelta(t, 0.28, *result, 1e-12)
 }
 
 func TestTryModelFilePricing_WithCacheTokens(t *testing.T) {
@@ -935,12 +967,16 @@ func TestApplyAccountStatsCost_UsesUsageLogServiceTier(t *testing.T) {
 		},
 	})
 	serviceTier := "priority"
-	usageLog := &UsageLog{ServiceTier: &serviceTier}
+	usageLog := &UsageLog{
+		ServiceTier:  &serviceTier,
+		InputTokens:  100,
+		OutputTokens: 50,
+	}
 
 	applyAccountStatsCost(
 		context.Background(), usageLog, cs, bs,
 		1, 10, "gpt-5.6-sol", "gpt-5.6-sol",
-		UsageTokens{InputTokens: 100, OutputTokens: 50}, 999,
+		999, time.Time{},
 	)
 
 	require.NotNil(t, usageLog.AccountStatsCost)

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -1721,15 +1721,31 @@ func (s *BillingService) CalculateCostWithConfig(model string, tokens UsageToken
 // 拆分为：范围内 (200k, 0) + 范围外 (10k, 10k)
 // 范围内正常计费，范围外 × 2 计费
 func (s *BillingService) CalculateCostWithLongContext(model string, tokens UsageTokens, rateMultiplier float64, threshold int, extraMultiplier float64) (*CostBreakdown, error) {
+	return s.CalculateCostWithLongContextAt(model, tokens, rateMultiplier, threshold, extraMultiplier, time.Time{})
+}
+
+func (s *BillingService) CalculateCostWithLongContextAt(
+	model string,
+	tokens UsageTokens,
+	rateMultiplier float64,
+	threshold int,
+	extraMultiplier float64,
+	billingAt time.Time,
+) (*CostBreakdown, error) {
+	at := RecordUsageBillingAt(billingAt)
+	costAt := func(chunk UsageTokens, mult float64) (*CostBreakdown, error) {
+		return s.calculateCostInternalWithPolicyAt(model, chunk, mult, "", nil, true, at)
+	}
+
 	// 未启用长上下文计费，直接走正常计费
 	if threshold <= 0 || extraMultiplier <= 1 {
-		return s.CalculateCost(model, tokens, rateMultiplier)
+		return costAt(tokens, rateMultiplier)
 	}
 
 	// 计算总输入 token（缓存读取 + 新输入）
 	total := tokens.CacheReadTokens + tokens.InputTokens
 	if total <= threshold {
-		return s.CalculateCost(model, tokens, rateMultiplier)
+		return costAt(tokens, rateMultiplier)
 	}
 
 	// 拆分成范围内和范围外
@@ -1759,8 +1775,9 @@ func (s *BillingService) CalculateCostWithLongContext(model string, tokens Usage
 		CacheCreation5mTokens: tokens.CacheCreation5mTokens,
 		CacheCreation1hTokens: tokens.CacheCreation1hTokens,
 		ImageOutputTokens:     tokens.ImageOutputTokens,
+		ImageInputTokens:      tokens.ImageInputTokens,
 	}
-	inRangeCost, err := s.CalculateCost(model, inRangeTokens, rateMultiplier)
+	inRangeCost, err := costAt(inRangeTokens, rateMultiplier)
 	if err != nil {
 		return nil, err
 	}
@@ -1770,7 +1787,7 @@ func (s *BillingService) CalculateCostWithLongContext(model string, tokens Usage
 		InputTokens:     outRangeInputTokens,
 		CacheReadTokens: outRangeCacheTokens,
 	}
-	outRangeCost, err := s.CalculateCost(model, outRangeTokens, rateMultiplier*extraMultiplier)
+	outRangeCost, err := costAt(outRangeTokens, rateMultiplier*extraMultiplier)
 	if err != nil {
 		return inRangeCost, fmt.Errorf("out-range cost: %w", err)
 	}

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -1598,6 +1598,20 @@ func (s *BillingService) calculateCostInternalWithPolicy(
 	channelPricing *ChannelModelPricing,
 	longContextBillingEnabled bool,
 ) (*CostBreakdown, error) {
+	return s.calculateCostInternalWithPolicyAt(
+		model, tokens, rateMultiplier, serviceTier, channelPricing, longContextBillingEnabled, time.Time{},
+	)
+}
+
+func (s *BillingService) calculateCostInternalWithPolicyAt(
+	model string,
+	tokens UsageTokens,
+	rateMultiplier float64,
+	serviceTier string,
+	channelPricing *ChannelModelPricing,
+	longContextBillingEnabled bool,
+	billingAt time.Time,
+) (*CostBreakdown, error) {
 	var pricing *ModelPricing
 	var err error
 	if channelPricing != nil {
@@ -1609,12 +1623,17 @@ func (s *BillingService) calculateCostInternalWithPolicy(
 		return nil, err
 	}
 
+	at := billingAt
+	if at.IsZero() {
+		at = timezone.Now()
+	}
+
 	source := PricingSourceLiteLLM
 	if channelPricing != nil {
 		source = PricingSourceChannel
 	}
 	pricing = s.applyModelSpecificPricingPolicy(model, pricing)
-	pricing = tkApplyDeepSeekPeakValleyPricing(model, pricing, timezone.Now(), source)
+	pricing = tkApplyDeepSeekPeakValleyPricing(model, pricing, at, source)
 
 	// 旧路径始终检查长上下文定价（无区间定价概念）。该路径不携带 enable_thinking
 	// （仅 CalculateCostUnified/CostInput 链路透传思考模式），故按非思考计费。

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -1308,6 +1308,23 @@ type CostInput struct {
 	BillingAt time.Time
 }
 
+// RecordUsageBillingAt is the single frozen instant for provider time-of-day
+// pricing (DeepSeek peak-valley) on a usage record. Prefer the request-level
+// pricingAt (same as channel TimePricing / profit gate D); fall back to now.
+func RecordUsageBillingAt(pricingAt time.Time) time.Time {
+	if !pricingAt.IsZero() {
+		return pricingAt
+	}
+	return timezone.Now()
+}
+
+func costInputBillingAt(input CostInput) time.Time {
+	if !input.BillingAt.IsZero() {
+		return input.BillingAt
+	}
+	return RecordUsageBillingAt(input.PricingAt)
+}
+
 // CalculateCostUnified 统一计费入口，支持三种计费模式。
 // 使用 ModelPricingResolver 解析定价，然后根据 BillingMode 分发计算。
 func (s *BillingService) CalculateCostUnified(input CostInput) (*CostBreakdown, error) {
@@ -1317,13 +1334,15 @@ func (s *BillingService) CalculateCostUnified(input CostInput) (*CostBreakdown, 
 		if input.LongContextBillingEnabled != nil {
 			applyLongContextBilling = *input.LongContextBillingEnabled
 		}
-		return s.calculateCostInternalWithPolicy(
+		billingAt := costInputBillingAt(input)
+		return s.calculateCostInternalWithPolicyAt(
 			input.Model,
 			input.Tokens,
 			input.RateMultiplier,
 			input.ServiceTier,
 			nil,
 			applyLongContextBilling,
+			billingAt,
 		)
 	}
 
@@ -1380,10 +1399,7 @@ func (s *BillingService) calculateTokenCost(resolved *ResolvedPricing, input Cos
 		return nil, fmt.Errorf("no pricing available for model: %s: %w", input.Model, ErrModelPricingUnavailable)
 	}
 
-	at := input.BillingAt
-	if at.IsZero() {
-		at = timezone.Now()
-	}
+	at := costInputBillingAt(input)
 	pricing = s.applyModelSpecificPricingPolicy(input.Model, pricing)
 	pricing = tkApplyDeepSeekPeakValleyPricing(input.Model, pricing, at, resolved.Source)
 
@@ -1574,16 +1590,6 @@ func (s *BillingService) CalculateCost(model string, tokens UsageTokens, rateMul
 
 func (s *BillingService) CalculateCostWithServiceTier(model string, tokens UsageTokens, rateMultiplier float64, serviceTier string) (*CostBreakdown, error) {
 	return s.calculateCostInternal(model, tokens, rateMultiplier, serviceTier, nil)
-}
-
-func (s *BillingService) calculateCostWithServiceTierPolicy(
-	model string,
-	tokens UsageTokens,
-	rateMultiplier float64,
-	serviceTier string,
-	longContextBillingEnabled bool,
-) (*CostBreakdown, error) {
-	return s.calculateCostInternalWithPolicy(model, tokens, rateMultiplier, serviceTier, nil, longContextBillingEnabled)
 }
 
 func (s *BillingService) calculateCostInternal(model string, tokens UsageTokens, rateMultiplier float64, serviceTier string, channelPricing *ChannelModelPricing) (*CostBreakdown, error) {

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -1232,6 +1232,23 @@ func TestCalculateCostWithLongContext_PropagatesError(t *testing.T) {
 	require.Contains(t, err.Error(), "pricing not found")
 }
 
+func TestCalculateCostWithLongContextAt_PropagatesBillingAt(t *testing.T) {
+	bs := newTestBillingService()
+	tokens := UsageTokens{InputTokens: 1_000_000, OutputTokens: 1_000_000}
+	shanghai, err := time.LoadLocation("Asia/Shanghai")
+	require.NoError(t, err)
+	peakAt := time.Date(2026, 7, 21, 10, 0, 0, 0, shanghai)
+	offPeakAt := time.Date(2026, 7, 21, 13, 0, 0, 0, shanghai)
+
+	peak, err := bs.CalculateCostWithLongContextAt("deepseek-v4-pro", tokens, 1, 0, 2, peakAt)
+	require.NoError(t, err)
+	offPeak, err := bs.CalculateCostWithLongContextAt("deepseek-v4-pro", tokens, 1, 0, 2, offPeakAt)
+	require.NoError(t, err)
+
+	require.Greater(t, peak.TotalCost, offPeak.TotalCost,
+		"long-context entry must pass BillingAt into calculateCostInternalWithPolicyAt")
+}
+
 func TestGetModelPricing_Grok45OfficialFallback(t *testing.T) {
 	svc := newTestBillingService()
 

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
@@ -312,12 +313,14 @@ func TestCalculateCost_OpenAIGPT54LongContextAppliesWholeSessionMultipliers(t *t
 func TestCalculateCost_OpenAIGPT54LongContextMarkerRequiresActualCostIncrease(t *testing.T) {
 	svc := newTestBillingService()
 
-	cost, err := svc.calculateCostWithServiceTierPolicy(
+	cost, err := svc.calculateCostInternalWithPolicyAt(
 		"gpt-5.4-2026-03-05",
 		UsageTokens{InputTokens: 300000},
 		0,
 		"",
+		nil,
 		true,
+		time.Time{},
 	)
 
 	require.NoError(t, err)

--- a/backend/internal/service/gateway_usage_billing.go
+++ b/backend/internal/service/gateway_usage_billing.go
@@ -878,16 +878,7 @@ func (s *GatewayService) recordUsageCore(ctx context.Context, input *recordUsage
 	if apiKey.GroupID != nil {
 		applyAccountStatsCost(ctx, usageLog, s.channelService, s.billingService,
 			account.ID, *apiKey.GroupID, result.UpstreamModel, result.Model,
-			// Anthropic's input_tokens excludes cache_read and cache_creation (billed separately);
-			// OpenAI gateway uses actualInputTokens which also excludes cache_read for the same reason.
-			UsageTokens{
-				InputTokens:         result.Usage.InputTokens,
-				OutputTokens:        result.Usage.OutputTokens,
-				CacheCreationTokens: result.Usage.CacheCreationInputTokens,
-				CacheReadTokens:     result.Usage.CacheReadInputTokens,
-				ImageOutputTokens:   result.Usage.ImageOutputTokens,
-			},
-			cost.TotalCost,
+			cost.TotalCost, pricingAt,
 		)
 	}
 
@@ -1164,6 +1155,8 @@ func (s *GatewayService) calculateTokenCost(
 		ImageOutputTokens:     result.Usage.ImageOutputTokens,
 	}
 
+	billingAt := RecordUsageBillingAt(pricingAt)
+
 	var cost *CostBreakdown
 	var err error
 
@@ -1180,6 +1173,7 @@ func (s *GatewayService) calculateTokenCost(
 			RequestCount:   1,
 			RateMultiplier: multiplier,
 			PricingAt:      pricingAt,
+			BillingAt:      billingAt,
 			ServiceTier:    optionalStringValue(result.ServiceTier),
 			Resolver:       s.resolver,
 			Resolved:       resolved,
@@ -1191,11 +1185,14 @@ func (s *GatewayService) calculateTokenCost(
 		gid := apiKey.Group.ID
 		cost, err = s.billingService.CalculateCostUnified(CostInput{
 			Ctx: ctx, Model: billingModel, GroupID: &gid, Group: apiKey.Group,
-			Tokens: tokens, RequestCount: 1, RateMultiplier: multiplier, PricingAt: pricingAt,
+			Tokens: tokens, RequestCount: 1, RateMultiplier: multiplier,
+			PricingAt: pricingAt, BillingAt: billingAt,
 			ServiceTier: optionalStringValue(result.ServiceTier), Resolver: s.resolver,
 		})
 	} else {
-		cost, err = s.billingService.CalculateCost(billingModel, tokens, multiplier)
+		cost, err = s.billingService.calculateCostInternalWithPolicyAt(
+			billingModel, tokens, multiplier, optionalStringValue(result.ServiceTier), nil, true, billingAt,
+		)
 	}
 	if err != nil {
 		// TK: surface pricing-missing as structured zero-cost logs instead of silent ActualCost:0.

--- a/backend/internal/service/gateway_usage_billing.go
+++ b/backend/internal/service/gateway_usage_billing.go
@@ -832,6 +832,7 @@ func (s *GatewayService) recordUsageCore(ctx context.Context, input *recordUsage
 	if err != nil {
 		return err
 	}
+	effectiveBillingModel := billingModel
 	// response_model：按上游成功响应自报的模型计费（渠道显式开启才生效）。
 	// 采纳条件见 responseModelBillingDeclaration + hasIdentifiedResponseModelPricing
 	// + responseModelBillingAdoptable。任一条件不满足都静默回落基线，即开启本模式前的
@@ -853,6 +854,7 @@ func (s *GatewayService) recordUsageCore(ctx context.Context, input *recordUsage
 				// 因此这里不改写它，改由日志记录实际生效的计费基准。
 				logResponseModelBillingApplied("service.gateway", account, result.RequestID, billingModel, responseModel, cost, responseCost)
 				cost = responseCost
+				effectiveBillingModel = responseModel
 			}
 		}
 	}
@@ -876,9 +878,13 @@ func (s *GatewayService) recordUsageCore(ctx context.Context, input *recordUsage
 
 	// 计算账号统计定价费用（使用最终上游模型匹配自定义规则）
 	if apiKey.GroupID != nil {
+		var mirroredTokenCost *float64
+		if cost != nil {
+			mirroredTokenCost = s.mirrorAccountStatsTokenCost(ctx, result, apiKey, effectiveBillingModel, pricingAt, opts, cost)
+		}
 		applyAccountStatsCost(ctx, usageLog, s.channelService, s.billingService,
 			account.ID, *apiKey.GroupID, result.UpstreamModel, result.Model,
-			cost.TotalCost, pricingAt,
+			cost.TotalCost, pricingAt, mirroredTokenCost,
 		)
 	}
 
@@ -1180,7 +1186,9 @@ func (s *GatewayService) calculateTokenCost(
 		})
 	} else if opts.LongContextThreshold > 0 && (apiKey.Group == nil || apiKey.Group.LongContextPricingEnabled) {
 		// 长上下文双倍计费（如 Gemini 200K 阈值）
-		cost, err = s.billingService.CalculateCostWithLongContext(billingModel, tokens, multiplier, opts.LongContextThreshold, opts.LongContextMultiplier)
+		cost, err = s.billingService.CalculateCostWithLongContextAt(
+			billingModel, tokens, multiplier, opts.LongContextThreshold, opts.LongContextMultiplier, billingAt,
+		)
 	} else if s.resolver != nil && apiKey.Group != nil {
 		gid := apiKey.Group.ID
 		cost, err = s.billingService.CalculateCostUnified(CostInput{
@@ -1318,4 +1326,37 @@ func optionalSubscriptionID(subscription *UserSubscription) *int64 {
 		return &subscription.ID
 	}
 	return nil
+}
+
+// mirrorAccountStatsTokenCost re-runs the user token billing path at multiplier=1 so
+// account stats priority-3 mirrors channel/resolver pricing instead of LiteLLM file prices.
+func (s *GatewayService) mirrorAccountStatsTokenCost(
+	ctx context.Context,
+	result *ForwardResult,
+	apiKey *APIKey,
+	billingModel string,
+	pricingAt time.Time,
+	opts *recordUsageOpts,
+	userCost *CostBreakdown,
+) *float64 {
+	if userCost == nil {
+		return nil
+	}
+	if userCost.BillingMode != "" && userCost.BillingMode != string(BillingModeToken) {
+		return nil
+	}
+	if result.AudioUsage != nil {
+		return nil
+	}
+	if result.ImageCount > 0 {
+		if resolved := s.resolveChannelPricing(ctx, billingModel, apiKey); resolved == nil || resolved.Mode != BillingModeToken {
+			return nil
+		}
+	}
+	mirror := s.calculateTokenCost(ctx, result, apiKey, billingModel, 1.0, pricingAt, opts)
+	if mirror == nil || mirror.TotalCost <= 0 {
+		return nil
+	}
+	cost := mirror.TotalCost
+	return &cost
 }

--- a/backend/internal/service/gateway_usage_billing.go
+++ b/backend/internal/service/gateway_usage_billing.go
@@ -1354,9 +1354,5 @@ func (s *GatewayService) mirrorAccountStatsTokenCost(
 		}
 	}
 	mirror := s.calculateTokenCost(ctx, result, apiKey, billingModel, 1.0, pricingAt, opts)
-	if mirror == nil || mirror.TotalCost <= 0 {
-		return nil
-	}
-	cost := mirror.TotalCost
-	return &cost
+	return accountStatsTokenCostFromBreakdown(mirror)
 }

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -981,9 +981,10 @@ func (s *OpenAIGatewayService) mirrorOpenAIAccountStatsTokenCost(
 		mirror, err := s.calculateOpenAIRecordUsageTokenCost(
 			ctx, apiKey, candidate, 1.0, pricingAt, tokens, serviceTier, longContextBillingGate,
 		)
-		if err == nil && mirror != nil && mirror.TotalCost > 0 {
-			cost := mirror.TotalCost
-			return &cost
+		if err == nil {
+			if cost := accountStatsTokenCostFromBreakdown(mirror); cost != nil {
+				return cost
+			}
 		}
 	}
 	return nil

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -365,6 +365,7 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 		CacheCreationTokens:   result.Usage.CacheCreationInputTokens,
 		CacheReadTokens:       result.Usage.CacheReadInputTokens,
 		ImageOutputTokens:     result.Usage.ImageOutputTokens,
+		ImageInputTokens:      result.Usage.ImageInputTokens,
 		ImageCount:            result.ImageCount,
 		ImageSize:             optionalTrimmedStringPtr(result.ImageSize),
 		ImageInputSize:        optionalTrimmedStringPtr(result.ImageInputSize),
@@ -449,7 +450,7 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 	if apiKey.GroupID != nil {
 		applyAccountStatsCost(ctx, usageLog, s.channelService, s.billingService,
 			account.ID, *apiKey.GroupID, result.UpstreamModel, result.Model,
-			tokens, cost.TotalCost,
+			cost.TotalCost, pricingAt,
 		)
 	}
 
@@ -671,19 +672,19 @@ func (s *OpenAIGatewayService) calculateOpenAIRecordUsageTokenCost(
 ) (*CostBreakdown, error) {
 	if s.resolver != nil && apiKey.Group != nil {
 		gid := apiKey.Group.ID
+		billingAt := RecordUsageBillingAt(pricingAt)
 		return s.billingService.CalculateCostUnified(CostInput{
 			Ctx: ctx, Model: billingModel, GroupID: &gid, Group: apiKey.Group,
-			Tokens: tokens, RequestCount: 1, RateMultiplier: multiplier, PricingAt: pricingAt,
+			Tokens: tokens, RequestCount: 1, RateMultiplier: multiplier,
+			PricingAt: pricingAt, BillingAt: billingAt,
 			ServiceTier: serviceTier, Resolver: s.resolver,
 			LongContextBillingEnabled: longContextBillingGate,
 		})
 	}
-	return s.billingService.calculateCostWithServiceTierPolicy(
-		billingModel,
-		tokens,
-		multiplier,
-		serviceTier,
+	return s.billingService.calculateCostInternalWithPolicyAt(
+		billingModel, tokens, multiplier, serviceTier, nil,
 		longContextBillingGate == nil || *longContextBillingGate,
+		RecordUsageBillingAt(pricingAt),
 	)
 }
 

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -448,9 +448,15 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 
 	// 计算账号统计定价费用（使用最终上游模型匹配自定义规则）
 	if apiKey.GroupID != nil {
+		var mirroredTokenCost *float64
+		if cost != nil {
+			mirroredTokenCost = s.mirrorOpenAIAccountStatsTokenCost(
+				ctx, result, apiKey, billingModels, pricingAt, tokens, serviceTier, longContextBillingGate, cost,
+			)
+		}
 		applyAccountStatsCost(ctx, usageLog, s.channelService, s.billingService,
 			account.ID, *apiKey.GroupID, result.UpstreamModel, result.Model,
-			cost.TotalCost, pricingAt,
+			cost.TotalCost, pricingAt, mirroredTokenCost,
 		)
 	}
 
@@ -929,6 +935,56 @@ func (s *OpenAIGatewayService) resolveOpenAIChannelPricing(ctx context.Context, 
 	resolved := s.resolver.Resolve(ctx, PricingInput{Model: billingModel, GroupID: &gid, Group: apiKey.Group})
 	if resolved.Source == PricingSourceGroup || resolved.Source == PricingSourceChannel {
 		return resolved
+	}
+	return nil
+}
+
+// mirrorOpenAIAccountStatsTokenCost re-runs OpenAI token billing at multiplier=1 for account stats.
+func (s *OpenAIGatewayService) mirrorOpenAIAccountStatsTokenCost(
+	ctx context.Context,
+	result *OpenAIForwardResult,
+	apiKey *APIKey,
+	billingModels []string,
+	pricingAt time.Time,
+	tokens UsageTokens,
+	serviceTier string,
+	longContextBillingGate *bool,
+	userCost *CostBreakdown,
+) *float64 {
+	if userCost == nil {
+		return nil
+	}
+	if userCost.BillingMode != "" && userCost.BillingMode != string(BillingModeToken) {
+		return nil
+	}
+	if result != nil {
+		if result.VideoCount > 0 || result.WebSearchCalls > 0 || result.AudioUsage != nil {
+			return nil
+		}
+		if result.ImageCount > 0 {
+			billingModel := firstUsageBillingModel(billingModels)
+			resolved := s.resolveOpenAIChannelPricing(ctx, billingModel, apiKey)
+			useTokenPath := resolved != nil && resolved.Mode == BillingModeToken
+			if useTokenPath && s.resolver != nil && s.resolver.tkResolveOverlayMediaPerRequest(billingModel) != nil {
+				useTokenPath = false
+			}
+			if !useTokenPath {
+				return nil
+			}
+		}
+	}
+	for _, candidate := range billingModels {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		mirror, err := s.calculateOpenAIRecordUsageTokenCost(
+			ctx, apiKey, candidate, 1.0, pricingAt, tokens, serviceTier, longContextBillingGate,
+		)
+		if err == nil && mirror != nil && mirror.TotalCost > 0 {
+			cost := mirror.TotalCost
+			return &cost
+		}
 	}
 	return nil
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7944,6 +7944,39 @@
         "TestMessagesChatSilentRefusal_AfterPingDoesNotEndTurn"
       ],
       "rationale": "Focused companion regressions pin the production role-only false-success shape, the non-zero usage and explicit non-stop terminal exemptions, and the late header-wait ping case so an upstream merge cannot restore empty end_turn framing or shrink ordinary no-write account failover while text/tool tests remain green."
+    },
+    {
+      "path": "backend/internal/service/account_stats_pricing.go",
+      "must_contain": [
+        "if mirroredTokenCostAtMultOne != nil {",
+        "func accountStatsTokenCostFromBreakdown(",
+        "return tryModelFilePricing(billingService, upstreamModel, tokens, serviceTier, billingAt)"
+      ],
+      "rationale": "Account-stats pricing priority 3 must treat a successfully mirrored user token cost, including an authoritative zero, as stronger than the LiteLLM fallback. Dropping the non-nil check or breakdown conversion silently makes account_stats_cost diverge from user TotalCost for channel overrides and peak-valley pricing while ordinary user billing remains correct."
+    },
+    {
+      "path": "backend/internal/service/account_stats_pricing_test.go",
+      "must_contain": [
+        "TestResolveAccountStatsCost_ZeroMirroredTokenCostOverridesLiteLLM",
+        "TestAccountStatsTokenCostFromBreakdown_PreservesZero"
+      ],
+      "rationale": "Focused regressions prove explicit zero-cost channel pricing cannot fall through to a positive LiteLLM row and that nil/negative breakdowns remain non-authoritative."
+    },
+    {
+      "path": "backend/internal/service/gateway_usage_billing.go",
+      "must_contain": [
+        "mirroredTokenCost = s.mirrorAccountStatsTokenCost(",
+        "return accountStatsTokenCostFromBreakdown(mirror)"
+      ],
+      "rationale": "Anthropic/generic usage settlement must re-run the user token path at multiplier 1 and hand the authoritative result to account-stats pricing. Losing either call site silently restores file-price drift."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_usage.go",
+      "must_contain": [
+        "mirroredTokenCost = s.mirrorOpenAIAccountStatsTokenCost(",
+        "if cost := accountStatsTokenCostFromBreakdown(mirror); cost != nil {"
+      ],
+      "rationale": "OpenAI-compatible usage settlement must mirror the same candidate and token policy used by user billing, including explicit zero, before account stats may consider LiteLLM fallback."
     }
   ]
 }


### PR DESCRIPTION
## 摘要

- 修复 priority-3 账号统计未应用 DeepSeek 峰谷价，导致峰时 A$ 约为 U$ 一半（volcengine DeepSeek 等）。
- 终态 SSOT：priority-3/4 token 计费统一走 `calculateCostInternalWithPolicyAt` → `computeTokenBreakdown`；`RecordUsageBillingAt` / `BillingAt` 对齐请求定价时刻；`usageLogAccountStatsTokens` 从落库字段派生完整 token。
- Gateway/OpenAI 在 token 模式下以倍率=1 重跑用户 token 计费路径，作为 priority-3 镜像成本（优先于 LiteLLM 文件价）；明确零价同样作为权威结果，不再错误回退到正价 LiteLLM。
- Gemini 长上下文改走 `CalculateCostWithLongContextAt` 传入 `BillingAt`。
- 历史 `usage_logs.account_stats_cost` 不做 backfill；2026-09-02 之前峰时 DeepSeek 行可能仍有偏差。

upstream-touch-guarded
upstream-conflict-surface-accepted
sentinel-registry-reviewed
no-web-impact

## 风险

- 常规风险：仅影响新写入的 `account_stats_cost` 与账号统计聚合；用户 `actual_cost` 不变。
- 仍有意保留的分叉：自定义账号统计规则、ApplyPricingToAccountStats 抄 totalCost、按次/图/音视频计费（mirror 不覆盖非 token 路径）。
- load-bearing 账号成本镜像 helper、两条 settlement 注入路径及明确零价回归测试已加入 `gateway-tk` sentinel。

## 验证

- `go test -tags=unit ./internal/service -run 'TestTryModelFilePricing|TestResolveAccountStatsCost|TestApplyAccountStatsCost|TestCalculateCostWithLongContext|TestRecordUsageBillingAt|TestAccountStatsTokenCostFromBreakdown' -count=1` - PASS
- `python3 scripts/sentinels/check-gateway-tk.py` - PASS（830/830）
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh` - PASS（HEAD `5e8a0f4b7`）
- 与 #1940 exact HEAD `a2f298778` 联合 merge-tree - PASS（tree `24390e716e`，无冲突）

## 提交

- 02c8357ac fix(billing): 账号统计定价与用户计费对齐 DeepSeek 峰谷价
- 2d6491f76 fix(billing): 账号统计 token 计费收敛到 computeTokenBreakdown SSOT
- 106f5dd09 fix(billing): 账号统计镜像用户 token 计费并补齐长上下文 BillingAt
- 5e8a0f4b7 fix(billing): address R-001 explicit-free account mirror

最新提交：5e8a0f4b7
