### PR TITLE
fix(obs): 未登记 probe 仍可投递，contract 仅约束 companions

### DIFF
--- a/ops/observability/run-probe.sh
+++ b/ops/observability/run-probe.sh
@@ -22,6 +22,12 @@
 #       [--timeout-seconds 120]
 #       [--describe-script]  print the registered companion/verdict contract and exit
 #
+# Probe contracts (ops/observability/probe-contracts.json):
+#   Optional for delivery. Registered scripts auto-upload companions and expose a
+#   machine-readable verdict vocabulary via --describe-script. Unregistered scripts
+#   still run (empty companions) so plain SQL/observability probes are not gated.
+#   --describe-script remains fail-closed for unregistered scripts.
+#
 # Endpoint route-gate matrix (group.platform × gateway path, prod):
 #   bash ops/observability/run-probe.sh --target prod \
 #       --script ops/observability/probe-endpoint-matrix.sh \
@@ -154,14 +160,12 @@ if [ "$DESCRIBE_SCRIPT" = "1" ]; then
   exit 0
 fi
 
-if [ ! -f "$PROBE_CONTRACTS" ] || ! probe_contract json >/dev/null 2>&1; then
-  echo "[run-probe] ERROR: no registered contract for $(basename "$SCRIPT_PATH")" >&2
-  exit 1
+# Registration is optional for delivery: only registered probes auto-load companions.
+if [ -f "$PROBE_CONTRACTS" ] && probe_contract json >/dev/null 2>&1; then
+  while IFS= read -r companion; do
+    [ -n "$companion" ] && WITH_FILES+=("$REPO_ROOT/$companion")
+  done < <(probe_contract companions)
 fi
-
-while IFS= read -r companion; do
-  [ -n "$companion" ] && WITH_FILES+=("$REPO_ROOT/$companion")
-done < <(probe_contract companions)
 
 for extra in "${WITH_FILES[@]+"${WITH_FILES[@]}"}"; do
   if [ ! -f "$extra" ]; then

--- a/ops/observability/test_run_probe.py
+++ b/ops/observability/test_run_probe.py
@@ -92,15 +92,9 @@ class RunProbeValidationTest(unittest.TestCase):
                 for companion in contract["companions"]:
                     self.assertTrue((repo / companion).is_file(), companion)
 
-    def test_unknown_probe_contract_is_rejected(self) -> None:
+    def test_unknown_probe_contract_is_rejected_for_describe(self) -> None:
         existing = pathlib.Path(__file__).resolve().parent / "probe-caps.sh"
         proc = _run("--script", str(existing), "--describe-script")
-        self.assertEqual(proc.returncode, 1)
-        self.assertIn("no registered contract", proc.stderr)
-
-    def test_unknown_probe_contract_cannot_run(self) -> None:
-        existing = pathlib.Path(__file__).resolve().parent / "probe-caps.sh"
-        proc = _run("--target", "prod", "--script", str(existing))
         self.assertEqual(proc.returncode, 1)
         self.assertIn("no registered contract", proc.stderr)
 
@@ -334,6 +328,15 @@ class RunProbePollingTest(unittest.TestCase):
         params = self.aws_params_log.read_text(encoding="utf-8")
         self.assertIn("/tmp/probe_openai_upstream_model.sh", params)
         self.assertIn("/tmp/probe_grok_upstream_model.sh", params)
+
+    def test_unregistered_probe_is_still_delivered(self) -> None:
+        unregistered = self.root / "probe_unregistered_obs.sh"
+        self._write_executable(unregistered, "#!/usr/bin/env bash\necho unused\n")
+        self.probe = unregistered
+        proc = self._run_scenario("terminal-failure")
+        self.assertEqual(proc.returncode, 3, proc.stderr)
+        self.assertNotIn("no registered contract", proc.stderr)
+        self._assert_one_command(expected_gets=1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 摘要

- 收窄 #1931 引入的 probe contract 门禁：`run-probe.sh` 投递时，未登记脚本仍可运行（空 companions），不再 fail-closed。
- 已登记脚本继续自动上传 companions；`--describe-script` 对未登记脚本仍 fail-closed（只服务有 verdict 词汇的 modelops probe）。
- 恢复 `probe-user-billing-watch.sh` 等 observability 盯盘在 main 上的可用性。

## 风险

- 低风险：仅放宽内部只读 probe 投递器；不改变已登记 modelops probe 的 companion/verdict 行为。
- Web impact: none

## 验证

- `python3 ops/observability/test_run_probe.py`（15 tests passed）
- `bash -n ops/observability/run-probe.sh`
- `bash ops/observability/run-probe.sh --target prod --script ops/observability/probe-user-billing-watch.sh --env WINDOW_MINUTES=30` → Success
- `./scripts/preflight.sh` PASS

## 提交

- 76acd0c1a fix(obs): 未登记 probe 仍可投递，contract 仅约束 companions

最新提交：76acd0c1a

Made with [Cursor](https://cursor.com)