### PR TITLE
fix(admin): 供应源页铺满主内容区，对齐其他管理页布局

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 715,
-  "hash": "df3d2b536714d700bc47edeaddaaeaf094c03c0ec667c396c544984fc0a02445",
+  "hash": "f3e8ff95d06dbd6540db45ee92624ad76c38e733cf70d9ff7057fe5dc7e0f673",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/views/admin/SupplierSourcesView.vue
+++ b/frontend/src/views/admin/SupplierSourcesView.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="mx-auto max-w-7xl space-y-6 p-4 sm:p-6">
+  <!--
+    Match Dashboard/RiskControl: fill AppLayout main (already padded via lg:p-8).
+    Do not re-introduce max-w-* / mx-auto / extra page padding — that shrinks the
+    page relative to Accounts/Groups and leaves empty side gutters.
+  -->
+  <div data-test="supplier-sources-page" class="w-full min-w-0 space-y-6">
     <header class="flex flex-wrap items-start justify-between gap-3">
       <div>
         <h1 class="text-2xl font-semibold text-gray-900 dark:text-white">
@@ -56,10 +61,10 @@
       </ul>
     </section>
 
-    <div class="grid items-start gap-6 lg:grid-cols-[minmax(220px,280px)_minmax(0,1fr)]">
+    <div class="grid items-start gap-6 lg:grid-cols-[minmax(16rem,20rem)_minmax(0,1fr)]">
       <section
         data-test="source-list"
-        class="flex max-h-[min(22rem,50vh)] flex-col overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-dark-700 dark:bg-dark-800 lg:sticky lg:top-4 lg:max-h-[calc(100dvh-6rem)]"
+        class="flex max-h-[min(22rem,50vh)] flex-col overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-dark-700 dark:bg-dark-800 lg:sticky lg:top-4 lg:max-h-[calc(100dvh-8rem)]"
       >
         <div class="shrink-0 space-y-2 border-b border-gray-200 p-3 dark:border-dark-700">
           <div class="flex items-center justify-between gap-2">
@@ -137,7 +142,7 @@
       <section
         ref="editorEl"
         data-test="source-editor"
-        class="space-y-5 rounded-xl border border-gray-200 bg-white p-4 dark:border-dark-700 dark:bg-dark-800"
+        class="min-w-0 space-y-5 rounded-xl border border-gray-200 bg-white p-4 sm:p-5 dark:border-dark-700 dark:bg-dark-800"
       >
         <form class="space-y-4" @submit.prevent="save">
           <div class="flex flex-wrap items-start justify-between gap-2">

--- a/frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts
+++ b/frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts
@@ -87,6 +87,17 @@ describe('SupplierSourcesView', () => {
     sync.mockReset()
   })
 
+  it('fills AppLayout main width like Dashboard/RiskControl (no max-w / mx-auto page shell)', async () => {
+    const wrapper = mount(SupplierSourcesView)
+    await flushPromises()
+
+    const root = wrapper.get('[data-test="supplier-sources-page"]')
+    expect(root.classes()).toEqual(expect.arrayContaining(['w-full', 'min-w-0', 'space-y-6']))
+    expect(root.classes()).not.toContain('max-w-7xl')
+    expect(root.classes()).not.toContain('mx-auto')
+    expect(root.classes().some((c) => c.startsWith('p-') || c.startsWith('sm:p-'))).toBe(false)
+  })
+
   it('defaults a new source to channel default and base priority 100', async () => {
     const wrapper = mount(SupplierSourcesView)
     await flushPromises()

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -1974,6 +1974,8 @@
     {
       "path": "frontend/src/views/admin/SupplierSourcesView.vue",
       "must_contain": [
+        "w-full min-w-0 space-y-6",
+        "data-test=\"supplier-sources-page\"",
         "const syncSucceeded = computed(() => (",
         "syncResult.value !== null",
         "syncError.value === ''",
@@ -1991,9 +1993,11 @@
       ],
       "must_not_contain": [
         "syncSucceeded = ref",
-        "watch(() => form.channel_type"
+        "watch(() => form.channel_type",
+        "max-w-7xl",
+        "mx-auto max-w-7xl"
       ],
-      "rationale": "The supplier page derives success from the current response, the current request error, and absence of failed_step. Discover polls async candidate jobs to completion; validate is a read-only preview; project displays the probe evidence returned by its own authoritative request without depending on prior validation state. Dirty or discover-backfilled drafts disable discover/validate/project. BaiduV2 remains an explicit supplier transport even though it is absent from NewAPI's generic model-fetch set, and catalog endpoint defaults apply only to operator channel changes so source hydration preserves persisted custom endpoints."
+      "rationale": "The supplier page derives success from the current response, the current request error, and absence of failed_step. Discover polls async candidate jobs to completion; validate is a read-only preview; project displays the probe evidence returned by its own authoritative request without depending on prior validation state. Dirty or discover-backfilled drafts disable discover/validate/project. BaiduV2 remains an explicit supplier transport even though it is absent from NewAPI's generic model-fetch set, and catalog endpoint defaults apply only to operator channel changes so source hydration preserves persisted custom endpoints. Also anchors the full-bleed admin page shell (no max-w-7xl / mx-auto page chrome) so the layout stays aligned with Dashboard/RiskControl."
     },
     {
       "path": "frontend/src/api/admin/supplierSources.ts",
@@ -2010,6 +2014,7 @@
     {
       "path": "frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts",
       "must_contain": [
+        "fills AppLayout main width like Dashboard/RiskControl (no max-w / mx-auto page shell)",
         "saves new and existing sources through create or update only",
         "requires saving edited supplier facts before syncing the selected source",
         "renders account changes returned by sync",
@@ -2020,7 +2025,7 @@
         "shows probe failure message and failed_step outside the sync-result block",
         "offers and hydrates BaiduV2 while preserving a custom endpoint during source selection"
       ],
-      "rationale": "Focused UI regressions pin discover/validate/project workflow: save is side-effect free, unsaved edits block discover/validate/project, project renders account changes only, validate failures stay in validate panel, resolved failed_step cannot show success, async discover polling completes without auto-project, discover failures visible outside project block, BaiduV2 stays selectable without hydration overwriting custom endpoint, no state machine or account-group controls."
+      "rationale": "Focused UI regressions pin discover/validate/project workflow: save is side-effect free, unsaved edits block discover/validate/project, project renders account changes only, validate failures stay in validate panel, resolved failed_step cannot show success, async discover polling completes without auto-project, discover failures visible outside project block, BaiduV2 stays selectable without hydration overwriting custom endpoint, no state machine or account-group controls. Also pins the full-bleed page-shell regression."
     },
     {
       "path": "frontend/src/composables/useSupplierManagedAccount.ts",


### PR DESCRIPTION
## 摘要
- 供应源管理页去掉 `max-w-7xl` / `mx-auto` 与双重 page padding，改为与 Dashboard / 风控一致的 `w-full min-w-0 space-y-6`，铺满 `AppLayout` 主区。
- 列表列略加宽，编辑区 `min-w-0` 吃掉剩余宽度；同步刷新 embedded dist fingerprint。
- review 修复：把全宽布局契约写入 `frontend-tk` sentinel（含 `must_not_contain: max-w-7xl`）。

## 风险
- 低风险 UI 布局调整；不改 API / 业务逻辑。
- 宽屏下编辑表单会更宽，属预期对齐；窄屏仍走原有 grid 折叠。

## 验证
- `pnpm test:run src/views/admin/__tests__/SupplierSourcesView.spec.ts`（20/20 通过，含全宽回归断言）
- `python3 scripts/sentinels/check-frontend-tk.py` PASS
- `python3 scripts/sentinels/check-registry-update-gate.py --base origin/main --head HEAD` ok
- `./scripts/preflight.sh` PASS

## 提交
- `fee6b6c72` fix(admin): 供应源页铺满主内容区，对齐其他管理页布局
- `807afde9a` chore(frontend): 刷新 dist fingerprint 对齐供应源布局
- `aeeb23e71` fix(admin): address R-001..R-002 — 供应源全宽布局写入 frontend-tk sentinel
- 最新提交：`aeeb23e71`