### PR TITLE
fix(supplier): 同源凭证不同 channel 可并行投影

### DIFF
--- a/.testing/user-stories/stories/US-048-model-supplier-source-management.md
+++ b/.testing/user-stories/stories/US-048-model-supplier-source-management.md
@@ -69,6 +69,7 @@
 - `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_IncompatibleTransportExactMatchBlocksAdoptionWithoutRewritingAccount`
 - `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_QianfanBaiduV2ExactMatchIsAdopted`
 - `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_BaiduV2TransportAgainstOpenAISupplierIsRejected`
+- `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_OpenAISupplierAccountsDoNotBlockAnthropicParallelSourceSync`
 - `backend/internal/service/supplier_managed_transport_test.go`::`TestUS048_ResolveSupplierManagedTransportSelectsBaiduV2ForQianfan`
 - `backend/internal/service/supplier_managed_account_commands_test.go`::`TestUS048_SupplierQianfanCreateUsesBaiduV2Transport`
 - `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_MultiBandExactAccountMatchBlocksDuplicateSupplierAccountCreation`

--- a/backend/internal/service/supplier_source_service.go
+++ b/backend/internal/service/supplier_source_service.go
@@ -462,21 +462,29 @@ func (s *SupplierSourceService) findReusableAccounts(
 	if err != nil {
 		return nil, err
 	}
-	externalMatches := make([]*Account, 0, len(matches))
+	// Only credential+endpoint matches that are relevant to THIS source's transport
+	// participate in adopt/conflict decisions. Other supplier-managed accounts that share
+	// the same key but a different channel_type (e.g. OpenAI chat vs Anthropic messages)
+	// must not block creating a parallel source — they are a separate projection identity.
+	relevantMatches := make([]*Account, 0, len(matches))
 	for _, match := range matches {
 		managedSourceID, managedMatch := supplierSourceIDFromAccount(match)
 		if managedMatch && managedSourceID == source.ID {
 			continue
 		}
-		externalMatches = append(externalMatches, match)
+		compatible := supplierReusableAccountTransport(match, source.Endpoint, source.ChannelType)
+		if managedMatch && !compatible {
+			continue
+		}
+		relevantMatches = append(relevantMatches, match)
 	}
-	if len(externalMatches) == 0 {
+	if len(relevantMatches) == 0 {
 		return result, nil
 	}
-	if len(externalMatches) > 1 {
+	if len(relevantMatches) > 1 {
 		return nil, ErrSupplierSourceMultipleMatches
 	}
-	match := externalMatches[0]
+	match := relevantMatches[0]
 	if len(managed) != 0 || len(targets) != 1 || IsSupplierManagedAccount(match) ||
 		match.Status != StatusActive || !supplierReusableAccountTransport(match, source.Endpoint, source.ChannelType) {
 		return nil, ErrSupplierSourceIdentityConflict

--- a/backend/internal/service/supplier_source_sync_test.go
+++ b/backend/internal/service/supplier_source_sync_test.go
@@ -653,6 +653,53 @@ func TestUS048_ExistingSupplierAccountMultipleMatchesStopBeforeProbeOrWrite(t *t
 	require.Empty(t, accounts.updated)
 }
 
+func TestUS048_OpenAISupplierAccountsDoNotBlockAnthropicParallelSourceSync(t *testing.T) {
+	// Same CloudWise credential already projected under OpenAI chat (source 9 / bands 3–5)
+	// must not 409 an Anthropic messages source that needs its own managed accounts.
+	fableRatio := 0.85
+	opusRatio := 0.2
+	repo := &supplierSourceRepoFake{stored: &SupplierSource{
+		ID: 13, SupplierName: "cloudwise", ChannelName: "anthropic",
+		ChannelType: newapiconstant.ChannelTypeAnthropic, Endpoint: "https://api.cloudwise.ai/api",
+		EncryptedCredential: "enc:secret", CredentialFingerprint: "fp:secret", BasePriority: 100,
+		AccountConcurrency: 1000,
+		Models: []SupplierSourceModel{
+			{ClientModelID: "claude-fable-5", UpstreamModelID: "claude-fable-5", PurchaseRatio: &fableRatio},
+			{ClientModelID: "claude-opus-4-6", UpstreamModelID: "claude-opus-4-6", PurchaseRatio: &opusRatio},
+		},
+	}}
+	openaiBand3 := supplierSyncManagedAccount(113, 9, 3, 130, map[string]string{"gpt-5.2": "gpt-5.2"}, true)
+	openaiBand3.ChannelType = newapiconstant.ChannelTypeOpenAI
+	openaiBand3.Credentials = supplierManagedCredentials(
+		"https://api.cloudwise.ai/api", "secret",
+		map[string]string{"gpt-5.2": "gpt-5.2"}, newapiconstant.ChannelTypeOpenAI,
+	)
+	openaiBand4 := supplierSyncManagedAccount(114, 9, 4, 140, map[string]string{"hy3": "hy3"}, true)
+	openaiBand4.ChannelType = newapiconstant.ChannelTypeOpenAI
+	openaiBand4.Credentials = supplierManagedCredentials(
+		"https://api.cloudwise.ai/api", "secret",
+		map[string]string{"hy3": "hy3"}, newapiconstant.ChannelTypeOpenAI,
+	)
+	openaiBand5 := supplierSyncManagedAccount(115, 9, 5, 150, map[string]string{"claude-fable-5": "claude-fable-5"}, true)
+	openaiBand5.ChannelType = newapiconstant.ChannelTypeOpenAI
+	openaiBand5.Credentials = supplierManagedCredentials(
+		"https://api.cloudwise.ai/api", "secret",
+		map[string]string{"claude-fable-5": "claude-fable-5"}, newapiconstant.ChannelTypeOpenAI,
+	)
+	accounts := &supplierSyncAccountStoreFake{
+		matches: []*Account{openaiBand3, openaiBand4, openaiBand5},
+	}
+	svc := NewSupplierSourceService(repo, accounts, &supplierSyncProbeFake{}, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{})
+
+	result, err := svc.Sync(context.Background(), 13)
+
+	require.NoError(t, err)
+	require.Empty(t, result.FailedStep)
+	require.Equal(t, 2, accounts.createCalls, "Anthropic source should create its own band accounts")
+	require.NotEmpty(t, accounts.updated)
+	require.NotEmpty(t, result.Changes)
+}
+
 func TestUS048_SupplierSyncSameBandRatioChangeDoesNotTouchAccounts(t *testing.T) {
 	ratio := 0.59
 	repo := &supplierSourceRepoFake{stored: &SupplierSource{

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7856,7 +7856,9 @@
         "TestUS048_SupplierSyncReprobesBeforeRepairingNonEmptySchedulingProjection",
         "TestUS048_SupplierSyncReprobesImmediatelyBeforeProjection",
         "TestUS048_SupplierSyncRepairsEmptySchedulingProjectionWithoutProbe",
-        "TestSupplierAccountNeedsProtocolRepublishDetectsTransportDrift"
+        "TestSupplierAccountNeedsProtocolRepublishDetectsTransportDrift",
+        "TestUS048_OpenAISupplierAccountsDoNotBlockAnthropicParallelSourceSync",
+        "TestUS048_QianfanBaiduV2ExactMatchIsAdopted"
       ],
       "rationale": "Sync regressions keep failed_step and completed changes present on early and mid-write errors, preserve successful additions, stop pending removals and prove retry convergence. They also block duplicate creation whenever an exact account match cannot satisfy the narrow adoption contract, including disabled/error accounts and multi-band sources, require an immediate reprobe before structural projection or repair, and keep empty-band scheduling repair on the metadata-only path."
     },
@@ -7933,9 +7935,12 @@
         "supplierAccountNeedsProtocolRepublish(account, source.Endpoint, source.ChannelType)",
         "UpdateManagedAccountConcurrency(",
         "ResolveSupplierSourceAccountConcurrency(source.AccountConcurrency)",
-        "identity.Key() != account.ProtocolEndpointCapability.CapabilityKey"
+        "identity.Key() != account.ProtocolEndpointCapability.CapabilityKey",
+        "compatible := supplierReusableAccountTransport(match, source.Endpoint, source.ChannelType)",
+        "if managedMatch && !compatible {",
+        "relevantMatches := make([]*Account, 0, len(matches))"
       ],
-      "rationale": "Supplier sync repairs managed-account concurrency through the narrow concurrency write, while transport or capability identity drift enters the normal real-probe path before any full projection republishes protocol evidence."
+      "rationale": "Supplier sync repairs managed-account concurrency through the narrow concurrency write, while transport or capability identity drift enters the normal real-probe path before any full projection republishes protocol evidence. Credential+endpoint collision with another supplier source is ignored when channel transports differ (OpenAI chat vs Anthropic messages), so parallel sources can create their own managed accounts."
     },
     {
       "path": "backend/internal/service/supplier_upstream_models.go",


### PR DESCRIPTION
## 摘要
- Sync 时忽略「另一供应源且 transport 不兼容」的已有账号，避免 CloudWise OpenAI(#9) 挡住 Anthropic Messages(#13) 新建投影账号
- 补回归：`TestUS048_OpenAISupplierAccountsDoNotBlockAnthropicParallelSourceSync`

## 风险
常规：供应源 sync 身份匹配；不改变公共 HTTP 契约字段语义（仅放宽并行 channel 投影）。

upstream-touch-trivial：仅 TK 供应源 sync 匹配过滤；无新增 upstream 热点语义缺口。
sentinel-registry-reviewed：gateway-tk 已锚住 transport 过滤与回归测试。

## 验证
- `go test -tags=unit ./internal/service/ -run 'TestUS048_OpenAISupplierAccountsDoNotBlockAnthropic|TestUS048_ExistingSupplierAccountMultipleMatches|TestUS048_BaiduV2|TestUS048_Qianfan'`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh` → PASS

## 提交
- 4c336ab11 fix(supplier): 同源凭证不同 channel 可并行投影
- 最新提交：4c336ab11

Made with [Cursor](https://cursor.com)