### PR TITLE
feat(supplier): Anthropic channel_type=14 走 Messages 探测与投影

### DIFF
--- a/.testing/user-stories/stories/US-048-model-supplier-source-management.md
+++ b/.testing/user-stories/stories/US-048-model-supplier-source-management.md
@@ -16,9 +16,9 @@
 
 1. AC-001 (正向): Given 运营新增供应源，When 只点击保存，Then 系统只写单表采购事实，凭证加密且不回显，新供应源默认 `base_priority=100`，不探测、不创建或修改账号。
 2. AC-002 (优先级): Given 模型采购比例落入六个固定档位，When 查看表单与全局预览，Then 档位分别贡献 `10, 20, …, 60`（相邻增量 10），账号 priority 严格等于 `base_priority + discount_priority`；同源同档模型合并为一个目标账号，预览只比较供应源目标 priority，且 `base_priority + 60` 不得越过 PostgreSQL `INTEGER`。
-3. AC-003 (只读校验): Given 已保存供应源，When 点击「校验模型」，Then 系统走 `POST .../validate`，用带 source/band 身份的内存账号逐模型使用明确 upstream ID 真实探测已保存配置；任一失败返回全部当次结果且不写账号。结果不缓存、不生成授权，也不改变投影按钮状态。Chat 通道只接受 Chat Completions 正向证据；视频通道（channel_type=54）走视频协议真实探测。Responses/Anthropic 等非通道能力证据返回 `protocol_unsupported`，不猜协议、不写账号。
-4. AC-004 (热更新): Given endpoint、credential、模型 ID、模型增减、跨档，或非空受管账号的 `status/schedulable` 与目标不一致，When 未先校验而直接点击「投影账号」，Then 系统走 `POST .../sync` 并在第一个结构写入前用当次目标逐模型重探；任一失败返回全部当次 `probe_results`、`failed_step=probe`、空 `changes` 且不写账号，重试时重新探测。全部成功后才以空 mapping、不可调度状态创建缺失账号；非空投影必须携带本次 Chat 正向证据，并在单账号事务内提交账号配置、Chat-only 现有协议能力、`InitialProbeCompleted=true`/`OfficialSeed=false` 证据和 scheduler outbox，再做配置读回确认而不进行写后二次网络探测，最后从旧档删除 mapping。单账号事务失败时已有账号保持旧配置、新账号保持空 mapping 不可调度；跨账号中途失败保留已完成增加、停止后续减少，返回 `failed_step + changes[]`，重试可继续收敛；空档账号保留并收敛为 `active + schedulable=false`。已选来源存在未保存表单修改时发现/校验/投影入口禁用并提示先保存，成功提示只能从当前结果派生。
-5. AC-005 (隔离回归): Given 供应源保存、预览或同步，When 执行任一路径，Then 供应源不读取、比较、返回或写入账号组，专用投影读取不调用通用 `GetByID`，并且只选择同步所需配置字段，不读取倍率或无关运行字段；新账号保持未分组且不借用 `newapi-default`，普通账号创建失败契约不变；受管/预探测账号只声明 Chat Completions；通用 host 末尾 `/v1` 只在 OpenAI 受管路径规范化，`qianfan.baidubce.com` 解析为 BaiduV2 + 根 URL 并声明 `/v2/chat/completions`，普通 NewAPI 账号行为不变；系统不修改倍率、定价或 scheduler，scheduler 继续只按更小的原有账号 priority 先调度，不读取供应来源 Extra。
+3. AC-003 (只读校验): Given 已保存供应源，When 点击「校验模型」，Then 系统走 `POST .../validate`，用带 source/band 身份的内存账号逐模型使用明确 upstream ID 真实探测已保存配置；任一失败返回全部当次结果且不写账号。结果不缓存、不生成授权，也不改变投影按钮状态。默认 Chat 通道只接受 Chat Completions 正向证据；视频通道（channel_type=54）走视频协议真实探测；Anthropic 通道（channel_type=14）走 Messages 真实探测。其它协议证据返回 `protocol_unsupported`，不猜协议、不写账号。
+4. AC-004 (热更新): Given endpoint、credential、模型 ID、模型增减、跨档，或非空受管账号的 `status/schedulable` 与目标不一致，When 未先校验而直接点击「投影账号」，Then 系统走 `POST .../sync` 并在第一个结构写入前用当次目标逐模型重探；任一失败返回全部当次 `probe_results`、`failed_step=probe`、空 `changes` 且不写账号，重试时重新探测。全部成功后才以空 mapping、不可调度状态创建缺失账号；非空投影必须携带本次通道协议正向证据，并在单账号事务内提交账号配置、通道单一协议能力（默认 Chat-only；Anthropic messages-only）、`InitialProbeCompleted=true`/`OfficialSeed=false` 证据和 scheduler outbox，再做配置读回确认而不进行写后二次网络探测，最后从旧档删除 mapping。单账号事务失败时已有账号保持旧配置、新账号保持空 mapping 不可调度；跨账号中途失败保留已完成增加、停止后续减少，返回 `failed_step + changes[]`，重试可继续收敛；空档账号保留并收敛为 `active + schedulable=false`。已选来源存在未保存表单修改时发现/校验/投影入口禁用并提示先保存，成功提示只能从当前结果派生。
+5. AC-005 (隔离回归): Given 供应源保存、预览或同步，When 执行任一路径，Then 供应源不读取、比较、返回或写入账号组，专用投影读取不调用通用 `GetByID`，并且只选择同步所需配置字段，不读取倍率或无关运行字段；新账号保持未分组且不借用 `newapi-default`，普通账号创建失败契约不变；受管/预探测账号按通道声明单一协议（默认 Chat Completions；Anthropic Messages）；通用 host 末尾 `/v1` 只在 OpenAI 受管路径规范化，`qianfan.baidubce.com` 解析为 BaiduV2 + 根 URL 并声明 `/v2/chat/completions`，普通 NewAPI 账号行为不变；系统不修改倍率、定价或 scheduler，scheduler 继续只按更小的原有账号 priority 先调度，不读取供应来源 Extra。
 6. AC-006 (ownership): Given 账号 Extra 存在 `supplier_source_id`，When 运营在账号页编辑、删除、复制、切换调度或批量更新，Then 行为与普通账号一致；普通创建和 CRS 导入不能伪造保留 Extra，普通 Extra 编辑保留受管身份键，复制剥离受管身份键。When 在供应源点击「投影账号」，Then 只走不携带 `rate_multiplier` 的窄写命令覆盖投影字段（含 priority/`model_mapping`/凭证/transport/`status/schedulable`），只合并 `supplier_source_id`、`supplier_discount_band` 并保留其他 Extra，不读写账号组。已有账号匹配覆盖全部未删除 NewAPI 候选，但只有 active 唯一精确匹配可接管；disabled/error 精确匹配返回冲突且不新建重复账号。恢复错误、配额重置、代理 fallback 与探测仍允许。真实账号 UI 显示“供应源托管”徽标与投影覆盖提示，点击徽标按 `source_id` 直接选中对应供应源。
 7. AC-007 (安全): Given 创建、更新、探测或同步供应源，When API、日志和 Admin Audit Log 记录请求与结果，Then 不包含凭证明文、密文、HMAC 指纹或上游原始响应；探测只返回固定状态、协议分类和脱敏说明；HMAC 指纹跟随凭证加密密钥而非 JWT secret 的生命周期。
 8. AC-008 (首批证据): Given 首批运营表和只读生产库存，When 记录验收结果，Then 三个案例必须各自提供完整准确的供应事实才能同步；信息不完整或不匹配时不扩大已有账号匹配、不改网关调度。佳杰/VSTECS 只保留两个最低合法比例 `0.50` 模型且因无生产凭证标记 `not_run`；FMGo Seedance 只保留官方 Seedance 2.0 / 2.0-fast / 2.5 remap，`channel_type=54` 走视频门禁，不以 OpenAI Chat 伪探测冒充成功；百度千帆在凭证齐备时以 BaiduV2 transport 接管账号 90（channel_type=46）。
@@ -32,9 +32,9 @@
 - 保存、名称/priority 元数据同步和投影同步是三条明确路径；结构变化或非空账号的调度投影漂移由投影路径即时探测。
 - 发现模型、校验模型、保存、投影账号是四个独立按钮；建议追加必须以发现探测通过为门禁，投影不依赖历史校验状态，而以自身当次探测为门禁。
 - 不存在进程内 validation cache、授权 TTL 或 probe token；重启、跨实例和等待都不能改变 Project 的探测要求。
-- 新建受管账号命令不接受 mapping；非空投影必须携带 Chat 正向探测证据，service 与 repository 双重拒绝绕过。
-- 单账号账号配置、Chat-only capability、探测证据与 scheduler outbox 原子提交；读回是配置确认，不是写后二次探测。
-- 供应源 `/v1` 规范化只由 OpenAI 受管路径触发；Qianfan 主机规范化为根 URL 并声明 `/v2/chat/completions`；普通 NewAPI base URL 不改写。
+- 新建受管账号命令不接受 mapping；非空投影必须携带当次通道协议正向探测证据，service 与 repository 双重拒绝绕过。
+- 单账号账号配置、通道单一协议能力（默认 Chat；Anthropic Messages）、探测证据与 scheduler outbox 原子提交；读回是配置确认，不是写后二次探测。
+- 供应源 `/v1` 规范化只由 OpenAI 受管路径触发；Qianfan 主机规范化为根 URL 并声明 `/v2/chat/completions`；Anthropic（14）声明 `/v1/messages`；普通 NewAPI base URL 不改写。
 - `supplier_source_id + supplier_discount_band` 是受管账号逻辑身份；账号组不参与匹配或同步成败。
 - 未删除的精确 endpoint + 凭证匹配不会因 disabled/error 被忽略；非 active 候选只报冲突，不绕过建号。
 - 供应投影读取只选择同步所需配置字段，不查询账号组、倍率或无关运行字段，并清空 `AccountGroups`、`GroupIDs`、`Groups`。
@@ -113,6 +113,11 @@
 - `backend/internal/service/supplier_source_probe_test.go`::`TestUS048_FMGoProbeSkipsNonVideoInventory`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_VideoProbeAcceptsHTTP202`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_SupplierManagedAccountDeclaresOnlyChatProtocol`
+- `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_SupplierManagedAnthropicDeclaresOnlyMessagesProtocol`
+- `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_AnthropicMessagesProbeAcceptsMessageShapeOnly`
+- `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_SupplierAnthropicMessagesProbeHitsMessagesPath`
+- `backend/internal/service/supplier_managed_account_commands_test.go`::`TestUS048_SupplierAnthropicCreateDeclaresMessagesExclusive`
+- `backend/internal/service/supplier_managed_transport_test.go`::`TestUS048_ResolveSupplierManagedTransportKeepsExplicitAnthropic`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_SupplierManagedQianfanDeclaresBaiduV2ChatProtocol`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_UnmanagedQianfanIdentityKeyStaysStable`
 - `backend/internal/service/account_test_service_supplier_probe_test.go`::`TestUS048_SupplierManagedOpenAIEndpointDoesNotDuplicateV1`

--- a/.testing/user-stories/stories/US-048-model-supplier-source-management.md
+++ b/.testing/user-stories/stories/US-048-model-supplier-source-management.md
@@ -80,7 +80,7 @@
 - `backend/internal/service/supplier_managed_account_commands_test.go`::`TestUS048_SupplierCreateStartsEmptyUngroupedAndUnschedulable`
 - `backend/internal/service/supplier_managed_account_commands_test.go`::`TestUS048_OrdinaryCreateAccountStillFailsWhenDefaultGroupBindFails`
 - `backend/internal/service/supplier_managed_account_commands_test.go`::`TestUS048_SupplierConfigurationUpdateUsesGroupFreeReadAndNarrowWrite`
-- `backend/internal/service/supplier_managed_account_commands_test.go`::`TestUS048_SupplierConfigurationUpdateRequiresPassedChatProbe`
+- `backend/internal/service/supplier_managed_account_commands_test.go`::`TestUS048_SupplierConfigurationUpdateRequiresPassedProtocolProbe`
 - `backend/internal/repository/account_repo_supplier_projection_test.go`::`TestUS048_SupplierConfigurationRepositoryRejectsUnverifiedNonEmptyMapping`
 - `backend/internal/repository/account_repo_supplier_projection_test.go`::`TestUS048_SupplierVerifiedProtocolForAnthropicIsMessages`
 - `backend/internal/repository/account_repo_supplier_projection_test.go`::`TestUS048_SupplierAnthropicProjectionRejectsChatOnlyIdentity`

--- a/.testing/user-stories/stories/US-048-model-supplier-source-management.md
+++ b/.testing/user-stories/stories/US-048-model-supplier-source-management.md
@@ -82,6 +82,9 @@
 - `backend/internal/service/supplier_managed_account_commands_test.go`::`TestUS048_SupplierConfigurationUpdateUsesGroupFreeReadAndNarrowWrite`
 - `backend/internal/service/supplier_managed_account_commands_test.go`::`TestUS048_SupplierConfigurationUpdateRequiresPassedChatProbe`
 - `backend/internal/repository/account_repo_supplier_projection_test.go`::`TestUS048_SupplierConfigurationRepositoryRejectsUnverifiedNonEmptyMapping`
+- `backend/internal/repository/account_repo_supplier_projection_test.go`::`TestUS048_SupplierVerifiedProtocolForAnthropicIsMessages`
+- `backend/internal/repository/account_repo_supplier_projection_test.go`::`TestUS048_SupplierAnthropicProjectionRejectsChatOnlyIdentity`
+- `backend/internal/repository/account_repo_supplier_projection_test.go`::`TestUS048_SupplierAnthropicProjectionPublishesMessagesCapability`
 - `backend/internal/repository/account_repo_supplier_projection_test.go`::`TestUS048_SupplierConfigurationRepositoryWritesOnlyOwnedFields`
 - `backend/internal/repository/account_repo_supplier_projection_test.go`::`TestUS048_SupplierProjectionReadSelectsOnlyRequiredConfigurationFields`
 - `backend/internal/repository/account_repo_supplier_projection_test.go`::`TestUS048_SupplierMetadataRepositoryWritesOnlyNameAndPriority`

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -228,9 +228,9 @@ func ensureAccountProtocolEndpointCapability(ctx context.Context, db protocolCap
 	return false, nil
 }
 
-const supplierVerifiedChatCapabilityLeaseTTL = 2 * time.Minute
+const supplierVerifiedProtocolCapabilityLeaseTTL = 2 * time.Minute
 
-func publishVerifiedSupplierChatCapability(
+func publishVerifiedSupplierProtocolCapability(
 	ctx context.Context,
 	repo *protocolEndpointCapabilityRepository,
 	account *service.Account,
@@ -272,7 +272,7 @@ func publishVerifiedSupplierChatCapability(
 		capability.CapabilityKey,
 		uuid.NewString(),
 		now,
-		supplierVerifiedChatCapabilityLeaseTTL,
+		supplierVerifiedProtocolCapabilityLeaseTTL,
 	)
 	if err != nil {
 		return false, err
@@ -872,11 +872,11 @@ func (r *accountRepository) UpdateSupplierConcurrency(ctx context.Context, accou
 	return nil
 }
 
-func (r *accountRepository) UpdateSupplierProjection(ctx context.Context, account *service.Account, chatProbePassed bool) error {
+func (r *accountRepository) UpdateSupplierProjection(ctx context.Context, account *service.Account, protocolProbePassed bool) error {
 	if account == nil {
 		return nil
 	}
-	if len(account.GetModelMapping()) > 0 && !chatProbePassed {
+	if len(account.GetModelMapping()) > 0 && !protocolProbePassed {
 		return service.ErrSupplierProjectionProtocolNotReady
 	}
 	credentials, err := json.Marshal(normalizeJSONMap(account.Credentials))
@@ -950,7 +950,7 @@ func (r *accountRepository) UpdateSupplierProjection(ctx context.Context, accoun
 	}
 	protocolPublished := false
 	if len(updatedAccount.GetModelMapping()) > 0 {
-		protocolPublished, err = publishVerifiedSupplierChatCapability(
+		protocolPublished, err = publishVerifiedSupplierProtocolCapability(
 			ctx,
 			r.protocolCapabilityRepository(ctx),
 			updatedAccount,

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	newapiconstant "github.com/QuantumNous/new-api/constant"
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	dbaccount "github.com/Wei-Shaw/sub2api/ent/account"
 	dbaccountgroup "github.com/Wei-Shaw/sub2api/ent/accountgroup"
@@ -241,10 +242,11 @@ func publishVerifiedSupplierChatCapability(
 	if err != nil {
 		return false, err
 	}
+	wantProtocol := supplierVerifiedProtocolForAccount(account)
 	if !input.Governed || len(input.Identity.ProtocolEndpoints) != 1 {
 		return false, service.ErrSupplierProjectionProtocolNotReady
 	}
-	if _, ok := input.Identity.ProtocolEndpoints[protocolrouter.ProtocolChatCompletions]; !ok {
+	if _, ok := input.Identity.ProtocolEndpoints[wantProtocol]; !ok {
 		return false, service.ErrSupplierProjectionProtocolNotReady
 	}
 
@@ -262,8 +264,8 @@ func publishVerifiedSupplierChatCapability(
 		return false, service.ErrSupplierProjectionProtocolNotReady
 	}
 
-	chatOnly := []protocolrouter.Protocol{protocolrouter.ProtocolChatCompletions}
-	projectionAlreadyChatOnly := slices.Equal(service.LegacySupportedProtocolsProjection(account), chatOnly)
+	protocolOnly := []protocolrouter.Protocol{wantProtocol}
+	projectionAlreadyProtocolOnly := slices.Equal(service.LegacySupportedProtocolsProjection(account), protocolOnly)
 	now := time.Now().UTC()
 	lease, acquired, err := repo.AcquireProbeLease(
 		ctx,
@@ -284,11 +286,11 @@ func publishVerifiedSupplierChatCapability(
 	for protocol, verdict := range evidence.Verdicts {
 		verdicts[protocol] = verdict
 	}
-	verdicts[string(protocolrouter.ProtocolChatCompletions)] = string(service.ProtocolProbePositive)
+	verdicts[string(wantProtocol)] = string(service.ProtocolProbePositive)
 	evidence.Verdicts = verdicts
 	evidence.IdentityConflict = false
 	updated, _, err := repo.CommitProbeResult(ctx, lease, service.ProtocolCapabilityMutation{
-		SupportedProtocols:    chatOnly,
+		SupportedProtocols:    protocolOnly,
 		ProbeEvidence:         evidence,
 		InitialProbeCompleted: true,
 		IdentityConflict:      false,
@@ -302,7 +304,14 @@ func publishVerifiedSupplierChatCapability(
 	}
 	account.ProtocolEndpointCapabilityID = &updated.ID
 	account.ProtocolEndpointCapability = updated
-	return !projectionAlreadyChatOnly, nil
+	return !projectionAlreadyProtocolOnly, nil
+}
+
+func supplierVerifiedProtocolForAccount(account *service.Account) protocolrouter.Protocol {
+	if account != nil && account.ChannelType == newapiconstant.ChannelTypeAnthropic {
+		return protocolrouter.ProtocolMessages
+	}
+	return protocolrouter.ProtocolChatCompletions
 }
 
 // NewAdminAccountRepository exposes the account repository's atomic duplication capability

--- a/backend/internal/repository/account_repo_supplier_cred_test.go
+++ b/backend/internal/repository/account_repo_supplier_cred_test.go
@@ -21,3 +21,18 @@ func supplierExclusiveChatCredentials(endpoint, apiKey string, mapping map[strin
 		service.ProtocolEndpointsExclusiveCredentialKey: true,
 	}
 }
+
+// supplierExclusiveMessagesCredentials mirrors Anthropic supplier messages-only
+// exclusive credentials (channel_type=14 projection path).
+func supplierExclusiveMessagesCredentials(endpoint, apiKey string, mapping map[string]any) map[string]any {
+	baseURL := strings.TrimRight(strings.TrimSpace(endpoint), "/")
+	return map[string]any{
+		"base_url":      baseURL,
+		"api_key":       strings.TrimSpace(apiKey),
+		"model_mapping": mapping,
+		"api_base_urls": map[string]any{
+			service.APIProtocolAnthropic: baseURL,
+		},
+		service.ProtocolEndpointsExclusiveCredentialKey: true,
+	}
+}

--- a/backend/internal/repository/account_repo_supplier_projection_test.go
+++ b/backend/internal/repository/account_repo_supplier_projection_test.go
@@ -9,7 +9,9 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	newapiconstant "github.com/QuantumNous/new-api/constant"
 	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 
@@ -136,6 +138,200 @@ func TestUS048_SupplierConfigurationRepositoryRejectsUnverifiedNonEmptyMapping(t
 	}, false)
 
 	require.ErrorIs(t, err, service.ErrSupplierProjectionProtocolNotReady)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUS048_SupplierVerifiedProtocolForAnthropicIsMessages(t *testing.T) {
+	require.Equal(t, protocolrouter.ProtocolMessages, supplierVerifiedProtocolForAccount(&service.Account{
+		ChannelType: newapiconstant.ChannelTypeAnthropic,
+	}))
+	require.Equal(t, protocolrouter.ProtocolChatCompletions, supplierVerifiedProtocolForAccount(&service.Account{
+		ChannelType: newapiconstant.ChannelTypeOpenAI,
+	}))
+	require.Equal(t, protocolrouter.ProtocolChatCompletions, supplierVerifiedProtocolForAccount(&service.Account{
+		ChannelType: newapiconstant.ChannelTypeBaiduV2,
+	}))
+	require.Equal(t, protocolrouter.ProtocolChatCompletions, supplierVerifiedProtocolForAccount(nil))
+}
+
+func TestUS048_SupplierAnthropicProjectionRejectsChatOnlyIdentity(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	client := dbent.NewClient(dbent.Driver(entsql.OpenDB(dialect.Postgres, db)))
+	t.Cleanup(func() { _ = client.Close() })
+	repo := newAccountRepositoryWithSQL(client, db, nil, nil)
+
+	creds := supplierExclusiveChatCredentials(
+		"https://api.cloudwise.ai/api", "secret",
+		map[string]any{"claude-opus-4-6": "claude-opus-4-6"},
+	)
+	credJSON, err := json.Marshal(creds)
+	require.NoError(t, err)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`(?s)UPDATE accounts\s+SET\s+name = \$1,\s+platform = \$2,\s+type = \$3,\s+channel_type = \$4,\s+credentials = \$5::jsonb,\s+extra = COALESCE\(extra, '\{\}'::jsonb\) \|\| \$6::jsonb,\s+priority = \$7,\s+status = \$8,\s+schedulable = \$9,\s+concurrency = \$10,\s+updated_at = NOW\(\)\s+WHERE id = \$11 AND deleted_at IS NULL`).
+		WithArgs(
+			"supplier/cloudwise · 档位 1",
+			service.PlatformNewAPI,
+			service.AccountTypeAPIKey,
+			newapiconstant.ChannelTypeAnthropic,
+			string(credJSON),
+			`{"supplier_discount_band":1,"supplier_source_id":7}`,
+			160,
+			service.StatusActive,
+			true,
+			1000,
+			int64(41),
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(`(?s)SELECT id, platform, type, credentials, extra, channel_type, protocol_endpoint_capability_id.*FOR UPDATE`).
+		WithArgs(int64(41)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "platform", "type", "credentials", "extra", "channel_type", "protocol_endpoint_capability_id",
+		}).AddRow(
+			int64(41), service.PlatformNewAPI, service.AccountTypeAPIKey,
+			string(credJSON),
+			`{"supplier_discount_band":1,"supplier_source_id":7}`,
+			newapiconstant.ChannelTypeAnthropic,
+			nil,
+		))
+	mock.ExpectRollback()
+
+	err = repo.UpdateSupplierProjection(context.Background(), &service.Account{
+		ID:          41,
+		Name:        "supplier/cloudwise · 档位 1",
+		Platform:    service.PlatformNewAPI,
+		Type:        service.AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeAnthropic,
+		Credentials: creds,
+		Extra: map[string]any{
+			service.SupplierSourceIDExtraKey:     int64(7),
+			service.SupplierDiscountBandExtraKey: 1,
+		},
+		Priority:    160,
+		Status:      service.StatusActive,
+		Schedulable: true,
+		Concurrency: 1000,
+	}, true)
+	require.ErrorIs(t, err, service.ErrSupplierProjectionProtocolNotReady)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUS048_SupplierAnthropicProjectionPublishesMessagesCapability(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	client := dbent.NewClient(dbent.Driver(entsql.OpenDB(dialect.Postgres, db)))
+	t.Cleanup(func() { _ = client.Close() })
+	repo := newAccountRepositoryWithSQL(client, db, nil, nil)
+
+	creds := supplierExclusiveMessagesCredentials(
+		"https://api.cloudwise.ai/api", "secret",
+		map[string]any{"claude-opus-4-6": "claude-opus-4-6"},
+	)
+	credJSON, err := json.Marshal(creds)
+	require.NoError(t, err)
+	account := &service.Account{
+		ID:          41,
+		Name:        "supplier/cloudwise · 档位 1",
+		Platform:    service.PlatformNewAPI,
+		Type:        service.AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeAnthropic,
+		Credentials: creds,
+		Extra: map[string]any{
+			service.SupplierSourceIDExtraKey:     int64(7),
+			service.SupplierDiscountBandExtraKey: 1,
+		},
+		Priority:    160,
+		Status:      service.StatusActive,
+		Schedulable: true,
+		Concurrency: 1000,
+	}
+	identity, governed, err := service.BuildProtocolEndpointIdentity(account)
+	require.NoError(t, err)
+	require.True(t, governed)
+	require.Len(t, identity.ProtocolEndpoints, 1)
+	_, hasMessages := identity.ProtocolEndpoints[protocolrouter.ProtocolMessages]
+	require.True(t, hasMessages)
+	identityJSON, err := identity.CanonicalJSON()
+	require.NoError(t, err)
+	now := time.Date(2026, time.August, 28, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`(?s)UPDATE accounts\s+SET\s+name = \$1,\s+platform = \$2,\s+type = \$3,\s+channel_type = \$4,\s+credentials = \$5::jsonb,\s+extra = COALESCE\(extra, '\{\}'::jsonb\) \|\| \$6::jsonb,\s+priority = \$7,\s+status = \$8,\s+schedulable = \$9,\s+concurrency = \$10,\s+updated_at = NOW\(\)\s+WHERE id = \$11 AND deleted_at IS NULL`).
+		WithArgs(
+			"supplier/cloudwise · 档位 1",
+			service.PlatformNewAPI,
+			service.AccountTypeAPIKey,
+			newapiconstant.ChannelTypeAnthropic,
+			string(credJSON),
+			`{"supplier_discount_band":1,"supplier_source_id":7}`,
+			160,
+			service.StatusActive,
+			true,
+			1000,
+			int64(41),
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(`(?s)SELECT id, platform, type, credentials, extra, channel_type, protocol_endpoint_capability_id.*FOR UPDATE`).
+		WithArgs(int64(41)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "platform", "type", "credentials", "extra", "channel_type", "protocol_endpoint_capability_id",
+		}).AddRow(
+			int64(41), service.PlatformNewAPI, service.AccountTypeAPIKey,
+			string(credJSON),
+			`{"supplier_discount_band":1,"supplier_source_id":7,"supported_protocols":[]}`,
+			newapiconstant.ChannelTypeAnthropic,
+			int64(8),
+		))
+	mock.ExpectExec(`INSERT INTO protocol_endpoint_capabilities`).
+		WithArgs(identity.Key(), string(identityJSON)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(`(?s)FROM protocol_endpoint_capabilities.*FOR UPDATE`).
+		WithArgs(identity.Key()).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "capability_key", "identity", "supported_protocols", "probe_evidence", "revision",
+			"last_probed_at", "probe_lease_owner", "probe_lease_until", "probe_generation",
+			"identity_conflict", "created_at", "updated_at",
+		}).AddRow(int64(9), identity.Key(), string(identityJSON), `[]`, `{}`, int64(1), nil, nil, nil, int64(0), false, now, now))
+	mock.ExpectExec(`UPDATE accounts\s+SET protocol_endpoint_capability_id=\$2\s+WHERE`).
+		WithArgs(int64(41), int64(9)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM accounts`).
+		WithArgs(int64(9)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery(`(?s)UPDATE protocol_endpoint_capabilities\s+SET probe_generation=probe_generation\+1.*RETURNING capability_key, probe_generation, revision, probe_lease_owner`).
+		WithArgs(identity.Key(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"capability_key", "probe_generation", "revision", "probe_lease_owner",
+		}).AddRow(identity.Key(), int64(1), int64(1), "supplier-messages-probe"))
+	mock.ExpectQuery(`(?s)FROM protocol_endpoint_capabilities.*FOR UPDATE`).
+		WithArgs(identity.Key()).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "capability_key", "identity", "supported_protocols", "probe_evidence", "revision",
+			"last_probed_at", "probe_lease_owner", "probe_lease_until", "probe_generation",
+			"identity_conflict", "created_at", "updated_at",
+		}).AddRow(
+			int64(9), identity.Key(), string(identityJSON), `[]`, `{}`, int64(1), nil,
+			"supplier-messages-probe", now.Add(time.Minute), int64(1), false, now, now,
+		))
+	mock.ExpectExec(`UPDATE protocol_endpoint_capabilities`).
+		WithArgs(
+			int64(9), `["messages"]`, sqlmock.AnyArg(), int64(2), sqlmock.AnyArg(), false,
+			int64(1), int64(1), "supplier-messages-probe",
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(`UPDATE accounts\s+SET extra=jsonb_set`).
+		WithArgs(int64(9), `["messages"]`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(41)))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO scheduler_outbox")).
+		WithArgs(service.SchedulerOutboxEventAccountChanged, int64(41), nil, nil, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err = repo.UpdateSupplierProjection(context.Background(), account, true)
+	require.NoError(t, err)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/backend/internal/service/account_protocol_endpoint_credentials.go
+++ b/backend/internal/service/account_protocol_endpoint_credentials.go
@@ -97,16 +97,30 @@ func deriveExclusiveChatProtocolURL(baseURL string, channelType int) string {
 	return trimmed
 }
 
-// applyExclusiveChatProtocolEndpoints writes the chat-only exclusive identity
-// block used by supplier-managed NewAPI accounts.
+// deriveExclusiveMessagesProtocolURL builds the messages base URL declared under
+// protocol_endpoints_exclusive for Anthropic supplier accounts. Identity
+// normalization appends /v1/messages when the path is not already complete.
+func deriveExclusiveMessagesProtocolURL(baseURL string) string {
+	return strings.TrimRight(strings.TrimSpace(baseURL), "/")
+}
+
+// applyExclusiveChatProtocolEndpoints writes the channel-appropriate exclusive
+// identity block used by supplier-managed NewAPI accounts. Anthropic (14) is
+// messages-only; all other supplier transports remain chat-only.
 func applyExclusiveChatProtocolEndpoints(credentials map[string]any, baseURL string, channelType int) {
 	if credentials == nil {
 		return
 	}
 	trimmed := strings.TrimRight(strings.TrimSpace(baseURL), "/")
 	credentials["base_url"] = trimmed
-	credentials[apiBaseURLsCredentialKey] = map[string]any{
-		APIProtocolChatCompletions: deriveExclusiveChatProtocolURL(trimmed, channelType),
+	if channelType == newapiconstant.ChannelTypeAnthropic {
+		credentials[apiBaseURLsCredentialKey] = map[string]any{
+			APIProtocolAnthropic: deriveExclusiveMessagesProtocolURL(trimmed),
+		}
+	} else {
+		credentials[apiBaseURLsCredentialKey] = map[string]any{
+			APIProtocolChatCompletions: deriveExclusiveChatProtocolURL(trimmed, channelType),
+		}
 	}
 	credentials[ProtocolEndpointsExclusiveCredentialKey] = true
 }
@@ -124,6 +138,14 @@ func reconcileExclusiveProtocolEndpointCredentials(credentials map[string]any, c
 		delete(credentials, apiBaseURLsCredentialKey)
 		return credentials
 	}
+	if channelType == newapiconstant.ChannelTypeAnthropic {
+		wantMessages := deriveExclusiveMessagesProtocolURL(baseURL)
+		credentials[apiBaseURLsCredentialKey] = map[string]any{
+			APIProtocolAnthropic: wantMessages,
+		}
+		credentials[ProtocolEndpointsExclusiveCredentialKey] = true
+		return credentials
+	}
 	wantChat := deriveExclusiveChatProtocolURL(baseURL, channelType)
 	raw, _ := credentials[apiBaseURLsCredentialKey].(map[string]any)
 	out := make(map[string]any, len(raw)+1)
@@ -134,6 +156,8 @@ func reconcileExclusiveProtocolEndpointCredentials(credentials map[string]any, c
 	if !exclusiveChatURLsAligned(gotChat, wantChat) {
 		out[APIProtocolChatCompletions] = wantChat
 	}
+	delete(out, APIProtocolAnthropic)
+	delete(out, APIProtocolResponses)
 	credentials[apiBaseURLsCredentialKey] = out
 	credentials[ProtocolEndpointsExclusiveCredentialKey] = true
 	return credentials

--- a/backend/internal/service/account_protocol_endpoint_credentials.go
+++ b/backend/internal/service/account_protocol_endpoint_credentials.go
@@ -104,10 +104,10 @@ func deriveExclusiveMessagesProtocolURL(baseURL string) string {
 	return strings.TrimRight(strings.TrimSpace(baseURL), "/")
 }
 
-// applyExclusiveChatProtocolEndpoints writes the channel-appropriate exclusive
+// applyExclusiveSupplierProtocolEndpoints writes the channel-appropriate exclusive
 // identity block used by supplier-managed NewAPI accounts. Anthropic (14) is
 // messages-only; all other supplier transports remain chat-only.
-func applyExclusiveChatProtocolEndpoints(credentials map[string]any, baseURL string, channelType int) {
+func applyExclusiveSupplierProtocolEndpoints(credentials map[string]any, baseURL string, channelType int) {
 	if credentials == nil {
 		return
 	}

--- a/backend/internal/service/account_test_service_supplier_probe.go
+++ b/backend/internal/service/account_test_service_supplier_probe.go
@@ -36,6 +36,9 @@ func (s *AccountTestService) ProbeSupplierModel(ctx context.Context, input Suppl
 	if supplierAccountUsesVideoProbe(input.Account) {
 		return s.probeSupplierVideoModel(ctx, input, baseResult)
 	}
+	if supplierAccountUsesAnthropicMessagesProbe(input.Account) {
+		return s.probeSupplierAnthropicMessagesModel(ctx, input, baseResult)
+	}
 	recorder := httptest.NewRecorder()
 	ginContext, _ := gin.CreateTestContext(recorder)
 	ginContext.Request = httptest.NewRequest("POST", "/internal/supplier-probe", nil).WithContext(ctx)
@@ -58,6 +61,102 @@ func (s *AccountTestService) ProbeSupplierModel(ctx context.Context, input Suppl
 
 func supplierAccountUsesVideoProbe(account *Account) bool {
 	return account != nil && account.ChannelType == newapiconstant.ChannelTypeDoubaoVideo
+}
+
+func supplierAccountUsesAnthropicMessagesProbe(account *Account) bool {
+	return account != nil && account.ChannelType == newapiconstant.ChannelTypeAnthropic
+}
+
+func (s *AccountTestService) probeSupplierAnthropicMessagesModel(
+	ctx context.Context,
+	input SupplierProbeInput,
+	baseResult SupplierProbeResult,
+) SupplierProbeResult {
+	account := input.Account
+	baseURL := strings.TrimRight(strings.TrimSpace(account.GetBaseURL()), "/")
+	apiKey := strings.TrimSpace(account.GetCredential("api_key"))
+	if baseURL == "" || apiKey == "" {
+		baseResult.Status = SupplierProbeStatusFailed
+		baseResult.Detail = supplierProbeSafeDetail(SupplierProbeStatusFailed)
+		return baseResult
+	}
+	messagesURL := supplierAnthropicMessagesProbeURL(baseURL)
+	body, err := json.Marshal(map[string]any{
+		"model":      baseResult.UpstreamModelID,
+		"max_tokens": 8,
+		"messages": []map[string]any{
+			{"role": "user", "content": "hi"},
+		},
+		"stream": false,
+	})
+	if err != nil {
+		baseResult.Status = SupplierProbeStatusFailed
+		baseResult.Detail = supplierProbeSafeDetail(SupplierProbeStatusFailed)
+		return baseResult
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, messagesURL, bytes.NewReader(body))
+	if err != nil {
+		baseResult.Status = SupplierProbeStatusFailed
+		baseResult.Detail = supplierProbeSafeDetail(SupplierProbeStatusFailed)
+		return baseResult
+	}
+	// CloudWise Anthropic MaaS accepts Bearer (prod matrix); also set x-api-key for
+	// Anthropic-native relays that ignore Authorization.
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	client := &http.Client{Timeout: 20 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		baseResult.Status = SupplierProbeStatusFailed
+		baseResult.Detail = supplierProbeSafeDetail(SupplierProbeStatusFailed)
+		return baseResult
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	status := supplierAnthropicMessagesProbeStatus(resp.StatusCode, raw)
+	baseResult.Status = status
+	if status == SupplierProbeStatusPassed {
+		baseResult.Protocol = "anthropic_messages"
+	} else {
+		baseResult.Detail = supplierProbeSafeDetail(status)
+	}
+	return baseResult
+}
+
+func supplierAnthropicMessagesProbeURL(baseURL string) string {
+	trimmed := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if strings.HasSuffix(trimmed, "/v1/messages") {
+		return trimmed
+	}
+	if strings.HasSuffix(trimmed, "/v1") {
+		return trimmed + "/messages"
+	}
+	return trimmed + "/v1/messages"
+}
+
+func supplierAnthropicMessagesProbeStatus(statusCode int, body []byte) SupplierProbeStatus {
+	lower := strings.ToLower(string(body))
+	switch {
+	case statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden:
+		return SupplierProbeStatusAuthFailed
+	case statusCode == http.StatusNotFound || strings.Contains(lower, "model not found") ||
+		strings.Contains(lower, "model_not_found") || strings.Contains(lower, "unknown model"):
+		return SupplierProbeStatusModelUnsupported
+	case statusCode == http.StatusOK && (strings.Contains(lower, "chat.completion") ||
+		strings.Contains(lower, "response.completed")):
+		return SupplierProbeStatusProtocolUnsupported
+	case statusCode == http.StatusOK && (strings.Contains(lower, `"type":"message"`) ||
+		strings.Contains(lower, `"type": "message"`) || strings.Contains(lower, "message_start")):
+		return SupplierProbeStatusPassed
+	case statusCode >= 200 && statusCode < 300:
+		// 2xx without Anthropic message shape is not Messages evidence.
+		return SupplierProbeStatusProtocolUnsupported
+	default:
+		return SupplierProbeStatusFailed
+	}
 }
 
 func (s *AccountTestService) probeSupplierVideoModel(

--- a/backend/internal/service/account_test_service_supplier_probe_test.go
+++ b/backend/internal/service/account_test_service_supplier_probe_test.go
@@ -210,6 +210,35 @@ func TestUS048_SupplierManagedAccountDeclaresOnlyChatProtocol(t *testing.T) {
 	require.Equal(t, []protocolrouter.Protocol{protocolrouter.ProtocolChatCompletions}, ProtocolProbeCandidates(account))
 }
 
+func TestUS048_SupplierManagedAnthropicDeclaresOnlyMessagesProtocol(t *testing.T) {
+	account := &Account{
+		ID:          114,
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeAnthropic,
+		Credentials: supplierManagedCredentials(
+			"https://api.cloudwise.ai/api", "secret",
+			map[string]string{"claude-opus-4-6": "claude-opus-4-6"}, newapiconstant.ChannelTypeAnthropic),
+		Extra: map[string]any{
+			SupplierSourceIDExtraKey:     int64(9),
+			SupplierDiscountBandExtraKey: 6,
+		},
+	}
+
+	identity, governed, err := BuildProtocolEndpointIdentity(account)
+
+	require.NoError(t, err)
+	require.True(t, governed)
+	require.Equal(t, map[protocolrouter.Protocol]ProtocolEndpoint{
+		protocolrouter.ProtocolMessages: {URL: "https://api.cloudwise.ai/api/v1/messages"},
+	}, identity.ProtocolEndpoints)
+	require.Equal(t, []protocolrouter.Protocol{protocolrouter.ProtocolMessages}, ProtocolProbeCandidates(account))
+	require.Equal(t, true, account.Credentials[ProtocolEndpointsExclusiveCredentialKey])
+	require.Equal(t, map[string]any{
+		APIProtocolAnthropic: "https://api.cloudwise.ai/api",
+	}, account.Credentials[apiBaseURLsCredentialKey])
+}
+
 func TestUS048_ChatOnlyIdentityDoesNotRequireSupplierSourceBinding(t *testing.T) {
 	// Scheduling/gateway identity must follow account credentials, not Extra.supplier_source_id.
 	account := &Account{
@@ -406,4 +435,71 @@ func TestUS048_SupplierProbeClassifiesEventsWithoutPersistingUpstreamDetail(t *t
 		require.Equal(t, "openai_responses", result.Protocol)
 		require.Equal(t, "supplier protocol unsupported", result.Detail)
 	})
+}
+
+func TestUS048_AnthropicMessagesProbeAcceptsMessageShapeOnly(t *testing.T) {
+	t.Run("message json passes", func(t *testing.T) {
+		require.Equal(t, SupplierProbeStatusPassed, supplierAnthropicMessagesProbeStatus(
+			http.StatusOK,
+			[]byte(`{"type":"message","role":"assistant","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":1,"output_tokens":1}}`),
+		))
+	})
+	t.Run("chat completion shape is protocol_unsupported", func(t *testing.T) {
+		require.Equal(t, SupplierProbeStatusProtocolUnsupported, supplierAnthropicMessagesProbeStatus(
+			http.StatusOK,
+			[]byte(`{"id":"chatcmpl-1","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"hi"}}]}`),
+		))
+	})
+	t.Run("auth failure", func(t *testing.T) {
+		require.Equal(t, SupplierProbeStatusAuthFailed, supplierAnthropicMessagesProbeStatus(
+			http.StatusUnauthorized, []byte(`{"error":{"type":"authentication_error"}}`),
+		))
+	})
+	t.Run("model unsupported", func(t *testing.T) {
+		require.Equal(t, SupplierProbeStatusModelUnsupported, supplierAnthropicMessagesProbeStatus(
+			http.StatusNotFound, []byte(`{"error":{"message":"model not found"}}`),
+		))
+	})
+}
+
+func TestUS048_AnthropicMessagesProbeURL(t *testing.T) {
+	require.Equal(t, "https://api.cloudwise.ai/api/v1/messages",
+		supplierAnthropicMessagesProbeURL("https://api.cloudwise.ai/api"))
+	require.Equal(t, "https://api.cloudwise.ai/api/v1/messages",
+		supplierAnthropicMessagesProbeURL("https://api.cloudwise.ai/api/v1"))
+	require.Equal(t, "https://api.cloudwise.ai/api/v1/messages",
+		supplierAnthropicMessagesProbeURL("https://api.cloudwise.ai/api/v1/messages"))
+}
+
+func TestUS048_SupplierAnthropicMessagesProbeHitsMessagesPath(t *testing.T) {
+	var gotMethod, gotPath, gotAuth, gotAPIKey, gotVersion string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotAPIKey = r.Header.Get("x-api-key")
+		gotVersion = r.Header.Get("anthropic-version")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"type":"message","role":"assistant","content":[{"type":"text","text":"OK"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	svc := &AccountTestService{}
+	account := &Account{
+		Platform: PlatformNewAPI, Type: AccountTypeAPIKey, ChannelType: newapiconstant.ChannelTypeAnthropic,
+		Credentials: supplierManagedCredentials(server.URL, "cw-secret", map[string]string{
+			"claude-sonnet-4-6": "claude-sonnet-4-6",
+		}, newapiconstant.ChannelTypeAnthropic),
+	}
+	result := svc.ProbeSupplierModel(context.Background(), SupplierProbeInput{
+		Account: account, ClientModelID: "claude-sonnet-4-6", UpstreamModelID: "claude-sonnet-4-6",
+	})
+
+	require.Equal(t, SupplierProbeStatusPassed, result.Status)
+	require.Equal(t, "anthropic_messages", result.Protocol)
+	require.Equal(t, http.MethodPost, gotMethod)
+	require.Equal(t, "/v1/messages", gotPath)
+	require.Equal(t, "Bearer cw-secret", gotAuth)
+	require.Equal(t, "cw-secret", gotAPIKey)
+	require.Equal(t, "2023-06-01", gotVersion)
 }

--- a/backend/internal/service/supplier_managed_account_commands.go
+++ b/backend/internal/service/supplier_managed_account_commands.go
@@ -18,21 +18,21 @@ type SupplierManagedAccountCreateInput struct {
 }
 
 type SupplierManagedAccountUpdateInput struct {
-	AccountID       int64
-	SourceID        int64
-	DiscountBand    int
-	MetadataOnly    bool
-	Adopt           bool
-	Name            string
-	Endpoint        string
-	ChannelType     int
-	Credential      string
-	ModelMapping    map[string]string
-	Priority        int
-	Concurrency     int
-	Status          string
-	Schedulable     bool
-	ChatProbePassed bool
+	AccountID           int64
+	SourceID            int64
+	DiscountBand        int
+	MetadataOnly        bool
+	Adopt               bool
+	Name                string
+	Endpoint            string
+	ChannelType         int
+	Credential          string
+	ModelMapping        map[string]string
+	Priority            int
+	Concurrency         int
+	Status              string
+	Schedulable         bool
+	ProtocolProbePassed bool
 }
 
 type SupplierManagedAccountCommands interface {
@@ -44,7 +44,7 @@ type SupplierManagedAccountCommands interface {
 type supplierProjectionAccountUpdater interface {
 	UpdateSupplierMetadata(ctx context.Context, accountID int64, name string, priority int) error
 	UpdateSupplierConcurrency(ctx context.Context, accountID int64, concurrency int) error
-	UpdateSupplierProjection(ctx context.Context, account *Account, chatProbePassed bool) error
+	UpdateSupplierProjection(ctx context.Context, account *Account, protocolProbePassed bool) error
 }
 
 type supplierManagedAccountReader interface {
@@ -145,7 +145,7 @@ func (s *adminServiceImpl) UpdateSupplierManagedAccount(
 	); err != nil {
 		return nil, err
 	}
-	if len(input.ModelMapping) > 0 && !input.ChatProbePassed {
+	if len(input.ModelMapping) > 0 && !input.ProtocolProbePassed {
 		return nil, ErrSupplierProjectionProtocolNotReady
 	}
 
@@ -172,7 +172,7 @@ func (s *adminServiceImpl) UpdateSupplierManagedAccount(
 		account.Status = input.Status
 	}
 	account.Schedulable = input.Schedulable && len(input.ModelMapping) > 0
-	if err := updateSupplierProjection(ctx, s.accountRepo, account, input.ChatProbePassed); err != nil {
+	if err := updateSupplierProjection(ctx, s.accountRepo, account, input.ProtocolProbePassed); err != nil {
 		return nil, err
 	}
 	return account, nil
@@ -223,12 +223,12 @@ func updateSupplierMetadata(ctx context.Context, repo AccountRepository, account
 	return updater.UpdateSupplierMetadata(ctx, account.ID, account.Name, account.Priority)
 }
 
-func updateSupplierProjection(ctx context.Context, repo AccountRepository, account *Account, chatProbePassed bool) error {
+func updateSupplierProjection(ctx context.Context, repo AccountRepository, account *Account, protocolProbePassed bool) error {
 	updater, ok := repo.(supplierProjectionAccountUpdater)
 	if !ok {
 		return ErrSupplierProjectionUpdaterMissing
 	}
-	return updater.UpdateSupplierProjection(ctx, account, chatProbePassed)
+	return updater.UpdateSupplierProjection(ctx, account, protocolProbePassed)
 }
 
 func validateSupplierManagedIdentity(sourceID int64, discountBand int) error {
@@ -266,6 +266,6 @@ func supplierManagedCredentials(endpoint, credential string, modelMapping map[st
 	}
 	// Account-self exclusive endpoint declaration — scheduling identity
 	// reads this, not supplier_source_id. Shared with FinalizeAccountCredentials.
-	applyExclusiveChatProtocolEndpoints(credentials, baseURL, channelType)
+	applyExclusiveSupplierProtocolEndpoints(credentials, baseURL, channelType)
 	return FinalizeAccountCredentials(credentials, channelType)
 }

--- a/backend/internal/service/supplier_managed_account_commands_test.go
+++ b/backend/internal/service/supplier_managed_account_commands_test.go
@@ -99,7 +99,7 @@ func TestUS048_SupplierConfigurationUpdateUsesGroupFreeReadAndNarrowWrite(t *tes
 		AccountID: 41, SourceID: 7, DiscountBand: 3, Name: "佳杰/stbl-5 · 档位 3",
 		Endpoint: "https://new.example/v1", Credential: "new-secret",
 		ModelMapping: map[string]string{"deepseek-v4-pro": "deepseek-v4-pro"},
-		Priority:     123, Status: StatusActive, Schedulable: true, ChatProbePassed: true,
+		Priority:     123, Status: StatusActive, Schedulable: true, ProtocolProbePassed: true,
 	})
 
 	require.NoError(t, err)
@@ -115,7 +115,7 @@ func TestUS048_SupplierConfigurationUpdateUsesGroupFreeReadAndNarrowWrite(t *tes
 	require.Equal(t, AccountTypeAPIKey, accounts.updated.Type)
 	require.Equal(t, newapiconstant.ChannelTypeOpenAI, accounts.updated.ChannelType, "generic supplier hosts keep the OpenAI Chat transport")
 	require.Equal(t, 1, accounts.projectionUpdateCalls)
-	require.True(t, accounts.projectionChatProbePassed)
+	require.True(t, accounts.projectionProtocolProbePassed)
 	require.Zero(t, accounts.genericUpdateCalls, "supplier projections must not use the generic account update path")
 }
 
@@ -159,7 +159,7 @@ func TestUS048_SupplierAnthropicCreateDeclaresMessagesExclusive(t *testing.T) {
 	require.Zero(t, accounts.bindCalls)
 }
 
-func TestUS048_SupplierConfigurationUpdateRequiresPassedChatProbe(t *testing.T) {
+func TestUS048_SupplierConfigurationUpdateRequiresPassedProtocolProbe(t *testing.T) {
 	accounts := &supplierManagedCommandsAccountRepoFake{existing: &Account{
 		ID: 41, Platform: PlatformNewAPI, Type: AccountTypeAPIKey, ChannelType: newapiconstant.ChannelTypeOpenAI,
 		Credentials: supplierManagedCredentials(
@@ -239,7 +239,7 @@ func TestUS048_SupplierAdoptAddsManagedIdentityWithoutReadingOrWritingGroups(t *
 		AccountID: 90, SourceID: 7, DiscountBand: 3, Name: "百度/千帆 · 档位 3",
 		Endpoint: "https://qianfan.baidubce.com/v1", Credential: "secret",
 		ModelMapping: map[string]string{"deepseek-v4-pro": "deepseek-v4-pro", "qwen": "qwen"},
-		Priority:     103, Status: StatusActive, Schedulable: true, Adopt: true, ChatProbePassed: true,
+		Priority:     103, Status: StatusActive, Schedulable: true, Adopt: true, ProtocolProbePassed: true,
 	})
 
 	require.NoError(t, err)
@@ -274,24 +274,24 @@ func TestUS048_SupplierUpdateRejectsCrossSourceOrCrossBandTakeover(t *testing.T)
 
 type supplierManagedCommandsAccountRepoFake struct {
 	AccountRepository
-	existing                  *Account
-	created                   *Account
-	updated                   *Account
-	boundGroupIDs             []int64
-	bindCalls                 int
-	genericUpdateCalls        int
-	projectionUpdateCalls     int
-	projectionChatProbePassed bool
-	metadataUpdateCalls       int
-	metadataAccountID         int64
-	metadataName              string
-	metadataPriority          int
-	concurrencyUpdateCalls    int
-	concurrencyAccountID      int64
-	concurrencyValue          int
-	bindErr                   error
-	genericGetCalls           int
-	supplierGetCalls          int
+	existing                      *Account
+	created                       *Account
+	updated                       *Account
+	boundGroupIDs                 []int64
+	bindCalls                     int
+	genericUpdateCalls            int
+	projectionUpdateCalls         int
+	projectionProtocolProbePassed bool
+	metadataUpdateCalls           int
+	metadataAccountID             int64
+	metadataName                  string
+	metadataPriority              int
+	concurrencyUpdateCalls        int
+	concurrencyAccountID          int64
+	concurrencyValue              int
+	bindErr                       error
+	genericGetCalls               int
+	supplierGetCalls              int
 }
 
 func (r *supplierManagedCommandsAccountRepoFake) Create(_ context.Context, account *Account) error {
@@ -324,9 +324,9 @@ func (r *supplierManagedCommandsAccountRepoFake) Update(_ context.Context, accou
 	return nil
 }
 
-func (r *supplierManagedCommandsAccountRepoFake) UpdateSupplierProjection(_ context.Context, account *Account, chatProbePassed bool) error {
+func (r *supplierManagedCommandsAccountRepoFake) UpdateSupplierProjection(_ context.Context, account *Account, protocolProbePassed bool) error {
 	r.projectionUpdateCalls++
-	r.projectionChatProbePassed = chatProbePassed
+	r.projectionProtocolProbePassed = protocolProbePassed
 	r.updated = cloneSupplierManagedCommandsTestAccount(account)
 	return nil
 }

--- a/backend/internal/service/supplier_managed_account_commands_test.go
+++ b/backend/internal/service/supplier_managed_account_commands_test.go
@@ -137,6 +137,28 @@ func TestUS048_SupplierQianfanCreateUsesBaiduV2Transport(t *testing.T) {
 	require.Zero(t, accounts.bindCalls)
 }
 
+func TestUS048_SupplierAnthropicCreateDeclaresMessagesExclusive(t *testing.T) {
+	accounts := &supplierManagedCommandsAccountRepoFake{}
+	groups := &supplierManagedCommandsGroupRepoFake{groups: []Group{{ID: 9, Name: PlatformNewAPI + "-default", Platform: PlatformNewAPI}}}
+	svc := &adminServiceImpl{accountRepo: accounts, groupRepo: groups}
+
+	_, err := svc.CreateSupplierManagedAccount(context.Background(), SupplierManagedAccountCreateInput{
+		SourceID: 9, DiscountBand: 6, Name: "CloudWise/Anthropic · 档位 6",
+		Endpoint: "https://api.cloudwise.ai/api", Credential: "secret",
+		ChannelType: newapiconstant.ChannelTypeAnthropic, Priority: 160,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, newapiconstant.ChannelTypeAnthropic, accounts.created.ChannelType)
+	require.Equal(t, "https://api.cloudwise.ai/api", accounts.created.Credentials["base_url"])
+	require.Equal(t, true, accounts.created.Credentials[ProtocolEndpointsExclusiveCredentialKey])
+	require.Equal(t, map[string]any{
+		APIProtocolAnthropic: "https://api.cloudwise.ai/api",
+	}, accounts.created.Credentials[apiBaseURLsCredentialKey])
+	require.False(t, accounts.created.Schedulable)
+	require.Zero(t, accounts.bindCalls)
+}
+
 func TestUS048_SupplierConfigurationUpdateRequiresPassedChatProbe(t *testing.T) {
 	accounts := &supplierManagedCommandsAccountRepoFake{existing: &Account{
 		ID: 41, Platform: PlatformNewAPI, Type: AccountTypeAPIKey, ChannelType: newapiconstant.ChannelTypeOpenAI,

--- a/backend/internal/service/supplier_managed_transport.go
+++ b/backend/internal/service/supplier_managed_transport.go
@@ -83,7 +83,7 @@ func supplierManagedTransportOK(account *Account) bool {
 		return false
 	}
 	switch account.ChannelType {
-	case newapiconstant.ChannelTypeOpenAI, newapiconstant.ChannelTypeBaiduV2, newapiconstant.ChannelTypeAli:
+	case newapiconstant.ChannelTypeOpenAI, newapiconstant.ChannelTypeBaiduV2, newapiconstant.ChannelTypeAli, newapiconstant.ChannelTypeAnthropic:
 		return true
 	default:
 		return newapiintegration.IsKnownChannelType(account.ChannelType)

--- a/backend/internal/service/supplier_managed_transport_test.go
+++ b/backend/internal/service/supplier_managed_transport_test.go
@@ -30,6 +30,13 @@ func TestUS048_ResolveSupplierManagedTransportKeepsOpenAIForGenericHosts(t *test
 	require.Equal(t, "https://token.vstecscloud.com/v1", transport.Endpoint)
 }
 
+func TestUS048_ResolveSupplierManagedTransportKeepsExplicitAnthropic(t *testing.T) {
+	transport, err := resolveSupplierManagedTransport("https://api.cloudwise.ai/api", newapiconstant.ChannelTypeAnthropic)
+	require.NoError(t, err)
+	require.Equal(t, newapiconstant.ChannelTypeAnthropic, transport.ChannelType)
+	require.Equal(t, "https://api.cloudwise.ai/api", transport.Endpoint)
+}
+
 func TestUS048_SupplierManagedEndpointsEqualCollapsesQianfanPathVariants(t *testing.T) {
 	require.True(t, supplierManagedEndpointsEqual(
 		"https://qianfan.baidubce.com/v2",

--- a/backend/internal/service/supplier_source_service.go
+++ b/backend/internal/service/supplier_source_service.go
@@ -332,7 +332,7 @@ func (s *SupplierSourceService) Sync(ctx context.Context, sourceID int64) (*Supp
 			ModelMapping: additionMapping, Priority: target.Priority, Concurrency: source.AccountConcurrency,
 			Status:      StatusActive,
 			Schedulable: len(additionMapping) > 0, Adopt: adopt,
-			ChatProbePassed: len(additionMapping) > 0,
+			ProtocolProbePassed: len(additionMapping) > 0,
 		}
 		updated, updateErr := s.accounts.UpdateManagedAccount(ctx, updateInput)
 		if updateErr != nil {
@@ -386,7 +386,7 @@ func (s *SupplierSourceService) Sync(ctx context.Context, sourceID int64) (*Supp
 			ModelMapping: cloneSupplierStringMap(desiredMapping), Priority: desiredPriority,
 			Concurrency: source.AccountConcurrency,
 			Status:      StatusActive, Schedulable: len(desiredMapping) > 0,
-			ChatProbePassed: len(desiredMapping) > 0,
+			ProtocolProbePassed: len(desiredMapping) > 0,
 		})
 		if updateErr != nil {
 			result.FailedStep = fmt.Sprintf("remove_band_%d", band)

--- a/backend/internal/service/supplier_source_sync_test.go
+++ b/backend/internal/service/supplier_source_sync_test.go
@@ -848,7 +848,7 @@ func (f *supplierSyncAccountStoreFake) CreateManagedAccount(_ context.Context, i
 func (f *supplierSyncAccountStoreFake) UpdateManagedAccount(_ context.Context, input SupplierManagedAccountUpdateInput) (*Account, error) {
 	f.updated = append(f.updated, input)
 	f.operations = append(f.operations, syncOperationLabel(input))
-	if len(input.ModelMapping) > 0 && !input.ChatProbePassed {
+	if len(input.ModelMapping) > 0 && !input.ProtocolProbePassed {
 		return nil, ErrSupplierProjectionProtocolNotReady
 	}
 	if f.updateErrAt > 0 && len(f.updated) == f.updateErrAt {
@@ -968,7 +968,7 @@ func TestUS048_SupplierSyncProtocolIdentityDriftReprobesBeforeRepair(t *testing.
 	require.NoError(t, err)
 	require.Len(t, result.ProbeResults, 1, "protocol identity repair must be backed by this sync call's real probe")
 	require.NotEmpty(t, accounts.updated)
-	require.True(t, accounts.updated[0].ChatProbePassed)
+	require.True(t, accounts.updated[0].ProtocolProbePassed)
 }
 
 func TestSupplierAccountNeedsProtocolRepublishDetectsTransportDrift(t *testing.T) {

--- a/docs/approved/model-supplier-source-management.md
+++ b/docs/approved/model-supplier-source-management.md
@@ -8,6 +8,11 @@ created: 2026-08-27
 owners: [tk-platform]
 scope: "supplier facts, admin API/UI, credential isolation, account projection, probe gate; managed accounts behave like ordinary accounts after create, with sync overwriting projection fields"
 related_stories: ["US-048"]
+revision_note: >
+  2026-09-02: Anthropic channel_type=14 is a first-class supplier transport exception
+  (like BaiduV2/46 and DoubaoVideo/54). CloudWise Claude opus/sonnet upstream only
+  accepts messages; supplier probe/project declare messages-only capability and refuse
+  Chat Completions evidence for that channel.
 ---
 
 # TokenKey 模型供应源管理审批基线
@@ -46,11 +51,13 @@ account.priority = source.base_priority + discount_priority
 - 供应源持久化 `channel_type`（Extension Engine 枚举）；Admin 表单必选类型，endpoint 主机仍可作
   兼容提示，但 transport / models 路径 / 受管账号投影以 `channel_type` 为准。默认 OpenAI
   Chat（1）；千帆 BaiduV2（46）规范化 `base_url` 为 `https://qianfan.baidubce.com`；DashScope Ali
-  （17）使用 `compatible-mode/v1/*` 路径。结构同步会把 transport 漂移修复回该解析结果。
-  账号先以空 `model_mapping`、`schedulable=false` 创建。
-- 受管账号和内存预探测账号只声明 Chat Completions。供应源 endpoint 末尾 `/v1` 只在 OpenAI
-  受管路径进入 NewAPI OpenAI 适配器前规范化；Qianfan 路径使用 `/v2/chat/completions`。普通
-  NewAPI 账号的 base URL 和协议行为保持不变。
+  （17）使用 `compatible-mode/v1/*` 路径；Anthropic（14）走原生 Messages（`/v1/messages`），用于
+  CloudWise 等上游仅 messages 可服务 Claude opus/sonnet 的供应源。结构同步会把 transport 漂移
+  修复回该解析结果。账号先以空 `model_mapping`、`schedulable=false` 创建。
+- 受管账号和内存预探测账号按通道声明**单一**协议能力：默认仅 Chat Completions；视频通道（54）走
+  视频方言；Anthropic（14）仅声明 Messages。供应源 endpoint 末尾 `/v1` 只在 OpenAI 受管路径进入
+  NewAPI OpenAI 适配器前规范化；Qianfan 路径使用 `/v2/chat/completions`；Anthropic 路径使用
+  `/v1/messages`。普通 NewAPI 账号的 base URL 和协议行为保持不变。
 - 供应源不读取或写入倍率、售价、pricing registry、计费规则、用户价格或利润数据。
 - 除把账号 `status/schedulable` 收敛到目标 mapping 的投影值外，供应源不修改 gateway、scheduler、
   sticky、运行期健康窗口、冷却、限流、fallback、`error_message` 或其他运行期字段。供应源拥有
@@ -58,8 +65,10 @@ account.priority = source.base_priority + discount_priority
   并发值。
 - 凭证使用最小权限 API Key；不保存供应商后台账号密码，不自动登录、处理 MFA 或代建 API Key。
 - API 不回显明文、密文或凭证指纹；日志和 Admin Audit Log 必须擦除请求字段 `credential`。
-- 未知或私有协议失败封闭；即使探测得到 Responses、Anthropic Messages 等非 Chat 成功证据，也返回
-  `protocol_unsupported`。不按模型前缀猜 transport，也不建设通用协议配置器。
+- 探测协议由 `channel_type` 决定，不按模型前缀猜 transport，也不建设通用协议配置器。默认只接受
+  Chat Completions 正向证据；视频通道走视频方言；Anthropic（14）只接受 Messages 正向证据。其它
+  协议成功证据（含 Anthropic 通道上的 Chat、Chat 通道上的 Messages/Responses）一律
+  `protocol_unsupported`。
 - 凭证 HMAC 指纹复用现有凭证加密密钥的生命周期，不随 JWT secret 轮换；探测日志不记录上游原始响应。
 
 ## 保存、预览与同步
@@ -76,9 +85,10 @@ priority 自行判断和修改 `base_priority`。已选来源的表单存在未�
 旧 `POST .../probe` 与 probe job 路由保留为 Discover 兼容别名；管理路由不再注册 `models-discover`。
 
 上游列表仍按通道能力拉取（OpenAI 兼容 `/v1/models`；千帆 BaiduV2 为 `/v2/models`；DashScope Ali
-为 `/compatible-mode/v1/models`）。探测协议由通道能力决定（如 `channel_type=54` 走视频门禁），
-不按 client 名字开例外。失败时 API 必须返回可读 `message` 与 `failed_step`；管理页必须在结果区
-之外独立展示错误文案，禁止只露出空标题。
+为 `/compatible-mode/v1/models`；Anthropic 14 仍用 `/v1/models` 发现）。探测协议由通道能力决定
+（`channel_type=54` 走视频门禁；`channel_type=14` 走 Messages），不按 client 名字开例外。失败时
+API 必须返回可读 `message` 与 `failed_step`；管理页必须在结果区之外独立展示错误文案，禁止只露出
+空标题。
 
 同步按以下最小规则执行：
 
@@ -86,11 +96,11 @@ priority 自行判断和修改 `base_priority`。已选来源的表单存在未�
 1b. `account_concurrency` 变化时，只更新受管账号 `concurrency`，不探测；
 2. endpoint、credential、模型 ID、模型增减、跨档，或非空受管账号的 `status/schedulable` 与目标
    不一致时，先用内存目标账号逐模型真实探测；空 mapping 的调度字段漂移无需探测；
-3. 任一模型失败，返回完整当次探测结果且不写账号；全部成功生成仅供本次同步调用链使用的 Chat
-   正向证据；
+3. 任一模型失败，返回完整当次探测结果且不写账号；全部成功生成仅供本次同步调用链使用的通道协议
+   正向证据（默认 Chat；Anthropic 14 为 Messages；视频 54 为视频方言）；
 4. 先创建空 mapping、不可调度的新档位账号。非空投影必须携带该证据；service 和 repository 双重
    拒绝未经探测的非空 mapping；
-5. 单账号事务同时提交账号配置、仅含 Chat Completions 的现有协议能力、
+5. 单账号事务同时提交账号配置、该通道单一协议能力（默认 Chat Completions；Anthropic 仅 Messages）、
    `InitialProbeCompleted=true`/`OfficialSeed=false` 的正向证据及普通 scheduler outbox；提交后只读回
    配置确认，不做写后二次网络探测；
 6. 再从旧档位移除不再属于它的 mapping；空 mapping 账号保留并设 `schedulable=false`；

--- a/docs/approved/model-supplier-source-probe-sync-split.md
+++ b/docs/approved/model-supplier-source-probe-sync-split.md
@@ -10,7 +10,7 @@ scope: "amend US-048 / model-supplier-source-management: four explicit actions; 
 related_stories: ["US-048"]
 amends: ["docs/approved/model-supplier-source-management.md"]
 related_design: ["docs/approved/model-supplier-source-fmgo-seedance-account-rewrite.md"]
-operator_locks: "2026-09-02: discover -> validate -> save -> project; validate is read-only preview, never write authorization; project re-probes immediately before structural writes; no validation cache/token; POST .../probe and probe job remain discover aliases"
+operator_locks: "2026-09-02: discover -> validate -> save -> project; validate is read-only preview, never write authorization; project re-probes immediately before structural writes; no validation cache/token; POST .../probe and probe job remain discover aliases; Anthropic channel_type=14 messages-only probe/project"
 ---
 
 # 供应源：发现 / 校验 / 保存 / 投影
@@ -91,6 +91,8 @@ GET  /admin/supplier-sources/:id/probe/jobs/:job_id
 
 - 默认：Chat Completions 正向证据。
 - 视频通道（DoubaoVideo / 54）：走该通道真实视频方言，不用 `hi` Chat 冒充成功。
+- Anthropic 通道（14）：走 `/v1/messages` 正向证据（CloudWise Claude opus/sonnet 上游仅 messages）；
+  不用 Chat Completions 冒充成功；投影账号仅声明 Messages。
 - 每一行用该行 `upstream_model_id` 探测；失败封闭。
 - 不按 client 名字猜 transport，不建设通用协议配置器。
 

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7650,15 +7650,15 @@
       "must_contain": [
         "func (r *accountRepository) UpdateSupplierMetadata(ctx context.Context, accountID int64, name string, priority int) error",
         "func (r *accountRepository) UpdateSupplierConcurrency(ctx context.Context, accountID int64, concurrency int) error",
-        "func (r *accountRepository) UpdateSupplierProjection(ctx context.Context, account *service.Account, chatProbePassed bool) error",
-        "if len(account.GetModelMapping()) > 0 && !chatProbePassed {",
-        "publishVerifiedSupplierChatCapability(",
+        "func (r *accountRepository) UpdateSupplierProjection(ctx context.Context, account *service.Account, protocolProbePassed bool) error",
+        "if len(account.GetModelMapping()) > 0 && !protocolProbePassed {",
+        "publishVerifiedSupplierProtocolCapability(",
         "concurrency = $10",
         "enqueueSchedulerOutbox(ctx, client, service.SchedulerOutboxEventAccountChanged, &accountID, nil, nil)",
         "enqueueSchedulerOutbox(ctx, client, service.SchedulerOutboxEventAccountChanged, &account.ID, nil, nil)",
         "extra = COALESCE(extra, '{}'::jsonb) || $6::jsonb"
       ],
-      "rationale": "Production-only narrow write paths for supplier metadata, concurrency and full projections. Concurrency-only sync writes the single owned column plus scheduler invalidation without fabricating probe evidence. Non-empty full projections fail closed without the current sync call's Chat probe evidence; the same account transaction publishes the verified Chat-only capability before ordinary scheduler invalidation. These writes avoid account-group payloads, and the full projection merges only the two owned supplier keys while preserving every non-owned Extra. The generic AccountRepository.Update forwards billing and unrelated runtime fields, so supplier sync must never fall back to it."
+      "rationale": "Production-only narrow write paths for supplier metadata, concurrency and full projections. Concurrency-only sync writes the single owned column plus scheduler invalidation without fabricating probe evidence. Non-empty full projections fail closed without the current sync call's protocol probe evidence; the same account transaction publishes the verified channel protocol capability (Chat Completions by default, Messages for Anthropic channel_type=14) before ordinary scheduler invalidation. These writes avoid account-group payloads, and the full projection merges only the two owned supplier keys while preserving every non-owned Extra. The generic AccountRepository.Update forwards billing and unrelated runtime fields, so supplier sync must never fall back to it."
     },
     {
       "path": "backend/internal/repository/account_repo.go",
@@ -7695,16 +7695,16 @@
         "ChannelType: transport.ChannelType",
         "account.ChannelType = transport.ChannelType",
         "SkipDefaultGroupBind: true",
-        "if len(input.ModelMapping) > 0 && !input.ChatProbePassed {",
+        "if len(input.ModelMapping) > 0 && !input.ProtocolProbePassed {",
         "return ErrSupplierProjectionUpdaterMissing",
         "return updater.UpdateSupplierMetadata(ctx, account.ID, account.Name, account.Priority)",
         "updater.UpdateSupplierConcurrency(ctx, account.ID, concurrency)",
-        "return updater.UpdateSupplierProjection(ctx, account, chatProbePassed)",
+        "return updater.UpdateSupplierProjection(ctx, account, protocolProbePassed)",
         "account.Concurrency = ResolveSupplierSourceAccountConcurrency(input.Concurrency)",
-        "applyExclusiveChatProtocolEndpoints(credentials, baseURL, channelType)",
+        "applyExclusiveSupplierProtocolEndpoints(credentials, baseURL, channelType)",
         "return FinalizeAccountCredentials(credentials, channelType)"
       ],
-      "rationale": "The supplier-source owner reads only the narrow projection, creates new managed accounts empty, unschedulable and ungrouped, resolves managed transport from the procurement endpoint (OpenAI Chat or Qianfan BaiduV2), preserves non-owned account metadata, requires current-call Chat probe evidence for every non-empty mapping, and fails closed unless both narrow repository writes are available. Supplier projection writes exclusive chat identity only through the shared applyExclusiveChatProtocolEndpoints helper so Qianfan/OpenAI chat shapes cannot drift from FinalizeAccountCredentials."
+      "rationale": "The supplier-source owner reads only the narrow projection, creates new managed accounts empty, unschedulable and ungrouped, resolves managed transport from the procurement endpoint (OpenAI Chat or Qianfan BaiduV2), preserves non-owned account metadata, requires current-call protocol probe evidence for every non-empty mapping, and fails closed unless both narrow repository writes are available. Supplier projection writes exclusive protocol identity only through the shared applyExclusiveSupplierProtocolEndpoints helper (messages for Anthropic; chat for other supplier transports) so shapes cannot drift from FinalizeAccountCredentials."
     },
     {
       "path": "backend/internal/service/supplier_managed_account_commands_test.go",
@@ -7713,13 +7713,13 @@
         "TestUS048_OrdinaryCreateAccountStillFailsWhenDefaultGroupBindFails",
         "TestUS048_SupplierConcurrencyUpdateUsesNarrowWriteWithoutProbeEvidence",
         "TestUS048_SupplierConfigurationUpdateUsesGroupFreeReadAndNarrowWrite",
-        "TestUS048_SupplierConfigurationUpdateRequiresPassedChatProbe",
+        "TestUS048_SupplierConfigurationUpdateRequiresPassedProtocolProbe",
         "TestUS048_SupplierQianfanCreateUsesBaiduV2Transport",
         "require.Equal(t, 1, accounts.projectionUpdateCalls)",
-        "require.True(t, accounts.projectionChatProbePassed)",
+        "require.True(t, accounts.projectionProtocolProbePassed)",
         "require.Zero(t, accounts.genericUpdateCalls"
       ],
-      "rationale": "Behavior regressions pin empty, unschedulable, ungrouped supplier creation, the unchanged ordinary CreateAccount group-bind failure contract, Qianfan BaiduV2 transport selection, the non-empty Chat evidence gate, and prove supplier configuration updates use a group-free read plus the isolated projection write exactly once, never the generic account update path."
+      "rationale": "Behavior regressions pin empty, unschedulable, ungrouped supplier creation, the unchanged ordinary CreateAccount group-bind failure contract, Qianfan BaiduV2 transport selection, the non-empty protocol probe evidence gate, and prove supplier configuration updates use a group-free read plus the isolated projection write exactly once, never the generic account update path."
     },
     {
       "path": "backend/internal/repository/account_repo_supplier_projection_test.go",
@@ -7727,6 +7727,9 @@
         "TestUS048_SupplierMetadataRepositoryWritesOnlyNameAndPriority",
         "TestUS048_SupplierConcurrencyRepositoryWritesOnlyConcurrency",
         "TestUS048_SupplierConfigurationRepositoryRejectsUnverifiedNonEmptyMapping",
+        "TestUS048_SupplierAnthropicProjectionPublishesMessagesCapability",
+        "TestUS048_SupplierAnthropicProjectionRejectsChatOnlyIdentity",
+        "TestUS048_SupplierVerifiedProtocolForAnthropicIsMessages",
         "TestUS048_SupplierConfigurationRepositoryWritesOnlyOwnedFields",
         "TestUS048_SupplierProjectionReadSelectsOnlyRequiredConfigurationFields",
         "rate_multiplier",
@@ -7948,7 +7951,7 @@
         "func MergeAccountCredentials(existing, incoming map[string]any, channelType int, mode CredentialMergeMode) map[string]any",
         "func FinalizeAccountCredentials(credentials map[string]any, channelType int) map[string]any",
         "func PrepareBulkCredentialPatch(patch map[string]any) map[string]any",
-        "func applyExclusiveChatProtocolEndpoints(credentials map[string]any, baseURL string, channelType int)",
+        "func applyExclusiveSupplierProtocolEndpoints(credentials map[string]any, baseURL string, channelType int)",
         "func deriveExclusiveChatProtocolURL(baseURL string, channelType int) string",
         "CredentialMergePreserveAll",
         "delete(merged, apiBaseURLsCredentialKey)",
@@ -7966,7 +7969,7 @@
         "TestSupplierManagedCredentials_UsesSharedExclusiveChatSSOT",
         "TestPrepareBulkCredentialPatch_LeavesExclusiveAloneForAPIKeyOnlyRotate"
       ],
-      "rationale": "Focused regressions for the exclusive-endpoint SSOT: CRS preserve-all drops stale identity, admin spread realigns chat URLs to the new base_url, Qianfan exclusive chat paths rebuild, bulk base_url/api_key patches clear identity keys, and supplierManagedCredentials shares applyExclusiveChatProtocolEndpoints."
+      "rationale": "Focused regressions for the exclusive-endpoint SSOT: CRS preserve-all drops stale identity, admin spread realigns chat URLs to the new base_url, Qianfan exclusive chat paths rebuild, bulk base_url/api_key patches clear identity keys, and supplierManagedCredentials shares applyExclusiveSupplierProtocolEndpoints."
     },
     {
       "path": "backend/internal/service/account_supported_protocols.go",


### PR DESCRIPTION
## 摘要
- 供应源 Anthropic（channel_type=14）走 Messages 探测与投影（Path C，对齐千帆 BaiduV2 式一等例外）
- 补 repository 层 `["messages"]` 投影回归与 chat-only identity 负向门禁
- 将 Chat 偏置命名改为协议中立（ProtocolProbePassed / publishVerifiedSupplierProtocolCapability / applyExclusiveSupplierProtocolEndpoints），并同步 gateway-tk sentinel

## 风险
高：公共供应源探测/投影契约与审批基线（docs/approved/model-supplier-source-*）；含 Anthropic messages 例外。

approval-anchor: docs/approved/model-supplier-source-management.md
approval-anchor: docs/approved/model-supplier-source-probe-sync-split.md

upstream-touch-trivial：触达 upstream 形路径仅为 TK 供应源例外与身份声明；无新增 sentinel 语义缺口，本次同步更新既有 gateway-tk 锚点命名与 Anthropic 投影测试锚点。
sentinel-registry-reviewed：gateway-tk 锚点随命名与 Anthropic 投影回归测试一并更新，覆盖 load-bearing 协议门禁语义。

## 验证
- `go test -tags=unit ./internal/service/ ./internal/repository/ -run 'TestUS048_Supplier|TestUS048_Anthropic|TestUS048_ResolveSupplier'`
- `python3 ./scripts/sentinels/check-gateway-tk.py` → PASS
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh` → PASS

## 提交
- ebf946cff refactor(supplier): 协议探测门禁命名去 Chat 偏置
- d3fe27f30 fix(supplier): 补 Anthropic 投影 messages 协议回归测试
- 1fa2e8c5d feat(supplier): Anthropic channel_type=14 走 Messages 探测与投影
- 最新提交：ebf946cff
