### PR TITLE
fix(admin): 供应源去掉页内标题并纵向铺满视口

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 715,
-  "hash": "f3e8ff95d06dbd6540db45ee92624ad76c38e733cf70d9ff7057fe5dc7e0f673",
+  "hash": "9c49cfa726d21fd6a14e6568024eb53b324e75ebaf71c9cec50f0605e8d1ed6a",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 715,
-  "hash": "9c49cfa726d21fd6a14e6568024eb53b324e75ebaf71c9cec50f0605e8d1ed6a",
+  "hash": "d775c1c3159683cdeb1e8b8cb353261aa4075c407c3a2858c7c1e19c533b1624",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/router/admin.tk.ts
+++ b/frontend/src/router/admin.tk.ts
@@ -132,8 +132,7 @@ export const adminRoutes: RouteRecordRaw[] = [
         component: () => import('@/views/admin/SupplierSourcesView.vue'),
         meta: {
           title: 'Supplier Sources',
-          titleKey: 'admin.supplierSources.title',
-          descriptionKey: 'admin.supplierSources.description'
+          titleKey: 'admin.supplierSources.title'
         }
       },
       {

--- a/frontend/src/styles/admin-ui-zoom.tk.css
+++ b/frontend/src/styles/admin-ui-zoom.tk.css
@@ -34,8 +34,10 @@ html.tk-admin-ui-zoom main {
 }
 
 /* Flex fill beats vh subtraction — chrome/padding drift under zoom caused the
-   post-#1047 gap below pagination on /admin/accounts. */
-html.tk-admin-ui-zoom .table-page-layout:not(.mobile-mode) {
+   post-#1047 gap below pagination on /admin/accounts. Same rule for Supplier
+   Sources (vh-fill page shell under AdminShell zoom). */
+html.tk-admin-ui-zoom .table-page-layout:not(.mobile-mode),
+html.tk-admin-ui-zoom .supplier-sources-page {
   flex: 1 1 auto;
   min-height: 0;
   height: auto !important;

--- a/frontend/src/views/admin/SupplierSourcesView.vue
+++ b/frontend/src/views/admin/SupplierSourcesView.vue
@@ -1,19 +1,13 @@
 <template>
   <!--
-    Match Dashboard/RiskControl: fill AppLayout main (already padded via lg:p-8).
-    Do not re-introduce max-w-* / mx-auto / extra page padding — that shrinks the
-    page relative to Accounts/Groups and leaves empty side gutters.
+    Fill AppLayout main like TablePageLayout (header 64px + lg:p-8). Title lives in
+    AppHeader only — do not reintroduce an in-page h1/description shell.
   -->
-  <div data-test="supplier-sources-page" class="w-full min-w-0 space-y-6">
-    <header class="flex flex-wrap items-start justify-between gap-3">
-      <div>
-        <h1 class="text-2xl font-semibold text-gray-900 dark:text-white">
-          {{ t('admin.supplierSources.title') }}
-        </h1>
-        <p class="mt-1 text-sm text-gray-500">
-          {{ t('admin.supplierSources.description') }}
-        </p>
-      </div>
+  <div
+    data-test="supplier-sources-page"
+    class="supplier-sources-page flex w-full min-w-0 flex-col gap-4"
+  >
+    <div class="flex shrink-0 flex-wrap items-center justify-end gap-2">
       <button
         data-test="priority-preview-button"
         type="button"
@@ -23,12 +17,12 @@
       >
         {{ t('admin.supplierSources.globalPriorityPreview') }}
       </button>
-    </header>
+    </div>
 
     <section
       v-if="priorityPreview"
       data-test="priority-preview"
-      class="rounded-xl border border-gray-200 bg-white p-4 dark:border-dark-700 dark:bg-dark-800"
+      class="shrink-0 rounded-xl border border-gray-200 bg-white p-4 dark:border-dark-700 dark:bg-dark-800"
     >
       <h2 class="font-medium">{{ t('admin.supplierSources.globalPriorityPreview') }}</h2>
       <p v-if="priorityPreview.entries.length === 0" class="mt-2 text-sm text-gray-500">
@@ -61,10 +55,13 @@
       </ul>
     </section>
 
-    <div class="grid items-start gap-6 lg:grid-cols-[minmax(16rem,20rem)_minmax(0,1fr)]">
+    <div
+      data-test="supplier-sources-workspace"
+      class="grid min-h-0 flex-1 items-stretch gap-4 lg:grid-cols-[minmax(16rem,20rem)_minmax(0,1fr)]"
+    >
       <section
         data-test="source-list"
-        class="flex max-h-[min(22rem,50vh)] flex-col overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-dark-700 dark:bg-dark-800 lg:sticky lg:top-4 lg:max-h-[calc(100dvh-8rem)]"
+        class="flex max-h-[min(22rem,50vh)] min-h-0 flex-col overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-dark-700 dark:bg-dark-800 lg:max-h-none lg:h-full"
       >
         <div class="shrink-0 space-y-2 border-b border-gray-200 p-3 dark:border-dark-700">
           <div class="flex items-center justify-between gap-2">
@@ -142,9 +139,9 @@
       <section
         ref="editorEl"
         data-test="source-editor"
-        class="min-w-0 space-y-5 rounded-xl border border-gray-200 bg-white p-4 sm:p-5 dark:border-dark-700 dark:bg-dark-800"
+        class="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-dark-700 dark:bg-dark-800 lg:h-full"
       >
-        <form class="space-y-4" @submit.prevent="save">
+        <form class="min-h-0 flex-1 space-y-4 overflow-y-auto p-4 sm:p-5" @submit.prevent="save">
           <div class="flex flex-wrap items-start justify-between gap-2">
             <div>
               <h2 data-test="editor-title" class="font-medium">{{ editorTitle }}</h2>
@@ -339,6 +336,10 @@
           </div>
         </form>
 
+        <div
+          v-if="syncError || discoverResult || validateResult || syncResult"
+          class="min-h-0 shrink-0 space-y-4 overflow-y-auto border-t border-gray-200 p-4 dark:border-dark-700 sm:p-5"
+        >
         <p
           v-if="syncError"
           data-test="sync-error"
@@ -350,7 +351,7 @@
         <section
           v-if="discoverResult"
           data-test="discover-result"
-          class="space-y-4 border-t border-gray-200 pt-4 dark:border-dark-700"
+          class="space-y-4"
         >
           <div class="flex flex-wrap items-center gap-3">
             <h2 class="font-medium">{{ t('admin.supplierSources.discoverPanelTitle') }}</h2>
@@ -452,7 +453,7 @@
         <section
           v-if="validateResult"
           data-test="validate-result"
-          class="space-y-4 border-t border-gray-200 pt-4 dark:border-dark-700"
+          class="space-y-4"
         >
           <div class="flex flex-wrap items-center gap-3">
             <h2 class="font-medium">{{ t('admin.supplierSources.validatePanelTitle') }}</h2>
@@ -484,7 +485,7 @@
         <section
           v-if="syncResult"
           data-test="sync-result"
-          class="space-y-4 border-t border-gray-200 pt-4 dark:border-dark-700"
+          class="space-y-4"
         >
           <div class="flex flex-wrap items-center gap-3">
             <h2 class="font-medium">{{ t('admin.supplierSources.syncResult') }}</h2>
@@ -527,6 +528,7 @@
             </ul>
           </div>
         </section>
+        </div>
       </section>
     </div>
   </div>
@@ -1056,3 +1058,17 @@ async function syncSelected(): Promise<void> {
 
 onMounted(load)
 </script>
+
+<style scoped>
+.supplier-sources-page {
+  /* Match TablePageLayout: header 64px + AppLayout lg:p-8 vertical padding. */
+  height: calc(100vh - 64px - 4rem);
+}
+
+@media (max-width: 1023px) {
+  .supplier-sources-page {
+    height: auto;
+    min-height: calc(100vh - 64px - 2rem);
+  }
+}
+</style>

--- a/frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts
+++ b/frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts
@@ -87,15 +87,19 @@ describe('SupplierSourcesView', () => {
     sync.mockReset()
   })
 
-  it('fills AppLayout main width like Dashboard/RiskControl (no max-w / mx-auto page shell)', async () => {
+  it('fills AppLayout viewport without an in-page title shell', async () => {
     const wrapper = mount(SupplierSourcesView)
     await flushPromises()
 
     const root = wrapper.get('[data-test="supplier-sources-page"]')
-    expect(root.classes()).toEqual(expect.arrayContaining(['w-full', 'min-w-0', 'space-y-6']))
+    expect(root.classes()).toEqual(expect.arrayContaining(['supplier-sources-page', 'w-full', 'min-w-0', 'flex', 'flex-col']))
     expect(root.classes()).not.toContain('max-w-7xl')
     expect(root.classes()).not.toContain('mx-auto')
-    expect(root.classes().some((c) => c.startsWith('p-') || c.startsWith('sm:p-'))).toBe(false)
+    expect(root.classes()).not.toContain('space-y-6')
+    expect(wrapper.find('h1').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('admin.supplierSources.description')
+    expect(wrapper.find('[data-test="supplier-sources-workspace"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="priority-preview-button"]').exists()).toBe(true)
   })
 
   it('defaults a new source to channel default and base priority 100', async () => {

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -1969,12 +1969,17 @@
         "name: 'AdminSupplierSources'",
         "component: () => import('@/views/admin/SupplierSourcesView.vue')"
       ],
-      "rationale": "The supplier-source page is the sole supported operations owner for supplier credentials, explicit model mappings, procurement ratios, supplier-only priority preview, current probe results and explicit one-source sync. An upstream rewrite of the admin route subtree could silently remove this entry while the backend and page still compile."
+      "rationale": "The supplier-source page is the sole supported operations owner for supplier credentials, explicit model mappings, procurement ratios, supplier-only priority preview, current probe results and explicit one-source sync. An upstream rewrite of the admin route subtree could silently remove this entry while the backend and page still compile. Supplier Sources keeps titleKey only so AppHeader does not repeat the long procurement blurb.",
+      "must_not_contain": [
+        "descriptionKey: 'admin.supplierSources.description'"
+      ]
     },
     {
       "path": "frontend/src/views/admin/SupplierSourcesView.vue",
       "must_contain": [
-        "w-full min-w-0 space-y-6",
+        "supplier-sources-page flex w-full min-w-0 flex-col gap-4",
+        "height: calc(100vh - 64px - 4rem)",
+        "data-test=\"supplier-sources-workspace\"",
         "data-test=\"supplier-sources-page\"",
         "const syncSucceeded = computed(() => (",
         "syncResult.value !== null",
@@ -1995,9 +2000,11 @@
         "syncSucceeded = ref",
         "watch(() => form.channel_type",
         "max-w-7xl",
-        "mx-auto max-w-7xl"
+        "mx-auto max-w-7xl",
+        "t('admin.supplierSources.description')",
+        "text-2xl font-semibold"
       ],
-      "rationale": "The supplier page derives success from the current response, the current request error, and absence of failed_step. Discover polls async candidate jobs to completion; validate is a read-only preview; project displays the probe evidence returned by its own authoritative request without depending on prior validation state. Dirty or discover-backfilled drafts disable discover/validate/project. BaiduV2 remains an explicit supplier transport even though it is absent from NewAPI's generic model-fetch set, and catalog endpoint defaults apply only to operator channel changes so source hydration preserves persisted custom endpoints. Also anchors the full-bleed admin page shell (no max-w-7xl / mx-auto page chrome) so the layout stays aligned with Dashboard/RiskControl."
+      "rationale": "The supplier page derives success from the current response, the current request error, and absence of failed_step. Discover polls async candidate jobs to completion; validate is a read-only preview; project displays the probe evidence returned by its own authoritative request without depending on prior validation state. Dirty or discover-backfilled drafts disable discover/validate/project. BaiduV2 remains an explicit supplier transport even though it is absent from NewAPI's generic model-fetch set, and catalog endpoint defaults apply only to operator channel changes so source hydration preserves persisted custom endpoints. Also anchors the full-bleed admin page shell (no max-w-7xl / mx-auto page chrome) so the layout stays aligned with Dashboard/RiskControl. Viewport-fill layout drops the in-page title/description shell (AppHeader owns the title) and stretches the list/editor workspace to the remaining main height."
     },
     {
       "path": "frontend/src/api/admin/supplierSources.ts",
@@ -2014,7 +2021,7 @@
     {
       "path": "frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts",
       "must_contain": [
-        "fills AppLayout main width like Dashboard/RiskControl (no max-w / mx-auto page shell)",
+        "fills AppLayout viewport without an in-page title shell",
         "saves new and existing sources through create or update only",
         "requires saving edited supplier facts before syncing the selected source",
         "renders account changes returned by sync",
@@ -2025,7 +2032,7 @@
         "shows probe failure message and failed_step outside the sync-result block",
         "offers and hydrates BaiduV2 while preserving a custom endpoint during source selection"
       ],
-      "rationale": "Focused UI regressions pin discover/validate/project workflow: save is side-effect free, unsaved edits block discover/validate/project, project renders account changes only, validate failures stay in validate panel, resolved failed_step cannot show success, async discover polling completes without auto-project, discover failures visible outside project block, BaiduV2 stays selectable without hydration overwriting custom endpoint, no state machine or account-group controls. Also pins the full-bleed page-shell regression."
+      "rationale": "Focused UI regressions pin discover/validate/project workflow: save is side-effect free, unsaved edits block discover/validate/project, project renders account changes only, validate failures stay in validate panel, resolved failed_step cannot show success, async discover polling completes without auto-project, discover failures visible outside project block, BaiduV2 stays selectable without hydration overwriting custom endpoint, no state machine or account-group controls. Also pins the full-bleed page-shell regression. Also pins viewport-fill layout without an in-page title shell."
     },
     {
       "path": "frontend/src/composables/useSupplierManagedAccount.ts",

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -156,11 +156,12 @@
       "must_contain": [
         "html.tk-admin-ui-zoom .min-h-screen",
         "html.tk-admin-ui-zoom .table-page-layout:not(.mobile-mode)",
+        "html.tk-admin-ui-zoom .supplier-sources-page",
         "flex: 1 1 auto",
         "height: auto !important",
         "var(--tk-admin-ui-zoom)"
       ],
-      "rationale": "Viewport layout for AdminShellView document zoom. min-h-screen compensation removes page-level bottom whitespace; the AppLayout flex stack + TablePageLayout flex-fill removes the residual dead band below pagination on dense admin tables (/admin/accounts)."
+      "rationale": "Viewport layout for AdminShellView document zoom. min-h-screen compensation removes page-level bottom whitespace; the AppLayout flex stack + TablePageLayout / Supplier Sources flex-fill removes the residual dead band below pagination or vh-fill page shells under zoom (/admin/accounts, /admin/supplier-sources)."
     },
     {
       "path": "frontend/src/views/user/studio/BakeOff.vue",


### PR DESCRIPTION
## 摘要
- 去掉供应源页内重复的标题/说明；顶栏只保留短标题（去掉 `descriptionKey`）。
- 列表 + 编辑区按 `TablePageLayout` 高度纵向铺满，编辑表单内部滚动，减少底部大块留白。
- 接入 `admin-ui-zoom` 的 flex-fill，使 AdminShell zoom 下与表格页同样铺满（R-001）。
- 同步 frontend-tk sentinel 与 embedded dist fingerprint。

## 风险
- 低风险 UI 布局；不改 API / 业务逻辑。
- 窄屏仍保持列表高度上限，桌面端拉伸到主区剩余高度。

## 验证
- `pnpm test:run src/views/admin/__tests__/SupplierSourcesView.spec.ts`（20/20）
- `python3 scripts/sentinels/check-frontend-tk.py` PASS
- `./scripts/preflight.sh` PASS

## 提交
- `4645ad1ce` fix(admin): 供应源去掉页内标题并纵向铺满视口
- `cb76bf237` fix(admin): address R-001 — 供应源页接入 admin zoom flex-fill
- 最新提交：`cb76bf237`

Made with [Cursor](https://cursor.com)