### PR TITLE
chore(ssot): 清理 TokenKey 过时引用

### DIFF
--- a/backend/ent/schema/qa_record.go
+++ b/backend/ent/schema/qa_record.go
@@ -55,7 +55,7 @@ func (QARecord) Fields() []ent.Field {
 		field.String("redaction_version").Default("logredact-v2"),
 		field.String("capture_status").Default("captured"),
 		field.JSON("tags", []string{}).Default([]string{}),
-		// Synthetic-pipeline tagging (issue #59 / docs/projects/auto-traj-from-supply-demand.md §6.1).
+		// Synthetic-pipeline tagging (issue #59 contract).
 		// All four fields are nullable / have defaults so existing online callers are NOT affected.
 		// Populated by qa.Middleware from request headers X-Synth-Session, X-Synth-Role,
 		// X-Synth-Engineer-Level, X-Synth-Pipeline; absent for normal traffic (non-synth).

--- a/backend/internal/observability/qa/middleware_synth_test.go
+++ b/backend/internal/observability/qa/middleware_synth_test.go
@@ -7,8 +7,7 @@ package qa
 // directly because the full Middleware path requires a wired APIKey
 // auth subject (covered by the integration tests). Pinning the
 // extractor here catches accidental rename/typo of the header names
-// (the M0 client writes these literal names per
-// docs/projects/auto-traj-from-supply-demand.md §6.1).
+// (the M0 client writes these literal names per the issue #59 contract).
 
 import (
 	"bytes"

--- a/backend/internal/observability/qa/service.go
+++ b/backend/internal/observability/qa/service.go
@@ -933,8 +933,7 @@ func captureStreamFlag(c *gin.Context, chunks []RawSSEChunk) bool {
 }
 
 // captureSynthHeaders extracts the X-Synth-* headers emitted by the M0
-// dual-CC synthetic pipeline (issue #59 /
-// docs/projects/auto-traj-from-supply-demand.md §6.1). Returns
+// dual-CC synthetic pipeline (issue #59 contract). Returns
 // (session, role, engineerLevel, dialogSynth). dialogSynth is true when
 // EITHER X-Synth-Session OR X-Synth-Pipeline is present — that pair is
 // our "this turn is a synth dialog" signal; the pipeline name itself is

--- a/backend/internal/server/routes/edge_tk_routes.go
+++ b/backend/internal/server/routes/edge_tk_routes.go
@@ -12,8 +12,8 @@ import (
 //
 //	GET /api/v1/edge/scheduling-capacity?platform=anthropic
 //
-// It is the read side of surface C (per docs/CLAUDE.md fifth-platform notes /
-// the anthropic-config plan): prod's reconciler calls it over HTTP to mirror a
+// It is the read side of the Anthropic config reconciliation surface C:
+// prod's reconciler calls it over HTTP to mirror a
 // live edge's Σ schedulable concurrency onto the prod stub account, using the
 // stub's already-held relay api-key (zero new secret).
 //

--- a/docs/approved/README.md
+++ b/docs/approved/README.md
@@ -2,7 +2,7 @@
 title: Approved docs index
 status: approved
 approved_by: "docs cleanup 2026-07-09"
-revised_at: 2026-09-01
+revised_at: 2026-09-03
 ---
 
 # Approved docs index
@@ -10,6 +10,12 @@ revised_at: 2026-09-01
 `docs/approved/` is the approval baseline for high-risk work. These files are
 load-bearing: code comments, sentinels, migrations, and preflight checks refer
 to their paths. Prefer status changes and short index notes over moving files.
+
+Published migration files are immutable. A historical migration may retain a
+reference to a retired design document; treat that path as migration history
+and do not restore the retired document or edit the migration to rewrite it.
+This applies to the legacy references in `tk_006_add_qa_records_synth_fields.sql`
+and `tk_054_qwen_glm_dashscope_model_mapping.sql`.
 
 Status vocabulary is enforced by `dev-rules/scripts/check_approved_docs.py`:
 `draft`, `pending`, `approved`, `shipped`, `archived`.
@@ -51,6 +57,8 @@ Watchlist 机器源：`ops/pricing/servable-reprobe-ledger.json`。
 
 | File | Topic |
 | --- | --- |
+| [`gateway-failover-policy-ssot.md`](gateway-failover-policy-ssot.md) | Gateway failover decision owner |
+| [`openai-compat-first-selection-failure.md`](openai-compat-first-selection-failure.md) | OpenAI-compatible first-selection failure contract |
 | [`universal-key-routing.md`](universal-key-routing.md) | Universal key routing |
 | [`universal-key-capability-discovery.md`](universal-key-capability-discovery.md) | Per-key protocol/operation discovery |
 | [`grok-relay-first-class-platform.md`](grok-relay-first-class-platform.md) | Grok relay platform |

--- a/docs/approved/newapi-as-fifth-platform.md
+++ b/docs/approved/newapi-as-fifth-platform.md
@@ -351,7 +351,7 @@ go test -tags=integration -run 'TestUS00[89]_|TestUS01[0-5]_' ./backend/internal
 
 ## 11. 实施情况（2026-04-19 ~ 2026-04-20）
 
-PR：[`feature/newapi-fifth-platform → main`](https://github.com/youxuanxue/sub2api/pull/) — 待开。
+PR：[`feature/newapi-fifth-platform → main`](https://github.com/youxuanxue/sub2api/pull/10) — 已于 2026-04-20 合并。
 
 ### 11.1 提交序列（review 顺序）
 

--- a/docs/operator/gcp-trial-vertex-onboarding.md
+++ b/docs/operator/gcp-trial-vertex-onboarding.md
@@ -60,7 +60,7 @@ Imagen / Veo **必须**走下面「推荐路径」；不要用 AI Studio API key
 - **可服务模型**：选择 **Vertex AI（channel_type 41）** 后，Admin 会**自动**从 `GET /api/v1/admin/channel-type-models` 读取 TokenKey Vertex 实测可服务清单并填入模型白名单（chat + Imagen + Veo，与 `supportedGeminiCatalogModels` 同源）。运营**无需手打**模型 ID；若要裁剪，在自动填充后取消勾选即可。
 - 也可点 **「获取模型列表」** 重新拉取同一预设（ch41 不走上游 GET /v1/models，无需 Base URL / API Key）。
 
-> 清单随 TokenKey 实测 allowlist 演进；勿填 `gemini-2.0-flash`、`gemini-3.x` 等未收录 ID。inventory 见 `docs/all-platform-model-inventory.md` §2.3。
+> 清单随 TokenKey 实测 allowlist 演进；勿填 `gemini-2.0-flash`、`gemini-3.x` 等未收录 ID。以 Admin 当前自动填充结果为准，不要依据历史清单手填。
 
 ### 3. 粘贴 Service Account JSON
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -2509,7 +2509,7 @@ fi
 
 # ---- sub2api: display-coverage audit selftest -------------------------------
 # Static display ownership is already enforced repository-wide by
-# catalog-serving-drift A4. This audit is the read-only live close-out: it checks
+# catalog-serving-drift static check. This audit is the read-only live close-out: it checks
 # that complete-registry + allowlist expectations reached public /pricing.
 echo ""
 echo "=== sub2api: display-coverage audit selftest ==="

--- a/scripts/release-bump-and-tag.sh
+++ b/scripts/release-bump-and-tag.sh
@@ -13,8 +13,7 @@
 # Flow (driven by scripts/release-decide-version.sh):
 #   action=skip-bump-skip-tag → nothing to do; exit 0 (deploy the existing tag).
 #   action=tag-only           → tag origin/main from an ephemeral worktree.
-#   action=bump-and-tag       → in the worktree: write VERSION, sync
-#                               endpoint-compat baseline anchor, commit
+#   action=bump-and-tag       → in the worktree: write VERSION, commit
 #                               "chore: bump VERSION to X.Y.Z" (pre-commit
 #                               preflight runs against the clean worktree),
 #                               push origin HEAD:main, then tag.
@@ -146,7 +145,7 @@ if [ "$ACTION" = "bump-and-tag" ]; then
   # (CLAUDE.md §9.2); release-tag.sh re-validates this before tagging.
   git -C "$WT_DIR" commit -m "chore: bump VERSION to $NEXT_VERSION
 
-Sync endpoint-compat baseline runtime anchor for release.yml gate.
+Release VERSION bump.
 no-web-impact"
   echo "[release-bump-and-tag] pushing bump commit to origin/main"
   PUSH_ERR=""


### PR DESCRIPTION
摘要
- 清理模型交付 SSOT 相关的已删除文档引用、旧发布说明和过时检查注释。
- 补齐 gateway failover 与 OpenAI-compatible first-selection failure 两个 approved SSOT 文档索引。
- 明确已发布 migration 的历史死链接不可改写，保留线上迁移字节不变。
- 保留现行模型 SSOT owner、工具和 sentinel，不拆分内部结构。

风险
- 仅修改文档、注释和发布事实描述，不改变线上服务、API、路由、数据库 schema 或部署行为。
- 已发布 migration 未修改。
- `edge_tk_routes.go` 仅修正文档注释路径；已审查 gateway sentinel，无需新增语义锚点（sentinel-registry-reviewed）。

验证
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：PASS（提交后 HEAD `4bfc89a7d`）。
- `git diff --check`：PASS。
- 过时路径/空 PR 链接扫描：无命中。
- migration immutability：PASS。

提交（origin/main..HEAD）
- `70c020a72 chore(ssot): remove stale TokenKey references no-web-impact`
- `4bfc89a7d chore(ssot): finish stale TokenKey references no-web-impact`

最新提交：`4bfc89a7d`

标记
- `no-web-impact`
- `upstream-touch-trivial`
- `sentinel-registry-reviewed`