### PR TITLE
fix: 修正视频供应源投影并新增发布后一致性检查

### DIFF
--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -499,6 +499,19 @@ jobs:
           set -euo pipefail
           bash ops/observability/endpoint-compat-audit.sh --ssot-model-matrix --gate --deploy-canary --deploy-closeout
 
+      - name: Post-deploy supplier projection check (read-only)
+        # ADVISORY ONLY: supplier/account config drift is reported after release,
+        # while status and schedulable remain scheduler-owned runtime state.
+        continue-on-error: true  # preflight-allow: advisory post-release drift report
+        env:
+          INSTANCE_ID: ${{ steps.instance.outputs.id }}
+        run: |
+          set -euo pipefail
+          bash ops/observability/check-supplier-projection.sh \
+            --target prod \
+            --expected-instance-id "$INSTANCE_ID" \
+            --timeout-seconds 180
+
       # Same deploy job: reuse the already-approved prod Environment + OIDC.
       # A second job with environment: prod would re-open Required reviewers
       # and start the +5min clock after that gate, not after cutover.

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -948,8 +948,12 @@ func (r *accountRepository) UpdateSupplierProjection(ctx context.Context, accoun
 	if err != nil {
 		return err
 	}
+	capabilityInput, err := service.BuildProtocolEndpointCapabilityLinkInput(updatedAccount)
+	if err != nil {
+		return err
+	}
 	protocolPublished := false
-	if len(updatedAccount.GetModelMapping()) > 0 {
+	if len(updatedAccount.GetModelMapping()) > 0 && capabilityInput.Governed {
 		protocolPublished, err = publishVerifiedSupplierProtocolCapability(
 			ctx,
 			r.protocolCapabilityRepository(ctx),

--- a/backend/internal/repository/account_repo_supplier_projection_test.go
+++ b/backend/internal/repository/account_repo_supplier_projection_test.go
@@ -141,6 +141,68 @@ func TestUS048_SupplierConfigurationRepositoryRejectsUnverifiedNonEmptyMapping(t
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestUS048_SupplierMediaProjectionUnlinksStaleTextCapability(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	client := dbent.NewClient(dbent.Driver(entsql.OpenDB(dialect.Postgres, db)))
+	t.Cleanup(func() { _ = client.Close() })
+	repo := newAccountRepositoryWithSQL(client, db, nil, nil)
+
+	credentials := map[string]any{
+		"api_key":                      "secret",
+		"base_url":                     "https://www.fmgo.top",
+		"protocol_endpoints_exclusive": true,
+		"api_base_urls": map[string]any{
+			"chat_completions": "https://www.fmgo.top",
+		},
+		"model_mapping": map[string]any{
+			"doubao-seedance-2-0-260128": "feimiao-v2-431-720p-15s",
+		},
+	}
+	credentialJSON, err := json.Marshal(credentials)
+	require.NoError(t, err)
+	account := &service.Account{
+		ID: 41, Name: "FMGo/seedance · 档位 3",
+		Platform: service.PlatformNewAPI, Type: service.AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeDoubaoVideo,
+		Credentials: credentials,
+		Extra: map[string]any{
+			service.SupplierSourceIDExtraKey:     int64(10),
+			service.SupplierDiscountBandExtraKey: 3,
+		},
+		Priority: 130, Status: service.StatusActive, Schedulable: true, Concurrency: 1000,
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`(?s)UPDATE accounts\s+SET\s+name = \$1,\s+platform = \$2,\s+type = \$3,\s+channel_type = \$4,\s+credentials = \$5::jsonb,\s+extra = COALESCE\(extra, '\{\}'::jsonb\) \|\| \$6::jsonb,\s+priority = \$7,\s+status = \$8,\s+schedulable = \$9,\s+concurrency = \$10,\s+updated_at = NOW\(\)\s+WHERE id = \$11 AND deleted_at IS NULL`).
+		WithArgs(
+			account.Name, account.Platform, account.Type, account.ChannelType,
+			string(credentialJSON), `{"supplier_discount_band":3,"supplier_source_id":10}`,
+			account.Priority, account.Status, account.Schedulable, account.Concurrency, account.ID,
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery(`(?s)SELECT id, platform, type, credentials, extra, channel_type, protocol_endpoint_capability_id.*FOR UPDATE`).
+		WithArgs(account.ID).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "platform", "type", "credentials", "extra", "channel_type", "protocol_endpoint_capability_id",
+		}).AddRow(
+			account.ID, account.Platform, account.Type, string(credentialJSON),
+			`{"supplier_discount_band":3,"supplier_source_id":10}`, account.ChannelType, int64(9),
+		))
+	mock.ExpectExec(`(?s)UPDATE accounts\s+SET protocol_endpoint_capability_id=NULL,\s+extra=jsonb_set`).
+		WithArgs(account.ID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO scheduler_outbox")).
+		WithArgs(service.SchedulerOutboxEventAccountChanged, account.ID, nil, nil, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err = repo.UpdateSupplierProjection(context.Background(), account, true)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestUS048_SupplierVerifiedProtocolForAnthropicIsMessages(t *testing.T) {
 	require.Equal(t, protocolrouter.ProtocolMessages, supplierVerifiedProtocolForAccount(&service.Account{
 		ChannelType: newapiconstant.ChannelTypeAnthropic,

--- a/backend/internal/service/protocol_probe_model_tk.go
+++ b/backend/internal/service/protocol_probe_model_tk.go
@@ -136,6 +136,9 @@ func protocolRoutingAccountHasNoTextModels(account *Account) bool {
 	if account == nil {
 		return false
 	}
+	if account.ChannelType == newapiconstant.ChannelTypeDoubaoVideo {
+		return true
+	}
 	if isNewAPIXRTokenAccount(account) {
 		return true
 	}

--- a/backend/internal/service/protocol_routing_migration_test.go
+++ b/backend/internal/service/protocol_routing_migration_test.go
@@ -387,6 +387,21 @@ func TestProtocolRoutingMediaOnlyClassificationExcludesKnownImageAliases(t *test
 	}
 }
 
+func TestProtocolRoutingMediaOnlyClassificationExcludesVideoChannelVendorSKU(t *testing.T) {
+	account := &Account{
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeDoubaoVideo,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{"video-client": "private-vendor-sku"},
+		},
+	}
+
+	if !protocolRoutingAccountHasNoTextModels(account) {
+		t.Fatal("channel 54 vendor SKU entered text protocol governance")
+	}
+}
+
 func TestProtocolRoutingMigrationReportFailsCutoverWhenRouterMissing(t *testing.T) {
 	repo := &protocolRoutingMigrationRepo{accounts: []Account{{
 		ID:       9,

--- a/backend/internal/service/supplier_source_service.go
+++ b/backend/internal/service/supplier_source_service.go
@@ -602,10 +602,6 @@ func supplierAccountNeedsProtocolRepublish(account *Account, sourceEndpoint stri
 	if account == nil || len(supplierModelMapping(account.Credentials)) == 0 {
 		return false
 	}
-	// Migrate legacy managed credentials that still fan identity from bare base_url.
-	if !accountDeclaresExclusiveProtocolEndpoints(account) {
-		return true
-	}
 	want, err := resolveSupplierManagedTransport(sourceEndpoint, sourceChannelType)
 	if err != nil {
 		return true
@@ -618,7 +614,16 @@ func supplierAccountNeedsProtocolRepublish(account *Account, sourceEndpoint stri
 		return true
 	}
 	identity, governed, err := BuildProtocolEndpointIdentity(account)
-	if err != nil || !governed {
+	if err != nil {
+		return true
+	}
+	if !governed {
+		// Media-only accounts intentionally have no text protocol identity. A stale
+		// link still needs one projection write so the repository can unlink it.
+		return account.ProtocolEndpointCapabilityID != nil || account.ProtocolEndpointCapability != nil
+	}
+	// Migrate legacy text credentials that still fan identity from bare base_url.
+	if !accountDeclaresExclusiveProtocolEndpoints(account) {
 		return true
 	}
 	if account.ProtocolEndpointCapability != nil &&

--- a/backend/internal/service/supplier_source_sync_test.go
+++ b/backend/internal/service/supplier_source_sync_test.go
@@ -1081,3 +1081,37 @@ func TestSupplierAccountNeedsProtocolRepublishDetectsLegacyNonExclusiveCredentia
 	}
 	require.False(t, supplierAccountNeedsProtocolRepublish(migrated, "https://supplier.example/v1", 1))
 }
+
+func TestSupplierAccountNeedsProtocolRepublishSkipsAlignedMediaOnlyAccount(t *testing.T) {
+	account := &Account{
+		Platform: PlatformNewAPI, Type: AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeDoubaoVideo,
+		Credentials: supplierManagedCredentials(
+			"https://www.fmgo.top", "secret",
+			map[string]string{"doubao-seedance-2-0-260128": "feimiao-v2-431-720p-15s"},
+			newapiconstant.ChannelTypeDoubaoVideo,
+		),
+	}
+
+	require.False(t, supplierAccountNeedsProtocolRepublish(
+		account, "https://www.fmgo.top", newapiconstant.ChannelTypeDoubaoVideo,
+	))
+}
+
+func TestSupplierAccountNeedsProtocolRepublishCleansStaleMediaOnlyCapability(t *testing.T) {
+	capabilityID := int64(797)
+	account := &Account{
+		Platform: PlatformNewAPI, Type: AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeDoubaoVideo,
+		Credentials: supplierManagedCredentials(
+			"https://www.fmgo.top", "secret",
+			map[string]string{"doubao-seedance-2-0-260128": "feimiao-v2-431-720p-15s"},
+			newapiconstant.ChannelTypeDoubaoVideo,
+		),
+		ProtocolEndpointCapabilityID: &capabilityID,
+	}
+
+	require.True(t, supplierAccountNeedsProtocolRepublish(
+		account, "https://www.fmgo.top", newapiconstant.ChannelTypeDoubaoVideo,
+	))
+}

--- a/ops/observability/check-supplier-projection.sh
+++ b/ops/observability/check-supplier-projection.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Run the prod supplier projection probe and preserve checker-style exit codes:
+# 0 aligned, 1 drift, 2 setup/transport failure.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TARGET="prod"
+EXPECTED_INSTANCE_ID=""
+TIMEOUT_SECONDS="180"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --target) TARGET="${2:-}"; shift 2 ;;
+    --expected-instance-id) EXPECTED_INSTANCE_ID="${2:-}"; shift 2 ;;
+    --timeout-seconds) TIMEOUT_SECONDS="${2:-}"; shift 2 ;;
+    -h|--help)
+      echo "usage: $0 [--target prod] [--expected-instance-id i-*] [--timeout-seconds 180]"
+      exit 0
+      ;;
+    *) echo "[check-supplier-projection] unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPORT_FILE="$(mktemp /tmp/tk-supplier-projection.XXXXXX)"
+trap 'rm -f "$REPORT_FILE"' EXIT
+RUN_PROBE="${SUPPLIER_PROJECTION_RUN_PROBE:-$ROOT/ops/observability/run-probe.sh}"
+ARGS=(
+  --target "$TARGET"
+  --script "$ROOT/ops/observability/probe-supplier-projection.sh"
+  --timeout-seconds "$TIMEOUT_SECONDS"
+)
+if [ -n "$EXPECTED_INSTANCE_ID" ]; then
+  ARGS+=(--expected-instance-id "$EXPECTED_INSTANCE_ID")
+fi
+
+set +e
+bash "$RUN_PROBE" "${ARGS[@]}" | tee "$REPORT_FILE"
+PROBE_RC=${PIPESTATUS[0]}
+set -e
+
+VERDICT="$(python3 - "$REPORT_FILE" <<'PY'
+import json
+import sys
+
+verdict = ""
+with open(sys.argv[1], encoding="utf-8") as handle:
+    for raw in handle:
+        try:
+            row = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(row, dict) and row.get("verdict"):
+            verdict = str(row["verdict"])
+print(verdict)
+PY
+)"
+
+case "$VERDICT" in
+  aligned)
+    [ "$PROBE_RC" -eq 0 ] || exit 2
+    exit 0
+    ;;
+  drift) exit 1 ;;
+  setup_error) exit 2 ;;
+  *)
+    echo "[check-supplier-projection] no valid verdict (probe rc=$PROBE_RC)" >&2
+    exit 2
+    ;;
+esac

--- a/ops/observability/probe-contracts.json
+++ b/ops/observability/probe-contracts.json
@@ -77,6 +77,16 @@
       "setup_error"
     ]
   },
+  "probe-supplier-projection.sh": {
+    "companions": [
+      "ops/observability/supplier_projection_check.py"
+    ],
+    "verdicts": [
+      "aligned",
+      "drift",
+      "setup_error"
+    ]
+  },
   "probe_kiro_claude_models.sh": {
     "companions": [
       "ops/stage0/probe_account_model.sh",

--- a/ops/observability/probe-supplier-projection.sh
+++ b/ops/observability/probe-supplier-projection.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Read-only post-release supplier-source -> managed-account projection check.
+# Runtime scheduling state (status/schedulable) is intentionally not queried.
+set -euo pipefail
+
+. /tmp/resolve-app-container.sh
+if ! APP_CONTAINER="$(tk_resolve_app_container auto)"; then
+  echo '{"verdict":"setup_error","error":"app_container_unresolved"}'
+  exit 2
+fi
+
+FINGERPRINT_KEY="$(docker exec "$APP_CONTAINER" sh -c 'printf %s "$TOTP_ENCRYPTION_KEY"')"
+if [ -z "$FINGERPRINT_KEY" ]; then
+  echo '{"verdict":"setup_error","error":"fingerprint_key_unavailable"}'
+  exit 2
+fi
+export TOTP_ENCRYPTION_KEY="$FINGERPRINT_KEY"
+unset FINGERPRINT_KEY
+
+SNAPSHOT_SQL=$(cat <<'SQL'
+SELECT jsonb_build_object(
+  'sources', COALESCE((
+    SELECT jsonb_agg(jsonb_build_object(
+      'id', id,
+      'supplier_name', supplier_name,
+      'supplier_lane', supplier_lane,
+      'channel_type', channel_type,
+      'endpoint', endpoint,
+      'credential_fingerprint', credential_fingerprint,
+      'base_priority', base_priority,
+      'account_concurrency', account_concurrency,
+      'models', models
+    ) ORDER BY id)
+    FROM model_supplier_sources
+  ), '[]'::jsonb),
+  'accounts', COALESCE((
+    SELECT jsonb_agg(jsonb_build_object(
+      'id', a.id,
+      'name', a.name,
+      'platform', a.platform,
+      'type', a.type,
+      'channel_type', a.channel_type,
+      'credentials', a.credentials,
+      'extra', a.extra,
+      'priority', a.priority,
+      'concurrency', a.concurrency,
+      'capability_id', a.protocol_endpoint_capability_id,
+      'capability_key', c.capability_key,
+      'capability_identity', c.identity,
+      'supported_protocols', c.supported_protocols,
+      'probe_evidence', c.probe_evidence,
+      'capability_identity_conflict', c.identity_conflict
+    ) ORDER BY a.id)
+    FROM accounts a
+    LEFT JOIN protocol_endpoint_capabilities c
+      ON c.id = a.protocol_endpoint_capability_id
+    WHERE a.deleted_at IS NULL
+      AND COALESCE(a.extra, '{}'::jsonb) ? 'supplier_source_id'
+  ), '[]'::jsonb)
+)::text;
+SQL
+)
+
+if ! SNAPSHOT="$(docker exec -i \
+    -e 'PGOPTIONS=-c default_transaction_read_only=on -c lock_timeout=100ms -c statement_timeout=10s' \
+    tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1 \
+    -c "$SNAPSHOT_SQL")"; then
+  echo '{"verdict":"setup_error","error":"snapshot_query_failed"}'
+  exit 2
+fi
+
+printf '%s\n' "$SNAPSHOT" | python3 /tmp/supplier_projection_check.py --snapshot -
+unset SNAPSHOT TOTP_ENCRYPTION_KEY

--- a/ops/observability/supplier_projection_check.py
+++ b/ops/observability/supplier_projection_check.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Evaluate supplier-source managed-account projection drift from a DB snapshot.
+
+The live probe supplies ``TOTP_ENCRYPTION_KEY`` only inside the remote host so
+credential fingerprints can be compared without returning account API keys.
+Scheduling fields are deliberately outside this contract: status and
+schedulable are runtime decisions, not supplier projection drift.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import sys
+import urllib.parse
+from pathlib import Path
+from typing import Any, TextIO
+
+
+MEDIA_ONLY_CHANNEL_TYPES = {54}
+DEFAULT_ACCOUNT_CONCURRENCY = 1000
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _discount_band(purchase_ratio: Any) -> int:
+    if purchase_ratio is None or float(purchase_ratio) == 1:
+        return 6
+    ratio = float(purchase_ratio)
+    if ratio < 0.2:
+        return 1
+    if ratio < 0.4:
+        return 2
+    if ratio < 0.6:
+        return 3
+    if ratio < 0.8:
+        return 4
+    return 5
+
+
+def _normalized_endpoint(value: Any) -> str:
+    raw = str(value or "").strip()
+    parsed = urllib.parse.urlsplit(raw)
+    host = (parsed.hostname or "").lower()
+    if host == "qianfan.baidubce.com":
+        return "https://qianfan.baidubce.com"
+    netloc = host
+    if parsed.port:
+        netloc += f":{parsed.port}"
+    return urllib.parse.urlunsplit(
+        (parsed.scheme.lower(), netloc, parsed.path.rstrip("/"), "", "")
+    )
+
+
+def _protocol_url(base_url: str, protocol: str) -> str:
+    parsed = urllib.parse.urlsplit(base_url)
+    path = parsed.path.rstrip("/")
+    if protocol == "messages":
+        suffix = "/v1/messages"
+        complete = path.endswith("/messages")
+    else:
+        suffix = "/v1/chat/completions"
+        complete = path.endswith("/chat/completions")
+    if not complete:
+        if path.endswith("/v1") and suffix.startswith("/v1/"):
+            suffix = suffix[3:]
+        path += suffix
+    return urllib.parse.urlunsplit(
+        (parsed.scheme.lower(), parsed.netloc.lower(), path or "/", "", "")
+    )
+
+
+def _mapping(value: Any) -> dict[str, str] | None:
+    if not isinstance(value, dict):
+        return None
+    result: dict[str, str] = {}
+    for key, target in value.items():
+        if not isinstance(key, str) or not isinstance(target, str):
+            return None
+        result[key] = target
+    return result
+
+
+def _credential_matches(api_key: Any, fingerprint: Any, key: str) -> bool:
+    digest = "hmac-sha256:" + hmac.new(
+        key.encode("utf-8"),
+        str(api_key or "").strip().encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return hmac.compare_digest(digest, str(fingerprint or ""))
+
+
+def _expected_protocol(source: dict[str, Any]) -> tuple[str, str, str]:
+    channel_type = int(source.get("channel_type") or 0)
+    endpoint = _normalized_endpoint(source.get("endpoint"))
+    if channel_type == 14:
+        return "messages", "anthropic", endpoint
+    if channel_type == 46:
+        return "chat_completions", "chat_completions", endpoint + "/v2/chat/completions"
+    return "chat_completions", "chat_completions", endpoint
+
+
+def _protocol_differences(
+    account: dict[str, Any], source: dict[str, Any], desired_mapping: dict[str, str]
+) -> list[str]:
+    capability_id = account.get("capability_id")
+    capability_key = account.get("capability_key")
+    supported = account.get("supported_protocols") or []
+    if not desired_mapping or int(source.get("channel_type") or 0) in MEDIA_ONLY_CHANNEL_TYPES:
+        if capability_id is not None or capability_key or supported:
+            return ["protocol_capability_link"]
+        return []
+
+    protocol, credential_protocol, expected_api_base = _expected_protocol(source)
+    credentials = account.get("credentials") or {}
+    differences: list[str] = []
+    api_bases = credentials.get("api_base_urls") or {}
+    if credentials.get("protocol_endpoints_exclusive") is not True:
+        differences.append("protocol_endpoints_exclusive")
+    if (
+        not isinstance(api_bases, dict)
+        or set(api_bases) != {credential_protocol}
+        or _normalized_endpoint(api_bases.get(credential_protocol))
+        != _normalized_endpoint(expected_api_base)
+    ):
+        differences.append("api_base_urls")
+    if not capability_id or not capability_key:
+        differences.append("protocol_capability_link")
+        return differences
+
+    identity = account.get("capability_identity") or {}
+    identity_protocols = identity.get("protocol_endpoints") or {}
+    actual_url = ""
+    if isinstance(identity_protocols, dict):
+        actual_url = str((identity_protocols.get(protocol) or {}).get("url") or "")
+    if (
+        identity.get("platform") != "newapi"
+        or identity.get("endpoint_profile") != "custom_api_key"
+        or str(identity.get("channel_type")) != str(source.get("channel_type"))
+        or not isinstance(identity_protocols, dict)
+        or set(identity_protocols) != {protocol}
+        or actual_url.rstrip("/") != _protocol_url(expected_api_base, protocol).rstrip("/")
+        or identity.get("upstream_request_profile") != "openai_json_v1"
+        or (identity.get("routing_headers") or {}) != {}
+    ):
+        differences.append("protocol_capability_identity")
+    if supported != [protocol]:
+        differences.append("supported_protocols")
+    evidence = account.get("probe_evidence") or {}
+    if (
+        evidence.get("initial_probe_completed") is not True
+        or evidence.get("identity_conflict") is True
+        or account.get("capability_identity_conflict") is True
+    ):
+        differences.append("protocol_probe_evidence")
+    return differences
+
+
+def evaluate_snapshot(snapshot: dict[str, Any], fingerprint_key: str) -> dict[str, Any]:
+    sources = snapshot.get("sources") or []
+    accounts = snapshot.get("accounts") or []
+    if not isinstance(sources, list) or not isinstance(accounts, list):
+        raise ValueError("snapshot must contain sources and accounts arrays")
+    if not fingerprint_key:
+        raise ValueError("TOTP_ENCRYPTION_KEY is unavailable")
+
+    source_ids = {_positive_int(source.get("id")) for source in sources}
+    source_ids.discard(None)
+    accounts_by_source: dict[int, list[dict[str, Any]]] = {}
+    orphans: list[dict[str, Any]] = []
+    for account in accounts:
+        extra = account.get("extra") or {}
+        source_id = _positive_int(extra.get("supplier_source_id"))
+        if source_id not in source_ids:
+            orphans.append(
+                {
+                    "account_id": account.get("id"),
+                    "supplier_source_id": extra.get("supplier_source_id"),
+                    "differences": ["supplier_source_id"],
+                }
+            )
+            continue
+        accounts_by_source.setdefault(source_id, []).append(account)
+
+    source_results: list[dict[str, Any]] = []
+    for source in sources:
+        source_id = _positive_int(source.get("id"))
+        if source_id is None:
+            raise ValueError("supplier source id must be positive")
+        targets: dict[int, dict[str, str]] = {}
+        for model in source.get("models") or []:
+            band = _discount_band(model.get("purchase_ratio"))
+            targets.setdefault(band, {})[str(model.get("client_model_id") or "")] = str(
+                model.get("upstream_model_id") or ""
+            )
+
+        managed = accounts_by_source.get(source_id, [])
+        by_band: dict[int, list[dict[str, Any]]] = {}
+        source_issues: list[dict[str, Any]] = []
+        account_results: list[dict[str, Any]] = []
+        invalid_account_ids: set[Any] = set()
+        duplicate_account_ids: set[Any] = set()
+        for account in managed:
+            band = _positive_int((account.get("extra") or {}).get("supplier_discount_band"))
+            if band is None or band > 6:
+                invalid_account_ids.add(account.get("id"))
+                source_issues.append(
+                    {"code": "invalid_band", "account_id": account.get("id")}
+                )
+                account_results.append(
+                    {
+                        "account_id": account.get("id"),
+                        "band": band,
+                        "aligned": False,
+                        "differences": ["supplier_discount_band"],
+                    }
+                )
+                continue
+            by_band.setdefault(band, []).append(account)
+
+        for band, rows in sorted(by_band.items()):
+            if len(rows) > 1:
+                ids = [row.get("id") for row in rows]
+                duplicate_account_ids.update(ids)
+                source_issues.append({"code": "duplicate_band", "band": band, "account_ids": ids})
+        for band, mapping in sorted(targets.items()):
+            if band not in by_band:
+                source_issues.append(
+                    {"code": "missing_account", "band": band, "model_count": len(mapping)}
+                )
+
+        endpoint = _normalized_endpoint(source.get("endpoint"))
+        expected_concurrency = int(source.get("account_concurrency") or 0) or DEFAULT_ACCOUNT_CONCURRENCY
+        for band, rows in sorted(by_band.items()):
+            desired_mapping = targets.get(band, {})
+            desired_name = f"{source.get('supplier_name')}/{source.get('supplier_lane')} · 档位 {band}"
+            expected_priority = int(source.get("base_priority") or 0) + band * 10
+            for account in rows:
+                credentials = account.get("credentials") or {}
+                actual_mapping = _mapping(credentials.get("model_mapping"))
+                differences: list[str] = []
+                if account.get("id") in duplicate_account_ids:
+                    differences.append("supplier_discount_band")
+                if account.get("name") != desired_name:
+                    differences.append("name")
+                if account.get("platform") != "newapi":
+                    differences.append("platform")
+                if account.get("type") != "apikey":
+                    differences.append("type")
+                if int(account.get("channel_type") or 0) != int(source.get("channel_type") or 0):
+                    differences.append("channel_type")
+                if _normalized_endpoint(credentials.get("base_url")) != endpoint:
+                    differences.append("endpoint")
+                if not _credential_matches(
+                    credentials.get("api_key"), source.get("credential_fingerprint"), fingerprint_key
+                ):
+                    differences.append("credential")
+                if actual_mapping != desired_mapping:
+                    differences.append("model_mapping")
+                if int(account.get("priority") or 0) != expected_priority:
+                    differences.append("priority")
+                if int(account.get("concurrency") or 0) != expected_concurrency:
+                    differences.append("concurrency")
+                differences.extend(_protocol_differences(account, source, desired_mapping))
+                account_results.append(
+                    {
+                        "account_id": account.get("id"),
+                        "band": band,
+                        "aligned": not differences,
+                        "differences": differences,
+                    }
+                )
+
+        aligned = not source_issues and all(row["aligned"] for row in account_results)
+        source_results.append(
+            {
+                "source_id": source_id,
+                "supplier": source.get("supplier_name"),
+                "lane": source.get("supplier_lane"),
+                "aligned": aligned,
+                "issues": source_issues,
+                "accounts": account_results,
+            }
+        )
+
+    account_rows = [account for source in source_results for account in source["accounts"]]
+    drift = bool(orphans) or any(not source["aligned"] for source in source_results)
+    return {
+        "verdict": "drift" if drift else "aligned",
+        "ignored_runtime_fields": ["status", "schedulable"],
+        "summary": {
+            "source_count": len(source_results),
+            "misaligned_source_count": sum(not source["aligned"] for source in source_results),
+            "managed_account_count": len(accounts),
+            "misaligned_account_count": sum(not account["aligned"] for account in account_rows),
+            "orphan_account_count": len(orphans),
+        },
+        "sources": source_results,
+        "orphans": orphans,
+    }
+
+
+def _read_snapshot(path: str) -> dict[str, Any]:
+    handle: TextIO
+    if path == "-":
+        handle = sys.stdin
+        return json.load(handle)
+    with Path(path).open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--snapshot", default="-", help="snapshot JSON path, or - for stdin")
+    args = parser.parse_args(argv)
+    try:
+        report = evaluate_snapshot(
+            _read_snapshot(args.snapshot), os.environ.get("TOTP_ENCRYPTION_KEY", "")
+        )
+    except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+        print(json.dumps({"verdict": "setup_error", "error": str(exc)}, ensure_ascii=False))
+        return 2
+    print(json.dumps(report, ensure_ascii=False, separators=(",", ":")))
+    return 0 if report["verdict"] == "aligned" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/observability/supplier_projection_check.py
+++ b/ops/observability/supplier_projection_check.py
@@ -208,12 +208,10 @@ def evaluate_snapshot(snapshot: dict[str, Any], fingerprint_key: str) -> dict[st
         by_band: dict[int, list[dict[str, Any]]] = {}
         source_issues: list[dict[str, Any]] = []
         account_results: list[dict[str, Any]] = []
-        invalid_account_ids: set[Any] = set()
         duplicate_account_ids: set[Any] = set()
         for account in managed:
             band = _positive_int((account.get("extra") or {}).get("supplier_discount_band"))
             if band is None or band > 6:
-                invalid_account_ids.add(account.get("id"))
                 source_issues.append(
                     {"code": "invalid_band", "account_id": account.get("id")}
                 )

--- a/ops/observability/supplier_projection_check.py
+++ b/ops/observability/supplier_projection_check.py
@@ -100,6 +100,37 @@ def _credential_matches(api_key: Any, fingerprint: Any, key: str) -> bool:
     return hmac.compare_digest(digest, str(fingerprint or ""))
 
 
+# Keep this conservative fallback aligned with protocolRoutingAccountHasNoTextModels.
+def _model_is_non_text(value: Any) -> bool:
+    model = str(value or "").strip().lower()
+    if not model:
+        return False
+    antigravity_model = model.removeprefix("models/")
+    return (
+        model.startswith("gpt-image-")
+        or model in {"grok-imagine", "grok-imagine-edit"}
+        or model.startswith(("grok-imagine-image", "grok-imagine-video", "grok-video"))
+        or "nano-banana" in antigravity_model
+        or (
+            antigravity_model.startswith("gemini-")
+            and (
+                antigravity_model.endswith("-image")
+                or "-image-" in antigravity_model
+            )
+        )
+        or "seedance" in model
+        or "seedream" in model
+        or model.startswith(("dall-e", "sora", "veo-", "imagen-"))
+        or "embedding" in model
+        or "rerank" in model
+        or model.startswith(("bge-", "tts-", "whisper-"))
+    )
+
+
+def _mapping_has_no_text_models(mapping: dict[str, str]) -> bool:
+    return bool(mapping) and all(_model_is_non_text(model) for model in mapping.values())
+
+
 def _expected_protocol(source: dict[str, Any]) -> tuple[str, str, str]:
     channel_type = int(source.get("channel_type") or 0)
     endpoint = _normalized_endpoint(source.get("endpoint"))
@@ -111,12 +142,15 @@ def _expected_protocol(source: dict[str, Any]) -> tuple[str, str, str]:
 
 
 def _protocol_differences(
-    account: dict[str, Any], source: dict[str, Any]
+    account: dict[str, Any], source: dict[str, Any], desired_mapping: dict[str, str]
 ) -> list[str]:
     capability_id = account.get("capability_id")
     capability_key = account.get("capability_key")
     supported = account.get("supported_protocols") or []
-    if int(source.get("channel_type") or 0) in MEDIA_ONLY_CHANNEL_TYPES:
+    if (
+        int(source.get("channel_type") or 0) in MEDIA_ONLY_CHANNEL_TYPES
+        or _mapping_has_no_text_models(desired_mapping)
+    ):
         if capability_id is not None or capability_key or supported:
             return ["protocol_capability_link"]
         return []
@@ -269,7 +303,7 @@ def evaluate_snapshot(snapshot: dict[str, Any], fingerprint_key: str) -> dict[st
                     differences.append("priority")
                 if int(account.get("concurrency") or 0) != expected_concurrency:
                     differences.append("concurrency")
-                differences.extend(_protocol_differences(account, source))
+                differences.extend(_protocol_differences(account, source, desired_mapping))
                 account_results.append(
                     {
                         "account_id": account.get("id"),

--- a/ops/observability/supplier_projection_check.py
+++ b/ops/observability/supplier_projection_check.py
@@ -111,12 +111,12 @@ def _expected_protocol(source: dict[str, Any]) -> tuple[str, str, str]:
 
 
 def _protocol_differences(
-    account: dict[str, Any], source: dict[str, Any], desired_mapping: dict[str, str]
+    account: dict[str, Any], source: dict[str, Any]
 ) -> list[str]:
     capability_id = account.get("capability_id")
     capability_key = account.get("capability_key")
     supported = account.get("supported_protocols") or []
-    if not desired_mapping or int(source.get("channel_type") or 0) in MEDIA_ONLY_CHANNEL_TYPES:
+    if int(source.get("channel_type") or 0) in MEDIA_ONLY_CHANNEL_TYPES:
         if capability_id is not None or capability_key or supported:
             return ["protocol_capability_link"]
         return []
@@ -269,7 +269,7 @@ def evaluate_snapshot(snapshot: dict[str, Any], fingerprint_key: str) -> dict[st
                     differences.append("priority")
                 if int(account.get("concurrency") or 0) != expected_concurrency:
                     differences.append("concurrency")
-                differences.extend(_protocol_differences(account, source, desired_mapping))
+                differences.extend(_protocol_differences(account, source))
                 account_results.append(
                     {
                         "account_id": account.get("id"),

--- a/ops/observability/test_check_supplier_projection.py
+++ b/ops/observability/test_check_supplier_projection.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parent / "check-supplier-projection.sh"
+
+
+class CheckSupplierProjectionWrapperTest(unittest.TestCase):
+    def run_case(self, verdict: str | None, remote_rc: int) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            fake = Path(directory) / "run-probe.sh"
+            payload = "" if verdict is None else json.dumps({"verdict": verdict})
+            fake.write_text(
+                "#!/usr/bin/env bash\n"
+                + (f"printf '%s\\n' '{payload}'\n" if payload else "")
+                + f"exit {remote_rc}\n",
+                encoding="utf-8",
+            )
+            fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
+            env = os.environ.copy()
+            env["SUPPLIER_PROJECTION_RUN_PROBE"] = str(fake)
+            return subprocess.run(
+                ["bash", str(SCRIPT)], capture_output=True, text=True, check=False, env=env
+            )
+
+    def test_aligned_is_success(self) -> None:
+        proc = self.run_case("aligned", 0)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    def test_remote_drift_is_checker_failure(self) -> None:
+        proc = self.run_case("drift", 3)
+        self.assertEqual(proc.returncode, 1, proc.stderr)
+
+    def test_setup_or_transport_failure_is_distinct(self) -> None:
+        self.assertEqual(self.run_case("setup_error", 3).returncode, 2)
+        self.assertEqual(self.run_case(None, 2).returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/observability/test_supplier_projection_check.py
+++ b/ops/observability/test_supplier_projection_check.py
@@ -132,6 +132,19 @@ class SupplierProjectionCheckTest(unittest.TestCase):
             ["protocol_capability_link"],
         )
 
+    def test_empty_text_band_retains_protocol_capability(self) -> None:
+        account = self.account()
+        account["name"] = "cloudwise/default · 档位 3"
+        account["credentials"]["model_mapping"] = {}
+        account["extra"]["supplier_discount_band"] = 3
+        account["priority"] = 230
+
+        report = MOD.evaluate_snapshot(
+            {"sources": [self.source()], "accounts": [self.account(), account]}, self.key
+        )
+
+        self.assertEqual(report["verdict"], "aligned")
+
     def test_missing_band_and_orphan_account_are_reported(self) -> None:
         orphan = self.account()
         orphan["id"] = 999

--- a/ops/observability/test_supplier_projection_check.py
+++ b/ops/observability/test_supplier_projection_check.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import hmac
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+MODULE_PATH = HERE / "supplier_projection_check.py"
+SPEC = importlib.util.spec_from_file_location("supplier_projection_check", MODULE_PATH)
+assert SPEC and SPEC.loader
+MOD = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MOD
+SPEC.loader.exec_module(MOD)
+
+
+class SupplierProjectionCheckTest(unittest.TestCase):
+    key = "test-fingerprint-key"
+
+    def fingerprint(self, credential: str) -> str:
+        return "hmac-sha256:" + hmac.new(
+            self.key.encode(), credential.encode(), hashlib.sha256
+        ).hexdigest()
+
+    def source(self, *, channel_type: int = 1) -> dict:
+        return {
+            "id": 9,
+            "supplier_name": "cloudwise",
+            "supplier_lane": "default",
+            "channel_type": channel_type,
+            "endpoint": "https://supplier.example/v1/",
+            "credential_fingerprint": self.fingerprint("secret"),
+            "base_priority": 200,
+            "account_concurrency": 1000,
+            "models": [
+                {
+                    "client_model_id": "model",
+                    "upstream_model_id": "upstream-model",
+                    "purchase_ratio": 0.3,
+                }
+            ],
+        }
+
+    def account(self, *, channel_type: int = 1) -> dict:
+        protocol = "chat_completions"
+        return {
+            "id": 126,
+            "name": "cloudwise/default · 档位 2",
+            "platform": "newapi",
+            "type": "apikey",
+            "channel_type": channel_type,
+            "credentials": {
+                "api_key": "secret",
+                "base_url": "https://supplier.example/v1",
+                "model_mapping": {"model": "upstream-model"},
+                "protocol_endpoints_exclusive": True,
+                "api_base_urls": {protocol: "https://supplier.example/v1"},
+            },
+            "extra": {"supplier_source_id": 9, "supplier_discount_band": 2},
+            "priority": 220,
+            "concurrency": 1000,
+            "status": "error",
+            "schedulable": False,
+            "capability_id": 7,
+            "capability_key": "capability",
+            "capability_identity": {
+                "platform": "newapi",
+                "endpoint_profile": "custom_api_key",
+                "channel_type": str(channel_type),
+                "protocol_endpoints": {
+                    protocol: {
+                        "url": "https://supplier.example/v1/chat/completions"
+                    }
+                },
+                "upstream_request_profile": "openai_json_v1",
+                "routing_headers": {},
+            },
+            "supported_protocols": [protocol],
+            "probe_evidence": {"initial_probe_completed": True},
+            "capability_identity_conflict": False,
+        }
+
+    def test_runtime_scheduling_state_does_not_create_drift(self) -> None:
+        report = MOD.evaluate_snapshot(
+            {"sources": [self.source()], "accounts": [self.account()]}, self.key
+        )
+
+        self.assertEqual(report["verdict"], "aligned")
+        self.assertEqual(report["ignored_runtime_fields"], ["status", "schedulable"])
+
+    def test_structural_and_credential_drift_is_field_named_and_redacted(self) -> None:
+        account = self.account()
+        account["priority"] = 999
+        account["credentials"]["api_key"] = "wrong-secret"
+
+        report = MOD.evaluate_snapshot(
+            {"sources": [self.source()], "accounts": [account]}, self.key
+        )
+
+        self.assertEqual(report["verdict"], "drift")
+        differences = report["sources"][0]["accounts"][0]["differences"]
+        self.assertIn("credential", differences)
+        self.assertIn("priority", differences)
+        self.assertNotIn("wrong-secret", str(report))
+
+    def test_media_only_projection_needs_no_text_capability(self) -> None:
+        source = self.source(channel_type=54)
+        account = self.account(channel_type=54)
+        account["capability_id"] = None
+        account["capability_key"] = None
+        account["capability_identity"] = None
+        account["supported_protocols"] = []
+        account["probe_evidence"] = None
+
+        report = MOD.evaluate_snapshot({"sources": [source], "accounts": [account]}, self.key)
+
+        self.assertEqual(report["verdict"], "aligned")
+
+    def test_media_only_stale_text_capability_is_drift(self) -> None:
+        source = self.source(channel_type=54)
+        account = self.account(channel_type=54)
+
+        report = MOD.evaluate_snapshot({"sources": [source], "accounts": [account]}, self.key)
+
+        self.assertEqual(report["verdict"], "drift")
+        self.assertEqual(
+            report["sources"][0]["accounts"][0]["differences"],
+            ["protocol_capability_link"],
+        )
+
+    def test_missing_band_and_orphan_account_are_reported(self) -> None:
+        orphan = self.account()
+        orphan["id"] = 999
+        orphan["extra"]["supplier_source_id"] = 404
+
+        report = MOD.evaluate_snapshot(
+            {"sources": [self.source()], "accounts": [orphan]}, self.key
+        )
+
+        self.assertEqual(report["verdict"], "drift")
+        self.assertEqual(report["summary"]["orphan_account_count"], 1)
+        self.assertEqual(report["sources"][0]["issues"][0]["code"], "missing_account")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/observability/test_supplier_projection_check.py
+++ b/ops/observability/test_supplier_projection_check.py
@@ -145,6 +145,24 @@ class SupplierProjectionCheckTest(unittest.TestCase):
 
         self.assertEqual(report["verdict"], "aligned")
 
+    def test_mixed_transport_media_mapping_needs_no_text_capability(self) -> None:
+        source = self.source(channel_type=45)
+        source["models"][0]["client_model_id"] = "doubao-seedream-5-0-260128"
+        source["models"][0]["upstream_model_id"] = "seedream-5-0-260128"
+        account = self.account(channel_type=45)
+        account["credentials"]["model_mapping"] = {
+            "doubao-seedream-5-0-260128": "seedream-5-0-260128"
+        }
+        account["capability_id"] = None
+        account["capability_key"] = None
+        account["capability_identity"] = None
+        account["supported_protocols"] = []
+        account["probe_evidence"] = None
+
+        report = MOD.evaluate_snapshot({"sources": [source], "accounts": [account]}, self.key)
+
+        self.assertEqual(report["verdict"], "aligned")
+
     def test_missing_band_and_orphan_account_are_reported(self) -> None:
         orphan = self.account()
         orphan["id"] = 999

--- a/ops/stage0/test_deploy_stage0_workflow.py
+++ b/ops/stage0/test_deploy_stage0_workflow.py
@@ -115,15 +115,24 @@ class DeployStage0WorkflowTest(unittest.TestCase):
 
         self.assertLess(baseline, image_mutation)
         post_release = deploy.index("name: Plan checks from live→new PRs")
+        supplier_projection = deploy.index(
+            "name: Post-deploy supplier projection check (read-only)"
+        )
         post_release_immediate = deploy.index("name: Check PR hooks immediately")
         post_release_delayed = deploy.index("name: Check traffic and 5xx after 5 minutes")
         post_release_gate = deploy.index("name: Enforce post-release verdicts")
         self.assertLess(smoke, post_release)
+        self.assertLess(smoke, supplier_projection)
+        self.assertLess(supplier_projection, post_release)
         self.assertLess(post_release, post_release_immediate)
         self.assertLess(post_release_immediate, post_release_delayed)
         self.assertLess(post_release_delayed, post_release_gate)
         self.assertLess(post_release_gate, notification)
         self.assertIn("release_post_check.py gate", deploy[post_release_gate:notification])
+        supplier_block = deploy[supplier_projection:post_release]
+        self.assertIn("continue-on-error: true", supplier_block)
+        self.assertIn("check-supplier-projection.sh", supplier_block)
+        self.assertIn('--expected-instance-id "$INSTANCE_ID"', supplier_block)
         block = deploy[baseline:image_mutation]
         self.assertIn("resolve-prod-running-tag-via-ssm.sh", block)
         self.assertIn('INSTANCE_ID: ${{ steps.instance.outputs.id }}', block)

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -990,6 +990,24 @@ else
     echo "  ok: account model_mapping tool/SSOT contract selftest"
 fi
 
+# ---- sub2api: supplier projection post-release check -----------------------
+# Supplier-source mapping ownership is separate from the platform model floor.
+# Keep its field diff, redaction, media-only and runtime-state exclusions tested.
+echo ""
+echo "=== sub2api: supplier projection post-release check ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required for supplier projection check tests)"
+    errors=$((errors + 1))
+elif ! python3 -m unittest \
+    ops.observability.test_supplier_projection_check \
+    ops.observability.test_check_supplier_projection >/dev/null 2>&1; then
+    echo "  FAIL: supplier projection post-release check tests"
+    echo "        - run: python3 -m unittest ops.observability.test_supplier_projection_check ops.observability.test_check_supplier_projection"
+    errors=$((errors + 1))
+else
+    echo "  ok: supplier projection post-release check tests"
+fi
+
 # ---- sub2api: generated model-surface bundle drift -------------------------
 # Rollout consumes the generated bundle without compiling Go. Keep the checked-in
 # artifact byte-identical to the Go owner so it cannot become a second hand-edited

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -8015,7 +8015,8 @@
         "test_runtime_scheduling_state_does_not_create_drift",
         "test_structural_and_credential_drift_is_field_named_and_redacted",
         "test_media_only_projection_needs_no_text_capability",
-        "test_media_only_stale_text_capability_is_drift"
+        "test_media_only_stale_text_capability_is_drift",
+        "test_empty_text_band_retains_protocol_capability"
       ],
       "rationale": "Behavior regressions pin runtime-state exclusion, credential redaction, structural drift, and the media-only capability lifecycle for the post-release checker."
     },

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7980,6 +7980,7 @@
       "must_contain": [
         "MEDIA_ONLY_CHANNEL_TYPES = {54}",
         "def evaluate_snapshot(snapshot: dict[str, Any], fingerprint_key: str)",
+        "def _mapping_has_no_text_models(mapping: dict[str, str]) -> bool",
         "\"ignored_runtime_fields\": [\"status\", \"schedulable\"]",
         "hmac.compare_digest",
         "\"verdict\": \"drift\" if drift else \"aligned\""
@@ -8016,7 +8017,8 @@
         "test_structural_and_credential_drift_is_field_named_and_redacted",
         "test_media_only_projection_needs_no_text_capability",
         "test_media_only_stale_text_capability_is_drift",
-        "test_empty_text_band_retains_protocol_capability"
+        "test_empty_text_band_retains_protocol_capability",
+        "test_mixed_transport_media_mapping_needs_no_text_capability"
       ],
       "rationale": "Behavior regressions pin runtime-state exclusion, credential redaction, structural drift, and the media-only capability lifecycle for the post-release checker."
     },

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -7671,12 +7671,14 @@
         "func (r *accountRepository) UpdateSupplierProjection(ctx context.Context, account *service.Account, protocolProbePassed bool) error",
         "if len(account.GetModelMapping()) > 0 && !protocolProbePassed {",
         "publishVerifiedSupplierProtocolCapability(",
+        "capabilityInput.Governed",
+        "ensureAccountProtocolEndpointCapability(ctx, client, updatedAccount)",
         "concurrency = $10",
         "enqueueSchedulerOutbox(ctx, client, service.SchedulerOutboxEventAccountChanged, &accountID, nil, nil)",
         "enqueueSchedulerOutbox(ctx, client, service.SchedulerOutboxEventAccountChanged, &account.ID, nil, nil)",
         "extra = COALESCE(extra, '{}'::jsonb) || $6::jsonb"
       ],
-      "rationale": "Production-only narrow write paths for supplier metadata, concurrency and full projections. Concurrency-only sync writes the single owned column plus scheduler invalidation without fabricating probe evidence. Non-empty full projections fail closed without the current sync call's protocol probe evidence; the same account transaction publishes the verified channel protocol capability (Chat Completions by default, Messages for Anthropic channel_type=14) before ordinary scheduler invalidation. These writes avoid account-group payloads, and the full projection merges only the two owned supplier keys while preserving every non-owned Extra. The generic AccountRepository.Update forwards billing and unrelated runtime fields, so supplier sync must never fall back to it."
+      "rationale": "Production-only narrow write paths for supplier metadata, concurrency and full projections. Concurrency-only sync writes the single owned column plus scheduler invalidation without fabricating probe evidence. Governed non-empty text projections publish the verified channel protocol capability (Chat Completions by default, Messages for Anthropic channel_type=14); ungoverned media projections use the ordinary lifecycle helper so a stale text capability is unlinked instead of blocking Sync. These writes avoid account-group payloads, and the full projection merges only the two owned supplier keys while preserving every non-owned Extra. The generic AccountRepository.Update forwards billing and unrelated runtime fields, so supplier sync must never fall back to it."
     },
     {
       "path": "backend/internal/repository/account_repo.go",
@@ -7745,6 +7747,7 @@
         "TestUS048_SupplierMetadataRepositoryWritesOnlyNameAndPriority",
         "TestUS048_SupplierConcurrencyRepositoryWritesOnlyConcurrency",
         "TestUS048_SupplierConfigurationRepositoryRejectsUnverifiedNonEmptyMapping",
+        "TestUS048_SupplierMediaProjectionUnlinksStaleTextCapability",
         "TestUS048_SupplierAnthropicProjectionPublishesMessagesCapability",
         "TestUS048_SupplierAnthropicProjectionRejectsChatOnlyIdentity",
         "TestUS048_SupplierVerifiedProtocolForAnthropicIsMessages",
@@ -7872,6 +7875,8 @@
         "TestUS048_SupplierSyncProjectsWithoutCallingProbe",
         "TestUS048_SupplierSyncRepairsEmptySchedulingProjectionWithoutProbe",
         "TestSupplierAccountNeedsProtocolRepublishDetectsTransportDrift",
+        "TestSupplierAccountNeedsProtocolRepublishSkipsAlignedMediaOnlyAccount",
+        "TestSupplierAccountNeedsProtocolRepublishCleansStaleMediaOnlyCapability",
         "TestUS048_OpenAISupplierAccountsDoNotBlockAnthropicParallelSourceSync",
         "TestUS048_SameTransportOtherSourceManagedStillConflicts",
         "TestUS048_IncompatibleTransportCandidatesAreIgnoredForOpenAISupplier",
@@ -7952,6 +7957,7 @@
         "supplierAccountNeedsProtocolRepublish(account, source.Endpoint, source.ChannelType)",
         "UpdateManagedAccountConcurrency(",
         "ResolveSupplierSourceAccountConcurrency(source.AccountConcurrency)",
+        "return account.ProtocolEndpointCapabilityID != nil || account.ProtocolEndpointCapability != nil",
         "identity.Key() != account.ProtocolEndpointCapability.CapabilityKey",
         "ChannelType:           source.ChannelType,",
         "relevantMatches := make([]*Account, 0, len(matches))"
@@ -7959,7 +7965,68 @@
       "must_not_contain": [
         "result.ProbeResults = s.probeSupplierTargets"
       ],
-      "rationale": "Supplier sync repairs managed-account concurrency through the narrow concurrency write. Transport or capability identity drift is repaired by projection writes that declare channel_type protocol capability without a live model probe. Adoption candidates are already transport-scoped by FindCredentialEndpointMatches(channel_type); sync only skips this source's managed accounts before adopt/conflict."
+      "rationale": "Supplier sync repairs managed-account concurrency through the narrow concurrency write. Governed text identity drift is repaired by a projection write; media-only accounts without a text capability are already converged, while a stale capability link triggers exactly one cleanup write. Adoption candidates are already transport-scoped by FindCredentialEndpointMatches(channel_type); sync only skips this source's managed accounts before adopt/conflict."
+    },
+    {
+      "path": "backend/internal/service/protocol_probe_model_tk.go",
+      "must_contain": [
+        "if account.ChannelType == newapiconstant.ChannelTypeDoubaoVideo {",
+        "func protocolRoutingAccountHasNoTextModels(account *Account) bool"
+      ],
+      "rationale": "Channel type 54 is a video endpoint family even when a private upstream SKU lacks a seedance-style name. It must never enter text protocol governance or supplier capability publication."
+    },
+    {
+      "path": "ops/observability/supplier_projection_check.py",
+      "must_contain": [
+        "MEDIA_ONLY_CHANNEL_TYPES = {54}",
+        "def evaluate_snapshot(snapshot: dict[str, Any], fingerprint_key: str)",
+        "\"ignored_runtime_fields\": [\"status\", \"schedulable\"]",
+        "hmac.compare_digest",
+        "\"verdict\": \"drift\" if drift else \"aligned\""
+      ],
+      "rationale": "Pure post-release supplier projection evaluator. It derives bands, compares supplier-owned structural fields and credential HMACs, excludes scheduler-owned runtime state, treats video as non-text, and emits only redacted field-named drift."
+    },
+    {
+      "path": "ops/observability/probe-supplier-projection.sh",
+      "must_contain": [
+        "default_transaction_read_only=on",
+        "python3 /tmp/supplier_projection_check.py --snapshot -",
+        "COALESCE(a.extra, '{}'::jsonb) ? 'supplier_source_id'"
+      ],
+      "must_not_contain": [
+        "'status', a.status",
+        "'schedulable', a.schedulable"
+      ],
+      "rationale": "Remote read-only owner for the post-release supplier/account snapshot. It computes credential alignment on-host and never selects scheduling state, so status or quota-driven schedulability cannot become configuration drift."
+    },
+    {
+      "path": "ops/observability/check-supplier-projection.sh",
+      "must_contain": [
+        "0 aligned, 1 drift, 2 setup/transport failure",
+        "--script \"$ROOT/ops/observability/probe-supplier-projection.sh\"",
+        "drift) exit 1",
+        "setup_error) exit 2"
+      ],
+      "rationale": "Local post-release entrypoint maps run-probe's generic remote-failure code back to stable checker semantics while preserving the redacted JSON report."
+    },
+    {
+      "path": "ops/observability/test_supplier_projection_check.py",
+      "must_contain": [
+        "test_runtime_scheduling_state_does_not_create_drift",
+        "test_structural_and_credential_drift_is_field_named_and_redacted",
+        "test_media_only_projection_needs_no_text_capability",
+        "test_media_only_stale_text_capability_is_drift"
+      ],
+      "rationale": "Behavior regressions pin runtime-state exclusion, credential redaction, structural drift, and the media-only capability lifecycle for the post-release checker."
+    },
+    {
+      "path": ".github/workflows/deploy-stage0.yml",
+      "must_contain": [
+        "name: Post-deploy supplier projection check (read-only)",
+        "bash ops/observability/check-supplier-projection.sh",
+        "--expected-instance-id \"$INSTANCE_ID\""
+      ],
+      "rationale": "The supplier projection audit runs automatically after the prod smoke/display gates as an advisory post-release check against the exact deployed instance."
     },
     {
       "path": "backend/internal/service/supplier_source_account_store.go",


### PR DESCRIPTION
## 摘要

- 修复 DoubaoVideo 等 media-only 供应源被误投影到文本协议路由的问题，并在同步时清理历史 stale protocol capability link。
- 新增供应源与受管账号投影一致性检查，覆盖基础字段、凭据 HMAC、model_mapping、优先级、并发与协议能力。
- 将检查接入 Stage0 部署后的 advisory post-release 流程；status/schedulable 属于运行时调度状态，明确不作为不一致判据。

## 风险

- 风险等级：normal。
- Web impact: none。
- 发布后检查为 advisory，不阻断已完成的部署。

## 验证

- `go test ./internal/service ./internal/repository -count=1`
- Python、workflow 与 run-probe 聚焦测试：42 tests passed
- `scripts/export_agent_contract.py --check`
- gateway sentinel check
- `PREFLIGHT_BASE=origin/main ./scripts/preflight.sh`：PASS
- 生产只读检查：13 个供应源、25 个受管账号；#9 cloudwise/default 当前完全对齐；调度状态已从差异中排除。

## 提交

- `c0abf18ab` fix(supplier): keep video projection out of text routing (no-web-impact)
- `bf6e07e2f` fix(supplier): remove dead audit bookkeeping (no-web-impact)
- `80d807299` Merge remote-tracking branch origin/main into chore/source0904

最新提交：`80d807299`