### PR TITLE
fix(ops): pgdump restore canary dump 过期自愈 (#1881-#1884)

### DIFF
--- a/ops/observability/pgdump_restore_canary_verdict.py
+++ b/ops/observability/pgdump_restore_canary_verdict.py
@@ -52,17 +52,30 @@ def _parse_time(value: object) -> dt.datetime | None:
     return parsed.astimezone(dt.timezone.utc)
 
 
-def _finding(target_id: str, *, healthy: bool, summary: str) -> dict[str, str]:
+def _finding(
+    target_id: str,
+    *,
+    healthy: bool,
+    summary: str,
+    status: str | None = None,
+    severity: str | None = None,
+) -> dict[str, str]:
+    if status is None:
+        status = "ok" if healthy else "issue_candidate"
+    if severity is None:
+        severity = "info" if healthy else "error"
+    if status == "warning":
+        title = f"pg_dump restore canary self-healed for {target_id}"
+    elif healthy:
+        title = f"pg_dump restore canary is current for {target_id}"
+    else:
+        title = f"pg_dump restore canary needs attention for {target_id}"
     return {
         "target_id": target_id,
         "kind": "pgdump_restore_canary",
-        "status": "ok" if healthy else "issue_candidate",
-        "severity": "info" if healthy else "error",
-        "title": (
-            f"pg_dump restore canary is current for {target_id}"
-            if healthy
-            else f"pg_dump restore canary needs attention for {target_id}"
-        ),
+        "status": status,
+        "severity": severity,
+        "title": title,
         "summary": summary,
         "signature": f"pgdump-restore-canary|{target_id}",
     }
@@ -143,6 +156,17 @@ def evaluate_receipt(
     age = current_time.astimezone(dt.timezone.utc) - completed_at
     if age < dt.timedelta(0) or age > MAX_RECEIPT_AGE:
         return _finding(target_id, healthy=False, summary=f"restore canary receipt is stale: age={age}")
+    if receipt.get("healed_from_stale_dump") is True:
+        return _finding(
+            target_id,
+            healthy=True,
+            status="warning",
+            severity="warning",
+            summary=(
+                "restore canary self-healed after a stale S3 dump; "
+                "verify tokenkey-pgdump.timer still publishes hourly objects"
+            ),
+        )
     return _finding(
         target_id,
         healthy=True,

--- a/ops/observability/test_pgdump_restore_canary_verdict.py
+++ b/ops/observability/test_pgdump_restore_canary_verdict.py
@@ -60,6 +60,15 @@ class PgdumpRestoreCanaryVerdictTest(unittest.TestCase):
         self.assertEqual(finding["status"], "ok")
         self.assertEqual(finding["kind"], "pgdump_restore_canary")
 
+    def test_healed_from_stale_dump_receipt_is_warning_not_missing(self) -> None:
+        receipt = valid_receipt()
+        receipt["healed_from_stale_dump"] = True
+        finding = self.evaluate(json.dumps(receipt))
+        self.assertEqual(finding["status"], "warning")
+        self.assertEqual(finding["severity"], "warning")
+        self.assertIn("self-healed", finding["summary"])
+        self.assertIn("tokenkey-pgdump.timer", finding["summary"])
+
     def test_missing_receipt_is_actionable(self) -> None:
         finding = self.evaluate("")
         self.assertEqual(finding["status"], "issue_candidate")

--- a/ops/stage0/pgdump_restore_canary.py
+++ b/ops/stage0/pgdump_restore_canary.py
@@ -546,9 +546,26 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: Iterable[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    receipt_root = pathlib.Path(args.receipt_root)
     try:
-        runner = run_fresh_dump_canary if args.create_dump else run_canary
-        receipt = runner(args.target, receipt_root=pathlib.Path(args.receipt_root))
+        if args.create_dump:
+            receipt = run_fresh_dump_canary(args.target, receipt_root=receipt_root)
+        else:
+            try:
+                receipt = run_canary(args.target, receipt_root=receipt_root)
+            except CanaryError as exc:
+                # Hourly dumps can gap after edge IP rotation / timer drift.
+                # Prefer restoring the newest S3 object when it is fresh; otherwise
+                # self-heal by creating one dump and proving its round-trip restore
+                # so daily diagnostics stop filing missing-receipt issues for a week.
+                if "stale or future-dated" not in str(exc):
+                    raise
+                print(
+                    f"pgdump restore canary: existing dump unusable ({exc}); "
+                    "creating a fresh dump",
+                    file=sys.stderr,
+                )
+                receipt = run_fresh_dump_canary(args.target, receipt_root=receipt_root)
     except CanaryError as exc:
         print(f"pgdump restore canary failed: {exc}", file=sys.stderr)
         return 2

--- a/ops/stage0/pgdump_restore_canary.py
+++ b/ops/stage0/pgdump_restore_canary.py
@@ -39,6 +39,10 @@ class CanaryError(RuntimeError):
     """The restore canary could not prove a usable recovery object."""
 
 
+class StaleDumpError(CanaryError):
+    """Newest matching S3 dump is outside the restore freshness window."""
+
+
 def _default_run(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
     return subprocess.run(args, **kwargs)
 
@@ -242,7 +246,7 @@ def _select_object(
     modified, key, modified_raw, size = max(candidates, key=lambda item: item[0])
     age = current_time.astimezone(dt.timezone.utc) - modified
     if age < dt.timedelta(0) or age > FRESHNESS:
-        raise CanaryError(f"newest S3 pgdump object is stale or future-dated: age={age}")
+        raise StaleDumpError(f"newest S3 pgdump object is stale or future-dated: age={age}")
     return key, modified_raw, size
 
 
@@ -553,19 +557,24 @@ def main(argv: Iterable[str] | None = None) -> int:
         else:
             try:
                 receipt = run_canary(args.target, receipt_root=receipt_root)
-            except CanaryError as exc:
+            except StaleDumpError as exc:
                 # Hourly dumps can gap after edge IP rotation / timer drift.
                 # Prefer restoring the newest S3 object when it is fresh; otherwise
                 # self-heal by creating one dump and proving its round-trip restore
                 # so daily diagnostics stop filing missing-receipt issues for a week.
-                if "stale or future-dated" not in str(exc):
-                    raise
+                # Stamp the receipt so verdict can warn: edges have no separate
+                # pgdump_freshness gate, and a silent healthy receipt would hide a
+                # broken tokenkey-pgdump.timer until the next weekly run.
                 print(
                     f"pgdump restore canary: existing dump unusable ({exc}); "
                     "creating a fresh dump",
                     file=sys.stderr,
                 )
-                receipt = run_fresh_dump_canary(args.target, receipt_root=receipt_root)
+                receipt = dict(
+                    run_fresh_dump_canary(args.target, receipt_root=receipt_root)
+                )
+                receipt["healed_from_stale_dump"] = True
+                _atomic_receipt(receipt_root / "latest.json", receipt)
     except CanaryError as exc:
         print(f"pgdump restore canary failed: {exc}", file=sys.stderr)
         return 2

--- a/ops/stage0/test_pgdump_restore_canary.py
+++ b/ops/stage0/test_pgdump_restore_canary.py
@@ -222,6 +222,49 @@ class PgdumpRestoreCanaryTest(unittest.TestCase):
             self.run_case(fake)
         self.assertFalse(any(call[:3] == ["aws", "s3", "cp"] for call in fake.calls))
 
+    def test_main_falls_back_to_fresh_dump_when_newest_object_is_stale(self) -> None:
+        healed = {
+            "schema_version": 2,
+            "mode": "pgdump_restore_canary",
+            "target": "edge:us3",
+            "completed_at": "2026-08-18T08:00:00Z",
+            "s3_round_trip_verified": True,
+        }
+        with tempfile.TemporaryDirectory() as raw:
+            receipt_root = pathlib.Path(raw) / "canary"
+            with mock.patch.object(
+                canary,
+                "run_canary",
+                side_effect=canary.CanaryError(
+                    "newest S3 pgdump object is stale or future-dated: age=2 days"
+                ),
+            ) as restore_existing:
+                with mock.patch.object(
+                    canary, "run_fresh_dump_canary", return_value=healed
+                ) as create_dump:
+                    code = canary.main(
+                        ["--target", "edge:us3", "--receipt-root", str(receipt_root)]
+                    )
+        self.assertEqual(code, 0)
+        restore_existing.assert_called_once()
+        create_dump.assert_called_once()
+        self.assertEqual(create_dump.call_args.kwargs["receipt_root"], receipt_root)
+
+    def test_main_does_not_fall_back_for_non_stale_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            receipt_root = pathlib.Path(raw) / "canary"
+            with mock.patch.object(
+                canary,
+                "run_canary",
+                side_effect=canary.CanaryError("live PostgreSQL container is not running"),
+            ):
+                with mock.patch.object(canary, "run_fresh_dump_canary") as create_dump:
+                    code = canary.main(
+                        ["--target", "edge:us3", "--receipt-root", str(receipt_root)]
+                    )
+        self.assertEqual(code, 2)
+        create_dump.assert_not_called()
+
     def test_insufficient_capacity_aborts_before_docker_run(self) -> None:
         fake = FakeCommands()
         with self.assertRaisesRegex(canary.CanaryError, "capacity"):

--- a/ops/stage0/test_pgdump_restore_canary.py
+++ b/ops/stage0/test_pgdump_restore_canary.py
@@ -218,7 +218,7 @@ class PgdumpRestoreCanaryTest(unittest.TestCase):
 
     def test_stale_object_fails_before_download(self) -> None:
         fake = FakeCommands(objects=[{"Key": "edge/us3/pgdump/tokenkey-20260818T010000Z.sql.gz", "LastModified": "2026-08-18T01:01:00Z", "Size": 2000}])
-        with self.assertRaisesRegex(canary.CanaryError, "stale"):
+        with self.assertRaisesRegex(canary.StaleDumpError, "stale"):
             self.run_case(fake)
         self.assertFalse(any(call[:3] == ["aws", "s3", "cp"] for call in fake.calls))
 
@@ -232,10 +232,11 @@ class PgdumpRestoreCanaryTest(unittest.TestCase):
         }
         with tempfile.TemporaryDirectory() as raw:
             receipt_root = pathlib.Path(raw) / "canary"
+            receipt_root.mkdir()
             with mock.patch.object(
                 canary,
                 "run_canary",
-                side_effect=canary.CanaryError(
+                side_effect=canary.StaleDumpError(
                     "newest S3 pgdump object is stale or future-dated: age=2 days"
                 ),
             ) as restore_existing:
@@ -245,10 +246,13 @@ class PgdumpRestoreCanaryTest(unittest.TestCase):
                     code = canary.main(
                         ["--target", "edge:us3", "--receipt-root", str(receipt_root)]
                     )
+            written = json.loads((receipt_root / "latest.json").read_text(encoding="utf-8"))
         self.assertEqual(code, 0)
         restore_existing.assert_called_once()
         create_dump.assert_called_once()
         self.assertEqual(create_dump.call_args.kwargs["receipt_root"], receipt_root)
+        self.assertTrue(written["healed_from_stale_dump"])
+        self.assertEqual(written["target"], "edge:us3")
 
     def test_main_does_not_fall_back_for_non_stale_failures(self) -> None:
         with tempfile.TemporaryDirectory() as raw:


### PR DESCRIPTION
## 摘要
- edge-us3/4/5/6 的 `#1881`–`#1884`：周 restore canary 因 S3 dump 过期（>3h）失败，主机无收据，日诊断连续报 `receipt is missing`
- 根因：8/28 IP 轮换后 dump 曾断档；8/31 周 canary 失败后直到下次周一都不会重写收据
- 修复：默认路径仍优先恢复最新 S3 dump；若 stale，自动回退 `--create-dump` 自愈，并在收据写入 `healed_from_stale_dump=true`，日诊断 verdict 以 warning 暴露 dump timer 断档
- 已对 `edge:*` 重跑 Fleet restore canary（run 33851279428）全部成功，收据已落盘；issues 已关闭

## 风险
- 常规风险：仅 ops canary / verdict 行为；非 stale 失败路径不变；不改网关/计费
- `#1810` upstream-merge 未纳入本 PR

## 验证
- `python3 -m unittest ops.stage0.test_pgdump_restore_canary ops.observability.test_pgdump_restore_canary_verdict -v` 全绿
- `./scripts/preflight.sh` 通过
- Fleet restore canary run 33851279428 success（us3/us4/us5/us6）

## 提交
- `24cb67b0b` fix(ops): pgdump restore canary 在 dump 过期时自愈建档
- `5f3afbe35` fix(ops): address R-001..R-002 — 自愈收据告警与 StaleDumpError
- 最新提交：`5f3afbe35`