### PR TITLE
feat(gateway): 增加 Seedance 1-5-pro 短名别名

### DIFF
--- a/backend/internal/service/account_test_service_supplier_probe.go
+++ b/backend/internal/service/account_test_service_supplier_probe.go
@@ -74,8 +74,15 @@ func (s *AccountTestService) probeSupplierVideoModel(
 		return baseResult
 	}
 	submitURL := supplierVideoProbeURL(account.ChannelType, baseURL, baseResult.UpstreamModelID)
-	body := []byte(fmt.Sprintf(`{"model":%q,"prompt":"probe"}`, baseResult.UpstreamModelID))
+	upstreamModelID := baseResult.UpstreamModelID
 	fmgo := newapiintegration.IsFMGoBaseURL(account.ChannelType, baseURL)
+	xrtoken := newapiintegration.IsXRTokenBaseURL(account.ChannelType, baseURL)
+	if xrtoken {
+		// XRToken publishes Ark SKUs under volcengine/; bare ids may work on
+		// some SKUs but production relay always prefixes — probe must match.
+		upstreamModelID = newapiintegration.XRTokenUpstreamVideoModel(upstreamModelID)
+	}
+	body := supplierArkContentsProbeBody(upstreamModelID)
 	fmgoVideos := fmgo && newapiintegration.FMGoUsesVideosDialect(baseResult.UpstreamModelID)
 	if fmgoVideos {
 		body = supplierFMGoVideosProbeBody(baseResult.UpstreamModelID)
@@ -127,6 +134,24 @@ func supplierVideoProbeURL(channelType int, baseURL, upstreamModelID string) str
 	default:
 		return baseURL + "/api/v3/contents/generations/tasks"
 	}
+}
+
+// supplierArkContentsProbeBody builds the Ark / XRToken contents.generations
+// probe payload. Official Ark and XRToken both reject a top-level `prompt`
+// field (MissingParameter: content); Sync used to send prompt-only and
+// permanently failed every XRToken configured model.
+func supplierArkContentsProbeBody(upstreamModelID string) []byte {
+	model := strings.TrimSpace(upstreamModelID)
+	body, err := json.Marshal(map[string]any{
+		"model": model,
+		"content": []map[string]any{
+			{"type": "text", "text": "probe"},
+		},
+	})
+	if err != nil {
+		return []byte(`{"model":` + strconv.Quote(model) + `,"content":[{"type":"text","text":"probe"}]}`)
+	}
+	return body
 }
 
 func supplierFMGoVideosProbeBody(upstreamModelID string) []byte {

--- a/backend/internal/service/account_test_service_supplier_probe_test.go
+++ b/backend/internal/service/account_test_service_supplier_probe_test.go
@@ -53,9 +53,11 @@ func TestUS048_SupplierProbeUsesInMemoryAccountWithoutRepositoryLookup(t *testin
 
 func TestUS048_DoubaoVideoChannelProbesVideoPathNotChat(t *testing.T) {
 	var hitPath string
+	var payload map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		hitPath = request.URL.Path
 		require.Equal(t, "Bearer secret", request.Header.Get("Authorization"))
+		require.NoError(t, json.NewDecoder(request.Body).Decode(&payload))
 		w.WriteHeader(http.StatusOK)
 		_, _ = fmt.Fprint(w, `{"id":"task-1"}`)
 	}))
@@ -77,6 +79,11 @@ func TestUS048_DoubaoVideoChannelProbesVideoPathNotChat(t *testing.T) {
 	require.Equal(t, SupplierProbeStatusPassed, result.Status)
 	require.Equal(t, "openai_video", result.Protocol)
 	require.Equal(t, "/api/v3/contents/generations/tasks", hitPath)
+	require.Equal(t, "feimiao-v2-720p-15s", payload["model"])
+	require.Nil(t, payload["prompt"], "Ark/XRToken Sync probes must not send top-level prompt")
+	content, ok := payload["content"].([]any)
+	require.True(t, ok, "Ark contents.generations body must include content[]")
+	require.Len(t, content, 1)
 	require.Zero(t, repo.getCalls)
 }
 

--- a/backend/internal/service/account_test_service_supplier_probe_test.go
+++ b/backend/internal/service/account_test_service_supplier_probe_test.go
@@ -116,6 +116,38 @@ func TestUS048_FMGoVideoProbeURLUsesVideosForLiveFamilies(t *testing.T) {
 	require.Equal(t, newapiintegration.FMGoBaseURL+newapiintegration.FMGoChatCompletionsPath, got)
 	got = supplierVideoProbeURL(newapiconstant.ChannelTypeDoubaoVideo, "https://ark.cn-beijing.volces.com", "feimiao-v2-431-720p-15s")
 	require.Equal(t, "https://ark.cn-beijing.volces.com/api/v3/contents/generations/tasks", got)
+	got = supplierVideoProbeURL(newapiconstant.ChannelTypeDoubaoVideo, newapiintegration.XRTokenBaseURL, "doubao-seedance-1-5-pro-251215")
+	require.Equal(t, newapiintegration.XRTokenBaseURL+"/v1/contents/generations/tasks", got)
+}
+
+func TestUS048_ArkContentsProbeBodyUsesContentArray(t *testing.T) {
+	body := supplierArkContentsProbeBody("doubao-seedance-1-5-pro-251215")
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(body, &payload))
+	require.Equal(t, "doubao-seedance-1-5-pro-251215", payload["model"])
+	require.Nil(t, payload["prompt"])
+	content, ok := payload["content"].([]any)
+	require.True(t, ok)
+	require.Len(t, content, 1)
+	item, ok := content[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "text", item["type"])
+	require.Equal(t, "probe", item["text"])
+}
+
+func TestUS048_XRTokenVideoProbeURLAndPrefix(t *testing.T) {
+	require.Equal(t,
+		newapiintegration.XRTokenBaseURL+"/v1/contents/generations/tasks",
+		supplierVideoProbeURL(newapiconstant.ChannelTypeDoubaoVideo, newapiintegration.XRTokenBaseURL, "doubao-seedance-1-5-pro-251215"),
+	)
+	require.Equal(t,
+		"volcengine/doubao-seedance-1-5-pro-251215",
+		newapiintegration.XRTokenUpstreamVideoModel("doubao-seedance-1-5-pro-251215"),
+	)
+	prefixedBody := supplierArkContentsProbeBody(newapiintegration.XRTokenUpstreamVideoModel("doubao-seedance-1-5-pro-251215"))
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(prefixedBody, &payload))
+	require.Equal(t, "volcengine/doubao-seedance-1-5-pro-251215", payload["model"])
 }
 
 func TestUS048_VideoProbeAcceptsHTTP202(t *testing.T) {

--- a/backend/internal/service/seedance_client_alias_tk.go
+++ b/backend/internal/service/seedance_client_alias_tk.go
@@ -12,6 +12,8 @@ import (
 // serving the dated whitelist keys. Aliases stay off the public catalog /
 // Studio menu.
 var seedanceClientAliases = map[string]string{
+	"doubao-seedance-1-5-pro":  "doubao-seedance-1-5-pro-251215",
+	"doubao-seedance-1.5-pro":  "doubao-seedance-1-5-pro-251215",
 	"doubao-seedance-2-0":      "doubao-seedance-2-0-260128",
 	"doubao-seedance-2.0":      "doubao-seedance-2-0-260128",
 	"doubao-seedance-2-0-fast": "doubao-seedance-2-0-fast-260128",

--- a/backend/internal/service/seedance_client_alias_tk_test.go
+++ b/backend/internal/service/seedance_client_alias_tk_test.go
@@ -14,17 +14,20 @@ func TestResolveSeedanceClientAlias(t *testing.T) {
 		want      string
 		wantAlias bool
 	}{
+		{"hyphen 1.5-pro", "doubao-seedance-1-5-pro", "doubao-seedance-1-5-pro-251215", true},
+		{"dotted 1.5-pro", "doubao-seedance-1.5-pro", "doubao-seedance-1-5-pro-251215", true},
 		{"hyphen 2.0", "doubao-seedance-2-0", "doubao-seedance-2-0-260128", true},
 		{"dotted 2.0", "doubao-seedance-2.0", "doubao-seedance-2-0-260128", true},
 		{"hyphen 2.0-fast", "doubao-seedance-2-0-fast", "doubao-seedance-2-0-fast-260128", true},
 		{"dotted 2.0-fast", "doubao-seedance-2.0-fast", "doubao-seedance-2-0-fast-260128", true},
 		{"hyphen 2.5", "doubao-seedance-2-5", "doubao-seedance-2-5-260628", true},
 		{"dotted 2.5", "doubao-seedance-2.5", "doubao-seedance-2-5-260628", true},
-		{"case fold", "Doubao-Seedance-2.5", "doubao-seedance-2-5-260628", true},
+		{"case fold", "Doubao-Seedance-1.5-Pro", "doubao-seedance-1-5-pro-251215", true},
+		{"dated 1.5-pro stays", "doubao-seedance-1-5-pro-251215", "", false},
 		{"dated 2.0 stays", "doubao-seedance-2-0-260128", "", false},
 		{"dated 2.5 stays", "doubao-seedance-2-5-260628", "", false},
 		{"mini is not 2.0", "doubao-seedance-2.0-mini", "", false},
-		{"unknown stays", "doubao-seedance-1-5-pro-251215", "", false},
+		{"unknown stays", "doubao-seedance-3-0", "", false},
 		{"empty", "", "", false},
 	}
 	for _, tc := range cases {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7741,15 +7741,17 @@
         "SupplierProbeStatusProtocolUnsupported",
         "return \"openai_responses\"",
         "return \"anthropic_messages\"",
+        "supplierArkContentsProbeBody",
         "supplierFMGoChatProbeBody",
         "supplierFMGoVideosProbeBody",
+        "XRTokenUpstreamVideoModel",
         "fmgo_chat_completions",
         "fmgo_videos",
         "respond-async",
         "FMGoSubmitPath",
         "FMGoUsesVideosDialect"
       ],
-      "rationale": "Version-one supplier probing is intentionally fixed to OpenAI Chat. Even successful Responses or Anthropic Messages evidence must fail closed as protocol_unsupported instead of silently expanding the production transport surface. FMGo ch54 live families (v2.5/431/mini) use official POST /v1/videos; legacy feimiao-v2 stays on async chat completions. Neither path is hi-Chat fake success or /v1/video/generations."
+      "rationale": "Version-one supplier probing is intentionally fixed to OpenAI Chat. Even successful Responses or Anthropic Messages evidence must fail closed as protocol_unsupported instead of silently expanding the production transport surface. FMGo ch54 live families (v2.5/431/mini) use official POST /v1/videos; legacy feimiao-v2 stays on async chat completions. XRToken/Ark Sync probes must send Ark content[] (not prompt) and XRToken must prefix volcengine/ so Sync does not fail every configured Seedance row."
     },
     {
       "path": "backend/internal/service/account_test_service_supplier_probe_test.go",
@@ -7761,11 +7763,13 @@
         "TestUS048_SupplierProbeClassifiesEventsWithoutPersistingUpstreamDetail",
         "successful non-chat protocol remains unsupported",
         "TestUS048_FMGoVideoProbeURLUsesVideosForLiveFamilies",
+        "TestUS048_ArkContentsProbeBodyUsesContentArray",
+        "TestUS048_XRTokenVideoProbeURLAndPrefix",
         "TestUS048_FMGoVideosProbeBodyMatchesOfficialDialect",
         "TestUS048_FMGoChatProbeBodyMatchesOfficialDialect",
         "TestUS048_VideoProbeAcceptsHTTP202"
       ],
-      "rationale": "Probe regressions pin in-memory execution, the managed identity's single Chat capability, supplier-only trailing-/v1 normalization, raw-upstream log redaction, fixed public result details, and non-Chat failure closure without persisting an account or upstream response body. Live FMGo families probe POST /v1/videos; legacy feimiao-v2 still uses official chat-completions video dialect and HTTP 202."
+      "rationale": "Probe regressions pin in-memory execution, the managed identity's single Chat capability, supplier-only trailing-/v1 normalization, raw-upstream log redaction, fixed public result details, and non-Chat failure closure without persisting an account or upstream response body. Live FMGo families probe POST /v1/videos; legacy feimiao-v2 still uses official chat-completions video dialect and HTTP 202. XRToken Sync probes lock Ark content[] + volcengine/ prefix."
     },
     {
       "path": "backend/internal/service/supplier_managed_account_guard.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2980,6 +2980,7 @@
       "must_contain": [
         "ResolveSeedanceClientAlias",
         "ApplySeedanceClientAlias",
+        "doubao-seedance-1-5-pro-251215",
         "doubao-seedance-2-0-260128",
         "doubao-seedance-2-0-fast-260128",
         "doubao-seedance-2-5-260628"
@@ -2992,9 +2993,10 @@
         "TestResolveSeedanceClientAlias",
         "TestApplySeedanceClientAlias_RewritesBody",
         "TestApplySeedanceClientAlias_LeavesForeignBody",
+        "doubao-seedance-1.5-pro",
         "doubao-seedance-2.0-mini"
       ],
-      "rationale": "Locks hyphen/dot aliases, rejects mini as 2.0, and proves body rewrite only touches model."
+      "rationale": "Locks hyphen/dot aliases including 1.5-pro, rejects mini as 2.0, and proves body rewrite only touches model."
     },
     {
       "path": "backend/internal/handler/openai_gateway_tk_video_test.go",


### PR DESCRIPTION
## 摘要
- 网关视频提交入口增加 `doubao-seedance-1-5-pro` / `doubao-seedance-1.5-pro` → `doubao-seedance-1-5-pro-251215`
- 修复供应源 Sync 对 XRToken 的视频探测体：改用 Ark `content[]`，并对 XRToken 加 `volcengine/` 前缀
- 补 httptest 断言：非 FMGo 视频探测必须发 content[]、禁止 prompt

## 风险
- **常规**：短名解析语义扩展；Sync 探测请求体变更影响 ch54 Ark/XRToken 探测路径
- `1-5-pro` 短名需合入并发版后网关生效

## 验证
- `go test -tags=unit ./internal/service/ -run 'TestResolveSeedanceClientAlias|TestApplySeedanceClientAlias|TestUS048_' -count=1` → ok
- `python3 scripts/sentinels/check-gateway-tk.py --quiet` → ok
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh` → PASS
- 现网：账号 122 + `doubao-seedance-1-5-pro-251215` submit/poll 200（不依赖本 PR 发版）

## 提交
- `8ccaacc2c` feat(gateway): 增加 Seedance 1-5-pro 短名别名
- `8f6882254` fix(supplier): XRToken Sync 探测改用 Ark content 体
- `fda7cbd55` test(supplier): ProbeSupplierModel 断言 Ark content 探测体
- 最新提交：`fda7cbd55`