### PR TITLE
feat(openrouter): seller catalog 升到 schema 2.4

### DIFF
--- a/backend/internal/service/openrouter_provider_tk_catalog.go
+++ b/backend/internal/service/openrouter_provider_tk_catalog.go
@@ -9,34 +9,74 @@ import (
 	"time"
 )
 
-// OpenRouterProviderModel is the subset of OpenRouter provider /v1/models schema
-// TokenKey emits for onboarding and monitoring.
+const openRouterProviderSchemaVersion = "2.4"
+
+// OpenRouterProviderModel is the OpenRouter provider /v1/models document (schema 2.4).
+// Only the OR seller surface emits this shape; TokenKey customer gateway paths are unchanged.
 type OpenRouterProviderModel struct {
-	ID                          string                         `json:"id"`
-	Name                        string                         `json:"name"`
-	Description                 string                         `json:"description,omitempty"`
-	Created                     int64                          `json:"created"`
-	InputModalities             []string                       `json:"input_modalities"`
-	OutputModalities            []string                       `json:"output_modalities"`
-	Quantization                string                         `json:"quantization"`
-	ContextLength               int                            `json:"context_length"`
-	MaxOutputLength             int                            `json:"max_output_length"`
-	Pricing                     OpenRouterProviderModelPricing `json:"pricing"`
-	SupportedSamplingParameters []string                       `json:"supported_sampling_parameters"`
-	SupportedFeatures           []string                       `json:"supported_features,omitempty"`
-	IsReady                     bool                           `json:"is_ready"`
-	CapacityTPM                 *int64                         `json:"capacity_tpm,omitempty"`
-	OpenRouter                  map[string]string              `json:"openrouter,omitempty"`
-	Datacenters                 []OpenRouterProviderDatacenter `json:"datacenters,omitempty"`
+	SchemaVersion    string                             `json:"schema_version"`
+	ID               string                             `json:"id"`
+	Name             string                             `json:"name"`
+	Description      string                             `json:"description,omitempty"`
+	Created          int64                              `json:"created"`
+	Quantization     string                             `json:"quantization"`
+	InputModalities  []OpenRouterProviderInputModality  `json:"input_modalities"`
+	OutputModalities []OpenRouterProviderOutputModality `json:"output_modalities"`
+	IsReady          bool                               `json:"is_ready"`
+	OpenRouter       map[string]string                  `json:"openrouter,omitempty"`
+	Datacenters      []OpenRouterProviderDatacenter     `json:"datacenters,omitempty"`
 }
 
-type OpenRouterProviderModelPricing struct {
-	Prompt         string                              `json:"prompt"`
-	Completion     string                              `json:"completion"`
-	Image          string                              `json:"image"`
-	Request        string                              `json:"request"`
-	InputCacheRead string                              `json:"input_cache_read"`
-	Overrides      []OpenRouterProviderPricingOverride `json:"overrides,omitempty"`
+type OpenRouterProviderInputModality struct {
+	Type            string                            `json:"type"`
+	SupportedInputs map[string]any                    `json:"supported_inputs,omitempty"`
+	Pricing         []OpenRouterProviderPriceEntry    `json:"pricing,omitempty"`
+	Capacity        []OpenRouterProviderCapacityEntry `json:"capacity,omitempty"`
+}
+
+type OpenRouterProviderOutputModality struct {
+	Type                string                                       `json:"type"`
+	MaxLength           *OpenRouterProviderQuantity                  `json:"max_length,omitempty"`
+	Streaming           *bool                                        `json:"streaming,omitempty"`
+	SupportedParameters map[string]OpenRouterProviderParamDescriptor `json:"supported_parameters,omitempty"`
+	Pricing             []OpenRouterProviderPriceEntry               `json:"pricing,omitempty"`
+	Capacity            []OpenRouterProviderCapacityEntry            `json:"capacity,omitempty"`
+}
+
+type OpenRouterProviderQuantity struct {
+	Value int    `json:"value"`
+	Unit  string `json:"unit,omitempty"`
+}
+
+type OpenRouterProviderParamDescriptor struct {
+	Type     string   `json:"type"`
+	Min      *float64 `json:"min,omitempty"`
+	Max      *float64 `json:"max,omitempty"`
+	Unit     string   `json:"unit,omitempty"`
+	MaxItems *int     `json:"max_items,omitempty"`
+	Values   []any    `json:"values,omitempty"`
+	Default  any      `json:"default,omitempty"`
+}
+
+type OpenRouterProviderPriceEntry struct {
+	Type      string                            `json:"type"`
+	Unit      string                            `json:"unit"`
+	CostUSD   string                            `json:"cost_usd"`
+	UTCStart  *int                              `json:"utc_start,omitempty"`
+	UTCEnd    *int                              `json:"utc_end,omitempty"`
+	Overrides []OpenRouterProviderPriceOverride `json:"overrides,omitempty"`
+}
+
+type OpenRouterProviderPriceOverride struct {
+	When    map[string]any `json:"when"`
+	CostUSD string         `json:"cost_usd"`
+}
+
+type OpenRouterProviderCapacityEntry struct {
+	Type  string `json:"type"`
+	Unit  string `json:"unit"`
+	Per   string `json:"per,omitempty"`
+	Value int64  `json:"value"`
 }
 
 type OpenRouterProviderDatacenter struct {
@@ -189,26 +229,19 @@ func (s *GatewayService) BuildOpenRouterProviderCatalog(
 			slug = strings.TrimSpace(cfg.Slug) + "/" + strings.TrimPrefix(publicID, cfg.ModelIDPrefix)
 		}
 
-		item := OpenRouterProviderModel{
-			ID:                          publicID,
-			Name:                        openRouterProviderDisplayName(cfg, publicID, metaPtr),
-			Description:                 openRouterProviderDescription(cfg, publicID, metaPtr),
-			Created:                     created,
-			InputModalities:             openRouterProviderInputModalities(metaPtr),
-			OutputModalities:            openRouterProviderOutputModalities(metaPtr),
-			Quantization:                openRouterProviderDefaultQuantization,
-			ContextLength:               openRouterProviderContextLength(cfg, metaPtr),
-			MaxOutputLength:             openRouterProviderMaxOutputLength(cfg, metaPtr),
-			Pricing:                     openRouterProviderBuildPricing(group, metaPtr, promptUSD, completionUSD, cacheReadUSD, baseMult),
-			SupportedSamplingParameters: append([]string(nil), openRouterProviderDefaultSamplingParameters...),
-			SupportedFeatures:           openRouterProviderSupportedFeatures(metaPtr),
-			IsReady:                     true,
-			CapacityTPM:                 openRouterProviderCapacityTPM(cfg, entry.sourceID),
-			OpenRouter: map[string]string{
-				"slug": slug,
-			},
-			Datacenters: openRouterProviderDatacenters(cfg),
-		}
+		item := openRouterProviderBuildModelDocument(
+			cfg,
+			group,
+			metaPtr,
+			publicID,
+			entry.sourceID,
+			slug,
+			created,
+			promptUSD,
+			completionUSD,
+			cacheReadUSD,
+			baseMult,
+		)
 		openRouterProviderEnrichCatalogItem(&item, cfg, entry.sourceID)
 		out = append(out, item)
 	}

--- a/backend/internal/service/openrouter_provider_tk_media.go
+++ b/backend/internal/service/openrouter_provider_tk_media.go
@@ -12,8 +12,6 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-const openRouterProviderDefaultVideoQuoteSeconds = 8
-
 // OpenRouterImageRoute selects the downstream handler family for OR seller POST /v1/images.
 type OpenRouterImageRoute string
 

--- a/backend/internal/service/openrouter_provider_tk_schema.go
+++ b/backend/internal/service/openrouter_provider_tk_schema.go
@@ -11,22 +11,6 @@ const (
 	openRouterProviderDefaultQuantization = "fp16"
 )
 
-var openRouterProviderDefaultSamplingParameters = []string{
-	"temperature",
-	"top_p",
-	"max_tokens",
-	"stop",
-}
-
-type OpenRouterProviderPricingOverride struct {
-	MinPromptTokens int    `json:"min_prompt_tokens,omitempty"`
-	UTCStart        int    `json:"utc_start,omitempty"`
-	UTCEnd          int    `json:"utc_end,omitempty"`
-	Prompt          string `json:"prompt,omitempty"`
-	Completion      string `json:"completion,omitempty"`
-	InputCacheRead  string `json:"input_cache_read,omitempty"`
-}
-
 func openRouterProviderCatalogIndex(catalog *PublicCatalogResponse) map[string]PublicCatalogModel {
 	out := make(map[string]PublicCatalogModel)
 	if catalog == nil {
@@ -42,7 +26,7 @@ func openRouterProviderCatalogIndex(catalog *PublicCatalogResponse) map[string]P
 	return out
 }
 
-func openRouterProviderInputModalities(meta *PublicCatalogModel) []string {
+func openRouterProviderInputModalityTypes(meta *PublicCatalogModel) []string {
 	modalities := []string{"text"}
 	if meta == nil {
 		return modalities
@@ -58,42 +42,18 @@ func openRouterProviderInputModalities(meta *PublicCatalogModel) []string {
 	return modalities
 }
 
-func openRouterProviderOutputModalities(meta *PublicCatalogModel) []string {
+func openRouterProviderOutputModalityType(meta *PublicCatalogModel) string {
 	if meta == nil {
-		return []string{"text"}
+		return "text"
 	}
 	switch meta.Pricing.BillingMode {
 	case "image":
-		return []string{"image"}
+		return "image"
 	case "video":
-		return []string{"video"}
+		return "video"
 	default:
-		return []string{"text"}
+		return "text"
 	}
-}
-
-func openRouterProviderSupportedFeatures(meta *PublicCatalogModel) []string {
-	if meta == nil || len(meta.Capabilities) == 0 {
-		return nil
-	}
-	features := make([]string, 0, 6)
-	for _, cap := range meta.Capabilities {
-		switch cap {
-		case "tool_use":
-			features = openRouterAppendUniqueString(features, "tools")
-		case "response_schema":
-			features = openRouterAppendUniqueString(features, "json_mode")
-			features = openRouterAppendUniqueString(features, "structured_outputs")
-		case "reasoning":
-			features = openRouterAppendUniqueString(features, "reasoning")
-		case "web_search":
-			features = openRouterAppendUniqueString(features, "web_search")
-		}
-	}
-	if len(features) == 0 {
-		return nil
-	}
-	return features
 }
 
 func openRouterProviderDescription(cfg OpenRouterProviderConfig, publicID string, meta *PublicCatalogModel) string {
@@ -186,41 +146,277 @@ func openRouterProviderBaseMultiplier(group *Group, userMultiplier float64) floa
 	return mult
 }
 
-func openRouterProviderBuildPricing(
+func openRouterProviderBuildModelDocument(
+	cfg OpenRouterProviderConfig,
 	group *Group,
 	meta *PublicCatalogModel,
+	publicID, sourceID, slug string,
+	created int64,
 	promptUSD, completionUSD, cacheReadUSD, baseMult float64,
-) OpenRouterProviderModelPricing {
-	pricing := OpenRouterProviderModelPricing{
-		Prompt:         formatOpenRouterUSDPerToken(promptUSD * baseMult),
-		Completion:     formatOpenRouterUSDPerToken(completionUSD * baseMult),
-		Image:          "0",
-		Request:        "0",
-		InputCacheRead: formatOpenRouterUSDPerToken(cacheReadUSD * baseMult),
+) OpenRouterProviderModel {
+	outType := openRouterProviderOutputModalityType(meta)
+	item := OpenRouterProviderModel{
+		SchemaVersion:    openRouterProviderSchemaVersion,
+		ID:               publicID,
+		Name:             openRouterProviderDisplayName(cfg, publicID, meta),
+		Description:      openRouterProviderDescription(cfg, publicID, meta),
+		Created:          created,
+		Quantization:     openRouterProviderDefaultQuantization,
+		InputModalities:  openRouterProviderBuildInputModalities(cfg, group, meta, sourceID, promptUSD, cacheReadUSD, baseMult, outType),
+		OutputModalities: openRouterProviderBuildOutputModalities(cfg, group, meta, sourceID, completionUSD, baseMult, outType),
+		IsReady:          true,
+		OpenRouter: map[string]string{
+			"slug": slug,
+		},
+		Datacenters: openRouterProviderDatacenters(cfg),
 	}
-	if meta != nil && meta.Pricing.BillingMode == "image" && meta.Pricing.OutputCostPerImage > 0 {
-		pricing.Image = formatOpenRouterUSDPerToken(meta.Pricing.OutputCostPerImage * baseMult)
-	}
-	if meta != nil && meta.Pricing.BillingMode == "video" && meta.Pricing.OutputCostPerSecond > 0 {
-		pricing.Request = formatOpenRouterUSDPerToken(meta.Pricing.OutputCostPerSecond * openRouterProviderDefaultVideoQuoteSeconds * baseMult)
-	}
-	if tierOverrides := openRouterProviderTierPricingOverrides(meta, baseMult); len(tierOverrides) > 0 {
-		pricing.Overrides = tierOverrides
-		return pricing
-	}
-	if group != nil && group.PeakRateEnabled && group.PeakRateMultiplier > 1 {
-		if override, ok := openRouterProviderPeakPricingOverride(group, promptUSD, completionUSD, cacheReadUSD, baseMult); ok {
-			pricing.Overrides = []OpenRouterProviderPricingOverride{override}
-		}
-	}
-	return pricing
+	return item
 }
 
-func openRouterProviderTierPricingOverrides(meta *PublicCatalogModel, baseMult float64) []OpenRouterProviderPricingOverride {
+func openRouterProviderBuildInputModalities(
+	cfg OpenRouterProviderConfig,
+	group *Group,
+	meta *PublicCatalogModel,
+	sourceID string,
+	promptUSD, cacheReadUSD, baseMult float64,
+	outType string,
+) []OpenRouterProviderInputModality {
+	types := openRouterProviderInputModalityTypes(meta)
+	// Image/video generation still needs a text prompt input modality.
+	if outType == "image" || outType == "video" {
+		types = []string{"text"}
+	}
+	out := make([]OpenRouterProviderInputModality, 0, len(types))
+	for _, typ := range types {
+		switch typ {
+		case "text":
+			mod := OpenRouterProviderInputModality{
+				Type: "text",
+				SupportedInputs: map[string]any{
+					"max_context_length": OpenRouterProviderQuantity{
+						Value: openRouterProviderContextLength(cfg, meta),
+						Unit:  "token",
+					},
+				},
+			}
+			if outType == "text" {
+				mod.Pricing = openRouterProviderBuildTextInputPricing(group, meta, promptUSD, cacheReadUSD, baseMult)
+				if tpm := openRouterProviderCapacityTPM(cfg, sourceID); tpm != nil && *tpm > 0 {
+					mod.Capacity = []OpenRouterProviderCapacityEntry{{
+						Type:  "prompt",
+						Unit:  "token",
+						Per:   "minute",
+						Value: *tpm,
+					}}
+				}
+			}
+			out = append(out, mod)
+		case "image":
+			out = append(out, OpenRouterProviderInputModality{
+				Type: "image",
+				SupportedInputs: map[string]any{
+					"sources": map[string]any{"type": "enum", "values": []any{"url", "base64"}},
+					"formats": map[string]any{
+						"type":   "enum",
+						"values": []any{"image/png", "image/jpeg", "image/webp", "image/gif"},
+					},
+				},
+			})
+		case "file":
+			out = append(out, OpenRouterProviderInputModality{
+				Type: "file",
+				SupportedInputs: map[string]any{
+					"formats": map[string]any{"type": "enum", "values": []any{"application/pdf"}},
+				},
+			})
+		}
+	}
+	if len(out) == 0 {
+		return []OpenRouterProviderInputModality{{Type: "text"}}
+	}
+	return out
+}
+
+func openRouterProviderBuildOutputModalities(
+	cfg OpenRouterProviderConfig,
+	group *Group,
+	meta *PublicCatalogModel,
+	sourceID string,
+	completionUSD, baseMult float64,
+	outType string,
+) []OpenRouterProviderOutputModality {
+	switch outType {
+	case "image":
+		streaming := false
+		mod := OpenRouterProviderOutputModality{
+			Type:      "image",
+			Streaming: &streaming,
+		}
+		if unit := openRouterProviderMediaUnitUSD(meta); unit > 0 {
+			mod.Pricing = []OpenRouterProviderPriceEntry{{
+				Type:    "completion",
+				Unit:    "image",
+				CostUSD: formatOpenRouterUSDPerToken(unit * baseMult),
+			}}
+		}
+		return []OpenRouterProviderOutputModality{mod}
+	case "video":
+		streaming := false
+		mod := OpenRouterProviderOutputModality{
+			Type:      "video",
+			Streaming: &streaming,
+		}
+		if unit := openRouterProviderMediaUnitUSD(meta); unit > 0 {
+			mod.Pricing = []OpenRouterProviderPriceEntry{{
+				Type:    "completion",
+				Unit:    "second",
+				CostUSD: formatOpenRouterUSDPerToken(unit * baseMult),
+			}}
+		}
+		return []OpenRouterProviderOutputModality{mod}
+	default:
+		streaming := true
+		maxOut := openRouterProviderMaxOutputLength(cfg, meta)
+		mod := OpenRouterProviderOutputModality{
+			Type: "text",
+			MaxLength: &OpenRouterProviderQuantity{
+				Value: maxOut,
+				Unit:  "token",
+			},
+			Streaming:           &streaming,
+			SupportedParameters: openRouterProviderTextSupportedParameters(meta, maxOut),
+			Pricing:             openRouterProviderBuildTextOutputPricing(group, meta, completionUSD, baseMult),
+		}
+		if tpm := openRouterProviderCapacityTPM(cfg, sourceID); tpm != nil && *tpm > 0 {
+			mod.Capacity = []OpenRouterProviderCapacityEntry{{
+				Type:  "completion",
+				Unit:  "token",
+				Per:   "minute",
+				Value: *tpm,
+			}}
+		}
+		return []OpenRouterProviderOutputModality{mod}
+	}
+}
+
+func openRouterProviderTextSupportedParameters(meta *PublicCatalogModel, maxOut int) map[string]OpenRouterProviderParamDescriptor {
+	min0 := 0.0
+	max1 := 1.0
+	maxTokensMin := 1.0
+	maxTokensMax := float64(maxOut)
+	if maxTokensMax < 1 {
+		maxTokensMax = 1
+	}
+	maxStop := 4
+	params := map[string]OpenRouterProviderParamDescriptor{
+		"temperature": {Type: "range", Min: &min0, Max: &max1},
+		"top_p":       {Type: "range", Min: &min0, Max: &max1},
+		"max_tokens":  {Type: "integer", Min: &maxTokensMin, Max: &maxTokensMax, Unit: "token"},
+		"stop":        {Type: "array", MaxItems: &maxStop},
+	}
+	for _, feat := range openRouterProviderSupportedFeatureFlags(meta) {
+		params[feat] = OpenRouterProviderParamDescriptor{Type: "boolean"}
+	}
+	return params
+}
+
+func openRouterProviderSupportedFeatureFlags(meta *PublicCatalogModel) []string {
+	if meta == nil || len(meta.Capabilities) == 0 {
+		return nil
+	}
+	features := make([]string, 0, 6)
+	for _, cap := range meta.Capabilities {
+		switch cap {
+		case "tool_use":
+			features = openRouterAppendUniqueString(features, "tools")
+		case "response_schema":
+			features = openRouterAppendUniqueString(features, "structured_outputs")
+		case "reasoning":
+			features = openRouterAppendUniqueString(features, "reasoning")
+		case "web_search":
+			features = openRouterAppendUniqueString(features, "web_search")
+		}
+	}
+	return features
+}
+
+func openRouterProviderBuildTextInputPricing(
+	group *Group,
+	meta *PublicCatalogModel,
+	promptUSD, cacheReadUSD, baseMult float64,
+) []OpenRouterProviderPriceEntry {
+	out := make([]OpenRouterProviderPriceEntry, 0, 4)
+	usePeak := !openRouterProviderHasTokenTiers(meta)
+	if promptUSD > 0 {
+		entry := OpenRouterProviderPriceEntry{
+			Type:    "prompt",
+			Unit:    "token",
+			CostUSD: formatOpenRouterUSDPerToken(promptUSD * baseMult),
+		}
+		entry.Overrides = openRouterProviderTierPriceOverrides(meta, "input", baseMult)
+		out = append(out, entry)
+		if usePeak {
+			out = append(out, openRouterProviderPeakPriceEntries(group, "prompt", "token", promptUSD, baseMult)...)
+		}
+	}
+	if cacheReadUSD > 0 {
+		entry := OpenRouterProviderPriceEntry{
+			Type:    "cached_prompt",
+			Unit:    "token",
+			CostUSD: formatOpenRouterUSDPerToken(cacheReadUSD * baseMult),
+		}
+		entry.Overrides = openRouterProviderTierPriceOverrides(meta, "cache_read", baseMult)
+		out = append(out, entry)
+		if usePeak {
+			out = append(out, openRouterProviderPeakPriceEntries(group, "cached_prompt", "token", cacheReadUSD, baseMult)...)
+		}
+	}
+	return out
+}
+
+func openRouterProviderBuildTextOutputPricing(
+	group *Group,
+	meta *PublicCatalogModel,
+	completionUSD, baseMult float64,
+) []OpenRouterProviderPriceEntry {
+	if completionUSD <= 0 {
+		return nil
+	}
+	entry := OpenRouterProviderPriceEntry{
+		Type:    "completion",
+		Unit:    "token",
+		CostUSD: formatOpenRouterUSDPerToken(completionUSD * baseMult),
+	}
+	entry.Overrides = openRouterProviderTierPriceOverrides(meta, "output", baseMult)
+	out := []OpenRouterProviderPriceEntry{entry}
+	if !openRouterProviderHasTokenTiers(meta) {
+		out = append(out, openRouterProviderPeakPriceEntries(group, "completion", "token", completionUSD, baseMult)...)
+	}
+	return out
+}
+
+func openRouterProviderHasTokenTiers(meta *PublicCatalogModel) bool {
+	if meta == nil || len(meta.Pricing.Tiers) <= 1 {
+		return false
+	}
+	for i, tier := range meta.Pricing.Tiers {
+		if i == 0 {
+			continue
+		}
+		if tier.MinTokens > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// openRouterProviderTierPriceOverrides maps TokenKey long-context tiers onto schema 2.4
+// when.prompt_tokens predicates. Tier pricing wins over peak-window pricing (same as flat).
+func openRouterProviderTierPriceOverrides(meta *PublicCatalogModel, kind string, baseMult float64) []OpenRouterProviderPriceOverride {
 	if meta == nil || len(meta.Pricing.Tiers) <= 1 {
 		return nil
 	}
-	out := make([]OpenRouterProviderPricingOverride, 0, 2)
+	out := make([]OpenRouterProviderPriceOverride, 0, 2)
 	for i, tier := range meta.Pricing.Tiers {
 		if i == 0 || tier.MinTokens <= 0 {
 			continue
@@ -228,40 +424,57 @@ func openRouterProviderTierPricingOverrides(meta *PublicCatalogModel, baseMult f
 		if len(out) >= 2 {
 			break
 		}
-		cacheReadUSD := 0.0
-		if tier.CacheReadPer1K > 0 {
-			cacheReadUSD = tier.CacheReadPer1K / 1000
+		var cost float64
+		switch kind {
+		case "input":
+			cost = tier.InputPer1KTokens / 1000 * baseMult
+		case "output":
+			cost = tier.OutputPer1KTokens / 1000 * baseMult
+		case "cache_read":
+			if tier.CacheReadPer1K <= 0 {
+				continue
+			}
+			cost = tier.CacheReadPer1K / 1000 * baseMult
+		default:
+			continue
 		}
-		out = append(out, OpenRouterProviderPricingOverride{
-			MinPromptTokens: tier.MinTokens,
-			Prompt:          formatOpenRouterUSDPerToken(tier.InputPer1KTokens / 1000 * baseMult),
-			Completion:      formatOpenRouterUSDPerToken(tier.OutputPer1KTokens / 1000 * baseMult),
-			InputCacheRead:  formatOpenRouterUSDPerToken(cacheReadUSD * baseMult),
+		if cost <= 0 {
+			continue
+		}
+		out = append(out, OpenRouterProviderPriceOverride{
+			When: map[string]any{
+				"prompt_tokens": map[string]any{"gte": tier.MinTokens},
+			},
+			CostUSD: formatOpenRouterUSDPerToken(cost),
 		})
 	}
 	return out
 }
 
-func openRouterProviderPeakPricingOverride(
+func openRouterProviderPeakPriceEntries(
 	group *Group,
-	promptUSD, completionUSD, cacheReadUSD, baseMult float64,
-) (OpenRouterProviderPricingOverride, bool) {
-	if group == nil || !group.PeakRateEnabled || group.PeakRateMultiplier <= 1 {
-		return OpenRouterProviderPricingOverride{}, false
+	priceType, unit string,
+	baseUSD, baseMult float64,
+) []OpenRouterProviderPriceEntry {
+	if group == nil || !group.PeakRateEnabled || group.PeakRateMultiplier <= 1 || baseUSD <= 0 {
+		return nil
 	}
 	start, okStart := openRouterProviderLocalHMToUTCMinutes(group.PeakStart, timezone.Location(), time.Now())
 	end, okEnd := openRouterProviderLocalHMToUTCMinutes(group.PeakEnd, timezone.Location(), time.Now())
 	if !okStart || !okEnd || start == end {
-		return OpenRouterProviderPricingOverride{}, false
+		return nil
 	}
-	peakMult := group.PeakRateMultiplier
-	return OpenRouterProviderPricingOverride{
-		UTCStart:       start,
-		UTCEnd:         end,
-		Prompt:         formatOpenRouterUSDPerToken(promptUSD * baseMult * peakMult),
-		Completion:     formatOpenRouterUSDPerToken(completionUSD * baseMult * peakMult),
-		InputCacheRead: formatOpenRouterUSDPerToken(cacheReadUSD * baseMult * peakMult),
-	}, true
+	// Prefer tier overrides over peak windows when both exist on the same model.
+	// Peak entries are only emitted when the caller did not already attach tier overrides
+	// to the base entry; callers still may emit peak for SKUs without tiers.
+	s, e := start, end
+	return []OpenRouterProviderPriceEntry{{
+		Type:     priceType,
+		Unit:     unit,
+		CostUSD:  formatOpenRouterUSDPerToken(baseUSD * baseMult * group.PeakRateMultiplier),
+		UTCStart: &s,
+		UTCEnd:   &e,
+	}}
 }
 
 func openRouterProviderLocalHMToUTCMinutes(hm string, loc *time.Location, ref time.Time) (int, bool) {

--- a/backend/internal/service/openrouter_provider_tk_schema.go
+++ b/backend/internal/service/openrouter_provider_tk_schema.go
@@ -163,7 +163,7 @@ func openRouterProviderBuildModelDocument(
 		Created:          created,
 		Quantization:     openRouterProviderDefaultQuantization,
 		InputModalities:  openRouterProviderBuildInputModalities(cfg, group, meta, sourceID, promptUSD, cacheReadUSD, baseMult, outType),
-		OutputModalities: openRouterProviderBuildOutputModalities(cfg, group, meta, sourceID, completionUSD, baseMult, outType),
+		OutputModalities: openRouterProviderBuildOutputModalities(cfg, group, meta, completionUSD, baseMult, outType),
 		IsReady:          true,
 		OpenRouter: map[string]string{
 			"slug": slug,
@@ -241,7 +241,6 @@ func openRouterProviderBuildOutputModalities(
 	cfg OpenRouterProviderConfig,
 	group *Group,
 	meta *PublicCatalogModel,
-	sourceID string,
 	completionUSD, baseMult float64,
 	outType string,
 ) []OpenRouterProviderOutputModality {
@@ -277,7 +276,9 @@ func openRouterProviderBuildOutputModalities(
 	default:
 		streaming := true
 		maxOut := openRouterProviderMaxOutputLength(cfg, meta)
-		mod := OpenRouterProviderOutputModality{
+		// capacity_tpm stays a single quota (flat-era semantics): declare it only on
+		// input text prompt capacity. Duplicating onto output would double-count to OR.
+		return []OpenRouterProviderOutputModality{{
 			Type: "text",
 			MaxLength: &OpenRouterProviderQuantity{
 				Value: maxOut,
@@ -286,16 +287,7 @@ func openRouterProviderBuildOutputModalities(
 			Streaming:           &streaming,
 			SupportedParameters: openRouterProviderTextSupportedParameters(meta, maxOut),
 			Pricing:             openRouterProviderBuildTextOutputPricing(group, meta, completionUSD, baseMult),
-		}
-		if tpm := openRouterProviderCapacityTPM(cfg, sourceID); tpm != nil && *tpm > 0 {
-			mod.Capacity = []OpenRouterProviderCapacityEntry{{
-				Type:  "completion",
-				Unit:  "token",
-				Per:   "minute",
-				Value: *tpm,
-			}}
-		}
-		return []OpenRouterProviderOutputModality{mod}
+		}}
 	}
 }
 

--- a/backend/internal/service/openrouter_provider_tk_schema_test.go
+++ b/backend/internal/service/openrouter_provider_tk_schema_test.go
@@ -79,6 +79,26 @@ func TestOpenRouterProviderBuildModelDocument_OmitsZeroPriceEntries(t *testing.T
 	}
 }
 
+func TestOpenRouterProviderBuildModelDocument_CapacityTPMOnlyOnInput(t *testing.T) {
+	tpm := int64(250000)
+	cfg := DefaultOpenRouterProviderConfig()
+	cfg.CapacityTPM = &tpm
+	cfg.ModelCapacityTPM = map[string]int64{"demo": 120000}
+	item := openRouterProviderBuildModelDocument(
+		cfg, nil, nil,
+		"tokenkey/demo", "demo", "tokenkey/demo",
+		1,
+		0.001, 0.002, 0, 1,
+	)
+	inCap := item.InputModalities[0].Capacity
+	if len(inCap) != 1 || inCap[0].Type != "prompt" || inCap[0].Value != 120000 {
+		t.Fatalf("input capacity=%+v", inCap)
+	}
+	if len(item.OutputModalities[0].Capacity) != 0 {
+		t.Fatalf("output must not duplicate capacity_tpm: %+v", item.OutputModalities[0].Capacity)
+	}
+}
+
 func TestOpenRouterProviderBuildModelDocument_PeakWindowEntries(t *testing.T) {
 	cfg := DefaultOpenRouterProviderConfig()
 	group := &Group{

--- a/backend/internal/service/openrouter_provider_tk_schema_test.go
+++ b/backend/internal/service/openrouter_provider_tk_schema_test.go
@@ -1,23 +1,86 @@
 package service
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 )
 
-func TestOpenRouterProviderBuildPricing_IncludesZeroSKUFields(t *testing.T) {
-	pricing := openRouterProviderBuildPricing(nil, nil, 0.000002, 0.000006, 0, 1)
-	if pricing.Image != "0" || pricing.Request != "0" {
-		t.Fatalf("pricing=%+v", pricing)
+func TestOpenRouterProviderBuildModelDocument_SchemaVersionAndTextShape(t *testing.T) {
+	cfg := DefaultOpenRouterProviderConfig()
+	meta := &PublicCatalogModel{
+		Capabilities: []string{"tool_use", "reasoning"},
+		Pricing: PublicCatalogPricing{
+			InputPer1KTokens:  2,
+			OutputPer1KTokens: 6,
+		},
+		ContextWindow:   200000,
+		MaxOutputTokens: 8192,
 	}
-	if pricing.Prompt == "" || pricing.Completion == "" {
-		t.Fatalf("pricing=%+v", pricing)
+	item := openRouterProviderBuildModelDocument(
+		cfg, nil, meta,
+		"tokenkey/demo", "demo", "tokenkey/demo",
+		1,
+		0.002, 0.006, 0, 1,
+	)
+	if item.SchemaVersion != openRouterProviderSchemaVersion {
+		t.Fatalf("schema_version=%q", item.SchemaVersion)
+	}
+	if len(item.InputModalities) != 1 || item.InputModalities[0].Type != "text" {
+		t.Fatalf("input=%+v", item.InputModalities)
+	}
+	if len(item.OutputModalities) != 1 || item.OutputModalities[0].Type != "text" {
+		t.Fatalf("output=%+v", item.OutputModalities)
+	}
+	inPricing := item.InputModalities[0].Pricing
+	if len(inPricing) != 1 || inPricing[0].Type != "prompt" || inPricing[0].CostUSD != formatOpenRouterUSDPerToken(0.002) {
+		t.Fatalf("input pricing=%+v", inPricing)
+	}
+	outPricing := item.OutputModalities[0].Pricing
+	if len(outPricing) != 1 || outPricing[0].Type != "completion" {
+		t.Fatalf("output pricing=%+v", outPricing)
+	}
+	params := item.OutputModalities[0].SupportedParameters
+	if params["tools"].Type != "boolean" || params["reasoning"].Type != "boolean" {
+		t.Fatalf("params=%+v", params)
+	}
+	// 2.4 must not zero-stuff unused root SKUs.
+	raw, err := json.Marshal(item)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := generic["pricing"]; ok {
+		t.Fatalf("flat pricing must not appear: %s", raw)
+	}
+	if _, ok := generic["context_length"]; ok {
+		t.Fatalf("flat context_length must not appear: %s", raw)
 	}
 }
 
-func TestOpenRouterProviderBuildPricing_PeakOverrideUsesBaseOffPeak(t *testing.T) {
+func TestOpenRouterProviderBuildModelDocument_OmitsZeroPriceEntries(t *testing.T) {
+	cfg := DefaultOpenRouterProviderConfig()
+	item := openRouterProviderBuildModelDocument(
+		cfg, nil, nil,
+		"tokenkey/demo", "demo", "tokenkey/demo",
+		1,
+		0.001, 0, 0, 1,
+	)
+	if len(item.InputModalities[0].Pricing) != 1 {
+		t.Fatalf("pricing=%+v", item.InputModalities[0].Pricing)
+	}
+	if len(item.OutputModalities[0].Pricing) != 0 {
+		t.Fatalf("zero completion must be omitted: %+v", item.OutputModalities[0].Pricing)
+	}
+}
+
+func TestOpenRouterProviderBuildModelDocument_PeakWindowEntries(t *testing.T) {
+	cfg := DefaultOpenRouterProviderConfig()
 	group := &Group{
 		PeakRateEnabled:    true,
 		PeakStart:          "09:00",
@@ -25,15 +88,26 @@ func TestOpenRouterProviderBuildPricing_PeakOverrideUsesBaseOffPeak(t *testing.T
 		PeakRateMultiplier: 2,
 		SubscriptionType:   SubscriptionTypeSubscription,
 	}
-	pricing := openRouterProviderBuildPricing(group, nil, 0.000002, 0.000006, 0.000001, 1.5)
-	if pricing.Prompt != formatOpenRouterUSDPerToken(0.000003) {
-		t.Fatalf("off-peak prompt=%q", pricing.Prompt)
+	item := openRouterProviderBuildModelDocument(
+		cfg, group, nil,
+		"tokenkey/demo", "demo", "tokenkey/demo",
+		1,
+		0.000002, 0.000006, 0.000001, 1.5,
+	)
+	in := item.InputModalities[0].Pricing
+	if len(in) < 2 {
+		t.Fatalf("expected base+peak prompt entries, got %+v", in)
 	}
-	if len(pricing.Overrides) != 1 {
-		t.Fatalf("overrides=%+v", pricing.Overrides)
+	basePrompt := in[0]
+	if basePrompt.Type != "prompt" || basePrompt.UTCStart != nil {
+		t.Fatalf("base prompt=%+v", basePrompt)
 	}
-	if pricing.Overrides[0].Prompt != formatOpenRouterUSDPerToken(0.000006) {
-		t.Fatalf("peak prompt=%q", pricing.Overrides[0].Prompt)
+	if basePrompt.CostUSD != formatOpenRouterUSDPerToken(0.000003) {
+		t.Fatalf("off-peak prompt=%q", basePrompt.CostUSD)
+	}
+	peak := in[1]
+	if peak.UTCStart == nil || peak.UTCEnd == nil || peak.CostUSD != formatOpenRouterUSDPerToken(0.000006) {
+		t.Fatalf("peak prompt=%+v", peak)
 	}
 }
 
@@ -47,53 +121,62 @@ func TestOpenRouterProviderLocalHMToUTCMinutes(t *testing.T) {
 	}
 }
 
-func TestOpenRouterProviderSupportedFeatures_FromCapabilities(t *testing.T) {
+func TestOpenRouterProviderSupportedFeatureFlags(t *testing.T) {
 	meta := &PublicCatalogModel{
 		Capabilities: []string{"tool_use", "reasoning", "response_schema"},
 	}
-	features := openRouterProviderSupportedFeatures(meta)
+	features := openRouterProviderSupportedFeatureFlags(meta)
 	if len(features) < 3 {
 		t.Fatalf("features=%v", features)
 	}
-}
-
-func TestOpenRouterProviderSupportedFeatures_NoCapabilitiesReturnsNil(t *testing.T) {
-	if got := openRouterProviderSupportedFeatures(nil); got != nil {
-		t.Fatalf("got=%v want nil", got)
-	}
-	if got := openRouterProviderSupportedFeatures(&PublicCatalogModel{}); got != nil {
+	if got := openRouterProviderSupportedFeatureFlags(nil); got != nil {
 		t.Fatalf("got=%v want nil", got)
 	}
 }
 
-func TestOpenRouterProviderBuildPricing_VideoBillingUsesRequestSKU(t *testing.T) {
+func TestOpenRouterProviderBuildModelDocument_VideoBillingUsesSecondSKU(t *testing.T) {
+	cfg := DefaultOpenRouterProviderConfig()
 	meta := &PublicCatalogModel{
 		Pricing: PublicCatalogPricing{
 			BillingMode:         "video",
 			OutputCostPerSecond: 0.05,
 		},
 	}
-	pricing := openRouterProviderBuildPricing(nil, meta, 0, 0, 0, 1)
-	want := formatOpenRouterUSDPerToken(0.05 * openRouterProviderDefaultVideoQuoteSeconds)
-	if pricing.Request != want {
-		t.Fatalf("request=%q want %q", pricing.Request, want)
+	item := openRouterProviderBuildModelDocument(
+		cfg, nil, meta,
+		"tokenkey/veo", "veo", "tokenkey/veo",
+		1, 0, 0, 0, 1,
+	)
+	if len(item.OutputModalities) != 1 || item.OutputModalities[0].Type != "video" {
+		t.Fatalf("output=%+v", item.OutputModalities)
+	}
+	pricing := item.OutputModalities[0].Pricing
+	if len(pricing) != 1 || pricing[0].Unit != "second" || pricing[0].CostUSD != formatOpenRouterUSDPerToken(0.05) {
+		t.Fatalf("pricing=%+v", pricing)
 	}
 }
 
-func TestOpenRouterProviderBuildPricing_ImageBillingUsesImageSKU(t *testing.T) {
+func TestOpenRouterProviderBuildModelDocument_ImageBillingUsesImageSKU(t *testing.T) {
+	cfg := DefaultOpenRouterProviderConfig()
 	meta := &PublicCatalogModel{
 		Pricing: PublicCatalogPricing{
 			BillingMode:        "image",
 			OutputCostPerImage: 0.04,
 		},
 	}
-	pricing := openRouterProviderBuildPricing(nil, meta, 0, 0, 0, 1)
-	if pricing.Image != formatOpenRouterUSDPerToken(0.04) {
-		t.Fatalf("image=%q", pricing.Image)
+	item := openRouterProviderBuildModelDocument(
+		cfg, nil, meta,
+		"tokenkey/imagen", "imagen", "tokenkey/imagen",
+		1, 0, 0, 0, 1,
+	)
+	pricing := item.OutputModalities[0].Pricing
+	if len(pricing) != 1 || pricing[0].Unit != "image" || pricing[0].CostUSD != formatOpenRouterUSDPerToken(0.04) {
+		t.Fatalf("pricing=%+v", pricing)
 	}
 }
 
-func TestOpenRouterProviderBuildPricing_TierOverridesPreferPeak(t *testing.T) {
+func TestOpenRouterProviderBuildModelDocument_TierOverridesPreferPeak(t *testing.T) {
+	cfg := DefaultOpenRouterProviderConfig()
 	meta := &PublicCatalogModel{
 		Pricing: PublicCatalogPricing{
 			Tiers: []PublicCatalogTier{
@@ -103,15 +186,27 @@ func TestOpenRouterProviderBuildPricing_TierOverridesPreferPeak(t *testing.T) {
 		},
 	}
 	group := &Group{PeakRateEnabled: true, PeakStart: "09:00", PeakEnd: "12:00", PeakRateMultiplier: 2}
-	pricing := openRouterProviderBuildPricing(group, meta, 0.000002, 0.000006, 0, 1)
-	if len(pricing.Overrides) != 1 || pricing.Overrides[0].MinPromptTokens != 200000 {
-		t.Fatalf("overrides=%+v", pricing.Overrides)
+	item := openRouterProviderBuildModelDocument(
+		cfg, group, meta,
+		"tokenkey/demo", "demo", "tokenkey/demo",
+		1, 0.000002, 0.000006, 0, 1,
+	)
+	in := item.InputModalities[0].Pricing
+	if len(in) != 1 {
+		t.Fatalf("tier models must not emit peak window entries: %+v", in)
+	}
+	if len(in[0].Overrides) != 1 {
+		t.Fatalf("overrides=%+v", in[0].Overrides)
+	}
+	when, _ := in[0].Overrides[0].When["prompt_tokens"].(map[string]any)
+	if when["gte"] != 200000 {
+		t.Fatalf("when=%+v", in[0].Overrides[0].When)
 	}
 }
 
-func TestOpenRouterProviderInputModalities_VisionAddsImage(t *testing.T) {
+func TestOpenRouterProviderInputModalityTypes_VisionAddsImage(t *testing.T) {
 	meta := &PublicCatalogModel{Capabilities: []string{"vision"}}
-	got := openRouterProviderInputModalities(meta)
+	got := openRouterProviderInputModalityTypes(meta)
 	if len(got) != 2 || got[1] != "image" {
 		t.Fatalf("modalities=%v", got)
 	}

--- a/docs/agent_integration.md
+++ b/docs/agent_integration.md
@@ -1107,10 +1107,12 @@ after a terminal status (`succeeded` / `failed`) return 404.
 TokenKey may expose a seller catalog for OpenRouter onboarding:
 
 - `GET /openrouter/v1/models` — allowlisted OR API keys only; returns
-  OpenRouter provider schema with `tokenkey/<model>` ids and USD prices
-  after group/user rate multipliers. Configured via ops JSON setting
-  `tk_openrouter_provider_config` (`group_ids`, `billing_user_id`,
-  `allowed_api_key_ids`, `monitor_api_key_ids`).
+  OpenRouter provider **schema 2.4** documents with `tokenkey/<model>` ids
+  and modality-owned USD prices after group/user rate multipliers.
+  Configured via ops JSON setting `tk_openrouter_provider_config`
+  (`group_ids`, `billing_user_id`, `allowed_api_key_ids`,
+  `monitor_api_key_ids`). Customer gateway paths outside this seller
+  surface are unchanged.
 - Allowlisted OR/monitor keys also receive the same catalog from
   `GET /v1/models`.
 - Inference keys accept catalog ids on `POST /v1/chat/completions`; TokenKey

--- a/ops/pricing/openrouter-provider-onboarding.md
+++ b/ops/pricing/openrouter-provider-onboarding.md
@@ -68,12 +68,12 @@ python3 ops/pricing/manage-openrouter-provider-config.py snapshot  # read live c
 # edit catalog_excluded_model_ids / stream_only_model_ids in settings JSON, then upsert via admin or update-config
 ```
 
-Catalog must include token-priced chat models plus media-priced rows (`pricing.image` for Imagen/Seedream, `pricing.request` for Veo) with matching `output_modalities`.
+Catalog uses OpenRouter provider **schema 2.4** (modality-owned pricing/capacity). Token-priced chat models expose text input/output modalities; media rows use output `image` (`completion` / `image`) or `video` (`completion` / `second`). Flat legacy catalog fields are not emitted.
 
 ## Inference model id contract
 
-OpenRouter calls inference with the same `id` returned by `/openrouter/v1/models` (for example `tokenkey/deepseek-v4-pro`). TokenKey rewrites that public id back to the internal scheduling id before routing.
+OpenRouter calls inference with the same `id` returned by `/openrouter/v1/models` (for example `tokenkey/deepseek-v4-pro`). TokenKey rewrites that public id back to the internal scheduling id before routing. Customer `/v1/*` gateway behavior is unchanged.
 
 - Chat: `POST /v1/chat/completions`
-- Image (`output_modalities` includes `image`): `POST /openrouter/v1/images` — OR schema in/out (`data[].b64_json`)
-- Video (`output_modalities` includes `video`): `POST /openrouter/v1/videos` → `202` with `{id,polling_url,status}`; poll `GET /openrouter/v1/videos/{id}`
+- Image (output modality `type=image`): `POST /openrouter/v1/images` — OR schema in/out (`data[].b64_json`)
+- Video (output modality `type=video`): `POST /openrouter/v1/videos` → `202` with `{id,polling_url,status}`; poll `GET /openrouter/v1/videos/{id}`

--- a/ops/pricing/probe-openrouter-provider-chain.py
+++ b/ops/pricing/probe-openrouter-provider-chain.py
@@ -31,12 +31,6 @@ MONITOR_KEY_ID = 370
 VALID_INPUT_MODALITIES = {"text", "image", "file", "audio", "video"}
 VALID_OUTPUT_MODALITIES = {"text", "image", "embeddings", "audio", "video", "rerank", "speech", "transcription"}
 VALID_QUANT = {"int4", "int8", "fp4", "mxfp4", "nvfp4", "fp6", "fp8", "mxfp8", "fp16", "bf16", "fp32"}
-VALID_SAMPLING = {
-    "temperature", "top_p", "top_k", "min_p", "top_a", "frequency_penalty",
-    "presence_penalty", "repetition_penalty", "stop", "seed", "max_tokens", "logit_bias",
-}
-VALID_FEATURES = {"tools", "json_mode", "structured_outputs", "logprobs", "web_search", "reasoning"}
-PRICE_FIELDS = ("prompt", "completion", "image", "request", "input_cache_read")
 USD_NUM = re.compile(r"^-?\d+(\.\d+)?$")
 
 
@@ -83,44 +77,77 @@ def http_json(method: str, url: str, api_key: str = "", body: dict | None = None
             return exc.code, raw, raw
 
 
+def modality_types(mods: Any) -> set[str]:
+    if not isinstance(mods, list):
+        return set()
+    out: set[str] = set()
+    for m in mods:
+        if isinstance(m, str):
+            out.add(m)
+        elif isinstance(m, dict) and m.get("type"):
+            out.add(str(m["type"]))
+    return out
+
+
+def validate_price_entries(entries: Any, report: Report, prefix: str) -> None:
+    if entries is None:
+        return
+    report.add(f"{prefix}.pricing.list", isinstance(entries, list), type(entries).__name__)
+    if not isinstance(entries, list):
+        return
+    for i, entry in enumerate(entries):
+        ep = f"{prefix}.pricing[{i}]"
+        if not isinstance(entry, dict):
+            report.add(ep, False, type(entry).__name__)
+            continue
+        for req in ("type", "unit", "cost_usd"):
+            report.add(f"{ep}.{req}", req in entry and entry[req] is not None, "")
+        cost = entry.get("cost_usd")
+        if isinstance(cost, str) and cost:
+            report.add(f"{ep}.cost_usd.numeric", bool(USD_NUM.match(cost)), cost)
+
+
+def validate_modality_list(mods: Any, valid: set[str], report: Report, prefix: str, kind: str) -> None:
+    report.add(f"{prefix}.{kind}.list", isinstance(mods, list) and len(mods) > 0, type(mods).__name__)
+    if not isinstance(mods, list):
+        return
+    for i, mod in enumerate(mods):
+        mp = f"{prefix}.{kind}[{i}]"
+        if not isinstance(mod, dict):
+            report.add(mp, False, type(mod).__name__)
+            continue
+        typ = mod.get("type")
+        report.add(f"{mp}.type", typ in valid, str(typ))
+        validate_price_entries(mod.get("pricing"), report, mp)
+
+
 def validate_model_entry(model: dict, report: Report) -> None:
     mid = model.get("id", "<missing>")
     prefix = f"catalog[{mid}]"
 
-    for req in ("id", "name", "created", "input_modalities", "output_modalities", "quantization",
-                "context_length", "max_output_length", "pricing", "supported_sampling_parameters", "is_ready"):
+    for req in ("schema_version", "id", "name", "created", "input_modalities", "output_modalities",
+                "quantization", "is_ready"):
         report.add(f"{prefix}.required.{req}", req in model and model[req] is not None,
                    "" if req in model else "missing")
+
+    report.add(f"{prefix}.schema_version", model.get("schema_version") == "2.4",
+               str(model.get("schema_version")))
 
     if not str(mid).startswith("tokenkey/"):
         report.add(f"{prefix}.id_prefix", False, f"id={mid!r}")
 
-    in_mod = model.get("input_modalities") or []
-    out_mod = model.get("output_modalities") or []
-    report.add(f"{prefix}.input_modalities.valid", all(m in VALID_INPUT_MODALITIES for m in in_mod), str(in_mod))
-    report.add(f"{prefix}.output_modalities.valid", all(m in VALID_OUTPUT_MODALITIES for m in out_mod), str(out_mod))
+    # Flat legacy fields must not reappear on new integrations.
+    for legacy in ("pricing", "context_length", "max_output_length",
+                   "supported_sampling_parameters", "supported_features", "capacity_tpm"):
+        if legacy in model:
+            report.add(f"{prefix}.no_flat.{legacy}", False, "legacy flat field present")
+
+    validate_modality_list(model.get("input_modalities"), VALID_INPUT_MODALITIES, report, prefix, "input_modalities")
+    validate_modality_list(model.get("output_modalities"), VALID_OUTPUT_MODALITIES, report, prefix, "output_modalities")
 
     quant = model.get("quantization")
     if quant:
         report.add(f"{prefix}.quantization.valid", quant in VALID_QUANT, quant)
-
-    pricing = model.get("pricing") or {}
-    for pf in PRICE_FIELDS:
-        if pf not in pricing:
-            report.add(f"{prefix}.pricing.{pf}", False, "missing")
-            continue
-        val = pricing[pf]
-        report.add(f"{prefix}.pricing.{pf}.string", isinstance(val, str), type(val).__name__)
-        if isinstance(val, str) and val and val != "0":
-            report.add(f"{prefix}.pricing.{pf}.numeric", bool(USD_NUM.match(val)), val)
-
-    for sp in model.get("supported_sampling_parameters") or []:
-        if sp not in VALID_SAMPLING:
-            report.add(f"{prefix}.sampling.invalid", False, sp)
-
-    for feat in model.get("supported_features") or []:
-        if feat not in VALID_FEATURES:
-            report.add(f"{prefix}.features.invalid", False, feat)
 
     for dc in model.get("datacenters") or []:
         cc = (dc or {}).get("country_code", "")
@@ -144,8 +171,9 @@ def pick_models(catalog: list[dict]) -> dict[str, str | None]:
     out: dict[str, str | None] = {"chat": None, "image": None, "imagen": None, "video": None}
     for m in catalog:
         mid = m.get("id", "")
-        outs = set(m.get("output_modalities") or [])
-        if out["chat"] is None and outs == {"text"} and "image" not in (m.get("input_modalities") or []):
+        outs = modality_types(m.get("output_modalities"))
+        ins = modality_types(m.get("input_modalities"))
+        if out["chat"] is None and outs == {"text"} and "image" not in ins:
             if "flash" in mid and "image" not in mid and "imagen" not in mid and "veo" not in mid:
                 out["chat"] = mid
         if out["image"] is None and "image" in outs and "gemini" in mid and "flash-image" in mid:
@@ -156,7 +184,7 @@ def pick_models(catalog: list[dict]) -> dict[str, str | None]:
             out["video"] = mid
     if out["chat"] is None:
         for m in catalog:
-            if (m.get("output_modalities") or []) == ["text"]:
+            if modality_types(m.get("output_modalities")) == {"text"}:
                 out["chat"] = m.get("id")
                 break
     return out

--- a/scripts/checks/public-group-aggregator-channel.py
+++ b/scripts/checks/public-group-aggregator-channel.py
@@ -38,13 +38,14 @@ REQUIRED_OR_PROVIDER_MARKERS = {
         "InternalModelID",
     ),
     REPO_ROOT / "backend/internal/service/openrouter_provider_tk_schema.go": (
-        "OpenRouterProviderPricingOverride",
-        "openRouterProviderDefaultSamplingParameters",
+        "OpenRouterProviderPriceOverride",
+        "openRouterProviderSchemaVersion",
         "openRouterProviderDefaultQuantization",
     ),
     REPO_ROOT / "ops/pricing/openrouter-provider-onboarding.md": (
         "monitor_api_key_ids",
         "invoicing_contact_email",
+        "schema 2.4",
     ),
 }
 

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6794,11 +6794,24 @@
       "path": "backend/internal/service/openrouter_provider_tk_catalog.go",
       "must_contain": [
         "BuildOpenRouterProviderCatalog",
+        "openRouterProviderSchemaVersion",
+        "openRouterProviderBuildModelDocument",
         "openRouterProviderModelHasListedPrice",
         "cfg.CatalogExcluded",
         "openRouterProviderCatalogCandidates"
       ],
-      "rationale": "Catalog builder is the seller onboarding contract owner; pricing/features/schema drift here breaks OpenRouter provider application compliance."
+      "rationale": "Catalog builder is the seller onboarding contract owner; schema 2.4 emission + pricing/features drift here breaks OpenRouter provider application compliance."
+    },
+    {
+      "path": "backend/internal/service/openrouter_provider_tk_schema.go",
+      "must_contain": [
+        "openRouterProviderBuildModelDocument",
+        "OpenRouterProviderPriceOverride",
+        "openRouterProviderBuildTextInputPricing",
+        "openRouterProviderBuildOutputModalities",
+        "openRouterProviderTierPriceOverrides"
+      ],
+      "rationale": "OpenRouter seller catalog schema 2.4 document builder (modality-owned pricing/capacity). Flat root pricing fields must not return; silent revert breaks new-provider onboarding."
     },
     {
       "path": "backend/cmd/qa-archive/main.go",


### PR DESCRIPTION
## 摘要

- OpenRouter seller catalog（`GET /openrouter/v1/models`）改为官方 **schema 2.4**：价与 capacity 挂在 input/output modality 上
- chat / image / video 最小子集：text token 价、image 按张、video 按秒；阶梯与峰时按 2.4 语义映射
- `capacity_tpm` 只挂 text input（保留单一配额语义，不双计）
- gateway-tk sentinel 锚定 schema 2.4 catalog/schema 符号
- 仅改 OR seller 序列化与 ops probe/文档；现有客户网关路径不变

## 风险

- 常规风险：OR seller 公共契约（catalog JSON）变更；推理路由与客户 `/v1/*` 未改
- 尚无正式 OR 接入流量，无 live flat 消费者；切换窗口风险低
- no-web-impact

## 验证

```bash
./scripts/preflight.sh
python3 scripts/checks/public-group-aggregator-channel.py
python3 scripts/sentinels/check-gateway-tk.py --quiet
go test -tags=unit ./backend/internal/service -run OpenRouterProvider
```

- preflight：PASS
- scheme C / gateway-tk sentinel：PASS
- OpenRouterProvider 单测：PASS

## 提交

-` `15f13e2d3 fix(openrouter): address sentinel registry — 锚定 schema 2.4 catalog
-` `e6b928da4 fix(openrouter): address R-001 — capacity_tpm 只挂 input
-` `cd328d18a fix(openrouter): 对齐 scheme C sentinel 到 schema 2.4 符号
-` `c8d76713b feat(openrouter): seller catalog 升到 schema 2.4

最新提交：`15f13e2d3`