### PR TITLE
chore(modelops): 收敛模型交付 SSOT

### DIFF
--- a/.cursor/skills/tokenkey-onboard-model/SKILL.md
+++ b/.cursor/skills/tokenkey-onboard-model/SKILL.md
@@ -8,7 +8,7 @@ description: >-
 
 # TokenKey：上架一个模型（newapi 策展模型面）
 
-经 hub **`tokenkey-modelops-planner` 分支 C** 进入。本 skill 准备 manifest、价格 owner、
+经 hub **`tokenkey-modelops-planner` 的 curated onboarding 路由**进入。本 skill 准备 manifest、价格 owner、
 生成 bundle 与激活证据；一次请求能不能交付仍看
 `docs/approved/pricing-serving-single-source-of-truth.md`。
 
@@ -38,13 +38,13 @@ description: >-
 
 ## 流程
 
-不确定缺口 → 先 hub **分支 A** `modelops.py plan`。
+不确定缺口 → 先走 hub 的 read-only planning 路由：`modelops.py plan`。
 
 1. **probe 可服务性** — DashScope 用 `DASHSCOPE_CHAT_MODELS`（思考+非思考）；Kimi/单账号用
    `probe_account_model`。命令见 README / `tokenkey-account-model-probe`。须
    `verdict=servable` 且 `usage_match.account_id` 命中目标账号。
-2. **写 manifest** — `tk_served_models.json` 加 `newapi/<id>`；新 floor 的 `notes` 必须含
-   `served-via-modelops-activation`；`display` / `price_source` 语义见 manifest `_schema`。
+2. **写 manifest** — `tk_served_models.json` 加 `newapi/<id>`；新 floor 声明
+   `mapping_source: activation`，人类证据留在 `notes`；其它字段语义见 manifest `_schema`。
 3. **价 + bundle** — 官方核价后修改 complete registry（或明确 scoped channel price）；
    `go run ./cmd/account-model-mapping bundle` 生成 target artifact（禁手改 JSON）。
 4. **activate** — 独立 probe/pricing evidence + `modelops.py activate` dry-run → 人审 →
@@ -58,7 +58,7 @@ description: >-
 
 `scripts/checks/catalog-serving-drift.py`（preflight）：A0 parse / A1 price / A2 display⇒owner /
 A3 served_on⇒mapping path / A4 enumeration WARN。新 floor 缺
-`served-via-modelops-activation` 会硬失败（#812）。
+`mapping_source: activation` 会硬失败（#812）。
 
 prod live 对账：`manage-account-model-mapping-runtime.py check-accounts --json --bundle …`。
 

--- a/.cursor/skills/tokenkey-servable-model-refresh/SKILL.md
+++ b/.cursor/skills/tokenkey-servable-model-refresh/SKILL.md
@@ -46,8 +46,8 @@ de-duplication and Go-map splicing. Do not reproduce those algorithms in this sk
 - Paid or high-cost media probes must be limited to models actually under review.
 - Review unexpected bulk additions/removals before opening a PR. Merge authorization stays
   with a human.
-- Watchlist freshness is an operational alert, not a candidate-generation gate. Use the
-  script's `watchlist-status` command for the machine-readable stale set.
+- Durable explicit candidates belong in ledger `probe_candidates`; time-bounded follow-up
+  belongs in `watchlist`. Use `watchlist-status` for its machine-readable stale set.
 
 ## Pricing findings
 

--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -125,7 +125,7 @@ Hard rules：`simple_release` 默认 false；bump/tag 提交不得带 skip-ci �
 | 无代理后 dispatch 报 `HTTP 403 Must have admin rights to Repository` | `gh` 可能切到另一个账号；先 `env -u GH_TOKEN ... gh auth status`，必要时 `gh auth switch -u <repo-owner>` 后重试 dispatch。 |
 | 发版后 Anthropic `check` 报 violation（tier/TLS/stub pool/balance） | **不要** rollback 镜像；按 `/tokenkey-anthropic-oauth-config` 从 `$JOBDIR/post-release-check.json` 派生 plan → apply → verify。TLS/UA 漂移优先 `remediate-guard-drift --sync-runtime`。 |
 | 发版后 Anthropic `snapshot` SSM 失败 | 记 yellow；prod/Edge 镜像仍有效。补 OIDC/实例在线后重跑 snapshot+check，或 `snapshot --skip-prod` 仅 edge。 |
-| 发版后 Account model_mapping `check-accounts` 报 violation | **不要** rollback 镜像；审 `$JOBDIR/post-release-account-model-mapping-check.json` 的账号/group diff。期望与 forbidden policy 均来自 Go SSOT；确认要覆盖 live 配置时走 `/tokenkey-modelops-planner` 分支 D：必要时 `validate/check/sync-runtime` 更新 desired layer，然后 `apply-accounts --confirm yes-apply-account-model-mapping`。 |
+| 发版后 Account model_mapping `check-accounts` 报 violation | **不要** rollback 镜像；审 `$JOBDIR/post-release-account-model-mapping-check.json` 的账号/group diff。期望与 forbidden policy 均来自 Go SSOT；确认要覆盖 live 配置时走 `/tokenkey-modelops-planner` 的 runtime/account mapping 路由：必要时 `validate/check/sync-runtime` 更新 desired layer，然后 `apply-accounts --confirm yes-apply-account-model-mapping`。 |
 | 发版后 Account model_mapping `check-accounts` SSM 失败 | 记 yellow；prod/Edge 镜像仍有效。补 OIDC/实例在线后重跑 `python3 ops/pricing/manage-account-model-mapping-runtime.py check-accounts --json`；仅排障 edge 时加 `--include-edges` 或 `--skip-prod`。 |
 
 ## 扩展阅读

--- a/backend/cmd/server/wire.go
+++ b/backend/cmd/server/wire.go
@@ -147,8 +147,8 @@ func provideCleanup(
 	// TokenKey: forces wire to evaluate ProvideTKGatewayPricingAvailability so
 	// GatewayService.SetPricingAvailabilityService is called at startup. The
 	// handler-side wiring is forced via ProvideTKPricingCatalogHandler being
-	// the constructor used by handler ProviderSet. See R-001 of
-	// docs/approved/pricing-availability-source-of-truth.md.
+	// the constructor used by handler ProviderSet. See
+	// docs/approved/pricing-availability-source-of-truth.md#availability-evidence-owner.
 	_ service.TKGatewayPricingAvailabilityReady,
 	// TokenKey: forces wire to evaluate ProvideTKPricingOverlayRuntime so the
 	// runtime hot-pushable pricing overlay (settings-blob getter + catalog cache
@@ -175,8 +175,8 @@ func provideCleanup(
 	// sustained relay empty-pool responses create exact-model cooldowns.
 	_ service.TKAntigravitySaturationReady,
 	// TokenKey: forces wire to evaluate ProvideTKGatewayHandlerModelList so
-	// GatewayHandler.SetModelListFilter is called at startup. See R-003 /
-	// Goal 2 of docs/approved/pricing-availability-source-of-truth.md.
+	// GatewayHandler.SetModelListFilter is called at startup. See
+	// docs/approved/pricing-availability-source-of-truth.md#availability-structural-pruning.
 	_ handler.TKGatewayHandlerModelListReady,
 	// TokenKey: forces wire to evaluate ProvideTKUniversalModelsProvider so the
 	// universal-key resolver's "group served-model set" truth source

--- a/backend/cmd/server/wire_assertion_tk_test.go
+++ b/backend/cmd/server/wire_assertion_tk_test.go
@@ -14,8 +14,8 @@ import (
 // GatewayService. The sentinel-style provider would silently no-op if its
 // implementation regressed; this test pins the behavior.
 //
-// R-001 of docs/approved/pricing-availability-source-of-truth.md mandates
-// production DI evidence.
+// docs/approved/pricing-availability-source-of-truth.md#availability-evidence-owner
+// requires production DI evidence.
 func TestProvideTKGatewayPricingAvailability_WiresGatewayService(t *testing.T) {
 	// Build a minimal GatewayService — only the availability slot is asserted.
 	gw := &service.GatewayService{}

--- a/backend/ent/schema/channel_monitor.go
+++ b/backend/ent/schema/channel_monitor.go
@@ -115,7 +115,7 @@ func (ChannelMonitor) Fields() []ent.Field {
 		// 自动维护的监控。系统监控由 pricing_availability_seeder_tk.go 生成，
 		// 周期性探测 catalog 内 cold-tail 模型可达性，复用 ChannelMonitorRunner
 		// 的 ticker / pond 调度基础设施而不新建 scheduler。详见
-		// docs/approved/pricing-availability-source-of-truth.md §1.1 / §5.
+		// docs/approved/pricing-availability-source-of-truth.md#availability-operations.
 		field.Enum("kind").
 			Values("user", "system_availability").
 			Default("user"),

--- a/backend/internal/handler/admin/channel_handler_tk_newapi_admin.go
+++ b/backend/internal/handler/admin/channel_handler_tk_newapi_admin.go
@@ -27,9 +27,9 @@ type TKChannelAdminHandler struct {
 //
 // pricingCatalog and availabilitySvc are wired into a DiscoveryFilter so the
 // "fetch upstream models" admin endpoint can tag pricing_status and drop
-// explicitly-unavailable models per docs/approved/pricing-availability-source-of-truth.md
-// §2.4 (Goal 1, R-002). Both may be nil — see DiscoveryFilter for nil-safety
-// semantics.
+// explicitly-unavailable models per
+// docs/approved/pricing-availability-source-of-truth.md#availability-admin-discovery.
+// Both may be nil — see DiscoveryFilter for nil-safety semantics.
 func NewTKChannelAdminHandler(
 	gatewayService *service.GatewayService,
 	adminService service.AdminService,
@@ -264,7 +264,8 @@ func (h *TKChannelAdminHandler) FetchUpstreamModels(c *gin.Context) {
 		return
 	}
 	// Pipeline: drop provider-marked unavailable + drop unreachable cells +
-	// tag pricing_status. Per docs/approved/pricing-availability-source-of-truth.md §2.4.
+	// tag pricing_status. Per
+	// docs/approved/pricing-availability-source-of-truth.md#availability-admin-discovery.
 	// Platform is "newapi" — the channel-type accounts always belong to the
 	// fifth platform (per CLAUDE.md fifth-platform doctrine).
 	models := h.discoveryFilter.Apply(c.Request.Context(), service.PlatformNewAPI, rawModels)

--- a/backend/internal/handler/gateway_handler_tk_forward_error.go
+++ b/backend/internal/handler/gateway_handler_tk_forward_error.go
@@ -6,8 +6,8 @@ package handler
 // failure tap site (5 today: gateway_handler.go × 2, chat_completions, responses,
 // gemini_v1beta) should be a single line; the errors.As extraction lives here.
 //
-// Why this helper exists (R-004 of
-// docs/approved/pricing-availability-source-of-truth.md):
+// Why this helper exists:
+// docs/approved/pricing-availability-source-of-truth.md#availability-evidence-owner.
 //
 // Before: handlers passed statusCode=0 to TKRecordForwardFailure. The
 // classifier in pricing_availability_service_tk.go requires UpstreamStatusCode

--- a/backend/internal/handler/gateway_handler_tk_model_list.go
+++ b/backend/internal/handler/gateway_handler_tk_model_list.go
@@ -18,8 +18,8 @@ import (
 // during Wire DI setup; absent call = filter disabled (FilterClientFacing is
 // nil-safe → fail-open, returns candidates unchanged).
 //
-// Per docs/approved/pricing-availability-source-of-truth.md §2.5 (Goal 2,
-// R-003). Mirrors GatewayService.SetPricingAvailabilityService in shape.
+// Per docs/approved/pricing-availability-source-of-truth.md#availability-structural-pruning.
+// Mirrors GatewayService.SetPricingAvailabilityService in shape.
 func (h *GatewayHandler) SetModelListFilter(f *service.ModelListFilter) {
 	if h != nil {
 		h.tkModelListFilter = f

--- a/backend/internal/integration/newapi/discover_filter_tk.go
+++ b/backend/internal/integration/newapi/discover_filter_tk.go
@@ -1,7 +1,7 @@
 package newapi
 
 // TokenKey: upstream model-discovery filter pipeline.
-// Spec: docs/approved/pricing-availability-source-of-truth.md §2.4 (R-002, Goal 1).
+// Spec: docs/approved/pricing-availability-source-of-truth.md#availability-admin-discovery.
 //
 // Pipeline:
 //   raw upstream /v1/models response

--- a/backend/internal/integration/newapi/fetch_upstream_models.go
+++ b/backend/internal/integration/newapi/fetch_upstream_models.go
@@ -37,7 +37,7 @@ func IsKnownChannelType(t int) bool {
 // DiscoveryFilter.Apply) is responsible for the model_availability table check
 // + pricing_status tagging.
 //
-// Per docs/approved/pricing-availability-source-of-truth.md §2.4 (Goal 1).
+// Per docs/approved/pricing-availability-source-of-truth.md#availability-admin-discovery.
 func FetchUpstreamModelList(ctx context.Context, baseURL string, channelType int, apiKey string) ([]rawDiscoveredModel, error) {
 	if ctx == nil {
 		ctx = context.Background()

--- a/backend/internal/repository/model_availability_repo_tk.go
+++ b/backend/internal/repository/model_availability_repo_tk.go
@@ -14,7 +14,7 @@ import (
 //
 // PR-1 synchronous implementation — one PG round-trip per RecordOutcome.
 // Redis write-buffer optimisation is deferred to PR-2 / PR-3 (see
-// docs/approved/pricing-availability-source-of-truth.md §2.2).
+// docs/approved/pricing-availability-source-of-truth.md#availability-catalog-decoration).
 type modelAvailabilityRepository struct {
 	client *dbent.Client
 

--- a/backend/internal/service/account_model_mapping_preset_tk_xrtoken_test.go
+++ b/backend/internal/service/account_model_mapping_preset_tk_xrtoken_test.go
@@ -114,7 +114,7 @@ func TestXRTokenManifestScopeOwnsAllFiveModels(t *testing.T) {
 // Before this override existed the bundle carried no XRToken scope at all, so
 // activation had nothing to add and refused with "bundle delta has no added or
 // retargeted required model mappings" — i.e. the documented
-// `served-via-modelops-activation` path could not actually run.
+// the declared modelops activation path could not actually run.
 //
 // Two assertions, both load-bearing:
 //

--- a/backend/internal/service/pricing_catalog_membership_tk.go
+++ b/backend/internal/service/pricing_catalog_membership_tk.go
@@ -1,7 +1,7 @@
 package service
 
-// TokenKey: catalog-membership predicates for the upstream-discovery filter
-// (R-002, Goal 1) and client model-list filter (R-003, Goal 2).
+// TokenKey: catalog-membership predicates shared by the upstream-discovery
+// filter and client model-list filter.
 //
 // Why this lives in a TK companion file rather than pricing_catalog_tk.go:
 // the catalog parsing/build code in the primary file is mostly upstream-shaped
@@ -22,11 +22,8 @@ import (
 )
 
 // IsModelPriced reports whether modelID has a pricing entry in the catalog.
-// The platform parameter is reserved for a future *cross-vendor* pricing
-// split — e.g. claude-3-haiku-20240307 priced differently on Bedrock vs
-// anthropic.com (see §8 of docs/approved/pricing-availability-source-of-truth.md
-// "遗留事项") — and is currently ignored; the catalog is platform-agnostic
-// in v1. Note: <vendor>/<model>-style ids already carry their own
+// The platform parameter is currently ignored because catalog membership is
+// platform-agnostic. Note: <vendor>/<model>-style ids already carry their own
 // per-vendor signal via the "/" prefix, which the fallback below consumes
 // without needing the platform argument.
 //

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -1,19 +1,20 @@
 {
   "_doc": "TokenKey served-models MANIFEST — the single declarative source of intent for 'TK serves model M on platform P via an account credentials.model_mapping whitelist, at price π, display=yes/no'. This is a THIN INTENT layer ABOVE the two mechanisms it must agree with: (1) per-account credentials.model_mapping (the runtime servable WHITELIST; new floors are written only by evidence-backed modelops activation, while legacy rows may come from migrations/admin seed state), and (2) tk_pricing_overlay.json as the complete global price registry. Generic deploy/rollback never writes live mappings or pricing. scripts/checks/catalog-serving-drift.py asserts repository agreement; modelops activate proves and writes live mapping agreement before release. SCOPE: ONLY the TK-curated, account-model_mapping-served newapi long-tail — qwen/deepseek, Moonshot/Kimi channel_type 25, GLM through the configured China newapi pool, and VolcEngine Ark chat/image/video. NOT the litellm catalog, native-platform allowlists, or grok. Consumers: drift guard, tokenkey-onboard-model skill, public /pricing + Group Catalog filters, and the account model_mapping bundle/reconciler. Co-located with tk_pricing_overlay.json so the same Go package embeds both and preflight parses both.",
   "_schema": {
-    "version": 1,
+    "version": 2,
     "entry_key": "<platform>/<model_id>",
     "fields": {
       "platform": "account/group platform string; for this manifest always 'newapi' (the fifth platform). MUST equal the served account's accounts.platform.",
       "model_id": "the client-facing model id that must appear as a KEY in the served account's credentials.model_mapping whitelist (identity-mapped: key==value for these accounts).",
-      "served_on": "string list of accounts.id (as strings) whose credentials.model_mapping MUST advertise model_id. This is a static drift-guard/evidence anchor, not the complete live serving pool; account membership can expand or shrink in runtime DB/admin config. New floors declare served-via-modelops-activation in notes; legacy rows may be evidenced by a migration or served-via-admin-ui marker.",
+      "served_on": "string list of accounts.id (as strings) whose credentials.model_mapping MUST advertise model_id. This is a static drift-guard/evidence anchor, not the complete live serving pool; account membership can expand or shrink in runtime DB/admin config. Rows without migration evidence declare mapping_source.",
       "channel_type": "the newapi channel_type of the serving account (17=Ali/DashScope, 25=Moonshot, 43=DeepSeek, 45=VolcEngine; 26=ZhipuV4 only if a future direct GLM pool is re-provisioned). Documents the upstream adaptor; not asserted against DB (admin-UI editable) but recorded for the reconciler.",
       "account_scope": "optional primary object with platform + channel_type + normalized base_url. When present, it adds a property-scoped serving pool; served_on remains evidence only.",
       "account_scopes": "optional additional platform + channel_type + normalized base_url objects for models shared by multiple property-scoped pools. Use this instead of duplicating model ids in Go.",
       "price_source": "one of 'overlay' (historical token meaning the complete tk_pricing_overlay.json registry) or 'channel' (explicitly scoped channel_model_pricing DB rows). Provider/LiteLLM mirrors are sensor evidence and never an effective price source.",
       "price_key": "the complete-registry owner key, or the scoped channel pricing model id. Usually == model_id.",
       "display": "bool. true => this manifest-listed, priced, mapped model is allowed to appear in public /pricing and model-menu display surfaces. false keeps the runtime mapping/pricing intent but hides the model until the SSOT display gate proves it or entitlement/provisioning is fixed.",
-      "notes": "free-form provenance / known-gap marker."
+      "notes": "free-form human provenance / known-gap context; never parsed for machine policy.",
+      "mapping_source": "optional repository mapping provenance when tk_*.sql does not evidence every served_on account: activation (evidence-backed modelops activation) or admin_legacy (pre-contract admin state, advisory only). Omit when migrations fully evidence the row."
     }
   },
   "entries": {
@@ -34,7 +35,15 @@
       "price_source": "overlay",
       "price_key": "deepseek-v4-pro",
       "display": true,
-      "notes": "ds-官 account 39. Mapped by tk_022 (identity whitelist). Priced in overlay from DeepSeek official list (https://api-docs.deepseek.com/quick_start/pricing, captured 2026-08-17); every serving account, including Baidu Qianfan account 90, bills from the single deepseek-v4-pro owner and follows its peak-valley policy. served-via-admin-ui (model_mapping predates the tk_*.sql era / set out-of-band; A3 downgraded to WARN). Also on VolcEngine Agent Plan account 88; mapped by tk_068; probe 200 on 2026-07-30. Also on Baidu Qianfan account 90 (ch46); probe 200 on 2026-08-07. Account 90 mapping: served-via-modelops-activation."
+      "notes": "ds-官 account 39. Mapped by tk_022 (identity whitelist). Priced in overlay from DeepSeek official list (https://api-docs.deepseek.com/quick_start/pricing, captured 2026-08-17); every serving account, including Baidu Qianfan account 90, bills from the single deepseek-v4-pro owner and follows its peak-valley policy. The account 39 model_mapping predates the tk_*.sql era and was provisioned through the admin UI. Also on VolcEngine Agent Plan account 88; mapped by tk_068; probe 200 on 2026-07-30. Also on Baidu Qianfan account 90 (ch46); probe 200 on 2026-08-07.",
+      "mapping_source": "activation",
+      "account_scopes": [
+        {
+          "platform": "newapi",
+          "channel_type": 46,
+          "base_url": "https://qianfan.baidubce.com"
+        }
+      ]
     },
     "newapi/deepseek-v4-flash": {
       "platform": "newapi",
@@ -53,7 +62,15 @@
       "price_source": "overlay",
       "price_key": "deepseek-v4-flash",
       "display": true,
-      "notes": "ds-官 account 39. Mapped by tk_022. Priced in overlay from DeepSeek official list (https://api-docs.deepseek.com/quick_start/pricing, captured 2026-08-17); every serving account, including Baidu Qianfan account 90, bills from the single deepseek-v4-flash owner and follows its peak-valley policy. served-via-admin-ui (model_mapping predates the tk_*.sql era / set out-of-band; A3 downgraded to WARN). Also on VolcEngine Agent Plan account 88; mapped by tk_068; probe 200 on 2026-07-30. Also on Baidu Qianfan account 90 (ch46); probe 200 on 2026-08-07. Account 90 mapping: served-via-modelops-activation."
+      "notes": "ds-官 account 39. Mapped by tk_022. Priced in overlay from DeepSeek official list (https://api-docs.deepseek.com/quick_start/pricing, captured 2026-08-17); every serving account, including Baidu Qianfan account 90, bills from the single deepseek-v4-flash owner and follows its peak-valley policy. The account 39 model_mapping predates the tk_*.sql era and was provisioned through the admin UI. Also on VolcEngine Agent Plan account 88; mapped by tk_068; probe 200 on 2026-07-30. Also on Baidu Qianfan account 90 (ch46); probe 200 on 2026-08-07.",
+      "mapping_source": "activation",
+      "account_scopes": [
+        {
+          "platform": "newapi",
+          "channel_type": 46,
+          "base_url": "https://qianfan.baidubce.com"
+        }
+      ]
     },
     "newapi/deepseek-chat": {
       "platform": "newapi",
@@ -89,7 +106,8 @@
       "price_source": "overlay",
       "price_key": "kimi-k2.5",
       "display": true,
-      "notes": "Moonshot China account 83 (kimi). served-via-modelops-activation. Official China price in overlay. Upstream /v1/models listed and direct chat plus prod gateway account probe returned 200 on 2026-07-20."
+      "notes": "Moonshot China account 83 (kimi). Official China price in overlay. Upstream /v1/models listed and direct chat plus prod gateway account probe returned 200 on 2026-07-20.",
+      "mapping_source": "activation"
     },
     "newapi/kimi-k2.6": {
       "platform": "newapi",
@@ -108,7 +126,15 @@
       "price_source": "overlay",
       "price_key": "kimi-k2.6",
       "display": true,
-      "notes": "Moonshot China account 83 (kimi). served-via-modelops-activation. Official China price in overlay. Upstream /v1/models listed and direct chat returned 200 on 2026-07-20. Also on VolcEngine Agent Plan account 88 (ch45 /api/plan/v3); mapped by tk_068; probe 200 on 2026-07-30. Also on Baidu Qianfan account 90 (ch46); probe 200 on 2026-08-07. Account 90 mapping: served-via-modelops-activation."
+      "notes": "Moonshot China account 83 (kimi). Official China price in overlay. Upstream /v1/models listed and direct chat returned 200 on 2026-07-20. Also on VolcEngine Agent Plan account 88 (ch45 /api/plan/v3); mapped by tk_068; probe 200 on 2026-07-30. Also on Baidu Qianfan account 90 (ch46); probe 200 on 2026-08-07.",
+      "mapping_source": "activation",
+      "account_scopes": [
+        {
+          "platform": "newapi",
+          "channel_type": 46,
+          "base_url": "https://qianfan.baidubce.com"
+        }
+      ]
     },
     "newapi/kimi-k2.7-code": {
       "platform": "newapi",
@@ -126,7 +152,8 @@
       "price_source": "overlay",
       "price_key": "kimi-k2.7-code",
       "display": true,
-      "notes": "Moonshot China account 83 (kimi). served-via-modelops-activation. Official China price in overlay. Upstream /v1/models listed and direct chat returned 200 on 2026-07-20. Also on VolcEngine Agent Plan account 88 (ch45 /api/plan/v3); mapped by tk_068; probe 200 on 2026-07-30."
+      "notes": "Moonshot China account 83 (kimi). Official China price in overlay. Upstream /v1/models listed and direct chat returned 200 on 2026-07-20. Also on VolcEngine Agent Plan account 88 (ch45 /api/plan/v3); mapped by tk_068; probe 200 on 2026-07-30.",
+      "mapping_source": "activation"
     },
     "newapi/kimi-k2.7-code-highspeed": {
       "platform": "newapi",
@@ -138,7 +165,8 @@
       "price_source": "overlay",
       "price_key": "kimi-k2.7-code-highspeed",
       "display": true,
-      "notes": "Moonshot China account 83 (kimi). served-via-modelops-activation. Official China high-speed price in overlay. Upstream /v1/models listed and direct chat returned 200 on 2026-07-20."
+      "notes": "Moonshot China account 83 (kimi). Official China high-speed price in overlay. Upstream /v1/models listed and direct chat returned 200 on 2026-07-20.",
+      "mapping_source": "activation"
     },
     "newapi/kimi-k3": {
       "platform": "newapi",
@@ -156,7 +184,8 @@
       "price_source": "overlay",
       "price_key": "kimi-k3",
       "display": true,
-      "notes": "Moonshot China account 83 (kimi). served-via-modelops-activation. Official China price in overlay. Upstream /v1/models listed and direct chat returned 200 on 2026-07-20. Also on VolcEngine Agent Plan account 88 (ch45 /api/plan/v3); mapped by tk_068; probe 200 on 2026-07-30."
+      "notes": "Moonshot China account 83 (kimi). Official China price in overlay. Upstream /v1/models listed and direct chat returned 200 on 2026-07-20. Also on VolcEngine Agent Plan account 88 (ch45 /api/plan/v3); mapped by tk_068; probe 200 on 2026-07-30.",
+      "mapping_source": "activation"
     },
     "newapi/moonshot-v1-8k": {
       "platform": "newapi",
@@ -168,7 +197,8 @@
       "price_source": "overlay",
       "price_key": "moonshot-v1-8k",
       "display": true,
-      "notes": "Moonshot China account 83 (kimi). served-via-modelops-activation. Official China 8K price in overlay. Upstream /v1/models listed and direct chat returned 200 on 2026-07-20; official docs announce Moonshot V1 retirement on 2026-08-31."
+      "notes": "Moonshot China account 83 (kimi). Official China 8K price in overlay. Upstream /v1/models listed and direct chat returned 200 on 2026-07-20; official docs announce Moonshot V1 retirement on 2026-08-31.",
+      "mapping_source": "activation"
     },
     "newapi/moonshot-v1-8k-vision-preview": {
       "platform": "newapi",
@@ -180,7 +210,8 @@
       "price_source": "overlay",
       "price_key": "moonshot-v1-8k-vision-preview",
       "display": true,
-      "notes": "Moonshot China account 83 (kimi). served-via-modelops-activation. Official China 8K vision price in overlay. Upstream /v1/models listed and direct text chat returned 200 on 2026-07-20; official docs announce Moonshot V1 retirement on 2026-08-31."
+      "notes": "Moonshot China account 83 (kimi). Official China 8K vision price in overlay. Upstream /v1/models listed and direct text chat returned 200 on 2026-07-20; official docs announce Moonshot V1 retirement on 2026-08-31.",
+      "mapping_source": "activation"
     },
     "newapi/moonshot-v1-32k": {
       "platform": "newapi",
@@ -192,7 +223,8 @@
       "price_source": "overlay",
       "price_key": "moonshot-v1-32k",
       "display": true,
-      "notes": "Moonshot China account 83 (kimi). served-via-modelops-activation. Official China 32K price in overlay. Upstream /v1/models listed and direct chat returned 200 on 2026-07-20; official docs announce Moonshot V1 retirement on 2026-08-31."
+      "notes": "Moonshot China account 83 (kimi). Official China 32K price in overlay. Upstream /v1/models listed and direct chat returned 200 on 2026-07-20; official docs announce Moonshot V1 retirement on 2026-08-31.",
+      "mapping_source": "activation"
     },
     "newapi/moonshot-v1-32k-vision-preview": {
       "platform": "newapi",
@@ -204,7 +236,8 @@
       "price_source": "overlay",
       "price_key": "moonshot-v1-32k-vision-preview",
       "display": true,
-      "notes": "Moonshot China account 83 (kimi). served-via-modelops-activation. Official China 32K vision price in overlay. Upstream /v1/models listed and direct text chat returned 200 on 2026-07-20; official docs announce Moonshot V1 retirement on 2026-08-31."
+      "notes": "Moonshot China account 83 (kimi). Official China 32K vision price in overlay. Upstream /v1/models listed and direct text chat returned 200 on 2026-07-20; official docs announce Moonshot V1 retirement on 2026-08-31.",
+      "mapping_source": "activation"
     },
     "newapi/moonshot-v1-128k": {
       "platform": "newapi",
@@ -216,7 +249,8 @@
       "price_source": "overlay",
       "price_key": "moonshot-v1-128k",
       "display": true,
-      "notes": "Moonshot China account 83 (kimi). served-via-modelops-activation. Official China 128K price in overlay. Upstream /v1/models listed and direct chat returned 200 on 2026-07-20; official docs announce Moonshot V1 retirement on 2026-08-31."
+      "notes": "Moonshot China account 83 (kimi). Official China 128K price in overlay. Upstream /v1/models listed and direct chat returned 200 on 2026-07-20; official docs announce Moonshot V1 retirement on 2026-08-31.",
+      "mapping_source": "activation"
     },
     "newapi/moonshot-v1-128k-vision-preview": {
       "platform": "newapi",
@@ -228,7 +262,8 @@
       "price_source": "overlay",
       "price_key": "moonshot-v1-128k-vision-preview",
       "display": true,
-      "notes": "Moonshot China account 83 (kimi). served-via-modelops-activation. Official China 128K vision price in overlay. Upstream /v1/models listed and direct text chat returned 200 on 2026-07-20; official docs announce Moonshot V1 retirement on 2026-08-31."
+      "notes": "Moonshot China account 83 (kimi). Official China 128K vision price in overlay. Upstream /v1/models listed and direct text chat returned 200 on 2026-07-20; official docs announce Moonshot V1 retirement on 2026-08-31.",
+      "mapping_source": "activation"
     },
     "newapi/moonshot-v1-auto": {
       "platform": "newapi",
@@ -240,7 +275,8 @@
       "price_source": "overlay",
       "price_key": "moonshot-v1-auto",
       "display": true,
-      "notes": "Moonshot China account 83 (kimi). served-via-modelops-activation. Fixed at the official Moonshot V1 128K price by operator decision because auto may select the highest tier; upstream /v1/models listed and direct chat returned 200 on 2026-07-20 (the minimal probe selected moonshot-v1-8k). Official docs announce Moonshot V1 retirement on 2026-08-31."
+      "notes": "Moonshot China account 83 (kimi). Fixed at the official Moonshot V1 128K price by operator decision because auto may select the highest tier; upstream /v1/models listed and direct chat returned 200 on 2026-07-20 (the minimal probe selected moonshot-v1-8k). Official docs announce Moonshot V1 retirement on 2026-08-31.",
+      "mapping_source": "activation"
     },
     "newapi/qwen3.7-max": {
       "platform": "newapi",
@@ -264,7 +300,8 @@
       "price_source": "overlay",
       "price_key": "qwen3.7-max-preview",
       "display": true,
-      "notes": "Qwen channel_type=17 pool; served_on account 60 is static mapping evidence, not complete live pool membership. Priced in overlay. Present in 2026-06-23 prod account mapping and confirmed by livefire: thinking 200; nonthinking 400 request-shape. served-via-admin-ui."
+      "notes": "Qwen channel_type=17 pool; served_on account 60 is static mapping evidence, not complete live pool membership. Priced in overlay. Present in 2026-06-23 prod account mapping and confirmed by livefire: thinking 200; nonthinking 400 request-shape.",
+      "mapping_source": "admin_legacy"
     },
     "newapi/qwen3.7-max-2026-05-17": {
       "platform": "newapi",
@@ -276,7 +313,8 @@
       "price_source": "overlay",
       "price_key": "qwen3.7-max-2026-05-17",
       "display": true,
-      "notes": "Qwen channel_type=17 pool; served_on account 60 is static mapping evidence, not complete live pool membership. Priced in overlay. Present in 2026-06-23 prod account mapping and confirmed by livefire: thinking 200; nonthinking 400 request-shape. served-via-admin-ui."
+      "notes": "Qwen channel_type=17 pool; served_on account 60 is static mapping evidence, not complete live pool membership. Priced in overlay. Present in 2026-06-23 prod account mapping and confirmed by livefire: thinking 200; nonthinking 400 request-shape.",
+      "mapping_source": "admin_legacy"
     },
     "newapi/qwen3.7-max-2026-05-20": {
       "platform": "newapi",
@@ -288,7 +326,8 @@
       "price_source": "overlay",
       "price_key": "qwen3.7-max-2026-05-20",
       "display": true,
-      "notes": "Qwen channel_type=17 pool; served_on account 60 is static mapping evidence, not complete live pool membership. Priced in overlay. Present in 2026-06-23 prod account mapping and confirmed by livefire: thinking 200; nonthinking 200. served-via-admin-ui."
+      "notes": "Qwen channel_type=17 pool; served_on account 60 is static mapping evidence, not complete live pool membership. Priced in overlay. Present in 2026-06-23 prod account mapping and confirmed by livefire: thinking 200; nonthinking 200.",
+      "mapping_source": "admin_legacy"
     },
     "newapi/qwen3.7-max-2026-06-08": {
       "platform": "newapi",
@@ -300,7 +339,8 @@
       "price_source": "overlay",
       "price_key": "qwen3.7-max-2026-06-08",
       "display": true,
-      "notes": "Qwen channel_type=17 pool; served_on account 60 is static mapping evidence, not complete live pool membership. Priced in overlay. Present in 2026-06-23 prod account mapping and confirmed by livefire: thinking 200; nonthinking 200. served-via-admin-ui."
+      "notes": "Qwen channel_type=17 pool; served_on account 60 is static mapping evidence, not complete live pool membership. Priced in overlay. Present in 2026-06-23 prod account mapping and confirmed by livefire: thinking 200; nonthinking 200.",
+      "mapping_source": "admin_legacy"
     },
     "newapi/qwen3.7-plus": {
       "platform": "newapi",
@@ -327,7 +367,8 @@
       "price_source": "overlay",
       "price_key": "qwen3.7-flash",
       "display": true,
-      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77,78 are static mapping evidence, not complete live pool membership. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14; account 78 exact-account gateway probes returned 200 on 2026-08-23. Tiered (overlay intervals)."
+      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77,78 are static mapping evidence, not complete live pool membership. Direct + exact-account gateway probes returned 200 on 2026-08-14; account 78 exact-account gateway probes returned 200 on 2026-08-23. Tiered (overlay intervals).",
+      "mapping_source": "activation"
     },
     "newapi/qwen3.7-flash-2026-07-15": {
       "platform": "newapi",
@@ -342,7 +383,8 @@
       "price_source": "overlay",
       "price_key": "qwen3.7-flash-2026-07-15",
       "display": true,
-      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77,78 are static mapping evidence, not complete live pool membership. Dated snapshot of qwen3.7-flash. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14; account 78 exact-account gateway probes returned 200 on 2026-08-23. Tiered (overlay intervals)."
+      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77,78 are static mapping evidence, not complete live pool membership. Dated snapshot of qwen3.7-flash. Direct + exact-account gateway probes returned 200 on 2026-08-14; account 78 exact-account gateway probes returned 200 on 2026-08-23. Tiered (overlay intervals).",
+      "mapping_source": "activation"
     },
     "newapi/qwen3.8-2.4t-a95b": {
       "platform": "newapi",
@@ -357,7 +399,8 @@
       "price_source": "overlay",
       "price_key": "qwen3.8-2.4t-a95b",
       "display": true,
-      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77,78 are static mapping evidence, not complete live pool membership. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14 (thinking/streaming only); account 78 exact-account gateway probes returned 200 on 2026-08-23 (thinking/streaming only). Non-thinking probe shape returns 400 (request-shape constraint, not upstream unavailability)."
+      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77,78 are static mapping evidence, not complete live pool membership. Direct + exact-account gateway probes returned 200 on 2026-08-14 (thinking/streaming only); account 78 exact-account gateway probes returned 200 on 2026-08-23 (thinking/streaming only). Non-thinking probe shape returns 400 (request-shape constraint, not upstream unavailability).",
+      "mapping_source": "activation"
     },
     "newapi/qwen3.8-max": {
       "platform": "newapi",
@@ -372,7 +415,8 @@
       "price_source": "overlay",
       "price_key": "qwen3.8-max",
       "display": true,
-      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77,78 are static mapping evidence, not complete live pool membership. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14; account 78 exact-account gateway probes returned 200 on 2026-08-23."
+      "notes": "Qwen channel_type=17 pool; served_on accounts 60,72,77,78 are static mapping evidence, not complete live pool membership. Direct + exact-account gateway probes returned 200 on 2026-08-14; account 78 exact-account gateway probes returned 200 on 2026-08-23.",
+      "mapping_source": "activation"
     },
     "newapi/qwen3.6-flash": {
       "platform": "newapi",
@@ -740,7 +784,8 @@
       "price_source": "overlay",
       "price_key": "doubao-seedance-1-5-pro-251215",
       "display": true,
-      "notes": "volcengine account 7. Seedance 1.5-pro VIDEO model, mapped by tk_033. Priced in overlay (output_cost_per_second, VolcEngine Ark official 1080p-with-audio max tier). Also served on XRToken account 96 through the additional property scope above; same Ark model id, so the adaptor-only vendor prefix leaves the overlay billing key unchanged. Account 96 mapping: served-via-modelops-activation."
+      "notes": "volcengine account 7. Seedance 1.5-pro VIDEO model, mapped by tk_033. Priced in overlay (output_cost_per_second, VolcEngine Ark official 1080p-with-audio max tier). Also served on XRToken account 96 through the additional property scope above; same Ark model id, so the adaptor-only vendor prefix leaves the overlay billing key unchanged.",
+      "mapping_source": "activation"
     },
     "newapi/doubao-seedance-1-0-pro-fast-251015": {
       "platform": "newapi",
@@ -772,7 +817,8 @@
       "price_source": "overlay",
       "price_key": "doubao-seedance-2-0-260128",
       "display": true,
-      "notes": "volcengine account 7. Seedance 2.0 VIDEO model, mapped by tk_033. Priced in overlay (output_cost_per_second, VolcEngine Ark official 1080p text/image-to-video tier). NOTE: video-input continuation is rejected upstream of pricing by the video submit guard until re-priced. Also served on XRToken account 96 through the additional property scope above; the task adaptor adds XRToken's vendor prefix only on the wire, preserving this Ark billing id. Account 96 mapping: served-via-modelops-activation."
+      "notes": "volcengine account 7. Seedance 2.0 VIDEO model, mapped by tk_033. Priced in overlay (output_cost_per_second, VolcEngine Ark official 1080p text/image-to-video tier). NOTE: video-input continuation is rejected upstream of pricing by the video submit guard until re-priced. Also served on XRToken account 96 through the additional property scope above; the task adaptor adds XRToken's vendor prefix only on the wire, preserving this Ark billing id.",
+      "mapping_source": "activation"
     },
     "newapi/doubao-seedance-2-0-fast-260128": {
       "platform": "newapi",
@@ -792,7 +838,8 @@
       "price_source": "overlay",
       "price_key": "doubao-seedance-2-0-fast-260128",
       "display": true,
-      "notes": "volcengine account 7. Seedance 2.0-fast VIDEO model, mapped by tk_033. Priced in overlay (output_cost_per_second, VolcEngine Ark official 720p max-output tier). Also served on XRToken account 96 through the additional property scope above; the task adaptor adds XRToken's vendor prefix only on the wire, preserving this Ark billing id. Account 96 mapping: served-via-modelops-activation."
+      "notes": "volcengine account 7. Seedance 2.0-fast VIDEO model, mapped by tk_033. Priced in overlay (output_cost_per_second, VolcEngine Ark official 720p max-output tier). Also served on XRToken account 96 through the additional property scope above; the task adaptor adds XRToken's vendor prefix only on the wire, preserving this Ark billing id.",
+      "mapping_source": "activation"
     },
     "newapi/doubao-seedance-2-5-260628": {
       "platform": "newapi",
@@ -809,7 +856,8 @@
       "price_source": "overlay",
       "price_key": "doubao-seedance-2-5-260628",
       "display": true,
-      "notes": "XRToken account 96 (platform=newapi, channel_type=54 DoubaoVideo, base_url=https://api.xrtoken.net). Seedance 2.5 VIDEO model reached through the ARK-compatible task-adaptor wrapper in internal/relay/bridge/video_relay_tk_xrtoken.go (XRToken serves Ark bodies at /v1/contents/generations/tasks instead of Ark's /api/v3 path). XRToken exposes the SKU as volcengine/doubao-seedance-2-5-260628; the task adaptor adds that prefix only on the upstream wire while the identity model_mapping preserves this Ark billing id, so the overlay price applies. Priced in overlay from the VolcEngine Ark official model-pricing page 70.00 CNY/M-token input-without-video rate; Ark publishes ONLY 480p/720p for this SKU, so the tiers stop at 720p on purpose — inventing a 1080p tier would silently bill a resolution the upstream does not produce. Video-input continuation stays rejected by the video submit guard (it bills input+output duration). Account 96 mapping: served-via-modelops-activation."
+      "notes": "XRToken account 96 (platform=newapi, channel_type=54 DoubaoVideo, base_url=https://api.xrtoken.net). Seedance 2.5 VIDEO model reached through the ARK-compatible task-adaptor wrapper in internal/relay/bridge/video_relay_tk_xrtoken.go (XRToken serves Ark bodies at /v1/contents/generations/tasks instead of Ark's /api/v3 path). XRToken exposes the SKU as volcengine/doubao-seedance-2-5-260628; the task adaptor adds that prefix only on the upstream wire while the identity model_mapping preserves this Ark billing id, so the overlay price applies. Priced in overlay from the VolcEngine Ark official model-pricing page 70.00 CNY/M-token input-without-video rate; Ark publishes ONLY 480p/720p for this SKU, so the tiers stop at 720p on purpose — inventing a 1080p tier would silently bill a resolution the upstream does not produce. Video-input continuation stays rejected by the video submit guard (it bills input+output duration).",
+      "mapping_source": "activation"
     },
     "newapi/doubao-seedance-2.0-mini": {
       "platform": "newapi",
@@ -826,7 +874,8 @@
       "price_source": "overlay",
       "price_key": "doubao-seedance-2.0-mini",
       "display": true,
-      "notes": "XRToken account 96 (platform=newapi, channel_type=54 DoubaoVideo, base_url=https://api.xrtoken.net). Seedance 2.0 Mini VIDEO model via the ARK-compatible task-adaptor wrapper in internal/relay/bridge/video_relay_tk_xrtoken.go. The dotted id is Ark's OWN spelling on the official model-pricing page (doubao-seedance-2.0-mini, no date suffix), not an XRToken rename, so it is also the Ark billing id and the overlay price key; XRToken exposes it as volcengine/doubao-seedance-2.0-mini; the task adaptor adds that prefix only on the upstream wire while the account model_mapping remains identity. Priced in overlay from the Ark official 23.00 CNY/M-token input-without-video LIST rate — the page's 限时4折 promo is deliberately NOT applied, matching every existing seedance row (a promo expiry would otherwise turn into silent under-billing). Ark publishes ONLY 480p/720p for this SKU so the tiers stop at 720p. Video-input continuation stays rejected by the video submit guard. Account 96 mapping: served-via-modelops-activation."
+      "notes": "XRToken account 96 (platform=newapi, channel_type=54 DoubaoVideo, base_url=https://api.xrtoken.net). Seedance 2.0 Mini VIDEO model via the ARK-compatible task-adaptor wrapper in internal/relay/bridge/video_relay_tk_xrtoken.go. The dotted id is Ark's OWN spelling on the official model-pricing page (doubao-seedance-2.0-mini, no date suffix), not an XRToken rename, so it is also the Ark billing id and the overlay price key; XRToken exposes it as volcengine/doubao-seedance-2.0-mini; the task adaptor adds that prefix only on the upstream wire while the account model_mapping remains identity. Priced in overlay from the Ark official 23.00 CNY/M-token input-without-video LIST rate — the page's 限时4折 promo is deliberately NOT applied, matching every existing seedance row (a promo expiry would otherwise turn into silent under-billing). Ark publishes ONLY 480p/720p for this SKU so the tiers stop at 720p. Video-input continuation stays rejected by the video submit guard.",
+      "mapping_source": "activation"
     },
     "newapi/doubao-seedream-4-0-250828": {
       "platform": "newapi",
@@ -882,7 +931,15 @@
       "price_source": "overlay",
       "price_key": "glm-5.2",
       "display": true,
-      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time). Also on VolcEngine Agent Plan account 88 (ch45 /api/plan/v3); mapped by tk_068; probe 200 on 2026-07-30. Also on Baidu Qianfan account 90 (ch46); Qianfan console confirms ¥0.008/¥0.028 per 1k in/out; probe 200 on 2026-08-07. Account 90 mapping: served-via-modelops-activation."
+      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time). Also on VolcEngine Agent Plan account 88 (ch45 /api/plan/v3); mapped by tk_068; probe 200 on 2026-07-30. Also on Baidu Qianfan account 90 (ch46); Qianfan console confirms ¥0.008/¥0.028 per 1k in/out; probe 200 on 2026-08-07.",
+      "mapping_source": "activation",
+      "account_scopes": [
+        {
+          "platform": "newapi",
+          "channel_type": 46,
+          "base_url": "https://qianfan.baidubce.com"
+        }
+      ]
     },
     "newapi/glm-5.2-fast-preview": {
       "platform": "newapi",
@@ -897,7 +954,8 @@
       "price_source": "overlay",
       "price_key": "glm-5.2-fast-preview",
       "display": true,
-      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on accounts 60,72,77,78 are static mapping-evidence anchors, while live account membership comes from runtime DB/admin config. served-via-modelops-activation. Direct + exact-account gateway probes returned 200 on 2026-08-14; account 78 exact-account gateway probes returned 200 on 2026-08-23. Overlay uses Alibaba DashScope official China-mainland pricing (https://help.aliyun.com/zh/model-studio/model-pricing, captured 2026-08-14; CNY/USD=6.7)."
+      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on accounts 60,72,77,78 are static mapping-evidence anchors, while live account membership comes from runtime DB/admin config. Direct + exact-account gateway probes returned 200 on 2026-08-14; account 78 exact-account gateway probes returned 200 on 2026-08-23. Overlay uses Alibaba DashScope official China-mainland pricing (https://help.aliyun.com/zh/model-studio/model-pricing, captured 2026-08-14; CNY/USD=6.7).",
+      "mapping_source": "activation"
     },
     "newapi/glm-5.1": {
       "platform": "newapi",
@@ -911,7 +969,15 @@
       "price_source": "overlay",
       "price_key": "glm-5.1",
       "display": true,
-      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time). Also on Baidu Qianfan account 90 (ch46); probe 200 on 2026-08-07. Account 90 mapping: served-via-modelops-activation."
+      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time). Also on Baidu Qianfan account 90 (ch46); probe 200 on 2026-08-07.",
+      "mapping_source": "activation",
+      "account_scopes": [
+        {
+          "platform": "newapi",
+          "channel_type": 46,
+          "base_url": "https://qianfan.baidubce.com"
+        }
+      ]
     },
     "newapi/glm-5": {
       "platform": "newapi",
@@ -925,7 +991,15 @@
       "price_source": "overlay",
       "price_key": "glm-5",
       "display": true,
-      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time). Also on Baidu Qianfan account 90 (ch46); probe 200 on 2026-08-07. Account 90 mapping: served-via-modelops-activation."
+      "notes": "Alibaba DashScope/Qwen pool (channel_type=17); served_on is only a static mapping-evidence anchor, while live account membership comes from runtime DB/admin config. BigModel is pricing source only, not the serving path. GLM direct account/group was removed. Overlay from BigModel official pricing (https://bigmodel.cn/pricing, captured 2026-07-09; CNY/USD=6.7, overlay official_list_base_tax policy applies at resolution/catalog time). Also on Baidu Qianfan account 90 (ch46); probe 200 on 2026-08-07.",
+      "mapping_source": "activation",
+      "account_scopes": [
+        {
+          "platform": "newapi",
+          "channel_type": 46,
+          "base_url": "https://qianfan.baidubce.com"
+        }
+      ]
     },
     "newapi/glm-4.7": {
       "platform": "newapi",
@@ -1130,7 +1204,8 @@
       "price_source": "overlay",
       "price_key": "ernie-4.5-turbo-vl-32k",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). Probe 200 via account 90 + china group 19 on 2026-08-07. Priced from Qianfan console ¥0.003/¥0.009 per 1k tok in/out; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). Probe 200 via account 90 + china group 19 on 2026-08-07. Priced from Qianfan console ¥0.003/¥0.009 per 1k tok in/out; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/deepseek-v4-flash-0731": {
       "platform": "newapi",
@@ -1148,7 +1223,8 @@
       "price_source": "overlay",
       "price_key": "deepseek-v4-flash",
       "display": true,
-      "notes": "Dated flash SKU. Probe 200 on 2026-08-07 via Baidu Qianfan account 90; also served by account 88 as an alias (tk_088; account 39 excluded while its DeepSeek path fails closed, see #1806). Bills from the deepseek-v4-flash official owner (the same upstream model, per the DeepSeek price page), so official peak windows apply. served-via-modelops-activation."
+      "notes": "Dated flash SKU. Probe 200 on 2026-08-07 via Baidu Qianfan account 90; also served by account 88 as an alias (tk_088; account 39 excluded while its DeepSeek path fails closed, see #1806). Bills from the deepseek-v4-flash official owner (the same upstream model, per the DeepSeek price page), so official peak windows apply.",
+      "mapping_source": "activation"
     },
     "newapi/deepseek-v3.2": {
       "platform": "newapi",
@@ -1165,7 +1241,8 @@
       "price_source": "overlay",
       "price_key": "deepseek-v3.2",
       "display": true,
-      "notes": "Baidu Qianfan account 90. Probe 200 on 2026-08-07. Qianfan tiered ¥0.002–0.004 in / ¥0.003–0.006 out per 1k; overlay intervals from GET /v2/models tier table. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90. Probe 200 on 2026-08-07. Qianfan tiered ¥0.002–0.004 in / ¥0.003–0.006 out per 1k; overlay intervals from GET /v2/models tier table.",
+      "mapping_source": "activation"
     },
     "newapi/deepseek-v3.2-think": {
       "platform": "newapi",
@@ -1182,7 +1259,8 @@
       "price_source": "overlay",
       "price_key": "deepseek-v3.2-think",
       "display": true,
-      "notes": "Baidu Qianfan account 90. Probe 200 on 2026-08-07 (reasoning path). Same Qianfan tier table as deepseek-v3.2; overlay intervals + thinking_output_cost_per_token from GET /v2/models tier table. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90. Probe 200 on 2026-08-07 (reasoning path). Same Qianfan tier table as deepseek-v3.2; overlay intervals + thinking_output_cost_per_token from GET /v2/models tier table.",
+      "mapping_source": "activation"
     },
     "newapi/bge-large-en": {
       "platform": "newapi",
@@ -1199,7 +1277,8 @@
       "price_source": "overlay",
       "price_key": "bge-large-en",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/bge-large-zh": {
       "platform": "newapi",
@@ -1216,7 +1295,8 @@
       "price_source": "overlay",
       "price_key": "bge-large-zh",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/deepseek-ocr": {
       "platform": "newapi",
@@ -1233,7 +1313,8 @@
       "price_source": "overlay",
       "price_key": "deepseek-ocr",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/ernie-4.5-turbo-128k": {
       "platform": "newapi",
@@ -1250,7 +1331,8 @@
       "price_source": "overlay",
       "price_key": "ernie-4.5-turbo-128k",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/ernie-4.5-turbo-20260402": {
       "platform": "newapi",
@@ -1267,7 +1349,8 @@
       "price_source": "overlay",
       "price_key": "ernie-4.5-turbo-20260402",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/ernie-4.5-turbo-32k": {
       "platform": "newapi",
@@ -1284,7 +1367,8 @@
       "price_source": "overlay",
       "price_key": "ernie-4.5-turbo-32k",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/ernie-4.5-turbo-vl": {
       "platform": "newapi",
@@ -1301,7 +1385,8 @@
       "price_source": "overlay",
       "price_key": "ernie-4.5-turbo-vl",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/ernie-5.0": {
       "platform": "newapi",
@@ -1318,7 +1403,8 @@
       "price_source": "overlay",
       "price_key": "ernie-5.0",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/ernie-5.0-thinking-preview": {
       "platform": "newapi",
@@ -1335,7 +1421,8 @@
       "price_source": "overlay",
       "price_key": "ernie-5.0-thinking-preview",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/ernie-5.1": {
       "platform": "newapi",
@@ -1352,7 +1439,8 @@
       "price_source": "overlay",
       "price_key": "ernie-5.1",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/ernie-x1.1": {
       "platform": "newapi",
@@ -1369,7 +1457,8 @@
       "price_source": "overlay",
       "price_key": "ernie-x1.1",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/ernie-x1.1-preview": {
       "platform": "newapi",
@@ -1386,7 +1475,8 @@
       "price_source": "overlay",
       "price_key": "ernie-x1.1-preview",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/internvl3-38b": {
       "platform": "newapi",
@@ -1403,7 +1493,8 @@
       "price_source": "overlay",
       "price_key": "internvl3-38b",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/qianfan-ocr": {
       "platform": "newapi",
@@ -1420,7 +1511,8 @@
       "price_source": "overlay",
       "price_key": "qianfan-ocr",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/qwen3-embedding-0.6b": {
       "platform": "newapi",
@@ -1437,7 +1529,8 @@
       "price_source": "overlay",
       "price_key": "qwen3-embedding-0.6b",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/qwen3-embedding-4b": {
       "platform": "newapi",
@@ -1454,7 +1547,8 @@
       "price_source": "overlay",
       "price_key": "qwen3-embedding-4b",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/qwen3-embedding-8b": {
       "platform": "newapi",
@@ -1471,7 +1565,8 @@
       "price_source": "overlay",
       "price_key": "qwen3-embedding-8b",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/qwen3.5-122b-a10b": {
       "platform": "newapi",
@@ -1488,7 +1583,8 @@
       "price_source": "overlay",
       "price_key": "qwen3.5-122b-a10b",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/qwen3.5-27b": {
       "platform": "newapi",
@@ -1505,7 +1601,8 @@
       "price_source": "overlay",
       "price_key": "qwen3.5-27b",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/qwen3.5-35b-a3b": {
       "platform": "newapi",
@@ -1522,7 +1619,8 @@
       "price_source": "overlay",
       "price_key": "qwen3.5-35b-a3b",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     },
     "newapi/qwen3.5-397b-a17b": {
       "platform": "newapi",
@@ -1539,7 +1637,8 @@
       "price_source": "overlay",
       "price_key": "qwen3.5-397b-a17b",
       "display": true,
-      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7. served-via-modelops-activation."
+      "notes": "Baidu Qianfan account 90 (ch46). v2 upstream probe servable 2026-08-07. Priced from GET /v2/models pricing tiered via overlay intervals when applicable; CNY/USD=6.7.",
+      "mapping_source": "activation"
     }
   }
 }

--- a/backend/internal/service/tk_served_models_manifest_tk.go
+++ b/backend/internal/service/tk_served_models_manifest_tk.go
@@ -226,33 +226,20 @@ func tkServedModelsManifestDisplayPresetIDsForSelector(platform string, channelT
 	return out
 }
 
-// qianfanSharedManifestModelIDs lists manifest rows also served on Baidu Qianfan
-// account 90 but indexed under other channel_type keys (manifest forbids duplicate model_id).
-var qianfanSharedManifestModelIDs = []string{
-	"deepseek-v4-pro",
-	"deepseek-v4-flash",
-	"glm-5",
-	"glm-5.1",
-	"glm-5.2",
-	"kimi-k2.6",
-}
-
 func newAPIQianfanModelMappingPresetIDs() []string {
-	scoped := tkServedModelsManifestPresetIDsForSelector(
+	return tkServedModelsManifestPresetIDsForSelector(
 		PlatformNewAPI,
 		newapiconstant.ChannelTypeBaiduV2,
 		newapiintegration.QianfanBaseURL,
 	)
-	return mergeSortedManifestModelIDs(scoped, qianfanSharedManifestModelIDs)
 }
 
 func newAPIQianfanModelDisplayPresetIDs() []string {
-	scoped := tkServedModelsManifestDisplayPresetIDsForSelector(
+	return tkServedModelsManifestDisplayPresetIDsForSelector(
 		PlatformNewAPI,
 		newapiconstant.ChannelTypeBaiduV2,
 		newapiintegration.QianfanBaseURL,
 	)
-	return mergeSortedManifestModelIDs(scoped, qianfanSharedManifestModelIDs)
 }
 
 func newAPIXRTokenModelMappingPresetIDs() []string {
@@ -269,41 +256,6 @@ func newAPIXRTokenModelDisplayPresetIDs() []string {
 		newapiconstant.ChannelTypeDoubaoVideo,
 		newapiintegration.XRTokenBaseURL,
 	)
-}
-
-func mergeSortedManifestModelIDs(primary, extra []string) []string {
-	if len(primary) == 0 && len(extra) == 0 {
-		return nil
-	}
-	seen := make(map[string]struct{}, len(primary)+len(extra))
-	out := make([]string, 0, len(primary)+len(extra))
-	for _, id := range primary {
-		id = strings.TrimSpace(id)
-		if id == "" {
-			continue
-		}
-		if _, ok := seen[id]; ok {
-			continue
-		}
-		seen[id] = struct{}{}
-		out = append(out, id)
-	}
-	for _, id := range extra {
-		id = strings.TrimSpace(id)
-		if id == "" {
-			continue
-		}
-		if _, ok := seen[id]; ok {
-			continue
-		}
-		seen[id] = struct{}{}
-		out = append(out, id)
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	sort.Strings(out)
-	return out
 }
 
 // tkServedModelsManifestPresetIDsByChannelType returns empirically verified

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -1120,8 +1120,8 @@ var ProviderSet = wire.NewSet(
 	// issuer onto AuthService post-construction. The returned sentinel is
 	// consumed by provideCleanup (cmd/server/wire.go) so wire forces evaluation.
 	ProvideTKAuthServiceColdStart,
-	// TokenKey: pricing-availability single-source-of-truth (R-001 of
-	// docs/approved/pricing-availability-source-of-truth.md). Builds the
+	// TokenKey: pricing-availability evidence owner; see
+	// docs/approved/pricing-availability-source-of-truth.md#availability-evidence-owner. Builds the
 	// availability service and wires it onto GatewayService post-construction.
 	// Handler-side wiring lives in handler/wire.go (ProvideTKPricingCatalogHandler).
 	ProvidePricingAvailabilityService,

--- a/backend/migrations/tk_054_qwen_glm_dashscope_model_mapping.sql
+++ b/backend/migrations/tk_054_qwen_glm_dashscope_model_mapping.sql
@@ -5,8 +5,9 @@
 -- dashscope.aliyuncs.com (channel_type=17):
 --   glm-5.2, glm-5.1, glm-5, glm-4.7, glm-4.6, glm-4.5, glm-4.5-air
 --
--- Mirror invariant (docs/approved/served-model-reconcile-planner.md):
---   account 72 model_mapping == account 60 model_mapping
+-- This migration gave accounts 60 and 72 the same GLM floor at apply time.
+-- Current mapping validity comes from the generated bundle and explicit activation:
+-- docs/approved/model-surface-activation-contract.md.
 --
 -- DashScope model ids match the Alibaba百炼 GLM section (华北2北京 mainland).
 -- User-facing overlay pricing follows Zhipu official list (https://open.bigmodel.cn/pricing).

--- a/backend/migrations/tk_054_qwen_glm_dashscope_model_mapping.sql
+++ b/backend/migrations/tk_054_qwen_glm_dashscope_model_mapping.sql
@@ -5,9 +5,8 @@
 -- dashscope.aliyuncs.com (channel_type=17):
 --   glm-5.2, glm-5.1, glm-5, glm-4.7, glm-4.6, glm-4.5, glm-4.5-air
 --
--- This migration gave accounts 60 and 72 the same GLM floor at apply time.
--- Current mapping validity comes from the generated bundle and explicit activation:
--- docs/approved/model-surface-activation-contract.md.
+-- Mirror invariant (docs/approved/served-model-reconcile-planner.md):
+--   account 72 model_mapping == account 60 model_mapping
 --
 -- DashScope model ids match the Alibaba百炼 GLM section (华北2北京 mainland).
 -- User-facing overlay pricing follows Zhipu official list (https://open.bigmodel.cn/pricing).

--- a/docs/approved/pricing-availability-source-of-truth.md
+++ b/docs/approved/pricing-availability-source-of-truth.md
@@ -24,6 +24,8 @@ structurally-gone 谓词，不另写一套 availability + pricing 准入。
 
 ## 1. 本文唯一拥有的事实
 
+<a id="availability-evidence-owner"></a>
+
 `model_availability` 只保存带时间范围的观测证据，例如：
 
 - 最近一次成功/失败时间；
@@ -47,16 +49,22 @@ structurally-gone 谓词，不另写一套 availability + pricing 准入。
 
 ### 2.1 Admin upstream discovery
 
+<a id="availability-admin-discovery"></a>
+
 上游 `/models` 是 discovery feed。admin 可以看到 retired/deprecated 元数据、是否存在
 canonical price owner、最近 evidence，以及 `priced` / `missing` 操作提示。
 这是运营候选信息，不是自动上架或自动写 mapping 的指令。
 
 ### 2.2 公共目录装饰
 
+<a id="availability-catalog-decoration"></a>
+
 公共目录可以展示 `degraded`、`stale`、`untested` 徽章。5xx、网络错误、限速或认证错误
 不得让模型在橱窗中闪进闪出。
 
 ### 2.3 结构性消失的裁剪
+
+<a id="availability-structural-pruning"></a>
 
 只有 provider 明确、可重复地返回 model-not-found/retired，且信号属于 platform/model
 而非单账号 auth/quota 时，公共投影可以隐藏 structurally-gone 模型。
@@ -65,6 +73,8 @@ canonical price owner、最近 evidence，以及 `priced` / `missing` 操作提�
 owner 不被 availability 改写；admin/审计面仍能看到原始证据。
 
 ### 2.4 运维触发器
+
+<a id="availability-operations"></a>
 
 availability 可以触发 re-probe、告警、人工 review、catalog/mapping/price drift 审计、
 provider 下线调查。它只能触发 owner 的正常写路径，不能直接跨写 owner。

--- a/ops/pricing/README.md
+++ b/ops/pricing/README.md
@@ -41,7 +41,7 @@ No tool in this directory may collapse those owners into a persistent `deliverab
 | `pricing-registry-sensor.py` | Provider comparison evidence and registry-only PR candidate generation. |
 | `manage-overlay-runtime.py` | Protected-main registry publication and read-only runtime audit. |
 | `apply-pricing-hotfix.py` | Provider lookup evidence and explicitly scoped channel-price remediation. |
-| `audit-display-coverage.py` | Live display-closeout audit paired with the static gate. |
+| `audit-display-coverage.py` | Read-only complete-registry → live `/pricing` projection close-out. |
 
 Provider-specific OpenRouter helpers are documented in
 `ops/pricing/openrouter-provider-onboarding.md` and are not modelops entrypoints.
@@ -96,9 +96,10 @@ Safety invariants:
 - source groups, accounts and deployable edges are resolved from live/machine owners, not
   copied into runbooks.
 
-`python3 ops/pricing/refresh-servable-allowlist.py candidates` reports stale watchlist
-evidence as a warning but remains usable. `watchlist-status` is the independent
-machine-readable operational alert and exits non-zero while stale entries exist.
+The reprobe ledger separates durable `probe_candidates` from time-bounded `watchlist`
+follow-up. Candidate generation reads only the durable set; `watchlist-status` is the
+independent machine-readable operational alert and exits non-zero while stale entries
+exist.
 
 Validate with the refresh selftest, inspect the Go diff, then run the focused catalog
 service tests before opening a PR.
@@ -146,5 +147,9 @@ Relevant preflight checks include:
 - refresh and modelops selftests;
 - pricing/serving document ownership;
 - generated agent CLI contract drift.
+
+The former diff-scoped `display-coverage-gate.py` remains as a compatibility
+entrypoint and delegates to `catalog-serving-drift.py`; preflight runs the owner
+once rather than maintaining a second display-price predicate.
 
 Run `./scripts/preflight.sh` at the repository exit gates defined by project rules.

--- a/ops/pricing/account_model_mapping_runtime_doc.py
+++ b/ops/pricing/account_model_mapping_runtime_doc.py
@@ -1,0 +1,93 @@
+"""Pure document handling for account model_mapping runtime replacements."""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import json
+from typing import Callable
+
+
+class RuntimeDocumentError(ValueError):
+    pass
+
+
+def _normalize_mapping(label: str, mapping) -> dict[str, str]:
+    if not isinstance(mapping, dict) or not mapping:
+        raise RuntimeDocumentError(f"{label}: model_mapping must be a non-empty object")
+    out: dict[str, str] = {}
+    for key_raw, value_raw in mapping.items():
+        if not isinstance(key_raw, str) or not isinstance(value_raw, str):
+            raise RuntimeDocumentError(f"{label}: keys and values must be strings")
+        key = key_raw.strip()
+        value = value_raw.strip()
+        if not key or not value:
+            raise RuntimeDocumentError(f"{label}: empty key/value is not allowed")
+        out[key] = value
+    return dict(sorted(out.items()))
+
+
+def normalize_platform_key(platform: str) -> str:
+    key = platform.strip().lower()
+    if key == "claude":
+        return "anthropic"
+    if key == "xai":
+        return "grok"
+    return key
+
+
+def normalize(doc) -> dict:
+    if not isinstance(doc, dict):
+        raise RuntimeDocumentError("runtime document must be a JSON object")
+    out: dict[str, dict] = {}
+    platforms = doc.get("platforms", {})
+    if platforms is None:
+        platforms = {}
+    if not isinstance(platforms, dict):
+        raise RuntimeDocumentError("platforms must be an object")
+    clean_platforms: dict[str, dict[str, str]] = {}
+    for platform, mapping in platforms.items():
+        if not isinstance(platform, str) or not platform.strip():
+            raise RuntimeDocumentError("platforms contains an empty platform key")
+        key = normalize_platform_key(platform)
+        if key in clean_platforms:
+            raise RuntimeDocumentError(
+                f"platforms.{platform}: duplicate normalized platform key {key!r}"
+            )
+        clean_platforms[key] = _normalize_mapping(f"platforms.{platform}", mapping)
+    if clean_platforms:
+        out["platforms"] = dict(sorted(clean_platforms.items()))
+
+    channel_types = doc.get("newapi_channel_types", {})
+    if channel_types is None:
+        channel_types = {}
+    if not isinstance(channel_types, dict):
+        raise RuntimeDocumentError("newapi_channel_types must be an object")
+    clean_channel_types: dict[str, dict[str, str]] = {}
+    for channel_type_raw, mapping in channel_types.items():
+        key = str(channel_type_raw).strip()
+        if not key.isdigit() or int(key) <= 0:
+            raise RuntimeDocumentError(f"invalid newapi channel_type {channel_type_raw!r}")
+        clean_channel_types[key] = _normalize_mapping(
+            f"newapi_channel_types.{key}", mapping
+        )
+    if clean_channel_types:
+        out["newapi_channel_types"] = dict(
+            sorted(clean_channel_types.items(), key=lambda item: int(item[0]))
+        )
+
+    if not out:
+        raise RuntimeDocumentError("runtime document has no replacement scopes")
+    return out
+
+
+def load(path, *, normalize_doc: Callable[[object], dict] = normalize) -> dict:
+    return normalize_doc(json.loads(path.read_text()))
+
+
+def decode_runtime_value(encoded: str) -> dict:
+    encoded = encoded.strip()
+    if not encoded:
+        return {}
+    raw = gzip.decompress(base64.b64decode(encoded)).decode("utf-8").strip()
+    return json.loads(raw) if raw else {}

--- a/ops/pricing/audit-display-coverage.py
+++ b/ops/pricing/audit-display-coverage.py
@@ -4,7 +4,8 @@
 The repository registry is the only editable global price owner. This audit is
 the read-only deployment close-out: every native model selected by the empirical
 allowlist and resolvable through a direct registry owner or ``_aliases`` must be
-present with a non-zero price in the live public catalog.
+present in the live public catalog. Paid rows must expose a non-zero price;
+``explicit_free`` rows must expose the row itself.
 
 ``check`` without ``--live`` validates the local projection inputs. ``--live``
 also fetches the public catalog and reports expected rows missing from that
@@ -42,7 +43,7 @@ def parse_allowlist(go_text: str) -> dict[str, set[str]]:
     return out
 
 
-def registry_entry_priced(entry: object) -> bool:
+def registry_entry_catalog_valid(entry: object) -> bool:
     if not isinstance(entry, dict):
         return False
     if entry.get("explicit_free") is True or entry.get("intervals"):
@@ -58,33 +59,46 @@ def registry_entry_priced(entry: object) -> bool:
     )
 
 
-def registry_priced_ids(registry: dict) -> set[str]:
+def registry_catalog_ids(registry: dict) -> tuple[set[str], set[str]]:
     owners = {
         model
         for model, entry in registry.items()
-        if not model.startswith("_") and registry_entry_priced(entry)
+        if not model.startswith("_") and registry_entry_catalog_valid(entry)
+    }
+    free_owners = {
+        model
+        for model, entry in registry.items()
+        if not model.startswith("_")
+        and isinstance(entry, dict)
+        and entry.get("explicit_free") is True
     }
     aliases = registry.get("_aliases") or {}
     if not isinstance(aliases, dict):
         raise ValueError("registry _aliases must be an object")
-    return owners | {
+    catalog_aliases = {
         alias
         for alias, owner in aliases.items()
         if isinstance(alias, str) and isinstance(owner, str) and owner in owners
     }
+    free_aliases = {
+        alias
+        for alias, owner in aliases.items()
+        if isinstance(alias, str) and isinstance(owner, str) and owner in free_owners
+    }
+    return owners | catalog_aliases, free_owners | free_aliases
 
 
 def expected_projection(
-    allowlist: dict[str, set[str]], priced_ids: set[str]
+    allowlist: dict[str, set[str]], catalog_ids: set[str]
 ) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
     expected: dict[str, set[str]] = {}
-    unpriced: dict[str, set[str]] = {}
+    unbacked: dict[str, set[str]] = {}
     for platform, models in allowlist.items():
-        expected[platform] = models & priced_ids
-        missing = models - priced_ids
+        expected[platform] = models & catalog_ids
+        missing = models - catalog_ids
         if missing:
-            unpriced[platform] = missing
-    return expected, unpriced
+            unbacked[platform] = missing
+    return expected, unbacked
 
 
 def live_row_priced(row: object) -> bool:
@@ -111,13 +125,16 @@ def live_row_priced(row: object) -> bool:
     )
 
 
-def live_priced_ids(payload: dict) -> set[str]:
+def live_covered_ids(payload: dict, free_ids: set[str]) -> set[str]:
     return {
         str(row.get("model_id") or row.get("id"))
         for row in payload.get("data", [])
         if isinstance(row, dict)
         and (row.get("model_id") or row.get("id"))
-        and live_row_priced(row)
+        and (
+            live_row_priced(row)
+            or str(row.get("model_id") or row.get("id")) in free_ids
+        )
     }
 
 
@@ -139,35 +156,46 @@ def cmd_check(args: argparse.Namespace) -> int:
     try:
         allowlist = parse_allowlist(GO_ALLOWLIST.read_text(encoding="utf-8"))
         registry = json.loads(REGISTRY.read_text(encoding="utf-8"))
-        expected, unpriced = expected_projection(allowlist, registry_priced_ids(registry))
+        catalog_ids, free_ids = registry_catalog_ids(registry)
+        expected, unbacked = expected_projection(allowlist, catalog_ids)
     except Exception as exc:  # noqa: BLE001
         print(f"ERROR: cannot build local catalog expectation: {exc}", file=sys.stderr)
         return 2
 
     if args.platform:
         expected = {args.platform: expected.get(args.platform, set())}
-        unpriced = {args.platform: unpriced.get(args.platform, set())} if args.platform in unpriced else {}
-    if unpriced:
-        for platform, models in sorted(unpriced.items()):
+        unbacked = (
+            {args.platform: unbacked.get(args.platform, set())}
+            if args.platform in unbacked
+            else {}
+        )
+    if unbacked:
+        for platform, models in sorted(unbacked.items()):
             for model in sorted(models):
-                print(f"GAP {platform}/{model}: allowlisted without registry owner", file=sys.stderr)
+                print(
+                    f"GAP {platform}/{model}: allowlisted without catalog-valid registry backing",
+                    file=sys.stderr,
+                )
         print("fix: run scripts/checks/catalog-serving-drift.py for the canonical static finding", file=sys.stderr)
         return 1
 
     if not args.live:
         total = sum(len(models) for models in expected.values())
-        print(f"display projection inputs: PASS ({total} registry-priced native rows)")
+        print(f"display projection inputs: PASS ({total} registry-backed native rows)")
         return 0
 
     try:
-        live = live_priced_ids(fetch_live(args.base_url))
+        live = live_covered_ids(fetch_live(args.base_url), free_ids)
     except Exception as exc:  # noqa: BLE001
         print(f"ERROR: live /pricing fetch failed: {exc}", file=sys.stderr)
         return 2
     gaps = projection_gaps(expected, live)
     for platform, models in sorted(gaps.items()):
         for model in models:
-            print(f"GAP {platform}/{model}: expected from registry+allowlist, absent/unpriced live", file=sys.stderr)
+            print(
+                f"GAP {platform}/{model}: expected from registry+allowlist, absent/invalid live",
+                file=sys.stderr,
+            )
     total = sum(len(models) for models in expected.values())
     missing = sum(len(models) for models in gaps.values())
     print(f"display projection audit: {missing} gap(s) across {total} expected native rows")
@@ -177,26 +205,38 @@ def cmd_check(args: argparse.Namespace) -> int:
 def cmd_selftest(_args: argparse.Namespace) -> int:
     go = (
         "// servable-allowlist:begin openai\n"
-        '\t"gpt-owner": {},\n\t"gpt-alias": {},\n\t"gpt-missing": {},\n'
+        '\t"gpt-owner": {},\n\t"gpt-alias": {},\n\t"free-owner": {},\n'
+        '\t"free-alias": {},\n\t"gpt-missing": {},\n'
         "// servable-allowlist:end openai\n"
     )
     allowlist = parse_allowlist(go)
     registry = {
         "gpt-owner": {"input_cost_per_token": 1e-6},
-        "_aliases": {"gpt-alias": "gpt-owner"},
+        "free-owner": {"explicit_free": True},
+        "_aliases": {
+            "gpt-alias": "gpt-owner",
+            "free-alias": "free-owner",
+        },
     }
-    expected, unpriced = expected_projection(allowlist, registry_priced_ids(registry))
-    assert expected["openai"] == {"gpt-owner", "gpt-alias"}, expected
-    assert unpriced == {"openai": {"gpt-missing"}}, unpriced
+    catalog_ids, free_ids = registry_catalog_ids(registry)
+    expected, unbacked = expected_projection(allowlist, catalog_ids)
+    assert expected["openai"] == {
+        "gpt-owner", "gpt-alias", "free-owner", "free-alias"
+    }, expected
+    assert free_ids == {"free-owner", "free-alias"}, free_ids
+    assert unbacked == {"openai": {"gpt-missing"}}, unbacked
     payload = {
         "data": [
             {"model_id": "gpt-owner", "pricing": {"input_per_1k_tokens": 0.001}},
             {"model_id": "image", "pricing": {"output_cost_per_image": 0.04}},
+            {"model_id": "free-owner", "pricing": {"input_per_1k_tokens": 0}},
+            {"model_id": "free-alias", "pricing": {"output_per_1k_tokens": 0}},
             {"model_id": "zero", "pricing": {"input_per_1k_tokens": 0}},
         ]
     }
-    assert live_priced_ids(payload) == {"gpt-owner", "image"}
-    assert projection_gaps(expected, {"gpt-owner"}) == {"openai": ["gpt-alias"]}
+    live = live_covered_ids(payload, free_ids)
+    assert live == {"gpt-owner", "image", "free-owner", "free-alias"}, live
+    assert projection_gaps(expected, live) == {"openai": ["gpt-alias"]}
     print("audit-display-coverage selftest: PASS")
     return 0
 

--- a/ops/pricing/audit-display-coverage.py
+++ b/ops/pricing/audit-display-coverage.py
@@ -1,47 +1,17 @@
 #!/usr/bin/env python3
-"""audit-display-coverage.py — servable ⇒ displayable completeness audit.
+"""Audit complete-registry catalog expectations against live ``/pricing``.
 
-The #1030 failure class: a model is in the Go servable allowlist
-(pricing_catalog_supported_models_tk.go) and bills correctly (fallbackPrices /
-family floor), but shows a BLANK price on /pricing because no DISPLAY source
-carries it. The display catalog is built from the upstream remote mirror
-(Wei-Shaw/model-price-repo, live-fetched) UNIONed with the TK overlay
-(tk_pricing_overlay.json, which INJECTS models the source lacks). The bundled
-backend/resources/model-pricing file is only a SHADOWED fallback prod does not
-read, and it is hand-maintained — so it is NOT a reliable "will it display"
-signal. The overlay is the only prod-reliable, repo-checkable display source.
+The repository registry is the only editable global price owner. This audit is
+the read-only deployment close-out: every native model selected by the empirical
+allowlist and resolvable through a direct registry owner or ``_aliases`` must be
+present with a non-zero price in the live public catalog.
 
-This tool asserts the invariant operators actually care about:
-
-    every model in the Go servable allowlist resolves to a NON-ZERO display
-    price, via the overlay (repo truth) OR the live prod /pricing (remote truth).
-
-"Display price" is media-aware: token models need input/output > 0; image
-models need output_cost_per_image > 0; video models need output_cost_per_second
-> 0.
-
-Coverage sources, in order:
-  - overlay  : tk_pricing_overlay.json carries the model with a non-zero price
-               (token OR media). Reliable in prod regardless of remote lag.
-  - live     : with --live, GET <base>/api/v1/public/pricing and treat a model
-               shown there with a non-zero token price as covered (this is how
-               standard upstream models — claude/gpt-5/… — are legitimately
-               sourced from the remote mirror, NOT the overlay).
-
-A model covered by NEITHER is a GAP (the #1030 shape). Antigravity/grok models
-are filtered out of the PUBLIC catalog by the vendor allowlist, so for those the
-overlay is the only coverage signal — exactly why #1029's antigravity image
-additions show as gaps until overlay-priced.
-
-Subcommands:
-  check        report gaps (exit 0 clean / 1 gaps / 2 error). --live to also
-               credit models displayed on prod. --platform to scope.
-  selftest     offline unit tests (no network, no repo reads).
-
-This is the LIVE CLOSE-OUT of model onboarding: run `check --live` after a
-catalog change is live and require 0 gaps. It is also a safe (read-only)
-periodic prod audit.
+``check`` without ``--live`` validates the local projection inputs. ``--live``
+also fetches the public catalog and reports expected rows missing from that
+runtime projection. Static ownership is enforced by
+``scripts/checks/catalog-serving-drift.py`` A4.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -52,192 +22,196 @@ import sys
 import urllib.request
 from pathlib import Path
 
+
 REPO = Path(__file__).resolve().parents[2]
 GO_ALLOWLIST = REPO / "backend/internal/service/pricing_catalog_supported_models_tk.go"
-OVERLAY = REPO / "backend/internal/service/tk_pricing_overlay.json"
+REGISTRY = REPO / "backend/internal/service/tk_pricing_overlay.json"
 DEFAULT_BASE = os.environ.get("TOKENKEY_BASE_URL", "https://api.tokenkey.dev")
 PLATFORMS = ("anthropic", "openai", "gemini", "antigravity", "grok")
 
 
 def parse_allowlist(go_text: str) -> dict[str, set[str]]:
-    """Extract {platform: {model_id, …}} from the splice-marked Go maps."""
     out: dict[str, set[str]] = {}
-    for plat in PLATFORMS:
-        m = re.search(
-            r"servable-allowlist:begin %s(.*?)servable-allowlist:end %s" % (plat, plat),
+    for platform in PLATFORMS:
+        match = re.search(
+            rf"servable-allowlist:begin {platform}(.*?)servable-allowlist:end {platform}",
             go_text,
             re.S,
         )
-        out[plat] = set(re.findall(r'"([^"]+)":\s*\{\}', m.group(1))) if m else set()
+        out[platform] = set(re.findall(r'"([^"]+)":\s*\{\}', match.group(1))) if match else set()
     return out
 
 
-def overlay_priced(entry: dict) -> bool:
-    """True iff the overlay entry carries a non-zero price (token OR media)."""
+def registry_entry_priced(entry: object) -> bool:
     if not isinstance(entry, dict):
         return False
-    return (
-        (entry.get("input_cost_per_token") or 0) > 0
-        or (entry.get("output_cost_per_token") or 0) > 0
-        or (entry.get("output_cost_per_image") or 0) > 0
-        or (entry.get("output_cost_per_second") or 0) > 0
+    if entry.get("explicit_free") is True or entry.get("intervals"):
+        return True
+    return any(
+        (entry.get(field) or 0) > 0
+        for field in (
+            "input_cost_per_token",
+            "output_cost_per_token",
+            "output_cost_per_image",
+            "output_cost_per_second",
+        )
     )
 
 
-def overlay_covered(overlay: dict) -> set[str]:
-    return {k for k, v in overlay.items() if k != "_meta" and overlay_priced(v)}
+def registry_priced_ids(registry: dict) -> set[str]:
+    owners = {
+        model
+        for model, entry in registry.items()
+        if not model.startswith("_") and registry_entry_priced(entry)
+    }
+    aliases = registry.get("_aliases") or {}
+    if not isinstance(aliases, dict):
+        raise ValueError("registry _aliases must be an object")
+    return owners | {
+        alias
+        for alias, owner in aliases.items()
+        if isinstance(alias, str) and isinstance(owner, str) and owner in owners
+    }
 
 
-def _row_token_priced(row: dict) -> bool:
-    pr = row.get("pricing") or {}
-    tiers = pr.get("tiers") or []
-    base = tiers[0] if tiers else pr
-    return (base.get("input_per_1k_tokens") or 0) > 0 or (base.get("output_per_1k_tokens") or 0) > 0
+def expected_projection(
+    allowlist: dict[str, set[str]], priced_ids: set[str]
+) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    expected: dict[str, set[str]] = {}
+    unpriced: dict[str, set[str]] = {}
+    for platform, models in allowlist.items():
+        expected[platform] = models & priced_ids
+        missing = models - priced_ids
+        if missing:
+            unpriced[platform] = missing
+    return expected, unpriced
 
 
-def live_token_priced(payload: dict) -> set[str]:
-    """Model ids that the live public catalog shows with a non-zero TOKEN price.
-    Media coverage is judged via the overlay (reliable), so the live signal only
-    needs to credit token models sourced from the remote mirror."""
-    out: set[str] = set()
-    for row in payload.get("data", []):
-        mid = row.get("model_id") or row.get("id")
-        if mid and _row_token_priced(row):
-            out.add(mid)
-    return out
+def live_row_priced(row: object) -> bool:
+    if not isinstance(row, dict):
+        return False
+    pricing = row.get("pricing") or {}
+    if not isinstance(pricing, dict):
+        return False
+    tiers = pricing.get("tiers") or []
+    candidates = list(tiers) if isinstance(tiers, list) else []
+    candidates.append(pricing)
+    return any(
+        isinstance(candidate, dict)
+        and any(
+            (candidate.get(field) or 0) > 0
+            for field in (
+                "input_per_1k_tokens",
+                "output_per_1k_tokens",
+                "output_cost_per_image",
+                "output_cost_per_second",
+            )
+        )
+        for candidate in candidates
+    )
+
+
+def live_priced_ids(payload: dict) -> set[str]:
+    return {
+        str(row.get("model_id") or row.get("id"))
+        for row in payload.get("data", [])
+        if isinstance(row, dict)
+        and (row.get("model_id") or row.get("id"))
+        and live_row_priced(row)
+    }
 
 
 def fetch_live(base_url: str) -> dict:
     url = base_url.rstrip("/") + "/api/v1/public/pricing"
-    with urllib.request.urlopen(url, timeout=25) as r:  # noqa: S310 (fixed prod URL)
-        return json.loads(r.read().decode())
+    with urllib.request.urlopen(url, timeout=25) as response:  # noqa: S310 operator URL
+        return json.loads(response.read().decode())
 
 
-def audit(
-    allowlist: dict[str, set[str]],
-    covered_overlay: set[str],
-    covered_live: set[str],
-) -> dict[str, list[tuple[str, str]]]:
-    """Return {platform: [(model, reason), …]} for allowlisted-but-uncovered."""
-    gaps: dict[str, list[tuple[str, str]]] = {}
-    for plat, ids in allowlist.items():
-        miss = []
-        for mid in sorted(ids):
-            if mid in covered_overlay:
-                continue
-            if mid in covered_live:
-                continue
-            reason = "no overlay entry; not displayed on live /pricing" if covered_live else "no overlay entry"
-            miss.append((mid, reason))
-        if miss:
-            gaps[plat] = miss
-    return gaps
+def projection_gaps(expected: dict[str, set[str]], live: set[str]) -> dict[str, list[str]]:
+    return {
+        platform: sorted(models - live)
+        for platform, models in expected.items()
+        if models - live
+    }
 
 
-def cmd_check(args) -> int:
+def cmd_check(args: argparse.Namespace) -> int:
     try:
         allowlist = parse_allowlist(GO_ALLOWLIST.read_text(encoding="utf-8"))
-        overlay = json.loads(OVERLAY.read_text(encoding="utf-8"))
-    except Exception as e:  # noqa: BLE001
-        print(f"ERROR: cannot read repo sources: {e}", file=sys.stderr)
+        registry = json.loads(REGISTRY.read_text(encoding="utf-8"))
+        expected, unpriced = expected_projection(allowlist, registry_priced_ids(registry))
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: cannot build local catalog expectation: {exc}", file=sys.stderr)
         return 2
-    covered_overlay = overlay_covered(overlay)
-    covered_live: set[str] = set()
-    if args.live:
-        try:
-            covered_live = live_token_priced(fetch_live(args.base_url))
-        except Exception as e:  # noqa: BLE001
-            print(f"ERROR: live /pricing fetch failed ({e}); rerun without --live for repo-only audit", file=sys.stderr)
-            return 2
+
     if args.platform:
-        allowlist = {args.platform: allowlist.get(args.platform, set())}
+        expected = {args.platform: expected.get(args.platform, set())}
+        unpriced = {args.platform: unpriced.get(args.platform, set())} if args.platform in unpriced else {}
+    if unpriced:
+        for platform, models in sorted(unpriced.items()):
+            for model in sorted(models):
+                print(f"GAP {platform}/{model}: allowlisted without registry owner", file=sys.stderr)
+        print("fix: run scripts/checks/catalog-serving-drift.py for the canonical static finding", file=sys.stderr)
+        return 1
 
-    gaps = audit(allowlist, covered_overlay, covered_live)
-    mode = "overlay ∪ live prod /pricing" if args.live else "overlay only (repo) — pass --live to credit remote-displayed models"
-    print(f"=== display-coverage audit (source: {mode}) ===")
-    total_models = sum(len(v) for v in allowlist.values())
-    total_gaps = sum(len(v) for v in gaps.values())
-    for plat, ids in allowlist.items():
-        plat_gaps = gaps.get(plat, [])
-        print(f"  {plat}: {len(plat_gaps)}/{len(ids)} uncovered")
-        for mid, why in plat_gaps:
-            print(f"      GAP {mid} — {why}")
-    print(f"TOTAL: {total_gaps} display gap(s) across {total_models} allowlisted model(s)")
-    if total_gaps:
-        print("\nfix: add a priced entry to tk_pricing_overlay.json (the prod-reliable display", file=sys.stderr)
-        print("source) for each GAP — use ops/pricing/apply-pricing-hotfix.py stage-overlay.", file=sys.stderr)
-    return 1 if total_gaps else 0
+    if not args.live:
+        total = sum(len(models) for models in expected.values())
+        print(f"display projection inputs: PASS ({total} registry-priced native rows)")
+        return 0
+
+    try:
+        live = live_priced_ids(fetch_live(args.base_url))
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: live /pricing fetch failed: {exc}", file=sys.stderr)
+        return 2
+    gaps = projection_gaps(expected, live)
+    for platform, models in sorted(gaps.items()):
+        for model in models:
+            print(f"GAP {platform}/{model}: expected from registry+allowlist, absent/unpriced live", file=sys.stderr)
+    total = sum(len(models) for models in expected.values())
+    missing = sum(len(models) for models in gaps.values())
+    print(f"display projection audit: {missing} gap(s) across {total} expected native rows")
+    return 1 if gaps else 0
 
 
-def cmd_selftest(_args) -> int:
-    # parse_allowlist
+def cmd_selftest(_args: argparse.Namespace) -> int:
     go = (
-        "x\n// servable-allowlist:begin openai\n"
-        '\t"gpt-5": {},\n\t"gpt-5.6-sol": {},\n'
+        "// servable-allowlist:begin openai\n"
+        '\t"gpt-owner": {},\n\t"gpt-alias": {},\n\t"gpt-missing": {},\n'
         "// servable-allowlist:end openai\n"
-        "// servable-allowlist:begin gemini\n"
-        '\t"imagen-4.0-generate-001": {},\n\t"gemini-2.5-pro": {},\n'
-        "// servable-allowlist:end gemini\n"
     )
-    al = parse_allowlist(go)
-    assert al["openai"] == {"gpt-5", "gpt-5.6-sol"}, al["openai"]
-    assert al["gemini"] == {"imagen-4.0-generate-001", "gemini-2.5-pro"}, al["gemini"]
-    assert al["anthropic"] == set() and al["grok"] == set(), al
-
-    # overlay_priced: token / image / video / zero / missing
-    assert overlay_priced({"input_cost_per_token": 5e-6})
-    assert overlay_priced({"output_cost_per_image": 0.04})
-    assert overlay_priced({"output_cost_per_second": 0.6})
-    assert not overlay_priced({"input_cost_per_token": 0, "output_cost_per_token": 0})
-    assert not overlay_priced({"litellm_provider": "openai"})  # no price fields
-    ov = {
-        "_meta": {"note": "x"},
-        "imagen-4.0-generate-001": {"output_cost_per_image": 0.04},  # media → covered
-        "veo-3.1-generate-001": {"output_cost_per_second": 0.6},     # media → covered
-        "zero-model": {"input_cost_per_token": 0},                   # zero → NOT covered
+    allowlist = parse_allowlist(go)
+    registry = {
+        "gpt-owner": {"input_cost_per_token": 1e-6},
+        "_aliases": {"gpt-alias": "gpt-owner"},
     }
-    assert overlay_covered(ov) == {"imagen-4.0-generate-001", "veo-3.1-generate-001"}, overlay_covered(ov)
-
-    # live_token_priced: tiers + flat, media-zero excluded
-    live = {"data": [
-        {"model_id": "gpt-5", "pricing": {"tiers": [{"input_per_1k_tokens": 0.01, "output_per_1k_tokens": 0.03}]}},
-        {"model_id": "imagen-4.0-generate-001", "pricing": {"tiers": [{"input_per_1k_tokens": 0, "output_per_1k_tokens": 0}]}},
-        {"model_id": "gpt-flat", "pricing": {"input_per_1k_tokens": 0.002}},
-    ]}
-    lt = live_token_priced(live)
-    assert lt == {"gpt-5", "gpt-flat"}, lt  # imagen has zero token price → not credited here (overlay covers media)
-
-    # audit: the #1030 + #1029-antigravity shapes
-    allowlist = {
-        "openai": {"gpt-5", "gpt-5.6-sol"},          # gpt-5 via live; gpt-5.6-sol uncovered
-        "gemini": {"imagen-4.0-generate-001"},        # media via overlay
-        "antigravity": {"gemini-3.5-flash"},          # uncovered (no overlay, filtered from public)
+    expected, unpriced = expected_projection(allowlist, registry_priced_ids(registry))
+    assert expected["openai"] == {"gpt-owner", "gpt-alias"}, expected
+    assert unpriced == {"openai": {"gpt-missing"}}, unpriced
+    payload = {
+        "data": [
+            {"model_id": "gpt-owner", "pricing": {"input_per_1k_tokens": 0.001}},
+            {"model_id": "image", "pricing": {"output_cost_per_image": 0.04}},
+            {"model_id": "zero", "pricing": {"input_per_1k_tokens": 0}},
+        ]
     }
-    covered_overlay = {"imagen-4.0-generate-001"}
-    covered_live = {"gpt-5"}
-    g = audit(allowlist, covered_overlay, covered_live)
-    assert g.get("openai") == [("gpt-5.6-sol", "no overlay entry; not displayed on live /pricing")], g
-    assert "gemini" not in g, g            # imagen covered by overlay (media)
-    assert g.get("antigravity") == [("gemini-3.5-flash", "no overlay entry; not displayed on live /pricing")], g
-
-    # repo-only mode (no live): gpt-5 also a gap (only overlay credited)
-    g2 = audit(allowlist, covered_overlay, set())
-    assert ("gpt-5", "no overlay entry") in g2["openai"], g2
+    assert live_priced_ids(payload) == {"gpt-owner", "image"}
+    assert projection_gaps(expected, {"gpt-owner"}) == {"openai": ["gpt-alias"]}
     print("audit-display-coverage selftest: PASS")
     return 0
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description="servable ⇒ displayable completeness audit")
-    sub = ap.add_subparsers(dest="cmd", required=True)
-    ck = sub.add_parser("check", help="report allowlisted-but-undisplayable models")
-    ck.add_argument("--live", action="store_true", help="also credit models shown priced on prod /pricing")
-    ck.add_argument("--base-url", default=DEFAULT_BASE, help=f"prod base (default {DEFAULT_BASE})")
-    ck.add_argument("--platform", choices=PLATFORMS, help="scope to one platform")
-    ck.set_defaults(func=cmd_check)
-    st = sub.add_parser("selftest", help="offline unit tests")
-    st.set_defaults(func=cmd_selftest)
-    args = ap.parse_args()
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    check = sub.add_parser("check")
+    check.add_argument("--live", action="store_true")
+    check.add_argument("--base-url", default=DEFAULT_BASE)
+    check.add_argument("--platform", choices=PLATFORMS)
+    check.set_defaults(func=cmd_check)
+    selftest = sub.add_parser("selftest")
+    selftest.set_defaults(func=cmd_selftest)
+    args = parser.parse_args()
     return args.func(args)
 
 

--- a/ops/pricing/manage-account-model-mapping-runtime.py
+++ b/ops/pricing/manage-account-model-mapping-runtime.py
@@ -78,6 +78,13 @@ from pathlib import Path
 from typing import Any, NoReturn
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+_runtime_doc_spec = importlib.util.spec_from_file_location(
+    "tk_account_model_mapping_runtime_doc",
+    REPO_ROOT / "ops" / "pricing" / "account_model_mapping_runtime_doc.py",
+)
+_RUNTIME_DOC = importlib.util.module_from_spec(_runtime_doc_spec)
+_runtime_doc_spec.loader.exec_module(_RUNTIME_DOC)
+
 SETTING_KEY = "tk_account_model_mapping_runtime"
 MANAGED_PLATFORMS = ("anthropic", "openai", "gemini", "antigravity", "newapi", "kiro", "grok")
 
@@ -165,67 +172,15 @@ def fail(msg: str) -> NoReturn:
     sys.exit(2)
 
 
-def _normalize_mapping(label: str, mapping) -> dict[str, str]:
-    if not isinstance(mapping, dict) or not mapping:
-        fail(f"{label}: model_mapping must be a non-empty object")
-    out: dict[str, str] = {}
-    for k, v in mapping.items():
-        if not isinstance(k, str) or not isinstance(v, str):
-            fail(f"{label}: keys and values must be strings")
-        key = k.strip()
-        val = v.strip()
-        if not key or not val:
-            fail(f"{label}: empty key/value is not allowed")
-        out[key] = val
-    return dict(sorted(out.items()))
-
-
 def normalize_platform_key(platform: str) -> str:
-    key = platform.strip().lower()
-    if key == "claude":
-        return "anthropic"
-    if key == "xai":
-        return "grok"
-    return key
+    return _RUNTIME_DOC.normalize_platform_key(platform)
 
 
 def normalize_runtime_doc(doc) -> dict:
-    if not isinstance(doc, dict):
-        fail("runtime document must be a JSON object")
-    out: dict[str, dict] = {}
-    platforms = doc.get("platforms", {})
-    if platforms is None:
-        platforms = {}
-    if not isinstance(platforms, dict):
-        fail("platforms must be an object")
-    clean_platforms: dict[str, dict[str, str]] = {}
-    for platform, mapping in platforms.items():
-        if not isinstance(platform, str) or not platform.strip():
-            fail("platforms contains an empty platform key")
-        key = normalize_platform_key(platform)
-        if key in clean_platforms:
-            fail(f"platforms.{platform}: duplicate normalized platform key {key!r}")
-        clean_platforms[key] = _normalize_mapping(f"platforms.{platform}", mapping)
-    if clean_platforms:
-        out["platforms"] = dict(sorted(clean_platforms.items()))
-
-    channel_types = doc.get("newapi_channel_types", {})
-    if channel_types is None:
-        channel_types = {}
-    if not isinstance(channel_types, dict):
-        fail("newapi_channel_types must be an object")
-    clean_ct: dict[str, dict[str, str]] = {}
-    for raw_ct, mapping in channel_types.items():
-        key = str(raw_ct).strip()
-        if not key.isdigit() or int(key) <= 0:
-            fail(f"invalid newapi channel_type {raw_ct!r}")
-        clean_ct[key] = _normalize_mapping(f"newapi_channel_types.{key}", mapping)
-    if clean_ct:
-        out["newapi_channel_types"] = dict(sorted(clean_ct.items(), key=lambda kv: int(kv[0])))
-
-    if not out:
-        fail("runtime document has no replacement scopes")
-    return out
+    try:
+        return _RUNTIME_DOC.normalize(doc)
+    except _RUNTIME_DOC.RuntimeDocumentError as exc:
+        fail(str(exc))
 
 
 def canonical_json(doc: dict) -> str:
@@ -234,7 +189,7 @@ def canonical_json(doc: dict) -> str:
 
 def load_doc(path: Path) -> dict:
     try:
-        return normalize_runtime_doc(json.loads(path.read_text()))
+        return _RUNTIME_DOC.load(path, normalize_doc=normalize_runtime_doc)
     except OSError as e:
         fail(f"cannot read {path}: {e}")
     except json.JSONDecodeError as e:
@@ -242,13 +197,7 @@ def load_doc(path: Path) -> dict:
 
 
 def _decode_runtime_value(out: str) -> dict:
-    out = out.strip()
-    if not out:
-        return {}
-    raw = gzip.decompress(base64.b64decode(out)).decode("utf-8").strip()
-    if not raw:
-        return {}
-    return json.loads(raw)
+    return _RUNTIME_DOC.decode_runtime_value(out)
 
 
 def read_runtime_blob(region: str, instance_id: str) -> dict:

--- a/ops/pricing/probe-servable-models.sh
+++ b/ops/pricing/probe-servable-models.sh
@@ -541,7 +541,8 @@ main() {
 			# (translation params) not documented in the new-api volcengine adaptor. Until
 			# that authoritative shape is known it stays inconclusive (the model is priced +
 			# served in prod regardless; this only affects probe classification). Do NOT ship
-			# a guessed shape. See SKILL.md "translation 族探测" note.
+				# a guessed shape. Keep the verdict inconclusive until the provider's
+				# authoritative translation request schema is represented by this probe.
 			[ -n "${ARK_CHAT_MODELS:-}" ] && probe_compat_endpoint volcengine "$arkbase" "$arkkey" /api/v3/chat/completions "$ARK_CHAT_MODELS" body_chat
 			[ -n "${ARK_IMAGE_MODELS:-}" ] && probe_compat_endpoint volcengine "$arkbase" "$arkkey" /api/v3/images/generations "$ARK_IMAGE_MODELS" body_ark_img
 			[ -n "${ARK_VIDEO_MODELS:-}" ] && probe_compat_endpoint volcengine "$arkbase" "$arkkey" /api/v3/contents/generations/tasks "$ARK_VIDEO_MODELS" body_ark_video

--- a/ops/pricing/refresh-servable-allowlist.py
+++ b/ops/pricing/refresh-servable-allowlist.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import importlib.util
 import json
 import os
 import re
@@ -46,6 +47,12 @@ import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
+_reprobe_spec = importlib.util.spec_from_file_location(
+    "tk_servable_reprobe_ledger", REPO / "ops" / "pricing" / "servable_reprobe_ledger.py"
+)
+_REPROBE = importlib.util.module_from_spec(_reprobe_spec)
+_reprobe_spec.loader.exec_module(_REPROBE)
+
 CATALOG = REPO / "backend/resources/model-pricing/model_prices_and_context_window.json"
 GO_FILE = REPO / "backend/internal/service/pricing_catalog_supported_models_tk.go"
 PROBE = REPO / "ops/pricing/probe-servable-models.sh"
@@ -116,7 +123,6 @@ GO_ALLOWLIST_PLATFORMS = ("anthropic", "openai", "gemini", "antigravity", "grok"
 # veo/seedance ids. Derived from the family table so a future *_video family is
 # covered automatically.
 VIDEO_FAMILIES = frozenset(f for f in FAMILY_PLATFORM if f.endswith("_video"))
-REPROBE_LISTS = ("watchlist", "skiplist", "structurally_gone")
 
 
 # ----- vendor → platform (mirrors service.inferPlatformFromVendor) -----
@@ -235,14 +241,7 @@ def _probe_family_for(platform: str, model: str, probe_family: str | None = None
 
 
 def load_reprobe_ledger(path: Path = REPROBE_LEDGER) -> dict:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def _parse_date(value: str, label: str) -> dt.date:
-    try:
-        return dt.date.fromisoformat(value)
-    except ValueError as exc:
-        raise ValueError(f"{label}: expected YYYY-MM-DD, got {value!r}") from exc
+    return _REPROBE.load(path)
 
 
 def _allowlist_members_for_platform(text: str, platform: str) -> list[str]:
@@ -332,10 +331,7 @@ def _candidate_members(candidates: dict[str, list[str]]) -> set[tuple[str, str]]
 
 
 def _ledger_entries(ledger: dict, list_name: str) -> list[dict]:
-    entries = ledger.get(list_name, [])
-    if not isinstance(entries, list):
-        raise ValueError(f"{list_name}: expected list")
-    return entries
+    return _REPROBE.entries(ledger, list_name)
 
 
 def validate_reprobe_ledger(
@@ -345,162 +341,35 @@ def validate_reprobe_ledger(
     allowlist_members: set[tuple[str, str]] | None = None,
     candidates: dict[str, list[str]] | None = None,
 ) -> None:
-    today = today or dt.date.today()
-    seen: dict[tuple[str, str], str] = {}
-    watch_keys: set[tuple[str, str]] = set()
-    skip_keys: set[tuple[str, str]] = set()
-    gone_keys: set[tuple[str, str]] = set()
-    candidate_keys = _candidate_members(candidates) if candidates is not None else set()
-
-    for list_name in REPROBE_LISTS:
-        for idx, entry in enumerate(_ledger_entries(ledger, list_name)):
-            if not isinstance(entry, dict):
-                raise ValueError(f"{list_name}[{idx}]: expected object")
-            platform = entry.get("platform")
-            model = entry.get("model")
-            reason = entry.get("reason")
-            if not platform or not model:
-                raise ValueError(f"{list_name}[{idx}]: platform and model are required")
-            if not reason:
-                raise ValueError(f"{list_name}[{idx}] {platform}/{model}: reason is required")
-            key = (platform, model)
-            if key in seen:
-                raise ValueError(f"{platform}/{model}: appears in both {seen[key]} and {list_name}")
-            seen[key] = list_name
-            if list_name == "watchlist":
-                watch_keys.add(key)
-                if entry.get("auto_probe", False):
-                    _probe_family_for(platform, model, entry.get("probe_family"))
-                last_probe = entry.get("last_probe")
-                expires = entry.get("expires")
-                freshness_days = entry.get("freshness_days")
-                if freshness_days is not None and (not isinstance(freshness_days, int) or freshness_days < 1):
-                    raise ValueError(f"watchlist {platform}/{model}: freshness_days must be a positive integer")
-                if last_probe:
-                    probed_at = _parse_date(str(last_probe), f"watchlist {platform}/{model} last_probe")
-                    if probed_at > today:
-                        raise ValueError(f"watchlist {platform}/{model}: last_probe {probed_at} is in the future")
-                elif not expires:
-                    raise ValueError(f"watchlist {platform}/{model}: last_probe or expires is required")
-                if expires:
-                    _parse_date(str(expires), f"watchlist {platform}/{model} expires")
-                elif freshness_days is None:
-                    raise ValueError(
-                        f"watchlist {platform}/{model}: freshness_days or expires is required"
-                    )
-                if entry.get("auto_probe") and candidates is not None and key not in candidate_keys:
-                    raise ValueError(f"watchlist {platform}/{model}: auto_probe entry missing from candidates")
-            elif list_name == "skiplist":
-                skip_keys.add(key)
-            else:
-                gone_keys.add(key)
-
-    blocked = skip_keys | gone_keys
-    overlap = watch_keys & blocked
-    if overlap:
-        rendered = ", ".join(f"{platform}/{model}" for platform, model in sorted(overlap))
-        raise ValueError(f"watchlist cannot overlap skiplist/structurally_gone: {rendered}")
-    if allowlist_members:
-        # A current row may intentionally appear in structurally_gone: apply uses
-        # that reviewed ledger entry as the only removal authority. A skiplist
-        # overlap remains contradictory because skiplist is candidate policy, not
-        # a removal instruction.
-        conflicts = allowlist_members & skip_keys
-        if conflicts:
-            rendered = ", ".join(f"{platform}/{model}" for platform, model in sorted(conflicts))
-            raise ValueError(f"servable allowlist cannot overlap skiplist: {rendered}")
-
-
-def watchlist_freshness(ledger: dict, *, today: dt.date | None = None) -> list[dict[str, object]]:
-    """Return stale watchlist rows without changing schema validation semantics."""
-    today = today or dt.date.today()
-    stale: list[dict[str, object]] = []
-    for entry in _ledger_entries(ledger, "watchlist"):
-        expires = entry.get("expires")
-        last_probe = entry.get("last_probe")
-        freshness_days = entry.get("freshness_days")
-        if expires:
-            deadline = _parse_date(
-                str(expires),
-                f"watchlist {entry.get('platform')}/{entry.get('model')} expires",
-            )
-        elif last_probe and isinstance(freshness_days, int):
-            deadline = _parse_date(
-                str(last_probe),
-                f"watchlist {entry.get('platform')}/{entry.get('model')} last_probe",
-            ) + dt.timedelta(days=freshness_days)
-        else:
-            continue
-        if today > deadline:
-            stale.append(
-                {
-                    "platform": entry["platform"],
-                    "model": entry["model"],
-                    "deadline": deadline.isoformat(),
-                    "days_stale": (today - deadline).days,
-                }
-            )
-    return sorted(stale, key=lambda row: (str(row["platform"]), str(row["model"])))
-
-
-def warn_stale_watchlist(ledger: dict, *, today: dt.date | None = None) -> None:
-    stale = watchlist_freshness(ledger, today=today)
-    if not stale:
-        return
-    oldest = max(int(row["days_stale"]) for row in stale)
-    print(
-        f"[refresh] WARN: {len(stale)} watchlist entr{'y is' if len(stale) == 1 else 'ies are'} "
-        f"stale (oldest={oldest}d); candidates remain usable. "
-        "Run `refresh-servable-allowlist.py watchlist-status` for details.",
-        file=sys.stderr,
+    _REPROBE.validate(
+        ledger,
+        probe_family_for=_probe_family_for,
+        candidate_members=_candidate_members(candidates) if candidates is not None else None,
+        today=today,
+        allowlist_members=allowlist_members,
     )
 
 
-def augment_candidates_with_watchlist(candidates: dict[str, list[str]], ledger: dict) -> dict[str, list[str]]:
-    out = {k: list(v) for k, v in candidates.items()}
-    for entry in _ledger_entries(ledger, "watchlist"):
-        if not entry.get("auto_probe", False):
-            continue
-        platform = entry["platform"]
-        model = entry["model"]
-        family = _probe_family_for(platform, model, entry.get("probe_family"))
-        for peer_family in PROBE_FAMILIES_BY_PLATFORM[platform]:
-            out[peer_family] = [mid for mid in out.get(peer_family, []) if mid != model]
-        out.setdefault(family, []).append(model)
-    blocked = {
-        (entry["platform"], entry["model"])
-        for list_name in ("skiplist", "structurally_gone")
-        for entry in _ledger_entries(ledger, list_name)
-    }
-    for family, platforms in (
-        ("anthropic", ("anthropic",)),
-        ("openai_chat", ("openai",)),
-        ("openai_responses", ("openai",)),
-        ("openai_image", ("openai",)),
-        ("gemini_chat", ("gemini",)),
-        ("gemini_chat_image", ("gemini",)),
-        ("gemini_image", ("gemini",)),
-        ("gemini_video", ("gemini",)),
-    ):
-        if family in out:
-            platform = platforms[0]
-            out[family] = [model for model in out[family] if (platform, model) not in blocked]
-    for family in out:
-        out[family] = sorted(set(out[family]))
-    return out
+def watchlist_freshness(ledger: dict, *, today: dt.date | None = None) -> list[dict[str, object]]:
+    return _REPROBE.watchlist_freshness(ledger, today=today)
+
+
+def warn_stale_watchlist(ledger: dict, *, today: dt.date | None = None) -> None:
+    _REPROBE.warn_stale_watchlist(ledger, today=today)
+
+
+def augment_candidates_with_probe_policy(candidates: dict[str, list[str]], ledger: dict) -> dict[str, list[str]]:
+    return _REPROBE.augment_candidates(
+        candidates,
+        ledger,
+        probe_families_by_platform=PROBE_FAMILIES_BY_PLATFORM,
+        family_platform=FAMILY_PLATFORM,
+        probe_family_for=_probe_family_for,
+    )
 
 
 def validate_results_against_reprobe_ledger(servable: dict[str, set[str]], ledger: dict) -> None:
-    blocked = {
-        (entry["platform"], entry["model"])
-        for list_name in ("skiplist", "structurally_gone")
-        for entry in _ledger_entries(ledger, list_name)
-    }
-    observed = {(platform, model) for platform, models in servable.items() for model in models}
-    conflicts = observed & blocked
-    if conflicts:
-        rendered = ", ".join(f"{platform}/{model}" for platform, model in sorted(conflicts))
-        raise SystemExit(f"FATAL: probe results mark skiplist/structurally_gone model as servable: {rendered}")
+    _REPROBE.validate_results(servable, ledger)
 
 
 def build_probe_candidates(
@@ -510,7 +379,7 @@ def build_probe_candidates(
     today: dt.date | None = None,
 ) -> tuple[dict[str, list[str]], dict]:
     ledger = load_reprobe_ledger()
-    cands = augment_candidates_with_watchlist(build_candidates(catalog, discovered), ledger)
+    cands = augment_candidates_with_probe_policy(build_candidates(catalog, discovered), ledger)
     validate_reprobe_ledger(
         ledger,
         today=today,
@@ -561,7 +430,7 @@ def proven_servable_from_traffic(
         (it stays in the probe set). A served model that is not a candidate is
         dropped (never injected into the allowlist).
       * Blocked models (skiplist/structurally_gone) are already absent from `candidates`
-        (augment_candidates_with_watchlist removed them), so they can never appear
+        (augment_candidates_with_probe_policy removed them), so they can never appear
         here even with a real traffic hit — a structurally-gone model cannot revive on one
         successful request. validate_results_against_reprobe_ledger is still run on
         the result by callers as defense-in-depth.
@@ -706,7 +575,7 @@ def project_allowlists(
     ledger: dict | None = None,
 ) -> tuple[str, dict[str, list[str]]]:
     """Pure catalog projection: current + positive - reviewed structural removals."""
-    ledger = ledger or {"watchlist": [], "skiplist": [], "structurally_gone": []}
+    ledger = ledger or {"probe_candidates": [], "watchlist": [], "skiplist": [], "structurally_gone": []}
     validate_results_against_reprobe_ledger(servable, ledger)
     platforms = ("anthropic", "openai", "gemini")
     for platform in platforms:
@@ -961,35 +830,30 @@ def selftest() -> int:
     assert "gpt-4o" not in sum(c.values(), []), "unpriced must be skipped"
     assert "gemini-2.5-pro" not in sum(c.values(), []), "vertex not a litellm-catalog candidate"
 
-    # Reprobe ledger: schema validity gates candidate generation, while freshness
-    # is an operational status. Stale evidence must remain visible without making
-    # the deterministic candidates command unusable.
+    # Durable explicit candidates and time-bounded operational follow-up are
+    # separate lists. Watchlist freshness never controls candidate generation.
     ledger = {
-        "watchlist": [
+        "probe_candidates": [
             {
                 "platform": "openai",
                 "model": "gpt-5.2",
                 "reason": "capacity-sensitive backend set; keep reprobing",
-                "last_probe": "2026-06-05",
-                "freshness_days": 30,
-                "auto_probe": True,
                 "probe_family": "openai_chat",
             },
             {
                 "platform": "gemini",
                 "model": "gemini-3-pro-image-preview",
                 "reason": "wrong-surface prior probe; reprobe via chat",
-                "last_probe": "2026-06-09",
-                "freshness_days": 30,
-                "auto_probe": True,
                 "probe_family": "gemini_chat",
             },
+        ],
+        "watchlist": [
             {
                 "platform": "antigravity",
                 "model": "gemini-2.5-pro",
                 "reason": "hand-maintained platform; separate probe runner",
-                "expires": "2026-07-13",
-                "auto_probe": False,
+                "last_probe": "2026-06-05",
+                "freshness_days": 30,
             },
         ],
         "skiplist": [
@@ -1000,9 +864,9 @@ def selftest() -> int:
             {"platform": "grok", "model": "grok-imagine-image-pro", "reason": "retired upstream"}
         ],
     }
-    aug = augment_candidates_with_watchlist(build_candidates(cat, ["gemini-3-pro-image-preview"]), ledger)
+    aug = augment_candidates_with_probe_policy(build_candidates(cat, ["gemini-3-pro-image-preview"]), ledger)
     assert "gpt-5.2" in aug["openai_chat"], aug["openai_chat"]
-    # watchlist probe_family override moves it from the base family (now
+    # probe_candidates probe_family override moves it from the base family (now
     # gemini_chat_image for *-image ids) to the overridden gemini_chat, and out of
     # all peers — proves the override wins over the systematic family routing.
     assert "gemini-3-pro-image-preview" in aug["gemini_chat"], aug["gemini_chat"]
@@ -1021,14 +885,14 @@ def selftest() -> int:
     stale_rows = watchlist_freshness(stale, today=dt.date(2026, 6, 22))
     assert stale_rows == [
         {
-            "platform": "openai",
-            "model": "gpt-5.2",
+            "platform": "antigravity",
+            "model": "gemini-2.5-pro",
             "deadline": "2026-05-31",
             "days_stale": 22,
         }
     ], stale_rows
     duplicate = json.loads(json.dumps(ledger))
-    duplicate["skiplist"].append({"platform": "openai", "model": "gpt-5.2", "reason": "bad duplicate"})
+    duplicate["skiplist"].append({"platform": "antigravity", "model": "gemini-2.5-pro", "reason": "bad duplicate"})
     try:
         validate_reprobe_ledger(duplicate, today=dt.date(2026, 6, 22), candidates=aug)
         raise AssertionError("watchlist/skiplist duplicate must fail")
@@ -1278,10 +1142,8 @@ def selftest() -> int:
     assert "gemini_video" in VIDEO_FAMILIES and not any(f.endswith("_chat") for f in VIDEO_FAMILIES), VIDEO_FAMILIES
 
     # The real machine ledger is part of preflight, not just a runtime input.
-    # Include discovered fixtures so skiplist removal and watchlist
+    # Include discovered fixtures so skiplist removal and durable candidate
     # probe_family overrides are both exercised without prod.
-    # Use the real current date: stale watchlist rows must warn but cannot make
-    # selftest green while the actual candidates command is broken.
     real_catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     real_cands, _real_ledger = build_probe_candidates(
         real_catalog,
@@ -1315,7 +1177,7 @@ def selftest() -> int:
     # 24h-traffic short-circuit: proven-by-traffic candidates skip the probe batch
     # but still land in the servable set, while non-candidates / blocked / untrafficked
     # models are handled correctly (no injection, no revival, no false negative).
-    traffic_cands = augment_candidates_with_watchlist(build_candidates(cat, ["gemini-2.5-pro"]), ledger)
+    traffic_cands = augment_candidates_with_probe_policy(build_candidates(cat, ["gemini-2.5-pro"]), ledger)
     assert "gpt-image-dead" not in traffic_cands["openai_image"], "skiplist must pre-exclude"
     assert candidate_model_platforms(traffic_cands)["gemini-2.5-pro"] == {"gemini"}
     mock_tsv = (
@@ -1344,7 +1206,7 @@ def selftest() -> int:
     assert "claude-opus-4-8" not in reduced["anthropic"], reduced["anthropic"]
     assert "claude-3-haiku-20240307" in reduced["anthropic"], "untrafficked candidate must still be probed"
     assert "gpt-5.4" not in reduced["openai_chat"], reduced["openai_chat"]
-    assert "gpt-5.2" in reduced["openai_chat"], "untrafficked watchlist candidate must still be probed"
+    assert "gpt-5.2" in reduced["openai_chat"], "untrafficked explicit candidate must still be probed"
     assert "gemini-2.5-pro" not in reduced["gemini_chat"], reduced["gemini_chat"]
     assert "gemini-3-pro-image-preview" in reduced["gemini_chat"], "untrafficked candidate must still be probed"
     orig_count = sum(len(v) for v in traffic_cands.values())

--- a/ops/pricing/servable-reprobe-ledger.json
+++ b/ops/pricing/servable-reprobe-ledger.json
@@ -1,402 +1,7 @@
 {
-  "_doc": "Machine-readable reprobe ledger for ops/pricing/refresh-servable-allowlist.py. Keys are platform/model pairs. watchlist freshness is an operational alert and never blocks candidate generation; skiplist entries are excluded from probing; structurally_gone entries are the reviewed authority for catalog removal.",
-  "_generated_from": "mechanized 2026-06-22 from then-current probe ledger; current owner is this file",
-  "watchlist": [
-    {
-      "platform": "antigravity",
-      "model": "gemini-2.5-pro",
-      "reason": "2026-06-23 prod /antigravity/v1beta generateContent returned 000 timeout/inconclusive; streamGenerateContent single-model retry also returned 000. Keep watchlisted because the same antigravity path served baseline models.",
-      "last_probe": "2026-07-24",
-      "freshness_days": 30,
-      "auto_probe": false,
-      "owner": "native-antigravity"
-    },
-    {
-      "platform": "antigravity",
-      "model": "claude-sonnet-4-5",
-      "reason": "2026-06-23 prod /antigravity/v1/messages returned 429 not_allowlisted for this specific legacy model. Antigravity Claude support was later reopened only for the live #1265 subset; keep this model out until reprobed.",
-      "last_probe": "2026-07-24",
-      "freshness_days": 30,
-      "auto_probe": false,
-      "owner": "native-antigravity"
-    },
-    {
-      "platform": "openai",
-      "model": "gpt-5.1-codex",
-      "reason": "2026-06-23 prod /v1/responses reprobe returned 400 unsupported; GPT OAuth backend model set can change.",
-      "last_probe": "2026-07-24",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "openai_responses"
-    },
-    {
-      "platform": "openai",
-      "model": "gpt-5.1-codex-max",
-      "reason": "2026-06-23 prod /v1/responses reprobe returned 400 unsupported; GPT OAuth backend model set can change.",
-      "last_probe": "2026-07-24",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "openai_responses"
-    },
-    {
-      "platform": "openai",
-      "model": "gpt-5.1-codex-mini",
-      "reason": "2026-06-23 prod /v1/responses reprobe returned 400 unsupported; GPT OAuth backend model set can change.",
-      "last_probe": "2026-07-24",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "openai_responses"
-    },
-    {
-      "platform": "openai",
-      "model": "gpt-5.2-codex",
-      "reason": "2026-06-23 prod /v1/responses reprobe returned 400 unsupported; GPT OAuth backend model set can change.",
-      "last_probe": "2026-07-24",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "openai_responses"
-    },
-    {
-      "platform": "gemini",
-      "model": "gemini-2.5-flash-image",
-      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_chat_image"
-    },
-    {
-      "platform": "gemini",
-      "model": "gemini-3.1-flash-image",
-      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_chat_image"
-    },
-    {
-      "platform": "gemini",
-      "model": "gemini-3-pro-image-preview",
-      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_chat_image"
-    },
-    {
-      "platform": "gemini",
-      "model": "nano-banana-pro-preview",
-      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_chat_image"
-    },
-    {
-      "platform": "gemini",
-      "model": "imagen-3.0-capability-001",
-      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_image"
-    },
-    {
-      "platform": "gemini",
-      "model": "imagen-3.0-fast-generate-001",
-      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_image"
-    },
-    {
-      "platform": "gemini",
-      "model": "imagen-3.0-generate-001",
-      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_image"
-    },
-    {
-      "platform": "gemini",
-      "model": "imagen-3.0-generate-002",
-      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_image"
-    },
-    {
-      "platform": "gemini",
-      "model": "veo-2.0-generate-001",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_video"
-    },
-    {
-      "platform": "gemini",
-      "model": "veo-3.0-fast-generate-001",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_video"
-    },
-    {
-      "platform": "gemini",
-      "model": "veo-3.0-generate-001",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_video"
-    },
-    {
-      "platform": "gemini",
-      "model": "veo-3.1-fast-generate-001",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_video"
-    },
-    {
-      "platform": "gemini",
-      "model": "veo-3.1-fast-generate-preview",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_video"
-    },
-    {
-      "platform": "gemini",
-      "model": "veo-3.1-generate-preview",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_video"
-    },
-    {
-      "platform": "gemini",
-      "model": "veo-3.1-lite-generate-preview",
-      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_video"
-    },
-    {
-      "platform": "newapi",
-      "model": "kimi-k2.x",
-      "reason": "Backlog candidate, never probed; not a native refresh-servable-allowlist platform.",
-      "expires": "2026-08-06",
-      "auto_probe": false,
-      "owner": "tokenkey-onboard-model"
-    },
-    {
-      "platform": "newapi",
-      "model": "qwq-32b",
-      "reason": "2026-06-23 prod Qwen-group thinking and nonthinking probes returned 429 not_allowlisted; no schedulable account currently maps this id.",
-      "last_probe": "2026-07-24",
-      "freshness_days": 30,
-      "auto_probe": false,
-      "owner": "tokenkey-onboard-model"
-    },
-    {
-      "platform": "newapi",
-      "model": "MiniMax-M2.x",
-      "reason": "Backlog candidate, never probed; not a native refresh-servable-allowlist platform.",
-      "expires": "2026-08-06",
-      "auto_probe": false,
-      "owner": "tokenkey-onboard-model"
-    },
-    {
-      "platform": "newapi",
-      "model": "deepseek-v4-none/max",
-      "reason": "2026-06-23 prod deepseek-group probes for deepseek-v4-none and deepseek-v4-max returned 429 not_allowlisted; registered DeepSeek ids deepseek-v4-pro/flash and deepseek-chat/reasoner returned 200.",
-      "last_probe": "2026-07-24",
-      "freshness_days": 30,
-      "auto_probe": false,
-      "owner": "tokenkey-onboard-model"
-    },
-    {
-      "platform": "newapi",
-      "model": "doubao-seed-translation-250915",
-      "reason": "2026-07-08 prod VolcEngine Ark /api/v3/chat/completions reprobe returned 400 does not support this api (gateway_rejected); tk_020 legacy mapping only — not in tk_served_models.json and must be dropped on apply.",
-      "last_probe": "2026-07-08",
-      "freshness_days": 30,
-      "auto_probe": false,
-      "owner": "tokenkey-onboard-model"
-    },
-    {
-      "platform": "gemini",
-      "model": "gemini-2.0-flash-exp-image-generation",
-      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; not in the current Vertex model_mapping. Reprobe only after mapping/account expansion.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_chat_image"
-    },
-    {
-      "platform": "openai",
-      "model": "gpt-image-1",
-      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "openai_image"
-    },
-    {
-      "platform": "openai",
-      "model": "gpt-image-1-mini",
-      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "openai_image"
-    },
-    {
-      "platform": "openai",
-      "model": "gpt-image-1.5",
-      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "openai_image"
-    },
-    {
-      "platform": "openai",
-      "model": "gpt-image-1.5-2025-12-16",
-      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "openai_image"
-    },
-    {
-      "platform": "openai",
-      "model": "gpt-image-2",
-      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "openai_image"
-    },
-    {
-      "platform": "openai",
-      "model": "gpt-image-2-2026-04-21",
-      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "openai_image"
-    },
-    {
-      "platform": "grok",
-      "model": "grok-imagine-image",
-      "reason": "2026-07-02 edge-us4 native-grok /v1/images/generations returned 429 inconclusive with an empty body. Existing public listing stays based on prior successful live evidence and pricing; reprobe before changing Grok media catalog.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": false,
-      "owner": "native-grok"
-    },
-    {
-      "platform": "grok",
-      "model": "grok-imagine-image-quality",
-      "reason": "2026-07-02 edge-us4 native-grok /v1/images/generations returned 429 inconclusive with an empty body. Existing public listing stays based on prior successful live evidence and pricing; reprobe before changing Grok media catalog.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": false,
-      "owner": "native-grok"
-    },
-    {
-      "platform": "grok",
-      "model": "grok-imagine-video",
-      "reason": "2026-07-02 edge-us4 native-grok /v1/video/generations returned 429 inconclusive with an empty body. Existing public listing stays based on prior successful live evidence and pricing; reprobe before changing Grok media catalog.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": false,
-      "owner": "native-grok"
-    },
-    {
-      "platform": "newapi",
-      "model": "doubao-seedance-2-0-mini-260615",
-      "reason": "2026-07-02 direct VolcEngine Ark /api/v3/contents/generations/tasks returned 404 but did not match the unsupported classifier; keep out of manifest and reprobe with the official task shape before deciding.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": false,
-      "owner": "tokenkey-onboard-model"
-    },
-    {
-      "platform": "antigravity",
-      "model": "gemini-2.5-flash-image",
-      "reason": "2026-07-02 prod ANTIGRAVITY_IMAGE_MODELS /v1/chat/completions via antigravity group_id=21 returned 200 servable after fixing the default source group id from 8 (Google-Gemini) to 21 (Google-Antigravity). Keep watchlisted only as a smoke sentinel for group-id drift.",
-      "last_probe": "2026-07-02",
-      "freshness_days": 30,
-      "auto_probe": false,
-      "owner": "native-antigravity"
-    },
-    {
-      "platform": "gemini",
-      "model": "gemini-2.0-flash",
-      "reason": "2026-06-09 project-scoped 502 on the then-current Vertex project was inconclusive and must not become permanent catalog-removal evidence.",
-      "last_probe": "2026-06-09",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_chat"
-    },
-    {
-      "platform": "gemini",
-      "model": "gemini-2.0-flash-001",
-      "reason": "2026-06-09 project-scoped 502 on the then-current Vertex project was inconclusive and must remain eligible for re-probe.",
-      "last_probe": "2026-06-09",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_chat"
-    },
-    {
-      "platform": "gemini",
-      "model": "gemini-2.0-flash-lite",
-      "reason": "2026-06-09 project-scoped 502 on the then-current Vertex project was inconclusive and must remain eligible for re-probe.",
-      "last_probe": "2026-06-09",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_chat"
-    },
-    {
-      "platform": "gemini",
-      "model": "gemini-2.0-flash-lite-001",
-      "reason": "2026-06-09 project-scoped 502 on the then-current Vertex project was inconclusive and must remain eligible for re-probe.",
-      "last_probe": "2026-06-09",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_chat"
-    },
-    {
-      "platform": "gemini",
-      "model": "gemini-3-pro-preview",
-      "reason": "2026-06-09 project-scoped 502 on the then-current Vertex project was inconclusive and must remain eligible for re-probe.",
-      "last_probe": "2026-06-09",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_chat"
-    },
-    {
-      "platform": "gemini",
-      "model": "gemini-3.1-pro-preview",
-      "reason": "2026-06-09 project-scoped 502 on the then-current Vertex project was inconclusive and must remain eligible for re-probe.",
-      "last_probe": "2026-06-09",
-      "freshness_days": 30,
-      "auto_probe": true,
-      "probe_family": "gemini_chat"
-    }
-  ],
+  "_doc": "Machine-readable reprobe policy for ops/pricing/refresh-servable-allowlist.py. probe_candidates are durable explicit candidate inputs with no freshness lifecycle; watchlist is only time-bounded operational follow-up; skiplist entries are excluded from probing; structurally_gone entries are the reviewed authority for catalog removal.",
+  "_generated_from": "2026-09-02 split durable probe candidates from expired watchlist evidence",
+  "watchlist": [],
   "skiplist": [
     {
       "platform": "openai",
@@ -494,6 +99,200 @@
       "platform": "grok",
       "model": "grok-imagine-image-pro",
       "reason": "Retired upstream on 2026-05-15; replaced by grok-imagine-image-quality."
+    }
+  ],
+  "probe_candidates": [
+    {
+      "platform": "openai",
+      "model": "gpt-5.1-codex",
+      "reason": "2026-06-23 prod /v1/responses reprobe returned 400 unsupported; GPT OAuth backend model set can change.",
+      "probe_family": "openai_responses"
+    },
+    {
+      "platform": "openai",
+      "model": "gpt-5.1-codex-max",
+      "reason": "2026-06-23 prod /v1/responses reprobe returned 400 unsupported; GPT OAuth backend model set can change.",
+      "probe_family": "openai_responses"
+    },
+    {
+      "platform": "openai",
+      "model": "gpt-5.1-codex-mini",
+      "reason": "2026-06-23 prod /v1/responses reprobe returned 400 unsupported; GPT OAuth backend model set can change.",
+      "probe_family": "openai_responses"
+    },
+    {
+      "platform": "openai",
+      "model": "gpt-5.2-codex",
+      "reason": "2026-06-23 prod /v1/responses reprobe returned 400 unsupported; GPT OAuth backend model set can change.",
+      "probe_family": "openai_responses"
+    },
+    {
+      "platform": "gemini",
+      "model": "gemini-2.5-flash-image",
+      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion.",
+      "probe_family": "gemini_chat_image"
+    },
+    {
+      "platform": "gemini",
+      "model": "gemini-3.1-flash-image",
+      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion.",
+      "probe_family": "gemini_chat_image"
+    },
+    {
+      "platform": "gemini",
+      "model": "gemini-3-pro-image-preview",
+      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion.",
+      "probe_family": "gemini_chat_image"
+    },
+    {
+      "platform": "gemini",
+      "model": "nano-banana-pro-preview",
+      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping exposes only gemini-2.5 text, Imagen 4.0, and veo-3.1-generate-001. Reprobe after Vertex mapping/account expansion.",
+      "probe_family": "gemini_chat_image"
+    },
+    {
+      "platform": "gemini",
+      "model": "imagen-3.0-capability-001",
+      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion.",
+      "probe_family": "gemini_image"
+    },
+    {
+      "platform": "gemini",
+      "model": "imagen-3.0-fast-generate-001",
+      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion.",
+      "probe_family": "gemini_image"
+    },
+    {
+      "platform": "gemini",
+      "model": "imagen-3.0-generate-001",
+      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion.",
+      "probe_family": "gemini_image"
+    },
+    {
+      "platform": "gemini",
+      "model": "imagen-3.0-generate-002",
+      "reason": "2026-07-02 prod /v1/images/generations via Vertex group_id=16 returned 429 not_allowlisted; current mapped Vertex image set is Imagen 4.0 only. Reprobe after Vertex mapping/account expansion.",
+      "probe_family": "gemini_image"
+    },
+    {
+      "platform": "gemini",
+      "model": "veo-2.0-generate-001",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
+      "probe_family": "gemini_video"
+    },
+    {
+      "platform": "gemini",
+      "model": "veo-3.0-fast-generate-001",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
+      "probe_family": "gemini_video"
+    },
+    {
+      "platform": "gemini",
+      "model": "veo-3.0-generate-001",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
+      "probe_family": "gemini_video"
+    },
+    {
+      "platform": "gemini",
+      "model": "veo-3.1-fast-generate-001",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
+      "probe_family": "gemini_video"
+    },
+    {
+      "platform": "gemini",
+      "model": "veo-3.1-fast-generate-preview",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
+      "probe_family": "gemini_video"
+    },
+    {
+      "platform": "gemini",
+      "model": "veo-3.1-generate-preview",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
+      "probe_family": "gemini_video"
+    },
+    {
+      "platform": "gemini",
+      "model": "veo-3.1-lite-generate-preview",
+      "reason": "2026-07-02 prod /v1/video/generations via Vertex group_id=16 returned 429 not_allowlisted; live Vertex model_mapping currently exposes only veo-3.1-generate-001, so keep out of the gemini allowlist until a 200 probe after mapping expansion.",
+      "probe_family": "gemini_video"
+    },
+    {
+      "platform": "gemini",
+      "model": "gemini-2.0-flash-exp-image-generation",
+      "reason": "2026-07-02 prod /v1/chat/completions via Vertex group_id=16 returned 429 not_allowlisted; not in the current Vertex model_mapping. Reprobe only after mapping/account expansion.",
+      "probe_family": "gemini_chat_image"
+    },
+    {
+      "platform": "openai",
+      "model": "gpt-image-1",
+      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
+      "probe_family": "openai_image"
+    },
+    {
+      "platform": "openai",
+      "model": "gpt-image-1-mini",
+      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
+      "probe_family": "openai_image"
+    },
+    {
+      "platform": "openai",
+      "model": "gpt-image-1.5",
+      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
+      "probe_family": "openai_image"
+    },
+    {
+      "platform": "openai",
+      "model": "gpt-image-1.5-2025-12-16",
+      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
+      "probe_family": "openai_image"
+    },
+    {
+      "platform": "openai",
+      "model": "gpt-image-2",
+      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
+      "probe_family": "openai_image"
+    },
+    {
+      "platform": "openai",
+      "model": "gpt-image-2-2026-04-21",
+      "reason": "2026-07-02 prod /v1/images/generations via OpenAI group_id=2 returned HTTP 400; upstream body says missing scope api.model.images.request on the serving account. Do not public/Studio-list until an OpenAI image-scoped account probes 200.",
+      "probe_family": "openai_image"
+    },
+    {
+      "platform": "gemini",
+      "model": "gemini-2.0-flash",
+      "reason": "2026-06-09 project-scoped 502 on the then-current Vertex project was inconclusive and must not become permanent catalog-removal evidence.",
+      "probe_family": "gemini_chat"
+    },
+    {
+      "platform": "gemini",
+      "model": "gemini-2.0-flash-001",
+      "reason": "2026-06-09 project-scoped 502 on the then-current Vertex project was inconclusive and must remain eligible for re-probe.",
+      "probe_family": "gemini_chat"
+    },
+    {
+      "platform": "gemini",
+      "model": "gemini-2.0-flash-lite",
+      "reason": "2026-06-09 project-scoped 502 on the then-current Vertex project was inconclusive and must remain eligible for re-probe.",
+      "probe_family": "gemini_chat"
+    },
+    {
+      "platform": "gemini",
+      "model": "gemini-2.0-flash-lite-001",
+      "reason": "2026-06-09 project-scoped 502 on the then-current Vertex project was inconclusive and must remain eligible for re-probe.",
+      "probe_family": "gemini_chat"
+    },
+    {
+      "platform": "gemini",
+      "model": "gemini-3-pro-preview",
+      "reason": "2026-06-09 project-scoped 502 on the then-current Vertex project was inconclusive and must remain eligible for re-probe.",
+      "probe_family": "gemini_chat"
+    },
+    {
+      "platform": "gemini",
+      "model": "gemini-3.1-pro-preview",
+      "reason": "2026-06-09 project-scoped 502 on the then-current Vertex project was inconclusive and must remain eligible for re-probe.",
+      "probe_family": "gemini_chat"
     }
   ]
 }

--- a/ops/pricing/servable_reprobe_ledger.py
+++ b/ops/pricing/servable_reprobe_ledger.py
@@ -1,0 +1,200 @@
+"""Pure schema and projection helpers for the servable reprobe ledger."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+from typing import Callable
+
+LEDGER_LISTS = ("probe_candidates", "watchlist", "skiplist", "structurally_gone")
+VOLATILE_CANDIDATE_FIELDS = {"auto_probe", "last_probe", "freshness_days", "expires"}
+
+
+def load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def entries(ledger: dict, list_name: str) -> list[dict]:
+    rows = ledger.get(list_name, [])
+    if not isinstance(rows, list):
+        raise ValueError(f"{list_name}: expected list")
+    return rows
+
+
+def _parse_date(value: str, label: str) -> dt.date:
+    try:
+        return dt.date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"{label}: expected YYYY-MM-DD, got {value!r}") from exc
+
+
+def validate(
+    ledger: dict,
+    *,
+    probe_family_for: Callable[[str, str, str | None], str],
+    candidate_members: set[tuple[str, str]] | None = None,
+    today: dt.date | None = None,
+    allowlist_members: set[tuple[str, str]] | None = None,
+) -> None:
+    today = today or dt.date.today()
+    seen: dict[tuple[str, str], str] = {}
+    list_keys = {name: set() for name in LEDGER_LISTS}
+
+    for list_name in LEDGER_LISTS:
+        for idx, entry in enumerate(entries(ledger, list_name)):
+            if not isinstance(entry, dict):
+                raise ValueError(f"{list_name}[{idx}]: expected object")
+            platform = entry.get("platform")
+            model = entry.get("model")
+            reason = entry.get("reason")
+            if not platform or not model:
+                raise ValueError(f"{list_name}[{idx}]: platform and model are required")
+            if not reason:
+                raise ValueError(f"{list_name}[{idx}] {platform}/{model}: reason is required")
+            key = (platform, model)
+            if key in seen:
+                raise ValueError(f"{platform}/{model}: appears in both {seen[key]} and {list_name}")
+            seen[key] = list_name
+            list_keys[list_name].add(key)
+
+            if list_name == "probe_candidates":
+                volatile = sorted(VOLATILE_CANDIDATE_FIELDS & set(entry))
+                if volatile:
+                    raise ValueError(
+                        f"probe_candidates {platform}/{model}: volatile fields are not allowed: {volatile}"
+                    )
+                probe_family_for(platform, model, entry.get("probe_family"))
+                if candidate_members is not None and key not in candidate_members:
+                    raise ValueError(f"probe_candidates {platform}/{model}: entry missing from candidates")
+            elif list_name == "watchlist":
+                last_probe = entry.get("last_probe")
+                expires = entry.get("expires")
+                freshness_days = entry.get("freshness_days")
+                if freshness_days is not None and (
+                    not isinstance(freshness_days, int) or freshness_days < 1
+                ):
+                    raise ValueError(
+                        f"watchlist {platform}/{model}: freshness_days must be a positive integer"
+                    )
+                if last_probe:
+                    probed_at = _parse_date(
+                        str(last_probe), f"watchlist {platform}/{model} last_probe"
+                    )
+                    if probed_at > today:
+                        raise ValueError(
+                            f"watchlist {platform}/{model}: last_probe {probed_at} is in the future"
+                        )
+                elif not expires:
+                    raise ValueError(f"watchlist {platform}/{model}: last_probe or expires is required")
+                if expires:
+                    _parse_date(str(expires), f"watchlist {platform}/{model} expires")
+                elif freshness_days is None:
+                    raise ValueError(
+                        f"watchlist {platform}/{model}: freshness_days or expires is required"
+                    )
+
+    blocked = list_keys["skiplist"] | list_keys["structurally_gone"]
+    tracked = list_keys["probe_candidates"] | list_keys["watchlist"]
+    overlap = tracked & blocked
+    if overlap:
+        rendered = ", ".join(f"{platform}/{model}" for platform, model in sorted(overlap))
+        raise ValueError(
+            "probe_candidates/watchlist cannot overlap skiplist/structurally_gone: " + rendered
+        )
+    if allowlist_members:
+        conflicts = allowlist_members & list_keys["skiplist"]
+        if conflicts:
+            rendered = ", ".join(f"{platform}/{model}" for platform, model in sorted(conflicts))
+            raise ValueError(f"servable allowlist cannot overlap skiplist: {rendered}")
+
+
+def watchlist_freshness(
+    ledger: dict, *, today: dt.date | None = None
+) -> list[dict[str, object]]:
+    today = today or dt.date.today()
+    stale: list[dict[str, object]] = []
+    for entry in entries(ledger, "watchlist"):
+        expires = entry.get("expires")
+        last_probe = entry.get("last_probe")
+        freshness_days = entry.get("freshness_days")
+        if expires:
+            deadline = _parse_date(
+                str(expires), f"watchlist {entry.get('platform')}/{entry.get('model')} expires"
+            )
+        elif last_probe and isinstance(freshness_days, int):
+            deadline = _parse_date(
+                str(last_probe),
+                f"watchlist {entry.get('platform')}/{entry.get('model')} last_probe",
+            ) + dt.timedelta(days=freshness_days)
+        else:
+            continue
+        if today > deadline:
+            stale.append(
+                {
+                    "platform": entry["platform"],
+                    "model": entry["model"],
+                    "deadline": deadline.isoformat(),
+                    "days_stale": (today - deadline).days,
+                }
+            )
+    return sorted(stale, key=lambda row: (str(row["platform"]), str(row["model"])))
+
+
+def warn_stale_watchlist(ledger: dict, *, today: dt.date | None = None) -> None:
+    stale = watchlist_freshness(ledger, today=today)
+    if not stale:
+        return
+    oldest = max(int(row["days_stale"]) for row in stale)
+    print(
+        f"[refresh] WARN: {len(stale)} watchlist entr{'y is' if len(stale) == 1 else 'ies are'} "
+        f"stale (oldest={oldest}d); candidates remain usable. "
+        "Run `refresh-servable-allowlist.py watchlist-status` for details.",
+        file=sys.stderr,
+    )
+
+
+def augment_candidates(
+    candidates: dict[str, list[str]],
+    ledger: dict,
+    *,
+    probe_families_by_platform: dict[str, tuple[str, ...]],
+    family_platform: dict[str, str],
+    probe_family_for: Callable[[str, str, str | None], str],
+) -> dict[str, list[str]]:
+    out = {key: list(values) for key, values in candidates.items()}
+    for entry in entries(ledger, "probe_candidates"):
+        platform = entry["platform"]
+        model = entry["model"]
+        family = probe_family_for(platform, model, entry.get("probe_family"))
+        for peer_family in probe_families_by_platform[platform]:
+            out[peer_family] = [mid for mid in out.get(peer_family, []) if mid != model]
+        out.setdefault(family, []).append(model)
+
+    blocked = {
+        (entry["platform"], entry["model"])
+        for list_name in ("skiplist", "structurally_gone")
+        for entry in entries(ledger, list_name)
+    }
+    for family, platform in family_platform.items():
+        if family in out:
+            out[family] = [model for model in out[family] if (platform, model) not in blocked]
+    for family in out:
+        out[family] = sorted(set(out[family]))
+    return out
+
+
+def validate_results(servable: dict[str, set[str]], ledger: dict) -> None:
+    blocked = {
+        (entry["platform"], entry["model"])
+        for list_name in ("skiplist", "structurally_gone")
+        for entry in entries(ledger, list_name)
+    }
+    observed = {(platform, model) for platform, models in servable.items() for model in models}
+    conflicts = observed & blocked
+    if conflicts:
+        rendered = ", ".join(f"{platform}/{model}" for platform, model in sorted(conflicts))
+        raise SystemExit(
+            f"FATAL: probe results mark skiplist/structurally_gone model as servable: {rendered}"
+        )

--- a/scripts/checks/catalog-serving-drift.py
+++ b/scripts/checks/catalog-serving-drift.py
@@ -25,12 +25,12 @@ but never actually wired onto the serving account's model_mapping => empty pool 
   A2 DISPLAY      native display==true => model_id present in the platform's Go
                   allowlist map. newapi display is owned by this manifest.     HARD
   A3 SERVED_ON    every served_on account => a legacy tk_*.sql migration maps the model,
-                  or notes explicitly declare `served-via-modelops-activation`. The
-                  latter is the approved path for new bundle floors and must complete
-                  before release; generic deploy never writes live account mappings.
-                  This is the #812-catching direction.                        HARD-FAIL
-                  Legacy escape hatch: `served-via-admin-ui` is downgraded to WARN for
-                  mapping state that predates the activation contract.
+                  or mapping_source declares `activation`. The latter is the approved
+                  path for new bundle floors and must complete before release; generic
+                  deploy never writes live account mappings. This is the #812-catching
+                  direction.                                                  HARD-FAIL
+                  Legacy mapping_source `admin_legacy` is downgraded to WARN for state
+                  that predates the activation contract.
   A4 ENUMERATION  native display allowlists also require a direct owner or `_aliases`;
                   (advisory WARN) every dashscope/deepseek chat overlay key SHOULD be a
                   manifest entry (catch a priced+served-but-forgotten model).
@@ -45,6 +45,7 @@ import json
 import pathlib
 import re
 import sys
+from typing import Any
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
 SERVICE_DIR = REPO_ROOT / "backend" / "internal" / "service"
@@ -73,9 +74,8 @@ ALLOWLIST_PLATFORMS = ("anthropic", "openai", "gemini", "antigravity", "grok")
 # A4 advisory: overlay vendors whose chat models are the manifest's curated long-tail.
 ENUMERATION_PROVIDERS = {"dashscope", "deepseek", "moonshot", "volcengine", "zhipu", "bigmodel", "zai"}
 
-# Recognized literal declarations in an entry's notes (A3 migration-scan alternatives).
-ADMIN_UI_OPT_OUT = "served-via-admin-ui"
-MODELOPS_ACTIVATION = "served-via-modelops-activation"
+VALID_MAPPING_SOURCES = {"activation", "admin_legacy"}
+STALE_MAPPING_MARKERS = ("served-via-admin-ui", "served-via-modelops-activation")
 
 REQUIRED_FIELDS = {
     "platform": str,
@@ -255,6 +255,24 @@ def evaluate(
         price_source = entry["price_source"]
         price_key = entry["price_key"]
         notes = entry.get("notes", "") or ""
+        if not isinstance(notes, str):
+            errors.append(f"{key}: notes must be a string")
+            continue
+        mapping_source = entry.get("mapping_source")
+        if mapping_source is not None and (
+            not isinstance(mapping_source, str) or mapping_source not in VALID_MAPPING_SOURCES
+        ):
+            errors.append(
+                f"{key}: mapping_source {mapping_source!r} not in {sorted(VALID_MAPPING_SOURCES)}"
+            )
+            continue
+        stale_markers = [marker for marker in STALE_MAPPING_MARKERS if marker in notes]
+        if stale_markers:
+            errors.append(
+                f"{key}: notes contains obsolete machine marker(s) {stale_markers}; "
+                "declare mapping_source instead"
+            )
+            continue
         manifest_model_ids.add(model_id)
 
         # ---- A1 price-resolvable -----------------------------------------------
@@ -315,23 +333,21 @@ def evaluate(
                 )
 
         # ---- A3 served_on => legacy migration or explicit activation -----------
-        admin_ui = ADMIN_UI_OPT_OUT in notes
-        modelops_activation = MODELOPS_ACTIVATION in notes
         for account in entry["served_on"]:
             if migration_maps_model(migration_files, account, model_id):
                 continue
-            if modelops_activation:
+            if mapping_source == "activation":
                 continue
             msg = (
                 f"{key}: served_on lists account {account} but NO tk_*.sql migration maps "
                 f'"{model_id}" onto it (`id = {account}` + quoted id). #812-class gap: the '
                 f"runtime pool is empty for this model until an explicit mapping write => 429/503. "
-                f"For a new bundle floor, declare {MODELOPS_ACTIVATION!r} in notes and complete "
+                "For a new bundle floor, declare mapping_source='activation' and complete "
                 f"modelops activate before release; otherwise remove this row."
             )
-            if admin_ui:
+            if mapping_source == "admin_legacy":
                 warnings.append(
-                    msg + f"  [downgraded to WARN: notes carries '{ADMIN_UI_OPT_OUT}']"
+                    msg + "  [downgraded to WARN: mapping_source='admin_legacy']"
                 )
             else:
                 errors.append(msg)
@@ -425,17 +441,17 @@ def _selftest() -> int:
         "newapi/good-chat-alias": {
             "platform": "newapi", "model_id": "good-chat-alias", "served_on": ["60"],
             "channel_type": 17, "price_source": "overlay", "price_key": "good-chat",
-            "display": True, "notes": "served-via-modelops-activation",
+            "display": True, "mapping_source": "activation", "notes": "ok",
         },
         "newapi/adminui-chat": {
             "platform": "newapi", "model_id": "adminui-chat", "served_on": ["60"],
             "channel_type": 17, "price_source": "overlay", "price_key": "good-chat",
-            "display": False, "notes": "applied out-of-band served-via-admin-ui",
+            "display": False, "mapping_source": "admin_legacy", "notes": "applied out-of-band",
         },
         "newapi/activation-chat": {
             "platform": "newapi", "model_id": "activation-chat", "served_on": ["60"],
             "channel_type": 17, "price_source": "overlay", "price_key": "good-chat",
-            "display": False, "notes": "pre-release served-via-modelops-activation",
+            "display": False, "mapping_source": "activation", "notes": "pre-release",
             "account_scope": {
                 "platform": "newapi", "channel_type": 45,
                 "base_url": "https://ark.cn-beijing.volces.com/api/plan/v3",
@@ -481,28 +497,28 @@ def _selftest() -> int:
     errs, _ = run({"newapi/absent": {
         "platform": "newapi", "model_id": "nope", "served_on": ["60"],
         "channel_type": 17, "price_source": "overlay", "price_key": "nonexistent",
-        "display": False, "notes": "served-via-admin-ui",
+        "display": False, "mapping_source": "admin_legacy", "notes": "legacy",
     }})
     if not any("absent from" in e for e in errs):
         failures.append("A1: missing overlay key not flagged")
     errs, _ = run({"newapi/zero": {
         "platform": "newapi", "model_id": "zero-chat", "served_on": ["60"],
         "channel_type": 43, "price_source": "overlay", "price_key": "zero-chat",
-        "display": False, "notes": "served-via-admin-ui",
+        "display": False, "mapping_source": "admin_legacy", "notes": "legacy",
     }})
     if not any("requires" in e and "> 0" in e for e in errs):
         failures.append("A1: $0 overlay price not flagged")
     errs, _ = run({"newapi/emb": {
         "platform": "newapi", "model_id": "good-embedding", "served_on": ["60"],
         "channel_type": 46, "price_source": "overlay", "price_key": "good-embedding",
-        "display": False, "notes": "served-via-admin-ui",
+        "display": False, "mapping_source": "admin_legacy", "notes": "legacy",
     }})
     if errs:
         failures.append(f"A1: valid embedding overlay flagged: {errs}")
     errs, _ = run({"newapi/zero-emb": {
         "platform": "newapi", "model_id": "zero-embedding", "served_on": ["60"],
         "channel_type": 46, "price_source": "overlay", "price_key": "zero-embedding",
-        "display": False, "notes": "served-via-admin-ui",
+        "display": False, "mapping_source": "admin_legacy", "notes": "legacy",
     }})
     if not any("requires" in e and "> 0" in e for e in errs):
         failures.append("A1: $0 embedding overlay price not flagged")
@@ -510,7 +526,7 @@ def _selftest() -> int:
     errs, _ = run({"newapi/mirror": {
         "platform": "newapi", "model_id": "good-chat", "served_on": ["60"],
         "channel_type": 43, "price_source": "mirror", "price_key": "good-chat",
-        "display": False, "notes": "served-via-admin-ui",
+        "display": False, "mapping_source": "admin_legacy", "notes": "legacy",
     }})
     if not any("price_source 'mirror' not in" in e for e in errs):
         failures.append("A1: external mirror accepted as an effective price source")
@@ -519,14 +535,14 @@ def _selftest() -> int:
     errs, _ = run({"other/disp": {
         "platform": "bedrock", "model_id": "good-chat", "served_on": ["60"],
         "channel_type": 17, "price_source": "overlay", "price_key": "good-chat",
-        "display": True, "notes": "served-via-admin-ui",
+        "display": True, "mapping_source": "admin_legacy", "notes": "legacy",
     }})
     if not any("has NO Go" in e for e in errs):
         failures.append("A2: display=true on no-map platform not flagged")
     errs, _ = run({"anthropic/disp": {
         "platform": "anthropic", "model_id": "claude-ghost", "served_on": ["1"],
         "channel_type": 0, "price_source": "overlay", "price_key": "good-chat",
-        "display": True, "notes": "served-via-admin-ui",
+        "display": True, "mapping_source": "admin_legacy", "notes": "legacy",
     }})
     if not any("absent from the anthropic servable-allowlist" in e for e in errs):
         failures.append("A2: display=true absent from real map not flagged")
@@ -542,7 +558,7 @@ def _selftest() -> int:
     errs, warns = run({"newapi/oob": {
         "platform": "newapi", "model_id": "unmapped", "served_on": ["60"],
         "channel_type": 17, "price_source": "overlay", "price_key": "good-chat",
-        "display": False, "notes": "applied out-of-band served-via-admin-ui",
+        "display": False, "mapping_source": "admin_legacy", "notes": "applied out-of-band",
     }})
     if any("#812-class gap" in e for e in errs):
         failures.append("A3: admin-ui opt-out still hard-failed")
@@ -551,12 +567,27 @@ def _selftest() -> int:
     errs, warns = run({"newapi/activation": {
         "platform": "newapi", "model_id": "unmapped", "served_on": ["60"],
         "channel_type": 17, "price_source": "overlay", "price_key": "good-chat",
-        "display": False, "notes": "served-via-modelops-activation",
+        "display": False, "mapping_source": "activation", "notes": "modelops activation",
     }})
     if any("#812-class gap" in e for e in errs):
         failures.append("A3: modelops activation declaration still hard-failed")
     if any("#812-class gap" in w for w in warns):
         failures.append(f"A3: modelops activation declaration produced mapping warnings: {warns}")
+    errs, _ = run({"newapi/stale-marker": {
+        "platform": "newapi", "model_id": "unmapped", "served_on": ["60"],
+        "channel_type": 17, "price_source": "overlay", "price_key": "good-chat",
+        "display": False, "mapping_source": "activation",
+        "notes": "served-via-modelops-activation",
+    }})
+    if not any("obsolete machine marker" in e for e in errs):
+        failures.append("A3: obsolete notes marker was accepted")
+    errs, _ = run({"newapi/bad-mapping-source": {
+        "platform": "newapi", "model_id": "unmapped", "served_on": ["60"],
+        "channel_type": 17, "price_source": "overlay", "price_key": "good-chat",
+        "display": False, "mapping_source": ["activation"], "notes": "bad enum type",
+    }})
+    if not any("mapping_source" in e for e in errs):
+        failures.append("A3: non-string mapping_source was accepted")
 
     # --- A3 prefix-quote: "good-chat" must NOT match "good-chat-preview" --------
     pmig = {"tk_902.sql": 'WHERE id = 60 ... "good-chat-preview": "good-chat-preview"'}

--- a/scripts/checks/display-coverage-gate.py
+++ b/scripts/checks/display-coverage-gate.py
@@ -1,181 +1,43 @@
 #!/usr/bin/env python3
-"""display-coverage-gate.py — forward guard against the #1030 / #1029 failure class.
+"""Compatibility entrypoint for the retired diff-scoped display gate.
 
-Both #1030 (gpt-5.6) and #1029 (antigravity gemini-* image/3.5-flash) added models
-to the Go servable allowlist (pricing_catalog_supported_models_tk.go) and to the
-BUNDLED litellm mirror (backend/resources/model-pricing/…), reasoning "it's priced
-in the mirror, so it displays." It does NOT: prod's /pricing catalog is built from
-the live UPSTREAM remote mirror (Wei-Shaw/model-price-repo) ∪ the TK overlay
-(tk_pricing_overlay.json). The bundled mirror is a hand-maintained, SHADOWED
-fallback prod never reads — so a model present only there shows a BLANK price.
-The overlay is the only prod-reliable, repo-checkable display source.
-
-This gate is DIFF-SCOPED: it only fires on models a PR ADDS to the allowlist
-(base..HEAD), so it passes on a clean main and never retroactively fails. For each
-newly-allowlisted model it requires display coverage in the overlay (non-zero,
-token OR media). The escape hatch is a falsifiable assertion, not a rubber stamp:
-a commit message carrying `display-via-remote-verified` declares the author
-confirmed the model already displays priced via the upstream remote (the only
-legitimate non-overlay source). The live backstop is
-ops/pricing/audit-display-coverage.py check --live (catches a wrong assertion).
-
-Exit: 0 clean / 1 gap (uncovered new allowlist entry, no marker) / 2 error.
+Static display ownership is now checked once, for the complete repository, by
+``catalog-serving-drift.py`` A4. Keep this path temporarily so operator scripts
+that still invoke ``check --base`` receive the canonical result instead of a
+missing command. The live projection close-out remains
+``ops/pricing/audit-display-coverage.py check --live``.
 """
+
 from __future__ import annotations
 
 import argparse
-import json
-import re
 import subprocess
 import sys
 from pathlib import Path
 
+
 REPO = Path(__file__).resolve().parents[2]
-GO_REL = "backend/internal/service/pricing_catalog_supported_models_tk.go"
-OVERLAY_REL = "backend/internal/service/tk_pricing_overlay.json"
-PLATFORMS = ("anthropic", "openai", "gemini", "antigravity", "grok")
-MARKER = "display-via-remote-verified"
+OWNER = REPO / "scripts/checks/catalog-serving-drift.py"
 
 
-def parse_allowlist(go_text: str) -> dict[str, set[str]]:
-    out: dict[str, set[str]] = {}
-    for plat in PLATFORMS:
-        m = re.search(
-            r"servable-allowlist:begin %s(.*?)servable-allowlist:end %s" % (plat, plat),
-            go_text,
-            re.S,
-        )
-        out[plat] = set(re.findall(r'"([^"]+)":\s*\{\}', m.group(1))) if m else set()
-    return out
-
-
-def overlay_priced(entry: object) -> bool:
-    if not isinstance(entry, dict):
-        return False
-    return (
-        (entry.get("input_cost_per_token") or 0) > 0
-        or (entry.get("output_cost_per_token") or 0) > 0
-        or (entry.get("output_cost_per_image") or 0) > 0
-        or (entry.get("output_cost_per_second") or 0) > 0
-    )
-
-
-def covered_overlay_ids(overlay: dict) -> set[str]:
-    return {k for k, v in overlay.items() if k != "_meta" and overlay_priced(v)}
-
-
-def _git(*args: str) -> str:
-    return subprocess.check_output(["git", "-C", str(REPO), *args], text=True)
-
-
-def added_allowlist_models(base: str) -> dict[str, set[str]]:
-    """Models present in HEAD's allowlist but not base's, per platform."""
-    try:
-        base_go = _git("show", f"{base}:{GO_REL}")
-    except subprocess.CalledProcessError:
-        base_go = ""  # file absent at base → everything is "added"
-    head_go = (REPO / GO_REL).read_text(encoding="utf-8")
-    base_al = parse_allowlist(base_go)
-    head_al = parse_allowlist(head_go)
-    return {p: head_al.get(p, set()) - base_al.get(p, set()) for p in PLATFORMS}
-
-
-def has_marker(base: str) -> bool:
-    try:
-        msgs = _git("log", "--format=%B", f"{base}..HEAD")
-    except subprocess.CalledProcessError:
-        return False
-    return MARKER in msgs
-
-
-def _base_resolves(base: str) -> bool:
-    try:
-        _git("rev-parse", "--verify", "--quiet", f"{base}^{{commit}}")
-        return True
-    except subprocess.CalledProcessError:
-        return False
-
-
-def cmd_check(args) -> int:
-    if not _base_resolves(args.base):
-        # Offline / shallow clone without the base ref: skip rather than treat the
-        # whole allowlist as "added" (a false-fail). CI fetches origin/main, so the
-        # gate is enforced there.
-        print(f"display-coverage-gate: skip (base {args.base!r} not resolvable locally)")
-        return 0
-    try:
-        overlay = json.loads((REPO / OVERLAY_REL).read_text(encoding="utf-8"))
-        added = added_allowlist_models(args.base)
-    except Exception as e:  # noqa: BLE001
-        print(f"display-coverage-gate: error: {e}", file=sys.stderr)
-        return 2
-    covered = covered_overlay_ids(overlay)
-    uncovered: list[tuple[str, str]] = []
-    for plat, ids in added.items():
-        for mid in sorted(ids):
-            if mid not in covered:
-                uncovered.append((plat, mid))
-    if not uncovered:
-        print("display-coverage-gate: ok (no new allowlist entries lack overlay display coverage)")
-        return 0
-    if has_marker(args.base):
-        print(f"display-coverage-gate: ok ({MARKER} present; "
-              f"{len(uncovered)} new allowlist entr(ies) declared remote-displayed)")
-        for plat, mid in uncovered:
-            print(f"    (remote-verified) {plat}: {mid}")
-        return 0
-    print("display-coverage-gate: FAIL — new servable-allowlist entr(ies) with NO display "
-          "price source (overlay). The bundled mirror does NOT display in prod.", file=sys.stderr)
-    for plat, mid in uncovered:
-        print(f"    {plat}: {mid}", file=sys.stderr)
-    print(f"\nfix: add a priced tk_pricing_overlay.json entry for each (ops/pricing/"
-          f"apply-pricing-hotfix.py stage-overlay), OR if it genuinely displays via the\n"
-          f"upstream remote mirror, put `{MARKER}` in a commit message after confirming with\n"
-          f"ops/pricing/audit-display-coverage.py check --live.", file=sys.stderr)
-    return 1
-
-
-def cmd_selftest(_args) -> int:
-    base_go = (
-        "// servable-allowlist:begin openai\n"
-        '\t"gpt-5": {},\n'
-        "// servable-allowlist:end openai\n"
-    )
-    head_go = (
-        "// servable-allowlist:begin openai\n"
-        '\t"gpt-5": {},\n\t"gpt-5.6-sol": {},\n\t"gpt-6": {},\n'
-        "// servable-allowlist:end openai\n"
-    )
-    bal, hal = parse_allowlist(base_go), parse_allowlist(head_go)
-    added = {p: hal.get(p, set()) - bal.get(p, set()) for p in PLATFORMS}
-    assert added["openai"] == {"gpt-5.6-sol", "gpt-6"}, added["openai"]
-
-    overlay = {"_meta": {}, "gpt-6": {"input_cost_per_token": 1e-5, "output_cost_per_token": 3e-5}}
-    covered = covered_overlay_ids(overlay)
-    assert covered == {"gpt-6"}, covered
-    # gpt-5.6-sol uncovered (the #1030 shape) → would FAIL without marker; gpt-6 covered.
-    uncovered = [(p, m) for p, ids in added.items() for m in ids if m not in covered]
-    assert uncovered == [("openai", "gpt-5.6-sol")], uncovered
-
-    # media coverage counts
-    assert overlay_priced({"output_cost_per_image": 0.04})
-    assert overlay_priced({"output_cost_per_second": 0.6})
-    assert not overlay_priced({"input_cost_per_token": 0})
-    assert not overlay_priced({"litellm_provider": "openai"})
-    print("display-coverage-gate selftest: PASS")
-    return 0
+def run_owner(selftest: bool) -> int:
+    command = [sys.executable, str(OWNER)]
+    if selftest:
+        command.append("--selftest")
+    result = subprocess.run(command, cwd=REPO, check=False)
+    if result.returncode == 0:
+        print("display-coverage-gate: delegated to catalog-serving-drift A4")
+    return result.returncode
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description="forward guard: new allowlist entry ⇒ overlay display coverage")
-    sub = ap.add_subparsers(dest="cmd", required=True)
-    ck = sub.add_parser("check")
-    ck.add_argument("--base", default="origin/main", help="diff base (default origin/main)")
-    ck.set_defaults(func=cmd_check)
-    st = sub.add_parser("selftest")
-    st.set_defaults(func=cmd_selftest)
-    args = ap.parse_args()
-    return args.func(args)
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    check = sub.add_parser("check")
+    check.add_argument("--base", default="origin/main", help="accepted for compatibility; ignored")
+    sub.add_parser("selftest")
+    args = parser.parse_args()
+    return run_owner(args.command == "selftest")
 
 
 if __name__ == "__main__":

--- a/scripts/checks/pricing-serving-docs.py
+++ b/scripts/checks/pricing-serving-docs.py
@@ -96,6 +96,21 @@ SECONDARY_TRUTH_PATTERNS = (
     re.compile(r"§2\.4\s*/\s*R-002"),
     re.compile(r"同一\s*servable\s+surface"),
     re.compile(r"account\.go:639"),
+    re.compile(r"pricing-availability-source-of-truth\.md\s+§", re.IGNORECASE),
+    re.compile(
+        r"§\d+(?:\.\d+)?[\s\S]{0,100}pricing-availability-source-of-truth\.md",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"(?:Goal\s+\d+|R-\d{3})[\s\S]{0,100}pricing-availability-source-of-truth\.md",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"pricing-availability-source-of-truth\.md[\s\S]{0,100}(?:Goal\s+\d+|R-\d{3})",
+        re.IGNORECASE,
+    ),
+    re.compile(r"served-model-reconcile-planner\.md", re.IGNORECASE),
+    re.compile(r"tokenkey-modelops-planner.{0,40}(?:分支|branch)\s+[A-Z]", re.IGNORECASE),
 )
 
 # Cheap literal cover of SECONDARY_TRUTH_PATTERNS. A file that cannot contain
@@ -119,6 +134,9 @@ SECONDARY_TRUTH_PREFILTER = (
     "r-002",
     "account.go:639",
     "four facts",
+    "pricing-availability-source-of-truth.md",
+    "served-model-reconcile-planner.md",
+    "tokenkey-modelops-planner",
 )
 
 

--- a/scripts/checks/test_pricing_serving_docs.py
+++ b/scripts/checks/test_pricing_serving_docs.py
@@ -322,6 +322,10 @@ class PricingServingDocsContractTest(unittest.TestCase):
             "one entry, four facts",
             "列出即可调用",
             "account.go:639",
+            "pricing-availability-source-of-truth.md §2.5",
+            "Goal 2 of pricing-availability-source-of-truth.md",
+            "served-model-reconcile-planner.md",
+            "tokenkey-modelops-planner 分支 C",
         )
         for sample in samples:
             with self.subTest(sample=sample):
@@ -331,6 +335,27 @@ class PricingServingDocsContractTest(unittest.TestCase):
         self.assertFalse(
             MODULE.secondary_truth_candidate("package service\n\nfunc add(a int, b int) int { return a + b }\n")
         )
+
+    def test_rejects_obsolete_availability_section_references_in_both_orders(self) -> None:
+        samples = (
+            "See R-001 of\n// docs/approved/pricing-availability-source-of-truth.md.",
+            "See R-003 /\n// docs/approved/pricing-availability-source-of-truth.md#availability-structural-pruning.",
+            "Why this helper exists (R-004 of\n// docs/approved/pricing-availability-source-of-truth.md):",
+            "pricing-availability single-source-of-truth (R-001 of\n"
+            "// docs/approved/pricing-availability-source-of-truth.md).",
+            "docs/approved/pricing-availability-source-of-truth.md\n"
+            "// §2.4 (Goal 1, R-002).",
+            "see §8 of docs/approved/pricing-availability-source-of-truth.md",
+        )
+        for index, sample in enumerate(samples):
+            with self.subTest(sample=sample):
+                root = self.fixture()
+                path = root / f"backend/internal/service/stale_reference_{index}.go"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("package service\n// " + sample + "\n", encoding="utf-8")
+                self.assertTrue(
+                    any("secondary delivery-truth claim" in error for error in MODULE.check(root))
+                )
 
 
 if __name__ == "__main__":

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -818,7 +818,7 @@ fi
 # service files (TkRecordFailureFromErr call sites, RecordOutcome hook) are
 # still present after any upstream merge. Without these taps the model_availability
 # table receives no data and the /pricing availability decoration silently stops
-# working. See docs/approved/pricing-availability-source-of-truth.md §4 and
+# working. See docs/approved/pricing-availability-source-of-truth.md#availability-evidence-owner and
 # CLAUDE.md §「升级原则」.
 echo ""
 echo "=== sub2api: pricing-availability sentinel registry ==="
@@ -2500,33 +2500,10 @@ else
     fi
 fi
 
-# ---- sub2api: display-coverage gate (servable ⇒ displayable) ----------------
-# Guards the #1030 / #1029 failure class: a model added to the Go servable
-# allowlist with NO display price source. Prod's /pricing reads the upstream
-# remote mirror ∪ tk_pricing_overlay.json; the bundled resources/model-pricing
-# mirror is a SHADOWED, hand-maintained fallback prod never reads — so a model
-# present only there renders a BLANK price (gpt-5.6 #1030; antigravity gemini-*
-# #1029). Diff-scoped: only NEW allowlist entries must be overlay-priced (or carry
-# `display-via-remote-verified`). Live backstop:
-# ops/pricing/audit-display-coverage.py check --live. CLAUDE.md §「升级原则」.
-echo ""
-echo "=== sub2api: display-coverage gate ==="
-if ! command -v python3 >/dev/null 2>&1; then
-    echo "  FAIL: python3 not on PATH (required by display-coverage-gate)"
-    errors=$((errors + 1))
-elif ! python3 ./scripts/checks/display-coverage-gate.py selftest >/dev/null 2>&1; then
-    echo "  FAIL: display-coverage-gate.py selftest (re-run: python3 scripts/checks/display-coverage-gate.py selftest)"
-    errors=$((errors + 1))
-elif ! python3 ./scripts/checks/display-coverage-gate.py check --base "${PREFLIGHT_BASE:-origin/main}"; then
-    # gate already printed the actionable failure.
-    errors=$((errors + 1))
-fi
-
 # ---- sub2api: display-coverage audit selftest -------------------------------
-# ops/pricing/audit-display-coverage.py is the LIVE close-out of any catalog
-# change (run `check --live`, require 0 gaps) and a safe read-only periodic prod
-# audit. CI only runs its offline selftest; the --live audit is an operator /
-# scheduled action (no prod network in CI).
+# Static display ownership is already enforced repository-wide by
+# catalog-serving-drift A4. This audit is the read-only live close-out: it checks
+# that complete-registry + allowlist expectations reached public /pricing.
 echo ""
 echo "=== sub2api: display-coverage audit selftest ==="
 if ! command -v python3 >/dev/null 2>&1; then

--- a/scripts/sentinels/check-pricing-availability.py
+++ b/scripts/sentinels/check-pricing-availability.py
@@ -29,7 +29,7 @@ Why this exists:
   don't exercise end-to-end. This script upgrades the protection from
   "code-reviewer must remember" to "preflight will fail".
 
-  See docs/approved/pricing-availability-source-of-truth.md §4 and
+  See docs/approved/pricing-availability-source-of-truth.md#availability-evidence-owner and
   CLAUDE.md §「升级原则」.
 """
 from __future__ import annotations

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2751,6 +2751,7 @@
       "path": "ops/pricing/manage-account-model-mapping-runtime.py",
       "must_contain": [
         "APPLY_CONFIRM = \"yes-apply-account-model-mapping\"",
+        "tk_account_model_mapping_runtime_doc",
         "DEFAULT_BUNDLE_PATH = _BUNDLE.DEFAULT_BUNDLE_PATH",
         "return _BUNDLE.load_bundle(_BUNDLE_PATH)",
         "def cmd_check_accounts(",
@@ -2777,6 +2778,17 @@
         "--allow-extra-model-mapping"
       ],
       "rationale": "Explicit ops check/apply surfaces for account model_mapping. The script must consume the checksummed bundle without Go/source discovery, prioritize property-selected account overrides over shared platform/channel floors, select VolcEngine Agent Plan by platform/channel/base_url rather than account ID, use one required-floor + forbidden-policy rule, preserve compatible extras, keep check-accounts read-only, scope release-gate to explicit model activation, require confirmation before writes, update only model_mapping/group scopes, and enqueue scheduler outbox events. Accounts with Extra.supplier_source_id are owned by supplier Sync (exact procurement subset) and must be exempt from floor check/apply/release-gate convergence. Activation pins the resolved prod instance and rechecks runtime-shadow absence under a settings-table lock before writes. Generic deploy wiring is prohibited by the workflow sentinel above, while direct Edge diagnostics/apply remain available."
+    },
+    {
+      "path": "ops/pricing/account_model_mapping_runtime_doc.py",
+      "must_contain": [
+        "class RuntimeDocumentError(ValueError):",
+        "def normalize_platform_key(",
+        "def normalize(doc)",
+        "def load(",
+        "def decode_runtime_value("
+      ],
+      "rationale": "Pure owner for runtime replacement document normalization, loading and settings-blob decoding. The stable CLI entrypoint delegates here so document policy stays testable without SSM/SQL side effects and cannot grow another copy inside the operator command."
     },
     {
       "path": "backend/cmd/account-model-mapping/main.go",

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -102,6 +102,8 @@
       "must_contain": [
         "def project_allowlists(",
         "current + positive - reviewed structural removals",
+        "tk_servable_reprobe_ledger",
+        "def augment_candidates_with_probe_policy(",
         "_ledger_entries(ledger, \"structurally_gone\")",
         "def watchlist_freshness(",
         "sub.add_parser(\"watchlist-status\")",
@@ -110,6 +112,19 @@
         "reviewed base retirement"
       ],
       "rationale": "Catalog refresh must be additive: current membership survives absent traffic, auth/setup failures, 429, 5xx and timeout; only the reviewed structurally_gone ledger may remove a row. The pure projection and mixed-result regression assertions keep this invariant executable without re-expanding dated aliases beside an existing base, while watchlist-status separates freshness alerting from candidate generation. Losing these anchors could silently reintroduce bulk catalog shrink, duplicate menu rows, or the selftest-green/candidates-broken failure mode."
+    },
+    {
+      "path": "ops/pricing/servable_reprobe_ledger.py",
+      "must_contain": [
+        "LEDGER_LISTS = (\"probe_candidates\", \"watchlist\", \"skiplist\", \"structurally_gone\")",
+        "VOLATILE_CANDIDATE_FIELDS",
+        "def validate(",
+        "def watchlist_freshness(",
+        "def augment_candidates(",
+        "for entry in entries(ledger, \"probe_candidates\")",
+        "for list_name in (\"skiplist\", \"structurally_gone\")"
+      ],
+      "rationale": "The refresh entrypoint delegates ledger schema and projection to this pure owner. Durable explicit probe candidates must remain independent from expiring operational follow-up, while skiplist and reviewed structurally_gone policy continue to filter candidate/results paths. Losing this split either restores permanent stale alerts or silently changes the generated candidate universe."
     },
     {
       "path": "backend/internal/service/tk_served_models_manifest_tk.go",
@@ -316,13 +331,14 @@
       "must_contain": [
         "tk_served_models.json",
         "servable-allowlist:begin",
-        "served-via-admin-ui",
-        "served-via-modelops-activation",
+        "VALID_MAPPING_SOURCES = {\"activation\", \"admin_legacy\"}",
+        "STALE_MAPPING_MARKERS",
+        "notes contains obsolete machine marker",
         "#812-class gap",
         "def _selftest(",
         "_aliases"
       ],
-      "rationale": "The served-models manifest drift guard asserts repository agreement for the thin intent layer: (A1) non-zero pricing, (A2) native allowlist or manifest-owned newapi display, and (A3) an explicit mapping write path. Legacy rows may be evidenced by a quoted model id plus account guard in tk_*.sql or by the served-via-admin-ui seed-state marker; every new floor must declare served-via-modelops-activation and then complete the approved evidence-backed prod activation before release. A3 catches the #812 priced/displayed-but-empty-pool failure without forcing generic deploy to mutate live accounts. Pinning both legacy and activation markers, the selftest, and the allowlist parser prevents an upstream merge from silently dropping either safety path. Wired into preflight and the upstream conflict gate."
+      "rationale": "The served-models manifest drift guard asserts repository agreement for the thin intent layer: (A1) non-zero pricing, (A2) native allowlist or manifest-owned newapi display, and (A3) an explicit mapping write path. Legacy rows may be evidenced by a quoted model id plus account guard in tk_*.sql or mapping_source=admin_legacy; every new floor declares mapping_source=activation and then completes the approved evidence-backed prod activation before release. A3 catches the #812 priced/displayed-but-empty-pool failure without forcing generic deploy to mutate live accounts. Pinning the structured enum, stale-marker rejection, selftest, and allowlist parser prevents an upstream merge from silently dropping either safety path. Wired into preflight and the upstream conflict gate."
     },
     {
       "path": "backend/internal/service/tk_served_models.json",
@@ -331,12 +347,14 @@
         "\"price_source\"",
         "\"served_on\"",
         "\"display\"",
+        "\"mapping_source\"",
+        "\"activation\"",
+        "\"admin_legacy\"",
         "account 88",
         "account 90",
-        "served-via-modelops-activation",
         "account 96"
       ],
-      "rationale": "The served-models MANIFEST is the single declarative intent source consumed by the drift guard, onboarding skill, display projections, and generated account-mapping bundle. Pinning the schema keys plus the modelops activation declaration prevents an upstream merge from truncating the manifest or reverting new mapping floors to generic-deploy migrations while leaving compile/tests superficially green. Co-located with the overlay so the same preflight parses price and serving intent. account 96 pins the XRToken ch54 Seedance serving intent (two XRToken-only SKUs plus three shared with the Ark pool) so a merge cannot revert the manifest to the Ark-only rows."
+      "rationale": "The served-models MANIFEST is the single declarative intent source consumed by the drift guard, onboarding skill, display projections, and generated account-mapping bundle. Pinning the schema keys plus structured mapping provenance prevents an upstream merge from truncating the manifest or reverting new mapping floors to generic-deploy migrations while leaving compile/tests superficially green. Co-located with the overlay so the same preflight parses price and serving intent. account 96 pins the XRToken ch54 Seedance serving intent (two XRToken-only SKUs plus three shared with the Ark pool) so a merge cannot revert the manifest to the Ark-only rows."
     },
     {
       "path": "backend/internal/service/pricing_service_tk_overlay.go",


### PR DESCRIPTION
## 摘要
- 收敛 TokenKey 模型交付 SSOT：用结构化 mapping_source 取代 notes 机器标记，并由 manifest account_scopes 投影 Qianfan 共享模型，移除 Go 手写清单。
- 合并重复 display coverage gate，由 catalog-serving-drift 统一静态判定；保留兼容入口，live /pricing close-out 继续只读。
- 将永久 probe candidate 与时效 watchlist 分离，清空失效告警；拆出纯 ledger 与 runtime-document 模块，保持现有 CLI、候选集、bundle 和 mapping 计划不变。
- 为 availability 文档补稳定 anchor，清理过时 Goal/R 编号、已删除文档和 skill 分支字母引用，并用 checker 防回归。
- 修正 display close-out 对 explicit_free 模型的口径：目录行存在即覆盖；付费模型仍必须暴露正价，普通零价行继续 fail-closed。

## 风险
- 常规风险。改动集中在仓库内 modelops 数据、检查器、文档与内部职责拆分，不部署、不写线上配置、不执行账号 mapping 变更。
- 运行时模型 bundle、价格/目录投影、CLI 参数与确认短语保持等价；已发布 tk_054 migration 恢复并保持 release checksum。
- no-web-impact
- sentinel-registry-reviewed

## 验证
- PREFLIGHT_BASE=origin/main bash scripts/preflight.sh：PASS（含 lint、migration immutability、sentinel、catalog/mapping/bundle drift、上游冲突面检查）。
- audit-display-coverage.py selftest/check 与 explicit-free 合成正负例：PASS；explicit-free owner/alias 可覆盖，普通零价及付费零价行不会被误放行。
- refresh-servable-allowlist.py selftest、manage-account-model-mapping-runtime.py --selftest、catalog-serving-drift.py --selftest/--quiet、display coverage selftests：PASS。
- Qianfan / manifest / XRToken focused Go tests：PASS。
- servable candidates SHA256 保持 1f57d303ef2a9317cb82000ad23b315fd69bfb6aa69acb1d1162af86d195cfa8；bundle floor_sha256 保持 0d13b7ea93c11fd6798ee557b511e6ab81c0a47623c2c1aca79cdd954b4545a8。
- xj-review：normal / concise，零 medium+ finding，merge-ready。

## 提交
- 74b895a47 chore(modelops): consolidate model delivery SSOT
- bbc33363d fix(migrations): restore shipped tk_054 checksum
- fa4d19d9f fix(modelops): close explicit-free display audit

最新提交：fa4d19d9f