### PR TITLE
fix(gateway): NewAPI 5xx 故障切换并记录真实端点

### DIFF
--- a/backend/internal/handler/endpoint.go
+++ b/backend/internal/handler/endpoint.go
@@ -319,6 +319,12 @@ func GetInboundEndpoint(c *gin.Context) string {
 // and the account platform. Handlers call this after scheduling an
 // account, passing account.Platform.
 func GetUpstreamEndpoint(c *gin.Context, platform string) string {
+	// OpenAI-compatible forwarding records the route selected by the immutable
+	// protocol plan. Error paths may not have a result object, so this shared
+	// runtime fact must win over platform-based inference for Ops and QA.
+	if endpoint := service.GetActualOpenAIUpstreamEndpoint(c); endpoint != "" {
+		return endpoint
+	}
 	if c != nil {
 		if value, ok := c.Get(ctxKeyActualUpstreamEndpoint); ok {
 			if endpoint, ok := value.(string); ok && endpoint != "" {

--- a/backend/internal/handler/endpoint_test.go
+++ b/backend/internal/handler/endpoint_test.go
@@ -443,3 +443,14 @@ func TestGetUpstreamEndpoint_FullFlow(t *testing.T) {
 	got := GetUpstreamEndpoint(c, service.PlatformOpenAI)
 	require.Equal(t, "/v1/responses/compact", got)
 }
+
+func TestGetUpstreamEndpoint_NewAPIUsesActualProtocolRouteOnError(t *testing.T) {
+	const actualEndpoint = "/api/v1/chat/completions"
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, EndpointChatCompletions, nil)
+	c.Set(ctxKeyInboundEndpoint, EndpointChatCompletions)
+	service.SetActualOpenAIUpstreamEndpoint(c, actualEndpoint)
+
+	require.Equal(t, actualEndpoint, GetUpstreamEndpoint(c, service.PlatformNewAPI))
+}

--- a/backend/internal/observability/qa/service.go
+++ b/backend/internal/observability/qa/service.go
@@ -825,6 +825,13 @@ func capturePlatform(current, inboundEndpoint string) string {
 
 func captureUpstreamEndpoint(inboundEndpoint, platform string, c *gin.Context) string {
 	inboundEndpoint = strings.TrimSpace(inboundEndpoint)
+	if c != nil {
+		if endpoint, ok := c.Get(string(ctxkey.ActualOpenAIUpstreamEndpoint)); ok {
+			if endpoint, ok := endpoint.(string); ok && strings.TrimSpace(endpoint) != "" {
+				return strings.TrimSpace(endpoint)
+			}
+		}
+	}
 	rawPath := ""
 	if c != nil && c.Request != nil && c.Request.URL != nil {
 		rawPath = c.Request.URL.Path

--- a/backend/internal/observability/qa/upstream_endpoint_test.go
+++ b/backend/internal/observability/qa/upstream_endpoint_test.go
@@ -1,0 +1,39 @@
+package qa
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/domain"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCaptureUpstreamEndpointPrefersActualProtocolRoute(t *testing.T) {
+	const actualEndpoint = "/api/v1/chat/completions"
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, qaEndpointChatCompletions, nil)
+	service.SetActualOpenAIUpstreamEndpoint(c, actualEndpoint)
+
+	require.Equal(t, actualEndpoint, captureUpstreamEndpoint(
+		qaEndpointChatCompletions,
+		domain.PlatformNewAPI,
+		c,
+	))
+}
+
+func TestCaptureUpstreamEndpointFallsBackWithoutActualRoute(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, qaEndpointChatCompletions, nil)
+
+	require.Equal(t, qaEndpointResponses, captureUpstreamEndpoint(
+		qaEndpointChatCompletions,
+		domain.PlatformNewAPI,
+		c,
+	))
+}

--- a/backend/internal/pkg/ctxkey/ctxkey.go
+++ b/backend/internal/pkg/ctxkey/ctxkey.go
@@ -41,6 +41,10 @@ const (
 	// ChannelType 当前请求最终命中的上游 channel_type（用于统一证据/排障链路字段）。
 	ChannelType Key = "ctx_channel_type"
 
+	// ActualOpenAIUpstreamEndpoint records the endpoint selected by OpenAI-compatible
+	// protocol routing so usage, Ops, and QA observe the same outbound path.
+	ActualOpenAIUpstreamEndpoint Key = "openai_actual_upstream_endpoint"
+
 	// RetryCount 表示当前请求在网关层的重试次数（用于 Ops 记录与排障）。
 	RetryCount Key = "ctx_retry_count"
 

--- a/backend/internal/service/newapi_bridge_failover_tk.go
+++ b/backend/internal/service/newapi_bridge_failover_tk.go
@@ -10,9 +10,10 @@ import (
 
 // tkBridgeUpstreamShouldFailoverAfterPenalty reports whether a bridge upstream
 // error should trigger the handler's existing failedAccountIDs failover loop
-// after the account-level penalty has been applied. Only account-standing /
-// credential / capacity failures qualify — never client-induced 400/404 or 5xx
-// provider outages (#617 pool-drain class).
+// after any account-level penalty has been applied. Account-standing failures
+// qualify, as do gateway outage statuses that are safe to retry on another
+// provider without mutating account state. Client-induced 400/404 and all other
+// 5xx remain terminal to avoid draining the pool (#617 class).
 func tkBridgeUpstreamShouldFailoverAfterPenalty(apiErr *newapitypes.NewAPIError) bool {
 	if apiErr == nil {
 		return false
@@ -20,7 +21,16 @@ func tkBridgeUpstreamShouldFailoverAfterPenalty(apiErr *newapitypes.NewAPIError)
 	if tkIsBridgeUpstreamArrears(apiErr) {
 		return true
 	}
-	return tkBridgePenaltyStatusEligible(apiErr.StatusCode)
+	return tkBridgePenaltyStatusEligible(apiErr.StatusCode) ||
+		tkBridgeRequestScopedFailoverStatusEligible(apiErr.StatusCode)
+}
+
+func tkBridgeRequestScopedFailoverStatusEligible(statusCode int) bool {
+	switch statusCode {
+	case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	}
+	return false
 }
 
 func tkNewAPIBridgeUpstreamFailoverError(c *gin.Context, apiErr *newapitypes.NewAPIError) *UpstreamFailoverError {

--- a/backend/internal/service/newapi_bridge_failover_tk_test.go
+++ b/backend/internal/service/newapi_bridge_failover_tk_test.go
@@ -5,6 +5,7 @@ package service
 import (
 	"context"
 	"errors"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -31,7 +32,18 @@ func TestTkBridgeUpstreamShouldFailoverAfterPenalty_AccountLevelStatuses(t *test
 	}
 }
 
-func TestTkBridgeUpstreamShouldFailoverAfterPenalty_ClientAndOutageNeverMatch(t *testing.T) {
+func TestTkBridgeUpstreamShouldFailoverAfterPenalty_RequestScopedGatewayOutages(t *testing.T) {
+	t.Parallel()
+	for _, statusCode := range []int{502, 503, 504} {
+		statusCode := statusCode
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			t.Parallel()
+			require.True(t, tkBridgeUpstreamShouldFailoverAfterPenalty(upstreamBridgeError(statusCode, "gateway outage")))
+		})
+	}
+}
+
+func TestTkBridgeUpstreamShouldFailoverAfterPenalty_ClientAndOtherServerErrorsNeverMatch(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
 		name string
@@ -40,7 +52,7 @@ func TestTkBridgeUpstreamShouldFailoverAfterPenalty_ClientAndOutageNeverMatch(t 
 		{"client 400", upstreamBridgeError(400, "The supported API model names are ...")},
 		{"model not found 404", upstreamBridgeError(404, "model_not_found")},
 		{"server 500", upstreamBridgeError(500, "internal error")},
-		{"server 502", upstreamBridgeError(502, "bad gateway")},
+		{"server 501", upstreamBridgeError(501, "not implemented")},
 		{"nil", nil},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -48,6 +60,27 @@ func TestTkBridgeUpstreamShouldFailoverAfterPenalty_ClientAndOutageNeverMatch(t 
 			require.False(t, tkBridgeUpstreamShouldFailoverAfterPenalty(tc.err))
 		})
 	}
+}
+
+func TestBridgeWrapRelayErrorAfterPenalty_GatewayOutageReturnsRequestScopedFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	account := newNewAPIBridgeAccount()
+	apiErr := upstreamBridgeError(502, "Network error, please try again later.")
+
+	err := bridgeWrapRelayErrorAfterPenalty(context.Background(), nil, c, account, apiErr)
+	require.Error(t, err)
+
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr))
+	require.Equal(t, 502, failoverErr.StatusCode)
+	require.Equal(t, NextAccountRetry, failoverErr.NextAccountAction)
+	require.True(t, failoverErr.ShouldRetryNextAccount())
+	require.Contains(t, string(failoverErr.ResponseBody), "Network error")
+
+	var relayErr *NewAPIRelayError
+	require.False(t, errors.As(err, &relayErr))
 }
 
 func TestBridgeWrapRelayErrorAfterPenalty_AccountLevelReturnsFailover(t *testing.T) {

--- a/backend/internal/service/newapi_bridge_penalty_tk.go
+++ b/backend/internal/service/newapi_bridge_penalty_tk.go
@@ -144,7 +144,9 @@ func tkBridgeUpstreamOpenAIError(apiErr *newapitypes.NewAPIError) (newapitypes.O
 // tkWrapBridgeRelayErrorWithPenalty is the OpenAIGatewayService dispatch-site
 // chokepoint: apply the account penalty for real upstream bridge errors, then
 // return UpstreamFailoverError for account-level faults (401/402/429 + arrears)
-// or NewAPIRelayError for client/outage errors. Use at every dispatch site that
+// and request-scoped gateway outages (502/503/504), or NewAPIRelayError for
+// other client/provider errors. Gateway outages do not mutate account state.
+// Use at every dispatch site that
 // wraps a REAL bridge upstream error and has the selected account in hand
 // (NOT for synthetic missing-credential / unsupported-channel errors, and NOT
 // for the account-agnostic video fetch path).

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ip"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
@@ -120,7 +121,7 @@ type OpenAIUsage struct {
 	ImageOutputTokens        int `json:"image_output_tokens,omitempty"`
 }
 
-const openAIUpstreamEndpointContextKey = "openai_actual_upstream_endpoint"
+const openAIUpstreamEndpointContextKey = string(ctxkey.ActualOpenAIUpstreamEndpoint)
 
 // OpenAIForwardResult represents the result of forwarding
 type OpenAIForwardResult struct {


### PR DESCRIPTION
## 摘要

- NewAPI bridge 遇到 `502` / `503` / `504` 时，在当前请求内切换其他账号，不持久化处罚、冷却或禁用故障账号
- Ops 与 QA 统一记录协议路由选择的实际上游端点，避免 Chat 请求误报为 `/v1/responses`

## 风险

- 仅 `502` / `503` / `504` 新增 failover；其他 `5xx`、`400`、`404` 保持原行为
- 首个上游仍需返回错误后才会切换，本改动不增加主动超时
- Web impact: none
- `sentinel-registry-reviewed`：现有 NewAPI/gateway sentinel 锚点完整，本次不新增承重点文件或注入边界
- `upstream-conflict-surface-accepted`：`endpoint.go` 的单点函数体插入用于读取 request-scoped 实际协议端点；状态 owner 已集中在 `ctxkey`，接受该最小 upstream merge 成本

## 验证

- `./scripts/preflight.sh`
- `go test -tags=unit ./internal/service ./internal/handler ./internal/observability/qa`（handler 与 QA 通过；service 首轮出现非确定性失败）
- `go test -json -tags=unit ./internal/service -count=1`（结构化重跑通过）
- `git diff --check`

## 提交

- `82f411c86 fix(gateway): NewAPI 网关故障切换账号并记录真实端点 (no-web-impact)`
- 最新提交：`82f411c86`
