### PR TITLE
fix(supplier): 投影账号不再探测，按钮改为发现/保存/校验/投影

### DIFF
--- a/.testing/user-stories/stories/US-048-model-supplier-source-management.md
+++ b/.testing/user-stories/stories/US-048-model-supplier-source-management.md
@@ -3,13 +3,13 @@
 - ID: US-048
 - Title: 运营以供应源安全接入并热更新模型供应账号
 - Priority: P0
-- As a / I want / So that: 作为 TokenKey 运营，我希望只维护供应商通道、API Key、明确模型、采购比例和基础 priority，并由投影路径在写入前自行校验后同步为现有账号配置，从而在不修改 scheduler、账号组、倍率和定价的前提下管理外部供给。
+- As a / I want / So that: 作为 TokenKey 运营，我希望只维护供应商通道、API Key、明确模型、采购比例和基础 priority，并由四个正交动作分别发现、校验、保存和投影，从而在不修改 scheduler、账号组、倍率和定价的前提下管理外部供给。
 - Trace: `docs/approved/model-supplier-source-management.md`
 - Risk Focus:
   - 逻辑错误：六档边界、同档合并、最终 priority 或先增后减顺序错误，导致模型进入错误账号或提前失去供给。
   - 行为回归：供应源引入第二套调度语义、覆盖账号组或普通运行字段、改变普通 NewAPI 网关行为，或者保存供应事实就直接改变线上账号。
   - 安全问题：凭证、指纹或上游原始错误经 API、日志或 Admin Audit Log 泄露，或通用账号入口绕过供应源 ownership。
-  - 运行时问题：探测部分失败仍写账号、复用进程内陈旧校验结果、未经当次 Chat 正向证据写入非空 mapping、账号配置与协议能力半写、
+  - 运行时问题：投影误调模型探测、把校验失败当成写入门禁、复用进程内陈旧校验结果、未声明通道协议能力写入非空 mapping、账号配置与协议能力半写、
     增加阶段失败后继续删除、重试不能收敛、空档账号继续可调度，或忽略 disabled/error 精确匹配而创建重复账号。
 
 ## Acceptance Criteria
@@ -17,7 +17,7 @@
 1. AC-001 (正向): Given 运营新增供应源，When 只点击保存，Then 系统只写单表采购事实，凭证加密且不回显，新供应源默认 `base_priority=100`，不探测、不创建或修改账号。
 2. AC-002 (优先级): Given 模型采购比例落入六个固定档位，When 查看表单与全局预览，Then 档位分别贡献 `10, 20, …, 60`（相邻增量 10），账号 priority 严格等于 `base_priority + discount_priority`；同源同档模型合并为一个目标账号，预览只比较供应源目标 priority，且 `base_priority + 60` 不得越过 PostgreSQL `INTEGER`。
 3. AC-003 (只读校验): Given 已保存供应源，When 点击「校验模型」，Then 系统走 `POST .../validate`，用带 source/band 身份的内存账号逐模型使用明确 upstream ID 真实探测已保存配置；任一失败返回全部当次结果且不写账号。结果不缓存、不生成授权，也不改变投影按钮状态。默认 Chat 通道只接受 Chat Completions 正向证据；视频通道（channel_type=54）走视频协议真实探测；Anthropic 通道（channel_type=14）走 Messages 真实探测。其它协议证据返回 `protocol_unsupported`，不猜协议、不写账号。
-4. AC-004 (热更新): Given endpoint、credential、模型 ID、模型增减、跨档，或非空受管账号的 `status/schedulable` 与目标不一致，When 未先校验而直接点击「投影账号」，Then 系统走 `POST .../sync` 并在第一个结构写入前用当次目标逐模型重探；任一失败返回全部当次 `probe_results`、`failed_step=probe`、空 `changes` 且不写账号，重试时重新探测。全部成功后才以空 mapping、不可调度状态创建缺失账号；非空投影必须携带本次通道协议正向证据，并在单账号事务内提交账号配置、通道单一协议能力（默认 Chat-only；Anthropic messages-only）、`InitialProbeCompleted=true`/`OfficialSeed=false` 证据和 scheduler outbox，再做配置读回确认而不进行写后二次网络探测，最后从旧档删除 mapping。单账号事务失败时已有账号保持旧配置、新账号保持空 mapping 不可调度；跨账号中途失败保留已完成增加、停止后续减少，返回 `failed_step + changes[]`，重试可继续收敛；空档账号保留并收敛为 `active + schedulable=false`。已选来源存在未保存表单修改时发现/校验/投影入口禁用并提示先保存，成功提示只能从当前结果派生。
+4. AC-004 (热更新): Given endpoint、credential、模型 ID、模型增减、跨档，或非空受管账号的 `status/schedulable` 与目标不一致，When 未先校验而直接点击「投影账号」，Then 系统走 `POST .../sync` 且不探测模型（`probe_results` 为空），即使 Validate 会对某行失败也直接写账号。以空 mapping、不可调度状态创建缺失账号；非空投影按 `channel_type` 声明通道单一协议能力（默认 Chat-only；Anthropic messages-only），并在单账号事务内提交账号配置、该协议能力、`InitialProbeCompleted=true`/`OfficialSeed=false` 和 scheduler outbox，再做配置读回确认而不进行网络探测，最后从旧档删除 mapping。单账号事务失败时已有账号保持旧配置、新账号保持空 mapping 不可调度；跨账号中途失败保留已完成增加、停止后续减少，返回 `failed_step + changes[]`，重试可继续收敛；空档账号保留并收敛为 `active + schedulable=false`。已选来源存在未保存表单修改时发现/校验/投影入口禁用并提示先保存，成功提示只能从当前结果派生。
 5. AC-005 (隔离回归): Given 供应源保存、预览或同步，When 执行任一路径，Then 供应源不读取、比较、返回或写入账号组，专用投影读取不调用通用 `GetByID`，并且只选择同步所需配置字段，不读取倍率或无关运行字段；新账号保持未分组且不借用 `newapi-default`，普通账号创建失败契约不变；受管/预探测账号按通道声明单一协议（默认 Chat Completions；Anthropic Messages）；通用 host 末尾 `/v1` 只在 OpenAI 受管路径规范化，`qianfan.baidubce.com` 解析为 BaiduV2 + 根 URL 并声明 `/v2/chat/completions`，普通 NewAPI 账号行为不变；系统不修改倍率、定价或 scheduler，scheduler 继续只按更小的原有账号 priority 先调度，不读取供应来源 Extra。
 6. AC-006 (ownership): Given 账号 Extra 存在 `supplier_source_id`，When 运营在账号页编辑、删除、复制、切换调度或批量更新，Then 行为与普通账号一致；普通创建和 CRS 导入不能伪造保留 Extra，普通 Extra 编辑保留受管身份键，复制剥离受管身份键。When 在供应源点击「投影账号」，Then 只走不携带 `rate_multiplier` 的窄写命令覆盖投影字段（含 priority/`model_mapping`/凭证/transport/`status/schedulable`），只合并 `supplier_source_id`、`supplier_discount_band` 并保留其他 Extra，不读写账号组。已有账号匹配覆盖全部未删除 NewAPI 候选，但只有 active 唯一精确匹配可接管；disabled/error 精确匹配返回冲突且不新建重复账号。恢复错误、配额重置、代理 fallback 与探测仍允许。真实账号 UI 显示“供应源托管”徽标与投影覆盖提示，点击徽标按 `source_id` 直接选中对应供应源。
 7. AC-007 (安全): Given 创建、更新、探测或同步供应源，When API、日志和 Admin Audit Log 记录请求与结果，Then 不包含凭证明文、密文、HMAC 指纹或上游原始响应；探测只返回固定状态、协议分类和脱敏说明；HMAC 指纹跟随凭证加密密钥而非 JWT secret 的生命周期。
@@ -29,10 +29,10 @@
 - `purchase_ratio` 只接受空值或 `0 < ratio <= 1`；`1.00` 与空值进入档位 6。
 - 同一供应源内 `client_model_id` 唯一，客户 ID 与上游 ID 必须逐行明确，不提供通用前缀替换器。
 - 首批佳杰模型筛选是运营输入边界；格式未确认的 `43折` 等文本不参与自动比较。
-- 保存、名称/priority 元数据同步和投影同步是三条明确路径；结构变化或非空账号的调度投影漂移由投影路径即时探测。
-- 发现模型、校验模型、保存、投影账号是四个独立按钮；建议追加必须以发现探测通过为门禁，投影不依赖历史校验状态，而以自身当次探测为门禁。
-- 不存在进程内 validation cache、授权 TTL 或 probe token；重启、跨实例和等待都不能改变 Project 的探测要求。
-- 新建受管账号命令不接受 mapping；非空投影必须携带当次通道协议正向探测证据，service 与 repository 双重拒绝绕过。
+- 保存、名称/priority 元数据同步和投影同步是三条明确路径；结构变化或非空账号的调度投影漂移由投影路径直接写入，不探测。
+- 发现模型、校验模型、保存、投影账号是四个独立正交按钮；建议追加必须以发现探测通过为门禁，投影不依赖也不执行模型探测。
+- 不存在进程内 validation cache、授权 TTL 或 probe token；重启、跨实例和等待都不能让投影去探测。
+- 新建受管账号命令不接受 mapping；非空投影必须声明通道协议能力，service 与 repository 双重拒绝绕过。
 - 单账号账号配置、通道单一协议能力（默认 Chat；Anthropic Messages）、探测证据与 scheduler outbox 原子提交；读回是配置确认，不是写后二次探测。
 - 供应源 `/v1` 规范化只由 OpenAI 受管路径触发；Qianfan 主机规范化为根 URL 并声明 `/v2/chat/completions`；Anthropic（14）声明 `/v1/messages`；普通 NewAPI base URL 不改写。
 - `supplier_source_id + supplier_discount_band` 是受管账号逻辑身份；账号组不参与匹配或同步成败。
@@ -56,8 +56,8 @@
 - `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_SupplierSyncGroupsSameBandModelsIntoOneAccount`
 - `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_SupplierProbeAccountCarriesManagedIdentity`
 - `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_ValidateFailureReturnsEveryResultAndWritesNothing`
-- `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_SupplierSyncProbeFailureReturnsEveryResultAndWritesNothing`
-- `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_SupplierSyncReprobesImmediatelyBeforeProjection`
+- `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_SupplierSyncProjectsEvenWhenValidateWouldFail`
+- `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_SupplierSyncProjectsWithoutCallingProbe`
 - `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_SupplierSyncMetadataOnlySkipsProbe`
 - `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_SupplierSyncNameChangeUpdatesAccountWithoutProbe`
 - `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_SupplierSyncMovesModelByAddingBeforeRemoving`
@@ -74,7 +74,8 @@
 - `backend/internal/service/supplier_managed_transport_test.go`::`TestUS048_ResolveSupplierManagedTransportSelectsBaiduV2ForQianfan`
 - `backend/internal/service/supplier_managed_account_commands_test.go`::`TestUS048_SupplierQianfanCreateUsesBaiduV2Transport`
 - `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_MultiBandExactAccountMatchBlocksDuplicateSupplierAccountCreation`
-- `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_SupplierSyncReprobesBeforeRepairingNonEmptySchedulingProjection`
+- `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_SupplierSyncRepairsNonEmptySchedulingProjectionWithoutProbe`
+- `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_SupplierSyncProtocolIdentityDriftRepairsWithoutProbe`
 - `backend/internal/service/supplier_source_sync_test.go`::`TestUS048_SupplierSyncRepairsEmptySchedulingProjectionWithoutProbe`
 - `backend/internal/service/supplier_source_account_store_test.go`::`TestUS048_SupplierAccountStoreMatchesWithoutReadingGroups`
 - `backend/internal/repository/account_repo_integration_test.go`::`TestAccountRepoSuite`（子测试：`TestUS048_SupplierProjectionReadsDoNotQueryAccountGroups`）
@@ -134,6 +135,7 @@
 - `backend/internal/handler/admin/supplier_source_handler_test.go`::`TestUS048_SupplierSourceProbeFailureReturns422WithCompleteResult`
 - `backend/internal/handler/admin/supplier_source_handler_test.go`::`TestUS048_SupplierSourceCreateRejectsMalformedPurchaseRatioAtJSONBoundary`
 - `backend/internal/service/audit_log_test.go`::`TestRedactAuditBody_RedactsSupplierSourceCredential`
+- `frontend/src/api/__tests__/admin.supplierSources.spec.ts`::`gives validate a long timeout because it probes every configured model`
 - `frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts`::`saves new and existing sources through create or update only`
 - `frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts`::`requires saving edited supplier facts before syncing the selected source`
 - `frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts`::`offers and hydrates BaiduV2 while preserving a custom endpoint during source selection`
@@ -151,7 +153,7 @@
 - `frontend/src/components/account/__tests__/EditAccountModal.spec.ts`::`shows the supplier-managed hint and submits a normal account update`
 - `frontend/src/components/account/__tests__/SupplierManagedBadge.spec.ts`::`uses marker presence, maps known sources, falls back safely, and refreshes after remount`
 - `backend/internal/server/routes/admin_routes_test.go`::`TestUS048_SupplierSourceRoutesAreRegistered`
-- `frontend/e2e/us048-supplier-source-management.e2e.ts`::`US048 project-before-validate reprobes, fails closed, and recovers on retry`
+- `frontend/e2e/us048-supplier-source-management.e2e.ts`::`US048 project-before-validate writes accounts without probing`
 - `frontend/e2e/us048-supplier-source-management.e2e.ts`::`US048 FMGo shows the fixed protocol boundary without account changes`
 - `frontend/e2e/us048-supplier-source-management.e2e.ts`::`US048 accounts UI marks supplier-managed accounts and allows ordinary edits`
 
@@ -160,14 +162,14 @@
 ```bash
 cd backend && go test ./internal/service ./internal/repository ./internal/handler/admin ./internal/server/routes -run 'TestUS048|TestSupplierSource|TestModelSupplierSource|TestSchedulingPriorityIgnoresAccountExtra|TestRedactAuditBody_RedactsSupplierSourceCredential' -count=1
 cd backend && DOCKER_HOST=unix:///Users/feng/.colima/default/docker.sock TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock go test -tags integration ./internal/repository -run 'TestAccountRepoSuite/TestUS048_Supplier|TestModelSupplierSourceMigrationCreatesOnlyTheSingleSourceTable' -count=1
-cd frontend && pnpm exec vitest run src/views/admin/__tests__/SupplierSourcesView.spec.ts src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts src/components/account/__tests__/SupplierManagedBadge.spec.ts
+cd frontend && pnpm exec vitest run src/api/__tests__/admin.supplierSources.spec.ts src/views/admin/__tests__/SupplierSourcesView.spec.ts src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts src/components/account/__tests__/SupplierManagedBadge.spec.ts
 cd frontend && pnpm exec playwright test e2e/us048-supplier-source-management.e2e.ts --project=chromium
 ```
 
 ## Evidence
 
 - 后端、组件和真实 UI 行为由 Linked Tests 生成。
-- Playwright Chromium 驱动真实页面，但 API 使用路由 mock；它证明表单、预览、同步结果、失败封闭和账号 ownership UI，不证明真实供应商接入成功。
+- Playwright Chromium 驱动真实页面，但 API 使用路由 mock；它证明表单、预览、未先校验即投影写入、和账号 ownership UI，不证明真实供应商接入成功。
 - 首批三个案例事实不完整或不匹配时保持 `not_run` / `protocol_unsupported` / 只读库存，要求补全准确信息，不以 mock 代替真实上游验收，也不扩大匹配。
 
 ## Status

--- a/backend/internal/service/supplier_source_service.go
+++ b/backend/internal/service/supplier_source_service.go
@@ -235,7 +235,7 @@ func (s *SupplierSourceService) Sync(ctx context.Context, sourceID int64) (*Supp
 	result := &SupplierSourceSyncResult{
 		SourceID: sourceID, ProbeResults: make([]SupplierProbeResult, 0), Changes: make([]SupplierSourceAccountChange, 0),
 	}
-	if s == nil || s.repo == nil || s.accounts == nil || s.probe == nil || s.encryptor == nil || sourceID <= 0 {
+	if s == nil || s.repo == nil || s.accounts == nil || s.encryptor == nil || sourceID <= 0 {
 		result.FailedStep = "validate_request"
 		return result, ErrSupplierSourceInvalidInput
 	}
@@ -286,14 +286,6 @@ func (s *SupplierSourceService) Sync(ctx context.Context, sourceID int64) (*Supp
 			return result, err
 		}
 		return result, nil
-	}
-
-	if len(source.Models) > 0 {
-		result.ProbeResults = s.probeSupplierTargets(ctx, source, credential, targets, managedByBand, adoptByBand)
-		if supplierProbeResultsFailed(result.ProbeResults) {
-			result.FailedStep = "probe"
-			return result, ErrSupplierSourceProbeFailed
-		}
 	}
 
 	workingByBand := make(map[int]*Account, len(managedByBand)+len(targets))

--- a/backend/internal/service/supplier_source_sync_test.go
+++ b/backend/internal/service/supplier_source_sync_test.go
@@ -26,7 +26,7 @@ func TestUS048_FMGoSeedanceSyncProjectsOfficialClientsOnly(t *testing.T) {
 		},
 	}}
 	accounts := &supplierSyncAccountStoreFake{}
-	probe := &supplierSyncProbeFake{}
+	probe := &supplierSyncProbeFake{failIfCalled: true}
 	svc := NewSupplierSourceService(repo, accounts, probe, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{})
 
 	result, err := svc.Sync(context.Background(), 10)
@@ -56,13 +56,13 @@ func TestUS048_SupplierSyncGroupsSameBandModelsIntoOneAccount(t *testing.T) {
 		},
 	}}
 	accounts := &supplierSyncAccountStoreFake{}
-	probe := &supplierSyncProbeFake{}
+	probe := &supplierSyncProbeFake{failIfCalled: true}
 	svc := NewSupplierSourceService(repo, accounts, probe, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{})
 
 	result, err := svc.Sync(context.Background(), 7)
 
 	require.NoError(t, err)
-	require.Len(t, result.ProbeResults, 2)
+	require.Empty(t, result.ProbeResults)
 	require.Equal(t, 1, accounts.createCalls)
 	require.Equal(t, 3, accounts.created[0].DiscountBand)
 	require.Equal(t, 130, accounts.created[0].Priority)
@@ -112,7 +112,29 @@ func TestUS048_ValidateFailureReturnsEveryResultAndWritesNothing(t *testing.T) {
 	require.Empty(t, accounts.updated)
 }
 
-func TestUS048_SupplierSyncProbeFailureReturnsEveryResultAndWritesNothing(t *testing.T) {
+func TestUS048_SupplierSyncProjectsWithoutCallingProbe(t *testing.T) {
+	ratio := 0.5
+	repo := &supplierSourceRepoFake{stored: &SupplierSource{
+		ID: 7, SupplierName: "佳杰", SupplierLane: "stbl-5", ChannelType: 1, Endpoint: "https://supplier.example/v1",
+		EncryptedCredential: "enc:secret", CredentialFingerprint: "fp:secret", BasePriority: 100,
+		Models: []SupplierSourceModel{
+			{ClientModelID: "deepseek-v4-pro", UpstreamModelID: "deepseek-v4-pro", PurchaseRatio: &ratio},
+		},
+	}}
+	accounts := &supplierSyncAccountStoreFake{}
+	probe := &supplierSyncProbeFake{failIfCalled: true}
+	svc := NewSupplierSourceService(repo, accounts, probe, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{})
+
+	result, err := svc.Sync(context.Background(), 7)
+
+	require.NoError(t, err)
+	require.Empty(t, result.ProbeResults)
+	require.Equal(t, 1, accounts.createCalls)
+	require.NotEmpty(t, accounts.updated)
+	require.True(t, accounts.updated[0].ProtocolProbePassed)
+}
+
+func TestUS048_SupplierSyncProjectsEvenWhenValidateWouldFail(t *testing.T) {
 	ratio := 0.5
 	repo := &supplierSourceRepoFake{stored: &SupplierSource{
 		ID: 7, SupplierName: "FMGo", SupplierLane: "seedance", ChannelType: 1, Endpoint: "https://supplier.example/v1",
@@ -130,35 +152,9 @@ func TestUS048_SupplierSyncProbeFailureReturnsEveryResultAndWritesNothing(t *tes
 
 	result, err := svc.Sync(context.Background(), 7)
 
-	require.ErrorIs(t, err, ErrSupplierSourceProbeFailed)
-	require.Equal(t, "probe", result.FailedStep)
-	require.Len(t, result.ProbeResults, 2)
-	require.Equal(t, SupplierProbeStatusPassed, result.ProbeResults[0].Status)
-	require.Equal(t, SupplierProbeStatusProtocolUnsupported, result.ProbeResults[1].Status)
-	require.Empty(t, result.Changes)
-	require.Zero(t, accounts.createCalls)
-	require.Empty(t, accounts.updated)
-}
-
-func TestUS048_SupplierSyncReprobesImmediatelyBeforeProjection(t *testing.T) {
-	ratio := 0.5
-	repo := &supplierSourceRepoFake{stored: &SupplierSource{
-		ID: 7, SupplierName: "佳杰", SupplierLane: "stbl-5", ChannelType: 1, Endpoint: "https://supplier.example/v1",
-		EncryptedCredential: "enc:secret", CredentialFingerprint: "fp:secret", BasePriority: 100,
-		Models: []SupplierSourceModel{
-			{ClientModelID: "deepseek-v4-pro", UpstreamModelID: "deepseek-v4-pro", PurchaseRatio: &ratio},
-		},
-	}}
-	accounts := &supplierSyncAccountStoreFake{}
-	svc := NewSupplierSourceService(
-		repo, accounts, &supplierSyncProbeFake{}, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{},
-	)
-
-	result, err := svc.Sync(context.Background(), 7)
-
 	require.NoError(t, err)
-	require.Len(t, result.ProbeResults, 1)
-	require.Equal(t, SupplierProbeStatusPassed, result.ProbeResults[0].Status)
+	require.Empty(t, result.ProbeResults)
+	require.Empty(t, result.FailedStep)
 	require.Equal(t, 1, accounts.createCalls)
 	require.NotEmpty(t, accounts.updated)
 }
@@ -524,7 +520,7 @@ func TestUS048_MultiBandExactAccountMatchBlocksDuplicateSupplierAccountCreation(
 	require.Empty(t, accounts.updated)
 }
 
-func TestUS048_SupplierSyncReprobesBeforeRepairingNonEmptySchedulingProjection(t *testing.T) {
+func TestUS048_SupplierSyncRepairsNonEmptySchedulingProjectionWithoutProbe(t *testing.T) {
 	ratio := 0.5
 	repo := &supplierSourceRepoFake{stored: &SupplierSource{
 		ID: 7, SupplierName: "佳杰", SupplierLane: "stbl-5", ChannelType: 1, Endpoint: "https://supplier.example/v1",
@@ -536,13 +532,13 @@ func TestUS048_SupplierSyncReprobesBeforeRepairingNonEmptySchedulingProjection(t
 	account.Status = StatusError
 	accounts := &supplierSyncAccountStoreFake{managed: []*Account{account}}
 	svc := NewSupplierSourceService(
-		repo, accounts, &supplierSyncProbeFake{}, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{},
+		repo, accounts, &supplierSyncProbeFake{failIfCalled: true}, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{},
 	)
 
 	result, err := svc.Sync(context.Background(), 7)
 
 	require.NoError(t, err)
-	require.Len(t, result.ProbeResults, 1)
+	require.Empty(t, result.ProbeResults)
 	require.NotEmpty(t, accounts.updated)
 	require.False(t, accounts.updated[0].MetadataOnly)
 	require.Equal(t, StatusActive, accounts.managed[0].Status)
@@ -1018,7 +1014,7 @@ func TestUS048_SupplierSyncAppliesSourceAccountConcurrency(t *testing.T) {
 	require.Equal(t, 1000, accounts.managed[0].Concurrency)
 }
 
-func TestUS048_SupplierSyncProtocolIdentityDriftReprobesBeforeRepair(t *testing.T) {
+func TestUS048_SupplierSyncProtocolIdentityDriftRepairsWithoutProbe(t *testing.T) {
 	ratio := 0.5
 	capabilityID := int64(797)
 	repo := &supplierSourceRepoFake{stored: &SupplierSource{
@@ -1040,13 +1036,13 @@ func TestUS048_SupplierSyncProtocolIdentityDriftReprobesBeforeRepair(t *testing.
 		ProtocolEndpointCapabilityID: &capabilityID,
 		ProtocolEndpointCapability:   &ProtocolEndpointCapability{ID: capabilityID, CapabilityKey: "stale-identity"},
 	}}}
-	probe := &supplierSyncProbeFake{}
+	probe := &supplierSyncProbeFake{failIfCalled: true}
 	svc := NewSupplierSourceService(repo, accounts, probe, supplierSyncEncryptor{}, supplierSourceTestFingerprinter{})
 
 	result, err := svc.Sync(context.Background(), 7)
 
 	require.NoError(t, err)
-	require.Len(t, result.ProbeResults, 1, "protocol identity repair must be backed by this sync call's real probe")
+	require.Empty(t, result.ProbeResults)
 	require.NotEmpty(t, accounts.updated)
 	require.True(t, accounts.updated[0].ProtocolProbePassed)
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 716,
-  "hash": "fb29fc6810b37125d4704f7cbca5cddef19eafcf5bbefafb9b3a274ca259abc4",
+  "hash": "953b2e48cc1564f6fb164ca6e791512067896daf58e141b28e077a2065a22f69",
   "schema": 1,
   "source": "frontend/"
 }

--- a/docs/approved/model-supplier-source-management.md
+++ b/docs/approved/model-supplier-source-management.md
@@ -9,16 +9,18 @@ owners: [tk-platform]
 scope: "supplier facts, admin API/UI, credential isolation, account projection, probe gate; managed accounts behave like ordinary accounts after create, with sync overwriting projection fields"
 related_stories: ["US-048"]
 revision_note: >
-  2026-09-03: Supplier identity SSOT — row unique key is
-  (supplier_name, endpoint, credential_fingerprint, channel_type);
-  DB/API field channel_name renamed to supplier_lane (display label only).
-  Adoption candidates filter by channel_type transport. 2026-09-02: Anthropic
+  2026-09-03: Project writes managed accounts only and never probes;
+  validate remains the sole configured-model probe. Same day: supplier
+  identity SSOT — row unique key is (supplier_name, endpoint,
+  credential_fingerprint, channel_type); DB/API field channel_name
+  renamed to supplier_lane (display label only). Adoption candidates
+  filter by channel_type transport. 2026-09-02: Anthropic
   channel_type=14 messages-only exception.
 ---
 
 # TokenKey 模型供应源管理审批基线
 
-> 按钮与探测主路径以 [`model-supplier-source-probe-sync-split.md`](model-supplier-source-probe-sync-split.md) 为准：发现模型 -> 校验模型 -> 保存 -> 投影账号。FMGo Seedance 改写见 [`model-supplier-source-fmgo-seedance-account-rewrite.md`](model-supplier-source-fmgo-seedance-account-rewrite.md)。
+> 按钮与探测主路径以 [`model-supplier-source-probe-sync-split.md`](model-supplier-source-probe-sync-split.md) 为准：发现模型 -> 保存 -> 校验模型 -> 投影账号。FMGo Seedance 改写见 [`model-supplier-source-fmgo-seedance-account-rewrite.md`](model-supplier-source-fmgo-seedance-account-rewrite.md)。
 
 ## 决策
 
@@ -81,10 +83,10 @@ account.priority = source.base_priority + discount_priority
 priority 自行判断和修改 `base_priority`。已选来源的表单存在未保存修改时，页面禁用发现、校验与投影并
 提示先保存；投影 API 始终只读取数据库中已保存的供应事实。
 
-发现、校验、保存、投影的按钮顺序、禁用矩阵与探测主路径以
+发现、保存、校验、投影的按钮顺序、禁用矩阵与探测主路径以
 [`model-supplier-source-probe-sync-split.md`](model-supplier-source-probe-sync-split.md) 为准。
 `POST .../discover` 只读发现候选，`POST .../validate` 只读校验已配置模型，保存只写供应源；
-`POST .../sync` 在结构写入前当次重探后投影账号。Validate 结果不缓存也不授权后续写入。
+`POST .../sync` 只投影账号，不探测。Validate 结果不缓存也不授权后续写入。
 旧 `POST .../probe` 与 probe job 路由保留为 Discover 兼容别名；管理路由不再注册 `models-discover`。
 
 上游列表仍按通道能力拉取（OpenAI 兼容 `/v1/models`；千帆 BaiduV2 为 `/v2/models`；DashScope Ali
@@ -98,11 +100,10 @@ API 必须返回可读 `message` 与 `failed_step`；管理页必须在结果区
 1. 供应商名称、`supplier_lane`（供应通道名）或 `base_priority` 变化时，只更新受管账号名称和 priority，不探测；
 1b. `account_concurrency` 变化时，只更新受管账号 `concurrency`，不探测；
 2. endpoint、credential、模型 ID、模型增减、跨档，或非空受管账号的 `status/schedulable` 与目标
-   不一致时，先用内存目标账号逐模型真实探测；空 mapping 的调度字段漂移无需探测；
-3. 任一模型失败，返回完整当次探测结果且不写账号；全部成功生成仅供本次同步调用链使用的通道协议
-   正向证据（默认 Chat；Anthropic 14 为 Messages；视频 54 为视频方言）；
-4. 先创建空 mapping、不可调度的新档位账号。非空投影必须携带该证据；service 和 repository 双重
-   拒绝未经探测的非空 mapping；
+   不一致时，直接按目标 mapping 投影，不探测；空 mapping 的调度字段漂移同样不探测；
+3. 非空投影按 `channel_type` 声明单一协议能力（默认 Chat；Anthropic 14 为 Messages；视频 54 为视频方言）；
+4. 先创建空 mapping、不可调度的新档位账号。非空投影必须携带该通道协议声明；service 和 repository 双重
+   拒绝未声明协议能力的非空 mapping；
 5. 单账号事务同时提交账号配置、该通道单一协议能力（默认 Chat Completions；Anthropic 仅 Messages）、
    `InitialProbeCompleted=true`/`OfficialSeed=false` 的正向证据及普通 scheduler outbox；提交后只读回
    配置确认，不做写后二次网络探测；

--- a/docs/approved/model-supplier-source-probe-sync-split.md
+++ b/docs/approved/model-supplier-source-probe-sync-split.md
@@ -1,30 +1,30 @@
 ---
 title: Supplier Source - discover, validate, save, and project
 status: approved
-approved_by: "xuejiao (operator directives 2026-09-01; revised 2026-09-02)"
+approved_by: "xuejiao (operator directives 2026-09-01; revised 2026-09-02; orthogonal project 2026-09-03)"
 approved_at: 2026-09-01
-updated: 2026-09-02
+updated: 2026-09-03
 created: 2026-09-01
 owners: [tk-platform]
-scope: "amend US-048 / model-supplier-source-management: four explicit actions; project owns its immediate write-gate probe; legacy probe routes remain aliases"
+scope: "amend US-048 / model-supplier-source-management: four orthogonal actions; validate owns model probe; project writes accounts only; legacy probe routes remain aliases"
 related_stories: ["US-048"]
 amends: ["docs/approved/model-supplier-source-management.md"]
 related_design: ["docs/approved/model-supplier-source-fmgo-seedance-account-rewrite.md"]
-operator_locks: "2026-09-02: discover -> validate -> save -> project; validate is read-only preview, never write authorization; project re-probes immediately before structural writes; no validation cache/token; POST .../probe and probe job remain discover aliases; Anthropic channel_type=14 messages-only probe/project"
+operator_locks: "2026-09-03: discover / validate / save / project are orthogonal; validate owns model probe; project never probes; no validation cache/token; POST .../probe and probe job remain discover aliases; Anthropic channel_type=14 messages-only validate/project"
 ---
 
 # 供应源：发现 / 校验 / 保存 / 投影
 
 ## 一件事
 
-把供应源页面的四个运营意图拆清楚，同时让账号写入门禁留在写路径自身：
+把供应源页面的四个运营意图拆成独立、正交的动作：
 
 ```text
-发现模型 -> 校验模型 -> 保存 -> 投影账号
+发现模型 | 保存 | 校验模型 | 投影账号
 ```
 
-四个按钮是职责顺序，不是可复用的授权状态机。`Validate` 提供只读预览；`Project` 对结构变化在写入前
-重新探测本次将投影的已保存模型。进程重启、多实例切换或时间经过都不能绕过这个门禁。
+四个按钮各做一件事，互不授权、互不复用结果。`Validate` 是唯一的已配置模型探测；`Project`
+只把库内已保存事实写入受管账号，不探测。进程重启、多实例切换或时间经过都不能让投影去探测。
 
 FMGo Seedance 账号侧动态改写不在本文件范围，见
 `docs/approved/model-supplier-source-fmgo-seedance-account-rewrite.md`。
@@ -33,10 +33,10 @@ FMGo Seedance 账号侧动态改写不在本文件范围，见
 
 | 项 | 决定 |
 |---|---|
-| 按钮顺序 | **发现模型 -> 校验模型 -> 保存 -> 投影账号** |
+| 按钮顺序 | **发现模型 -> 保存 -> 校验模型 -> 投影账号** |
 | Validate | 只读探测已保存配置；结果只用于当下判断，不授权未来写入 |
-| Project | 结构变化 / 非空 mapping 投影前即时重探；失败不写账号 |
-| 元数据快路 | 名称、priority、concurrency 等不改变结构时可不探测 |
+| Project | 只窄写受管账号；不探测模型，也不消费 Validate 结果 |
+| 元数据快路 | 名称、priority、concurrency 等不改变结构时只改元数据 |
 | 缓存 / token | 不存在 validation cache、TTL、probe token 或证据表 |
 | 新 API | `discover`、`discover job`、`validate`、`sync` |
 | 兼容 API | 旧 `probe`、`probe job` 路由继续注册，复用 Discover handler |
@@ -67,10 +67,9 @@ FMGo Seedance 账号侧动态改写不在本文件范围，见
 ### 投影账号
 
 - 只读取库内已保存事实，不消费 Discover/Validate 的浏览器或进程状态。
-- 结构变化时，在第一个结构写入之前用当次目标账号逐模型重探。
-- 任一探测失败，返回完整当次 `probe_results`、`failed_step=probe`、空 `changes`，不创建或更新账号。
-- 全部成功后，才按先增后减规则执行窄写；非空 mapping 携带本次探测证据。
-- 失败后重试会重新探测，不能复用上次成功或失败结果。
+- 不探测已配置模型；`probe_results` 为空。
+- 结构变化按先增后减规则窄写受管账号；非空 mapping 按 `channel_type` 声明单一协议能力。
+- 写失败返回 `failed_step + changes[]`，重试重新计算差异并继续收敛。
 
 ## API
 
@@ -89,6 +88,8 @@ GET  /admin/supplier-sources/:id/probe/jobs/:job_id
 
 ## 探测协议
 
+本节只约束发现/校验。投影不探测，只按 `channel_type` 声明协议能力。
+
 - 默认：Chat Completions 正向证据。
 - 视频通道（DoubaoVideo / 54）：走该通道真实视频方言，不用 `hi` Chat 冒充成功。
 - Anthropic 通道（14）：走 `/v1/messages` 正向证据（CloudWise Claude opus/sonnet 上游仅 messages）；
@@ -98,19 +99,19 @@ GET  /admin/supplier-sources/:id/probe/jobs/:job_id
 
 ## 状态矩阵
 
-| 表单状态 | 发现 | 校验 | 保存 | 投影 |
+| 表单状态 | 发现 | 保存 | 校验 | 投影 |
 |---|---|---|---|---|
-| 干净（与库一致） | 可 | 可 | 禁 | 可 |
-| 手改未保存 | 禁 | 禁 | 可 | 禁 |
-| 发现回填草稿 | 禁 | 禁 | 可 | 禁 |
+| 干净（与库一致） | 可 | 禁 | 可 | 可 |
+| 手改未保存 | 禁 | 可 | 禁 | 禁 |
+| 发现回填草稿 | 禁 | 可 | 禁 | 禁 |
 
-Validate 成功或失败都不改变矩阵。Project 未先 Validate 仍可执行，因为它拥有自己的即时探测门禁。
+Validate 成功或失败都不改变矩阵。Project 未先 Validate 仍可执行，因为它不探测、也不依赖校验结果。
 
 ## 验收场景
 
-1. 干净表单直接 Project：结构变化路径先探测；成功才写账号。
-2. 干净表单直接 Project：探测失败返回完整结果且零账号写；上游恢复后重试重新探测并成功。
-3. 先 Validate 成功、进程重启或请求落到另一实例、再 Project：Project 仍重新探测。
+1. 干净表单直接 Project：不探测，结构变化直接写账号。
+2. 干净表单直接 Project：即使 Validate 会对某行失败，Project 仍写账号且 `probe_results` 为空。
+3. 先 Validate 失败、再 Project：Project 仍写账号，不复用也不重放校验结果。
 4. 仅名称、priority 或 concurrency 漂移：Project 走元数据快路，不做模型探测。
 5. 旧客户端调用 `/probe` 与 probe job：仍得到 Discover 结果，不出现 404。
 6. 表单脏：发现、校验、投影都禁用，只能先保存。
@@ -124,7 +125,7 @@ pnpm --dir frontend exec vitest run src/views/admin/__tests__/SupplierSourcesVie
 pnpm --dir frontend exec playwright test e2e/us048-supplier-source-management.e2e.ts
 ```
 
-Playwright 必须覆盖未先 Validate 的 Project 失败、零写入和重试恢复；API-only 测试不能代替该 UI 流程。
+Playwright 必须覆盖未先 Validate 的 Project 直接成功写入；API-only 测试不能代替该 UI 流程。
 
 ## 非目标
 
@@ -137,8 +138,8 @@ Playwright 必须覆盖未先 Validate 的 Project 失败、零写入和重试�
 
 - [x] 四按钮顺序固定
 - [x] Validate 只读，不是写授权
-- [x] Project 在结构写入前即时重探
+- [x] Project 不探测，只写受管账号
 - [x] 旧 `/probe` 路由保留为兼容别名
 - [x] 无 validation cache / token
-- [x] Playwright 覆盖 Project-before-Validate 失败与恢复
-- [x] 2026-09-02 运营修订已批准
+- [x] Playwright 覆盖未先 Validate 的 Project 直接写入
+- [x] 2026-09-03 运营修订：四步正交，探测只属于校验模型

--- a/frontend/e2e/us048-supplier-source-management.e2e.ts
+++ b/frontend/e2e/us048-supplier-source-management.e2e.ts
@@ -191,10 +191,11 @@ function validateOK(src: SupplierSource) {
   }
 }
 
-test('US048 project-before-validate reprobes, fails closed, and recovers on retry', async ({ page }) => {
+test('US048 project-before-validate writes accounts without probing', async ({ page }) => {
   let sources: SupplierSource[] = []
   let submitted: Record<string, unknown> | null = null
   let syncRequests = 0
+  let validateRequests = 0
 
   await installBase(page, async (route, path) => {
     const request = route.request()
@@ -243,44 +244,15 @@ test('US048 project-before-validate reprobes, fails closed, and recovers on retr
       return true
     }
     if (path === '/api/v1/admin/supplier-sources/7/validate' && request.method() === 'POST') {
+      validateRequests += 1
       await fulfillSuccess(route, validateOK(sources[0]))
       return true
     }
     if (path === '/api/v1/admin/supplier-sources/7/sync' && request.method() === 'POST') {
       syncRequests += 1
-      if (syncRequests === 1) {
-        await fulfillError(route, 422, 'one or more supplier models failed validation', {
-          source_id: 7,
-          probe_results: [{
-            client_model_id: 'deepseek-v4-pro',
-            upstream_model_id: 'deepseek-v4-pro',
-            status: 'failed',
-            protocol: 'openai_chat_completions',
-            detail: 'temporary upstream failure',
-          }, {
-            client_model_id: 'qwen-3.7-max',
-            upstream_model_id: 'qwen-3.7-max',
-            status: 'passed',
-            protocol: 'openai_chat_completions',
-          }],
-          changes: [],
-          failed_step: 'probe',
-        })
-        return true
-      }
       await fulfillSuccess(route, {
         source_id: 7,
-        probe_results: [{
-          client_model_id: 'deepseek-v4-pro',
-          upstream_model_id: 'deepseek-v4-pro',
-          status: 'passed',
-          protocol: 'openai_chat_completions',
-        }, {
-          client_model_id: 'qwen-3.7-max',
-          upstream_model_id: 'qwen-3.7-max',
-          status: 'passed',
-          protocol: 'openai_chat_completions',
-        }],
+        probe_results: [],
         changes: [{
           account_id: 101,
           discount_band: 3,
@@ -353,23 +325,25 @@ test('US048 project-before-validate reprobes, fails closed, and recovers on retr
   expect(syncRequests).toBe(0)
   await page.locator('[data-test="notes"]').fill('首批最低合法比例')
   await expect(page.locator('[data-test="sync-source"]')).toBeEnabled()
+  await expect.poll(async () => page.locator(
+    '[data-test="discover-source"], [data-test="save-source"], [data-test="validate-source"], [data-test="sync-source"]',
+  ).evaluateAll(buttons => buttons.map(button => button.getAttribute('data-test')))).toEqual([
+    'discover-source',
+    'save-source',
+    'validate-source',
+    'sync-source',
+  ])
 
   await page.locator('[data-test="sync-source"]').click()
   const result = page.locator('[data-test="sync-result"]')
-  await expect(page.locator('[data-test="sync-error"]')).toContainText('one or more supplier models failed validation')
-  await expect(result).toContainText('失败步骤: probe')
-  await expect(result).toContainText('temporary upstream failure')
-  await expect(result).toContainText('qwen-3.7-max')
-  await expect(result).not.toContainText('投影完成')
-  expect(syncRequests).toBe(1)
-
-  await page.locator('[data-test="sync-source"]').click()
   await expect(result).toContainText('投影完成')
-  await expect(result).toContainText('passed')
   await expect(result).toContainText('新增模型: deepseek-v4-pro, qwen-3.7-max')
   await expect(result).toContainText('#101 · created · band 3')
   await expect(result).toContainText('priority — → 130')
-  expect(syncRequests).toBe(2)
+  await expect(result).not.toContainText('passed')
+  await expect(result).not.toContainText('失败步骤')
+  expect(syncRequests).toBe(1)
+  expect(validateRequests).toBe(0)
   await expect(page.getByRole('button', { name: /激活|暂停/ })).toHaveCount(0)
 })
 

--- a/frontend/src/api/__tests__/admin.supplierSources.spec.ts
+++ b/frontend/src/api/__tests__/admin.supplierSources.spec.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { post } = vi.hoisted(() => ({
+  post: vi.fn(),
+}))
+
+vi.mock('../client', () => ({
+  apiClient: {
+    post,
+  },
+}))
+
+import supplierSources from '@/api/admin/supplierSources'
+
+describe('admin supplierSources API', () => {
+  beforeEach(() => {
+    post.mockReset()
+  })
+
+  it('gives validate a long timeout because it probes every configured model', async () => {
+    post.mockResolvedValue({ data: { source_id: 7, probe_results: [] } })
+
+    await supplierSources.validate(7)
+
+    expect(post).toHaveBeenCalledWith(
+      '/admin/supplier-sources/7/validate',
+      undefined,
+      { timeout: 300_000 },
+    )
+  })
+
+  it('keeps discover and project on the default client timeout', async () => {
+    post.mockResolvedValue({ data: { source_id: 7 } })
+
+    await supplierSources.discover(7)
+    await supplierSources.sync(7)
+
+    expect(post).toHaveBeenCalledWith('/admin/supplier-sources/7/discover')
+    expect(post).toHaveBeenCalledWith('/admin/supplier-sources/7/sync')
+  })
+})

--- a/frontend/src/api/admin/supplierSources.ts
+++ b/frontend/src/api/admin/supplierSources.ts
@@ -176,9 +176,13 @@ async function getDiscoverJob(id: number, jobId: string): Promise<SupplierSource
   return data
 }
 
+const SUPPLIER_SOURCE_VALIDATE_TIMEOUT_MS = 300_000
+
 async function validate(id: number): Promise<SupplierSourceValidateResult> {
   const { data } = await apiClient.post<SupplierSourceValidateResult>(
     `/admin/supplier-sources/${id}/validate`,
+    undefined,
+    { timeout: SUPPLIER_SOURCE_VALIDATE_TIMEOUT_MS },
   )
   return data
 }

--- a/frontend/src/i18n/locales/en/admin/supplierSources.ts
+++ b/frontend/src/i18n/locales/en/admin/supplierSources.ts
@@ -1,7 +1,7 @@
 export default {
   supplierSources: {
     title: 'Supplier Sources',
-    description: 'Maintain procurement facts. Discover reads upstream; validate probes saved models; save writes the source; project writes managed accounts.',
+    description: 'Maintain procurement facts. Discover reads upstream; validate probes saved models; save writes the source; project writes managed accounts and never probes.',
     sources: 'Sources',
     newSource: 'New source',
     empty: 'No supplier sources',

--- a/frontend/src/i18n/locales/zh/admin/supplierSources.ts
+++ b/frontend/src/i18n/locales/zh/admin/supplierSources.ts
@@ -1,7 +1,7 @@
 export default {
   supplierSources: {
     title: '供应源',
-    description: '维护采购事实。发现模型只读上游；校验模型探测已保存配置；保存落库；投影账号写入受管账号。',
+    description: '维护采购事实。发现模型只读上游；校验模型探测已保存配置；保存只写供应源；投影账号只写受管账号，不探测。',
     sources: '供应源列表',
     newSource: '新增供应源',
     empty: '暂无供应源',

--- a/frontend/src/views/admin/SupplierSourcesView.vue
+++ b/frontend/src/views/admin/SupplierSourcesView.vue
@@ -301,6 +301,14 @@
               {{ t('admin.supplierSources.discover') }}
             </button>
             <button
+              data-test="save-source"
+              type="submit"
+              :disabled="saving || discovering || validating || syncing || !canSaveSelected"
+              class="rounded-lg bg-primary-600 px-4 py-2 text-white disabled:opacity-50"
+            >
+              {{ t('admin.supplierSources.save') }}
+            </button>
+            <button
               v-if="selected"
               data-test="validate-source"
               type="button"
@@ -309,14 +317,6 @@
               @click="validateSelected"
             >
               {{ t('admin.supplierSources.validate') }}
-            </button>
-            <button
-              data-test="save-source"
-              type="submit"
-              :disabled="saving || discovering || validating || syncing || !canSaveSelected"
-              class="rounded-lg bg-primary-600 px-4 py-2 text-white disabled:opacity-50"
-            >
-              {{ t('admin.supplierSources.save') }}
             </button>
             <button
               v-if="selected"
@@ -499,9 +499,9 @@
             </span>
           </div>
 
-          <div>
+          <div v-if="syncResult.probe_results.length">
             <h3 class="text-sm font-medium">{{ t('admin.supplierSources.configuredProbes') }}</h3>
-            <ul v-if="syncResult.probe_results.length" class="mt-2 space-y-2 text-sm">
+            <ul class="mt-2 space-y-2 text-sm">
               <li
                 v-for="probe in syncResult.probe_results"
                 :key="`projected-${probe.client_model_id}-${probe.upstream_model_id}`"

--- a/frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts
+++ b/frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts
@@ -150,6 +150,12 @@ describe('SupplierSourcesView', () => {
     expect(wrapper.get('[data-test="discover-source"]').attributes('disabled')).toBeUndefined()
     expect(wrapper.get('[data-test="save-source"]').attributes('disabled')).toBeDefined()
     expect(wrapper.find('[data-test="sync-save-first"]').exists()).toBe(false)
+    expect(wrapper.findAll('[data-test="discover-source"], [data-test="save-source"], [data-test="validate-source"], [data-test="sync-source"]').map(button => button.attributes('data-test'))).toEqual([
+      'discover-source',
+      'save-source',
+      'validate-source',
+      'sync-source',
+    ])
   })
 
   it('shows blank purchase ratio as band 6 and priority base plus 60', async () => {
@@ -495,10 +501,7 @@ describe('SupplierSourcesView', () => {
     list.mockResolvedValueOnce([source])
     sync.mockResolvedValueOnce({
       source_id: 7,
-      probe_results: [{
-        client_model_id: 'deepseek-v4-pro', upstream_model_id: 'deepseek-v4-pro',
-        status: 'passed', protocol: 'openai_chat_completions',
-      }],
+      probe_results: [],
       changes: [{
         account_id: 101, discount_band: 3, action: 'created',
         added_models: ['deepseek-v4-pro', 'qwen-3.7-max'], removed_models: [],
@@ -517,7 +520,8 @@ describe('SupplierSourcesView', () => {
     expect(result).toContain('qwen-3.7-max')
     expect(result).toContain('101')
     expect(result).toContain('created')
-    expect(result).toContain('passed')
+    expect(result).not.toContain('passed')
+    expect(result).not.toContain('admin.supplierSources.configuredProbes')
     expect(validate).not.toHaveBeenCalled()
   })
 

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -1996,7 +1996,10 @@
         "useNewApiChannelTypes",
         "supplierChannelTypeOptions",
         "item.channel_type === SUPPLIER_BAIDU_V2_CHANNEL_TYPE",
-        "@change=\"applyChannelTypeDefaultEndpoint(form.channel_type)\""
+        "@change=\"applyChannelTypeDefaultEndpoint(form.channel_type)\"",
+        "v-if=\"syncResult.probe_results.length\"",
+        "data-test=\"save-source\"",
+        "data-test=\"validate-source\""
       ],
       "must_not_contain": [
         "syncSucceeded = ref",
@@ -2006,7 +2009,7 @@
         "t('admin.supplierSources.description')",
         "text-2xl font-semibold"
       ],
-      "rationale": "The supplier page derives success from the current response, the current request error, and absence of failed_step. Discover polls async candidate jobs to completion; validate is a read-only preview; project displays the probe evidence returned by its own authoritative request without depending on prior validation state. Dirty or discover-backfilled drafts disable discover/validate/project. BaiduV2 remains an explicit supplier transport even though it is absent from NewAPI's generic model-fetch set, and catalog endpoint defaults apply only to operator channel changes so source hydration preserves persisted custom endpoints. Also anchors the full-bleed admin page shell (no max-w-7xl / mx-auto page chrome) so the layout stays aligned with Dashboard/RiskControl. Viewport-fill layout drops the in-page title/description shell (AppHeader owns the title) and stretches the list/editor workspace to the remaining main height."
+      "rationale": "The supplier page derives success from the current response, the current request error, and absence of failed_step. Discover polls async candidate jobs to completion; validate is a read-only preview; project writes accounts and hides an empty probe list. Dirty or discover-backfilled drafts disable discover/validate/project. Visible action order is discover, save, validate, project. BaiduV2 remains an explicit supplier transport even though it is absent from NewAPI's generic model-fetch set, and catalog endpoint defaults apply only to operator channel changes so source hydration preserves persisted custom endpoints. Also anchors the full-bleed admin page shell (no max-w-7xl / mx-auto page chrome) so the layout stays aligned with Dashboard/RiskControl. Viewport-fill layout drops the in-page title/description shell (AppHeader owns the title) and stretches the list/editor workspace to the remaining main height."
     },
     {
       "path": "frontend/src/api/admin/supplierSources.ts",
@@ -2016,9 +2019,11 @@
         "async function getDiscoverJob(id: number, jobId: string): Promise<SupplierSourceProbeResult>",
         "`/admin/supplier-sources/${id}/discover/jobs/${encodeURIComponent(jobId)}`",
         "async function validate(id: number): Promise<SupplierSourceValidateResult>",
-        "`/admin/supplier-sources/${id}/validate`"
+        "`/admin/supplier-sources/${id}/validate`",
+        "SUPPLIER_SOURCE_VALIDATE_TIMEOUT_MS = 300_000",
+        "{ timeout: SUPPLIER_SOURCE_VALIDATE_TIMEOUT_MS }"
       ],
-      "rationale": "Admin client must expose discover start + job poll, validate configured models, and project accounts via sync. Dropping poll forces synchronous long discovers behind the browser timeout again."
+      "rationale": "Admin client must expose discover start + job poll, validate configured models, and project accounts via sync. Validate keeps a long timeout because it probes every configured model; discover and project stay on the default client timeout. Dropping poll forces synchronous long discovers behind the browser timeout again."
     },
     {
       "path": "frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts",
@@ -2032,9 +2037,13 @@
         "contains no state machine, audit, activation, pause, or account-group controls",
         "polls a running probe job until completed without syncing",
         "shows probe failure message and failed_step outside the sync-result block",
-        "offers and hydrates BaiduV2 while preserving a custom endpoint during source selection"
+        "offers and hydrates BaiduV2 while preserving a custom endpoint during source selection",
+        "'discover-source'",
+        "'save-source'",
+        "'validate-source'",
+        "'sync-source'"
       ],
-      "rationale": "Focused UI regressions pin discover/validate/project workflow: save is side-effect free, unsaved edits block discover/validate/project, project renders account changes only, validate failures stay in validate panel, resolved failed_step cannot show success, async discover polling completes without auto-project, discover failures visible outside project block, BaiduV2 stays selectable without hydration overwriting custom endpoint, no state machine or account-group controls. Also pins the full-bleed page-shell regression. Also pins viewport-fill layout without an in-page title shell."
+      "rationale": "Focused UI regressions pin discover/save/validate/project workflow: save is side-effect free, unsaved edits block discover/validate/project, project renders account changes without probe rows, validate failures stay in validate panel, resolved failed_step cannot show success, async discover polling completes without auto-project, discover failures visible outside project block, visible button order is discover then save then validate then project, BaiduV2 stays selectable without hydration overwriting custom endpoint, no state machine or account-group controls. Also pins the full-bleed page-shell regression. Also pins viewport-fill layout without an in-page title shell."
     },
     {
       "path": "frontend/src/composables/useSupplierManagedAccount.ts",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7863,12 +7863,12 @@
         "TestUS048_SupplierSyncEarlyErrorsAlwaysReportFailedStep",
         "TestUS048_SupplierSyncAdditionFailureStopsBeforeRemovalAndRetryConverges",
         "TestUS048_SupplierSyncReadbackFailureReportsTheCompletedAddition",
-        "TestUS048_SupplierSyncProbeFailureReturnsEveryResultAndWritesNothing",
+        "TestUS048_SupplierSyncProjectsEvenWhenValidateWouldFail",
         "TestUS048_NonActiveExactAccountMatchBlocksDuplicateSupplierAccountCreation",
         "TestUS048_IncompatibleTransportExactMatchDoesNotBlockParallelProjection",
         "TestUS048_MultiBandExactAccountMatchBlocksDuplicateSupplierAccountCreation",
-        "TestUS048_SupplierSyncReprobesBeforeRepairingNonEmptySchedulingProjection",
-        "TestUS048_SupplierSyncReprobesImmediatelyBeforeProjection",
+        "TestUS048_SupplierSyncRepairsNonEmptySchedulingProjectionWithoutProbe",
+        "TestUS048_SupplierSyncProjectsWithoutCallingProbe",
         "TestUS048_SupplierSyncRepairsEmptySchedulingProjectionWithoutProbe",
         "TestSupplierAccountNeedsProtocolRepublishDetectsTransportDrift",
         "TestUS048_OpenAISupplierAccountsDoNotBlockAnthropicParallelSourceSync",
@@ -7876,7 +7876,7 @@
         "TestUS048_IncompatibleTransportCandidatesAreIgnoredForOpenAISupplier",
         "TestUS048_QianfanBaiduV2ExactMatchIsAdopted"
       ],
-      "rationale": "Sync regressions keep failed_step and completed changes present on early and mid-write errors, preserve successful additions, stop pending removals and prove retry convergence. They also block duplicate creation whenever an exact account match cannot satisfy the narrow adoption contract, including disabled/error accounts and multi-band sources, require an immediate reprobe before structural projection or repair, and keep empty-band scheduling repair on the metadata-only path. Transport-incompatible credential matches are ignored; same-transport other-source managed accounts still conflict."
+      "rationale": "Sync regressions keep failed_step and completed changes present on early and mid-write errors, preserve successful additions, stop pending removals and prove retry convergence. They also block duplicate creation whenever an exact account match cannot satisfy the narrow adoption contract, including disabled/error accounts and multi-band sources. Project writes managed accounts without probing; validate owns configured-model probes. Empty-band scheduling repair stays on the metadata-only path. Transport-incompatible credential matches are ignored; same-transport other-source managed accounts still conflict."
     },
     {
       "path": "backend/internal/service/crs_sync_supplier_managed_test.go",
@@ -7955,7 +7955,10 @@
         "ChannelType:           source.ChannelType,",
         "relevantMatches := make([]*Account, 0, len(matches))"
       ],
-      "rationale": "Supplier sync repairs managed-account concurrency through the narrow concurrency write, while transport or capability identity drift enters the normal real-probe path before any full projection republishes protocol evidence. Adoption candidates are already transport-scoped by FindCredentialEndpointMatches(channel_type); sync only skips this source's managed accounts before adopt/conflict."
+      "must_not_contain": [
+        "result.ProbeResults = s.probeSupplierTargets"
+      ],
+      "rationale": "Supplier sync repairs managed-account concurrency through the narrow concurrency write. Transport or capability identity drift is repaired by projection writes that declare channel_type protocol capability without a live model probe. Adoption candidates are already transport-scoped by FindCredentialEndpointMatches(channel_type); sync only skips this source's managed accounts before adopt/conflict."
     },
     {
       "path": "backend/internal/service/supplier_source_account_store.go",


### PR DESCRIPTION
## 摘要
- 发现、保存、校验、投影四个动作正交：探测只属于校验模型，投影只写受管账号。
- 管理页按钮顺序改为发现模型 → 保存 → 校验模型 → 投影账号。
- 校验请求单独放宽到 5 分钟超时；发现/投影仍走默认超时。
- 同 PR 修订审批基线、US-048 与 sentinel。

## 风险
- 常规偏高：投影不再把当次模型探测当写入门禁，未先校验也可直接写账号。
- 审批锚点：`docs/approved/model-supplier-source-probe-sync-split.md`、`docs/approved/model-supplier-source-management.md`。
- 非空 mapping 仍按 `channel_type` 声明协议能力后写入。

## 验证
- `./scripts/preflight.sh` PASS
- `go test -tags=unit ./internal/service -run 'US048|SupplierSource|Probe|Discover|Validate'`
- `go test -tags=unit ./internal/handler/admin ./internal/server/routes -run 'US048|SupplierSource'`
- `pnpm exec vitest run src/views/admin/__tests__/SupplierSourcesView.spec.ts src/api/__tests__/admin.supplierSources.spec.ts`
- `pnpm exec playwright test e2e/us048-supplier-source-management.e2e.ts --project=chromium`（4 passed）

## 提交
- `b5ff9f1c3` fix(supplier): 投影账号与校验模型正交，不再在写入前探测
- `976633f5e` chore: 刷新嵌入前端 dist 源哈希
- 最新提交：`976633f5e`

Made with [Cursor](https://cursor.com)