### PR TITLE
fix(openrouter): OR gemini image 按模型 id 选路 (no-web-impact)

### DIFF
--- a/backend/internal/handler/gateway_handler_tk_openrouter_provider_media.go
+++ b/backend/internal/handler/gateway_handler_tk_openrouter_provider_media.go
@@ -101,7 +101,7 @@ func (h *Handlers) OpenRouterProviderImages(c *gin.Context) {
 	}
 
 	model := strings.TrimSpace(gjsonGetString(body, "model"))
-	route := service.OpenRouterProviderImageRoute(openRouterProviderGroupPlatform(c), model)
+	route := service.OpenRouterProviderImageRoute(model)
 
 	var (
 		forwardBody       []byte
@@ -145,14 +145,6 @@ func (h *Handlers) OpenRouterProviderImages(c *gin.Context) {
 		return
 	}
 	c.Data(status, "application/json", orBody)
-}
-
-func openRouterProviderGroupPlatform(c *gin.Context) string {
-	apiKey, ok := middleware2.GetAPIKeyFromContext(c)
-	if !ok || apiKey == nil || apiKey.Group == nil {
-		return ""
-	}
-	return strings.TrimSpace(apiKey.Group.Platform)
 }
 
 // OpenRouterProviderVideoSubmit serves POST /openrouter/v1/videos for OpenRouter provider inference.

--- a/backend/internal/service/openrouter_provider_tk_media.go
+++ b/backend/internal/service/openrouter_provider_tk_media.go
@@ -23,19 +23,29 @@ const (
 
 var openRouterChatCompletionDataURIRe = regexp.MustCompile(`data:([^;)\s]+);base64,([A-Za-z0-9+/=]+)`)
 
-// OpenRouterProviderImageRoute picks the backend pipeline after universal routing has
-// bound the inference key to a concrete group platform.
+// OpenRouterProviderImageRoute picks the backend pipeline for OR seller POST /v1/images.
+// Route by model identity (after stripping public tokenkey/ prefix). Do NOT require
+// apiKey.Group.Platform: OR inference keys are universal (group_id NULL) and platform
+// is only known after later universal routing — waiting on Group.Platform sent every
+// gemini-*-image request down the OpenAI images path as "Unsupported model".
 func OpenRouterProviderImageRoute(platform, model string) OpenRouterImageRoute {
-	platform = strings.TrimSpace(platform)
-	model = strings.TrimSpace(model)
+	_ = platform // retained for call-site compatibility; model id is the SSOT
+	model = openRouterProviderImageRouteModelID(model)
 	switch {
-	case platform == PlatformAntigravity && antigravity.IsImageModel(model):
+	case antigravity.IsImageModel(model):
 		return OpenRouterImageRouteAntigravityChat
-	case platform == PlatformGrok && isGrokImageGenerationModel(model):
+	case isGrokImageGenerationModel(model):
 		return OpenRouterImageRouteGrok
 	default:
 		return OpenRouterImageRouteOpenAICompat
 	}
+}
+
+func openRouterProviderImageRouteModelID(model string) string {
+	model = strings.TrimSpace(model)
+	model = strings.TrimPrefix(model, "tokenkey/")
+	model = strings.TrimPrefix(model, "models/")
+	return model
 }
 
 // TranslateOpenRouterImageToChatCompletions maps OR POST /v1/images to OpenAI chat

--- a/backend/internal/service/openrouter_provider_tk_media.go
+++ b/backend/internal/service/openrouter_provider_tk_media.go
@@ -24,12 +24,11 @@ const (
 var openRouterChatCompletionDataURIRe = regexp.MustCompile(`data:([^;)\s]+);base64,([A-Za-z0-9+/=]+)`)
 
 // OpenRouterProviderImageRoute picks the backend pipeline for OR seller POST /v1/images.
-// Route by model identity (after stripping public tokenkey/ prefix). Do NOT require
+// Route by model identity (after stripping public tokenkey/ prefix). Do NOT use
 // apiKey.Group.Platform: OR inference keys are universal (group_id NULL) and platform
 // is only known after later universal routing — waiting on Group.Platform sent every
 // gemini-*-image request down the OpenAI images path as "Unsupported model".
-func OpenRouterProviderImageRoute(platform, model string) OpenRouterImageRoute {
-	_ = platform // retained for call-site compatibility; model id is the SSOT
+func OpenRouterProviderImageRoute(model string) OpenRouterImageRoute {
 	model = openRouterProviderImageRouteModelID(model)
 	switch {
 	case antigravity.IsImageModel(model):

--- a/backend/internal/service/openrouter_provider_tk_media_test.go
+++ b/backend/internal/service/openrouter_provider_tk_media_test.go
@@ -21,6 +21,25 @@ func TestOpenRouterProviderImageRoute(t *testing.T) {
 	}
 }
 
+func TestOpenRouterProviderImageRoute_UniversalKeyIgnoresEmptyPlatform(t *testing.T) {
+	// Repro: OR inference api_keys.group_id IS NULL → Group.Platform "".
+	if got := OpenRouterProviderImageRoute("", "tokenkey/gemini-2.5-flash-image"); got != OpenRouterImageRouteAntigravityChat {
+		t.Fatalf("tokenkey-prefixed gemini image with empty platform=%q", got)
+	}
+	if got := OpenRouterProviderImageRoute("", "tokenkey/gemini-3-pro-image"); got != OpenRouterImageRouteAntigravityChat {
+		t.Fatalf("pro-image=%q", got)
+	}
+	if got := OpenRouterProviderImageRoute(PlatformOpenAI, "tokenkey/gemini-3.1-flash-image"); got != OpenRouterImageRouteAntigravityChat {
+		t.Fatalf("wrong bound platform must not force openai path=%q", got)
+	}
+	if got := OpenRouterProviderImageRoute("", "tokenkey/grok-imagine-image"); got != OpenRouterImageRouteGrok {
+		t.Fatalf("tokenkey-prefixed grok image=%q", got)
+	}
+	if got := OpenRouterProviderImageRoute("", "tokenkey/imagen-4.0-fast-generate-001"); got != OpenRouterImageRouteOpenAICompat {
+		t.Fatalf("imagen stays openai-compat=%q", got)
+	}
+}
+
 func TestTranslateOpenRouterImageToChatCompletions(t *testing.T) {
 	body := []byte(`{"model":"gemini-2.5-flash-image","prompt":"a cat","aspect_ratio":"16:9"}`)
 	out, err := TranslateOpenRouterImageToChatCompletions(body)

--- a/backend/internal/service/openrouter_provider_tk_media_test.go
+++ b/backend/internal/service/openrouter_provider_tk_media_test.go
@@ -7,35 +7,35 @@ import (
 )
 
 func TestOpenRouterProviderImageRoute(t *testing.T) {
-	if got := OpenRouterProviderImageRoute(PlatformAntigravity, "gemini-2.5-flash-image"); got != OpenRouterImageRouteAntigravityChat {
+	if got := OpenRouterProviderImageRoute("gemini-2.5-flash-image"); got != OpenRouterImageRouteAntigravityChat {
 		t.Fatalf("antigravity gemini image=%q", got)
 	}
-	if got := OpenRouterProviderImageRoute(PlatformGrok, "grok-imagine-image"); got != OpenRouterImageRouteGrok {
+	if got := OpenRouterProviderImageRoute("grok-imagine-image"); got != OpenRouterImageRouteGrok {
 		t.Fatalf("grok image=%q", got)
 	}
-	if got := OpenRouterProviderImageRoute(PlatformNewAPI, "imagen-4.0-fast-generate-001"); got != OpenRouterImageRouteOpenAICompat {
+	if got := OpenRouterProviderImageRoute("imagen-4.0-fast-generate-001"); got != OpenRouterImageRouteOpenAICompat {
 		t.Fatalf("imagen=%q", got)
 	}
-	if got := OpenRouterProviderImageRoute(PlatformAntigravity, "gemini-2.5-flash"); got != OpenRouterImageRouteOpenAICompat {
+	if got := OpenRouterProviderImageRoute("gemini-2.5-flash"); got != OpenRouterImageRouteOpenAICompat {
 		t.Fatalf("antigravity text=%q", got)
 	}
 }
 
 func TestOpenRouterProviderImageRoute_UniversalKeyIgnoresEmptyPlatform(t *testing.T) {
-	// Repro: OR inference api_keys.group_id IS NULL → Group.Platform "".
-	if got := OpenRouterProviderImageRoute("", "tokenkey/gemini-2.5-flash-image"); got != OpenRouterImageRouteAntigravityChat {
-		t.Fatalf("tokenkey-prefixed gemini image with empty platform=%q", got)
+	// Repro: OR inference api_keys.group_id IS NULL; route must not depend on Group.Platform.
+	if got := OpenRouterProviderImageRoute("tokenkey/gemini-2.5-flash-image"); got != OpenRouterImageRouteAntigravityChat {
+		t.Fatalf("tokenkey-prefixed gemini image=%q", got)
 	}
-	if got := OpenRouterProviderImageRoute("", "tokenkey/gemini-3-pro-image"); got != OpenRouterImageRouteAntigravityChat {
+	if got := OpenRouterProviderImageRoute("tokenkey/gemini-3-pro-image"); got != OpenRouterImageRouteAntigravityChat {
 		t.Fatalf("pro-image=%q", got)
 	}
-	if got := OpenRouterProviderImageRoute(PlatformOpenAI, "tokenkey/gemini-3.1-flash-image"); got != OpenRouterImageRouteAntigravityChat {
-		t.Fatalf("wrong bound platform must not force openai path=%q", got)
+	if got := OpenRouterProviderImageRoute("tokenkey/gemini-3.1-flash-image"); got != OpenRouterImageRouteAntigravityChat {
+		t.Fatalf("flash-image=%q", got)
 	}
-	if got := OpenRouterProviderImageRoute("", "tokenkey/grok-imagine-image"); got != OpenRouterImageRouteGrok {
+	if got := OpenRouterProviderImageRoute("tokenkey/grok-imagine-image"); got != OpenRouterImageRouteGrok {
 		t.Fatalf("tokenkey-prefixed grok image=%q", got)
 	}
-	if got := OpenRouterProviderImageRoute("", "tokenkey/imagen-4.0-fast-generate-001"); got != OpenRouterImageRouteOpenAICompat {
+	if got := OpenRouterProviderImageRoute("tokenkey/imagen-4.0-fast-generate-001"); got != OpenRouterImageRouteOpenAICompat {
 		t.Fatalf("imagen stays openai-compat=%q", got)
 	}
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6748,11 +6748,10 @@
         "OpenRouterProviderVideoSubmit",
         "OpenRouterProviderVideoFetch",
         "OpenRouterProviderImageRoute",
-        "openRouterProviderGroupPlatform",
         "TranslateOpenRouterImageRequestToOpenAI",
         "BuildOpenRouterVideoSubmitResponse"
       ],
-      "rationale": "OpenRouter seller image/video inference adapters: OR JSON ↔ internal handlers with platform dispatch (antigravity chat for gemini-*-image, grok/openai-compat otherwise) and OR response shapes (b64_json images, 202 video submit + poll)."
+      "rationale": "OpenRouter seller image/video inference adapters: OR JSON ↔ internal handlers with model-id dispatch (antigravity chat for gemini-*-image, grok/openai-compat otherwise) and OR response shapes (b64_json images, 202 video submit + poll)."
     },
     {
       "path": "backend/internal/service/openrouter_provider_tk_media.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6758,6 +6758,7 @@
       "path": "backend/internal/service/openrouter_provider_tk_media.go",
       "must_contain": [
         "OpenRouterProviderImageRoute",
+        "openRouterProviderImageRouteModelID",
         "TranslateOpenRouterImageToChatCompletions",
         "TranslateChatCompletionsImageResponseToOpenRouter",
         "TranslateOpenRouterImageRequestToOpenAI",
@@ -6765,7 +6766,7 @@
         "TranslateOpenRouterVideoRequestToOpenAI",
         "TranslateOpenAIVideoFetchToOpenRouter"
       ],
-      "rationale": "Pure translation layer for OpenRouter provider image/video protocol compliance; gemini-native image maps OR /v1/images ↔ antigravity chat generateContent, other models stay on OpenAI-compat paths."
+      "rationale": "Pure translation layer for OpenRouter provider image/video protocol compliance; OR image route picks pipeline by bare model id (strip tokenkey/) so universal inference keys skip Group.Platform; gemini-native image maps OR /v1/images ↔ antigravity chat generateContent, other models stay on OpenAI-compat paths."
     },
     {
       "path": "backend/internal/service/openrouter_provider_tk_policy.go",


### PR DESCRIPTION
## 摘要

- 修复 OpenRouter seller `POST /v1/images` 对 `tokenkey/gemini-*-image` 返回 400 `Unsupported model` 的问题。
- 根因：OR 推理 key 为万能 key（`group_id NULL`），`OpenRouterProviderImageRoute` 依赖 `Group.Platform`，platform 为空时一律走 OpenAI images；且 `tokenkey/` 前缀未剥除导致 `IsImageModel` 不匹配。
- 改为按剥前缀后的模型 id 选路：gemini image → antigravity chat；grok image → grok；其余 → openai-compat。
- xj-review R-001：去掉已无用的 `platform` 形参与 `openRouterProviderGroupPlatform`，同步 sentinel。

## 风险

- 常规风险，仅影响 OR seller image 路由；客户网关 `/v1/*` 不变。
- Imagen 404 为 Vertex 项目权限问题，本 PR 不覆盖。

## 验证

```bash
cd backend && go test -tags=unit ./internal/service -run 'OpenRouterProviderImageRoute|TranslateOpenRouterImage'
# ok

./scripts/preflight.sh
# PASS
```

合并发版后建议重跑 `ops/pricing/probe-openrouter-provider-chain.py --via-ssm` 验证 gemini image。

## 提交

- b847dfe fix(openrouter): OR gemini image 按模型 id 选路，不依赖 Group.Platform (no-web-impact)
- 8c32736f0 fix(openrouter): address R-001 — 去掉死参 platform 与 Group.Platform helper (no-web-impact)

最新提交：8c32736f0