### PR TITLE
refactor: P0 上游热点 TK companion 抽取（功能不变）

### DIFF
--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -3,9 +3,6 @@ package admin
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -19,14 +16,9 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/handler/dto"
-	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
-	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
-	"github.com/Wei-Shaw/sub2api/internal/pkg/geminicli"
-	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/response"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
-	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 
 	"github.com/gin-gonic/gin"
@@ -36,43 +28,6 @@ import (
 // OAuthHandler handles OAuth-related operations for accounts
 type OAuthHandler struct {
 	oauthService *service.OAuthService
-}
-
-type protocolCapabilityProbeScheduler interface {
-	ProbeAccountProtocolCapabilitiesBatch(ctx context.Context, accountIDs []int64)
-}
-
-type protocolCapabilityProbeRunner interface {
-	ProbeAccountProtocolCapabilitiesNow(ctx context.Context, accountID int64) (service.ProtocolProbeRunResult, error)
-}
-
-type protocolCapabilityProbeResponse struct {
-	CapabilityKey        string     `json:"capability_key"`
-	SupportedProtocols   []string   `json:"supported_protocols"`
-	Revision             int64      `json:"revision"`
-	LastProbedAt         *time.Time `json:"last_probed_at"`
-	AffectedAccountCount int        `json:"affected_account_count"`
-}
-
-func protocolCapabilityProbeProjection(result service.ProtocolProbeRunResult) *protocolCapabilityProbeResponse {
-	if result.Capability == nil {
-		return nil
-	}
-	protocols, err := service.NormalizeSupportedProtocols(result.Capability.SupportedProtocols)
-	if err != nil {
-		protocols = nil
-	}
-	supportedProtocols := make([]string, len(protocols))
-	for i, protocol := range protocols {
-		supportedProtocols[i] = string(protocol)
-	}
-	return &protocolCapabilityProbeResponse{
-		CapabilityKey:        result.Capability.CapabilityKey,
-		SupportedProtocols:   supportedProtocols,
-		Revision:             result.Capability.Revision,
-		LastProbedAt:         result.Capability.LastProbedAt,
-		AffectedAccountCount: result.AffectedAccountCount,
-	}
 }
 
 // NewOAuthHandler creates a new OAuth handler
@@ -696,44 +651,15 @@ func (h *AccountHandler) List(c *gin.Context) {
 	// Build response with concurrency info
 	result := make([]AccountWithConcurrency, len(accounts))
 	for i := range accounts {
-		acc := &accounts[i]
-		// In lite mode (list view) use the shallow mapper, which keeps GroupIDs but
-		// omits the fully-embedded Groups/AccountGroups objects. Those dominate the
-		// list payload (~3.1KB of ~4.5KB per row — the same group definitions are
-		// duplicated across every account row), and the list resolves group chips
-		// client-side from group_ids + the already-loaded groups list. The full
-		// payload (with embedded Groups) is still served for non-lite callers and
-		// for single-account detail/edit fetches.
-		accountDTO := dto.AccountFromService(acc)
-		if lite {
-			accountDTO = dto.AccountFromServiceShallow(acc)
-		}
-		accountDTO = h.enrichAccountResponse(accountDTO)
-		item := AccountWithConcurrency{
-			Account:            accountDTO,
-			CurrentConcurrency: concurrencyCounts[acc.ID],
-			SchedulerScore:     schedulerScores[acc.ID],
-			SchedulerScores:    schedulerGroupScores[acc.ID],
-			// TK: tag anthropic mirror-stub rows with their edge id so the accounts
-			// UI can expand them into that edge's accounts inline ("" for non-stubs).
-			EdgeID: service.MirrorStubEdgeID(acc),
-		}
-
-		// 添加活跃会话数（仅当启用时）
-		if activeSessions != nil {
-			if count, ok := activeSessions[acc.ID]; ok {
-				item.ActiveSessions = &count
-			}
-		}
-
-		// 添加 RPM 计数（仅当启用时）
-		if rpmCounts != nil {
-			if rpm, ok := rpmCounts[acc.ID]; ok {
-				item.CurrentRPM = &rpm
-			}
-		}
-
-		result[i] = item
+		result[i] = h.tkBuildAccountListRow(
+			&accounts[i],
+			lite,
+			concurrencyCounts,
+			schedulerScores,
+			schedulerGroupScores,
+			activeSessions,
+			rpmCounts,
+		)
 	}
 
 	h.enrichShadowParents(c.Request.Context(), result)
@@ -749,76 +675,6 @@ func (h *AccountHandler) List(c *gin.Context) {
 	}
 
 	response.Paginated(c, result, total, page, pageSize)
-}
-
-func parseAccountListChannelTypeQuery(raw string) (int, error) {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return 0, nil
-	}
-	parsed, err := strconv.Atoi(raw)
-	if err != nil || parsed < 0 {
-		return 0, infraerrors.BadRequest("INVALID_CHANNEL_TYPE_FILTER", "invalid channel_type filter")
-	}
-	return parsed, nil
-}
-
-func buildAccountsListETag(
-	items []AccountWithConcurrency,
-	total int64,
-	page, pageSize int,
-	platform, accountType, status, search string,
-	channelType int,
-	lite bool,
-) string {
-	payload := struct {
-		Total       int64                    `json:"total"`
-		Page        int                      `json:"page"`
-		PageSize    int                      `json:"page_size"`
-		Platform    string                   `json:"platform"`
-		AccountType string                   `json:"type"`
-		Status      string                   `json:"status"`
-		Search      string                   `json:"search"`
-		ChannelType int                      `json:"channel_type"`
-		Lite        bool                     `json:"lite"`
-		Items       []AccountWithConcurrency `json:"items"`
-	}{
-		Total:       total,
-		Page:        page,
-		PageSize:    pageSize,
-		Platform:    platform,
-		AccountType: accountType,
-		Status:      status,
-		Search:      search,
-		ChannelType: channelType,
-		Lite:        lite,
-		Items:       items,
-	}
-	raw, err := json.Marshal(payload)
-	if err != nil {
-		return ""
-	}
-	sum := sha256.Sum256(raw)
-	return "\"" + hex.EncodeToString(sum[:]) + "\""
-}
-
-func ifNoneMatchMatched(ifNoneMatch, etag string) bool {
-	if etag == "" || ifNoneMatch == "" {
-		return false
-	}
-	for _, token := range strings.Split(ifNoneMatch, ",") {
-		candidate := strings.TrimSpace(token)
-		if candidate == "*" {
-			return true
-		}
-		if candidate == etag {
-			return true
-		}
-		if strings.HasPrefix(candidate, "W/") && strings.TrimPrefix(candidate, "W/") == etag {
-			return true
-		}
-	}
-	return false
 }
 
 // GetByID handles getting an account by ID
@@ -1102,50 +958,6 @@ func (h *AccountHandler) Update(c *gin.Context) {
 	response.Success(c, h.buildAccountResponseWithRuntime(c.Request.Context(), account))
 }
 
-func (h *AccountHandler) scheduleProtocolCapabilityProbes(account *service.Account) {
-	if account == nil {
-		return
-	}
-	if h.protocolProbeScheduler == nil {
-		return
-	}
-	if len(service.ProtocolProbeCandidates(account)) == 0 {
-		return
-	}
-	h.scheduleProtocolCapabilityProbeBatch([]int64{account.ID})
-}
-
-func (h *AccountHandler) scheduleProtocolCapabilityProbeBatch(accountIDs []int64) {
-	if h == nil || h.protocolProbeScheduler == nil || len(accountIDs) == 0 {
-		return
-	}
-	ids := append([]int64(nil), accountIDs...)
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				slog.Error("protocol_capability_probe_panic", "account_count", len(ids), "recover", r)
-			}
-		}()
-		h.protocolProbeScheduler.ProbeAccountProtocolCapabilitiesBatch(context.Background(), ids)
-	}()
-}
-
-func protocolCapabilityProbeRequiredForUpdate(req UpdateAccountRequest) bool {
-	if req.Type != "" || req.ChannelType != nil || len(req.Credentials) > 0 {
-		return true
-	}
-	return protocolCapabilityExtraChanged(req.Extra)
-}
-
-func protocolCapabilityExtraChanged(extra map[string]any) bool {
-	if len(extra) == 0 {
-		return false
-	}
-	_, customBaseURLChanged := extra["custom_base_url"]
-	_, customBaseURLEnabledChanged := extra["custom_base_url_enabled"]
-	return customBaseURLChanged || customBaseURLEnabledChanged
-}
-
 // Delete handles deleting an account
 // DELETE /api/v1/admin/accounts/:id
 func (h *AccountHandler) Delete(c *gin.Context) {
@@ -1221,57 +1033,6 @@ func (h *AccountHandler) Test(c *gin.Context) {
 	if account, err := h.adminService.GetAccount(c.Request.Context(), accountID); err == nil {
 		h.scheduleProtocolCapabilityProbes(account)
 	}
-}
-
-// ProbeProtocols synchronously re-tests the native text protocols for one
-// account and returns the refreshed account snapshot.
-// POST /api/v1/admin/accounts/:id/protocol-probe
-func (h *AccountHandler) ProbeProtocols(c *gin.Context) {
-	accountID, err := strconv.ParseInt(c.Param("id"), 10, 64)
-	if err != nil {
-		response.BadRequest(c, "Invalid account ID")
-		return
-	}
-
-	account, err := h.adminService.GetAccount(c.Request.Context(), accountID)
-	if err != nil {
-		response.ErrorFrom(c, err)
-		return
-	}
-	if h.protocolProbeScheduler == nil {
-		response.ErrorWithDetails(c, http.StatusServiceUnavailable, "Protocol probe unavailable", "protocol_probe_unavailable", nil)
-		return
-	}
-	if len(service.ProtocolProbeCandidates(account)) == 0 {
-		response.Success(c, gin.H{
-			"account": h.buildAccountResponseWithRuntime(c.Request.Context(), account),
-			"outcome": service.ProtocolProbeRunNotApplicable,
-			"reason":  "no_protocol_probe_candidates",
-		})
-		return
-	}
-	runner, ok := h.protocolProbeScheduler.(protocolCapabilityProbeRunner)
-	if !ok {
-		response.ErrorWithDetails(c, http.StatusServiceUnavailable, "Protocol probe unavailable", "protocol_probe_unavailable", nil)
-		return
-	}
-	result, err := runner.ProbeAccountProtocolCapabilitiesNow(c.Request.Context(), accountID)
-	if err != nil {
-		response.ErrorFrom(c, fmt.Errorf("protocol probe account %d: %w", accountID, err))
-		return
-	}
-	account, err = h.adminService.GetAccount(c.Request.Context(), accountID)
-	if err != nil {
-		response.ErrorFrom(c, err)
-		return
-	}
-
-	response.Success(c, gin.H{
-		"account":    h.buildAccountResponseWithRuntime(c.Request.Context(), account),
-		"capability": protocolCapabilityProbeProjection(result),
-		"outcome":    result.Outcome,
-		"reason":     result.Reason,
-	})
 }
 
 // RecoverState handles unified recovery of recoverable account runtime state.
@@ -2875,197 +2636,6 @@ func (h *AccountHandler) GetAvailableModels(c *gin.Context) {
 	}
 
 	response.Success(c, tkClaudeAdminModelsForIDs(sortedModelMappingKeys(mapping)))
-}
-
-// Admin available-models always crosses the HTTP boundary as one minimal DTO;
-// platform package model types remain internal metadata sources.
-func tkAdminModelOptions[T any](models []T, fields func(T) (string, string)) []dto.AccountModelOption {
-	out := make([]dto.AccountModelOption, 0, len(models))
-	for _, model := range models {
-		id, displayName := fields(model)
-		if displayName == "" {
-			displayName = id
-		}
-		out = append(out, dto.AccountModelOption{ID: id, DisplayName: displayName})
-	}
-	return out
-}
-
-func tkAdminModelOptionsForIDs(ids []string) []dto.AccountModelOption {
-	out := make([]dto.AccountModelOption, 0, len(ids))
-	for _, id := range ids {
-		out = append(out, dto.AccountModelOption{ID: id, DisplayName: id})
-	}
-	return out
-}
-
-func sortedModelMappingKeys(mapping map[string]string) []string {
-	ids := make([]string, 0, len(mapping))
-	for id := range mapping {
-		ids = append(ids, id)
-	}
-	sort.Strings(ids)
-	return ids
-}
-
-func tkOpenAIAdminModelsForIDs(ids []string) []dto.AccountModelOption {
-	return tkAdminModelOptions(openai.ModelsForIDs(ids), func(model openai.Model) (string, string) {
-		return model.ID, model.DisplayName
-	})
-}
-
-func tkOpenAIAdminDefaultModels(ctx context.Context) []dto.AccountModelOption {
-	ids := service.ServableClientFacingIDs(ctx, service.PlatformOpenAI, nil, nil)
-	defaultModelID := openai.DefaultModels[0].ID
-	sort.SliceStable(ids, func(i, j int) bool {
-		if ids[i] == defaultModelID || ids[j] == defaultModelID {
-			return ids[i] == defaultModelID && ids[j] != defaultModelID
-		}
-		return ids[i] < ids[j]
-	})
-	return tkOpenAIAdminModelsForIDs(ids)
-}
-
-func tkGrokAdminModelsForIDs(ids []string) []dto.AccountModelOption {
-	return tkAdminModelOptions(xai.ModelsForIDs(ids), func(model xai.Model) (string, string) {
-		return model.ID, model.DisplayName
-	})
-}
-
-func tkGrokAdminDefaultModels(ctx context.Context) []dto.AccountModelOption {
-	ids := service.ServableClientFacingIDs(ctx, service.PlatformGrok, nil, nil)
-	sort.SliceStable(ids, func(i, j int) bool {
-		if ids[i] == service.GrokDefaultTestModelID {
-			return true
-		}
-		if ids[j] == service.GrokDefaultTestModelID {
-			return false
-		}
-		return ids[i] < ids[j]
-	})
-	return tkGrokAdminModelsForIDs(ids)
-}
-
-func accountHasExplicitModelMapping(account *service.Account) bool {
-	if account == nil {
-		return false
-	}
-	switch rawMapping := account.Credentials["model_mapping"].(type) {
-	case map[string]any:
-		return len(rawMapping) > 0
-	case map[string]string:
-		return len(rawMapping) > 0
-	default:
-		return false
-	}
-}
-
-func tkGeminiAdminModelsForIDs(ids []string) []dto.AccountModelOption {
-	return tkAdminModelOptions(geminicli.ModelsForIDs(ids), func(model geminicli.Model) (string, string) {
-		return model.ID, model.DisplayName
-	})
-}
-
-func tkGeminiAdminDefaultModels(ctx context.Context) []dto.AccountModelOption {
-	return tkGeminiAdminModelsForIDs(
-		service.ServableClientFacingIDs(ctx, service.PlatformGemini, nil, nil),
-	)
-}
-
-func tkGeminiAdminAvailableModels(ctx context.Context, account *service.Account) []dto.AccountModelOption {
-	mapping := account.GetModelMapping()
-	if len(mapping) == 0 {
-		return tkGeminiAdminDefaultModels(ctx)
-	}
-	// Google One mapping is already a conservative whitelist; do not intersect
-	// with the global servable catalog (gemini-2.0-flash may be menu-hidden).
-	if account.IsGeminiGoogleOne() {
-		ids := make([]string, 0, len(mapping))
-		for requestedModel := range mapping {
-			ids = append(ids, requestedModel)
-		}
-		sort.Strings(ids)
-		return tkGeminiAdminModelsForIDs(ids)
-	}
-	return tkGeminiAdminModelsForMapping(ctx, mapping)
-}
-
-func tkGeminiAdminModelsForMapping(ctx context.Context, mapping map[string]string) []dto.AccountModelOption {
-	if len(mapping) == 0 {
-		return tkGeminiAdminDefaultModels(ctx)
-	}
-
-	servable := service.ServableClientFacingIDs(ctx, service.PlatformGemini, nil, nil)
-	servableSet := make(map[string]struct{}, len(servable))
-	for _, id := range servable {
-		servableSet[id] = struct{}{}
-	}
-
-	ids := make([]string, 0, len(mapping))
-	for requestedModel := range mapping {
-		if len(servableSet) > 0 {
-			if _, ok := servableSet[requestedModel]; !ok {
-				continue
-			}
-		}
-		ids = append(ids, requestedModel)
-	}
-	sort.Strings(ids)
-	return tkGeminiAdminModelsForIDs(ids)
-}
-
-// tkAntigravityAdminDefaultModels returns admin account-test models from the unified
-// antigravity servable set, intersected with the account whitelist (mapAntigravityModel).
-// Matches gateway tkAntigravityDefaultModels; DefaultModels only supplies display metadata.
-func tkAntigravityAdminDefaultModels(ctx context.Context, account *service.Account) []dto.AccountModelOption {
-	defaults := antigravity.DefaultModels()
-	byID := make(map[string]antigravity.ClaudeModel, len(defaults))
-	for _, m := range defaults {
-		byID[m.ID] = m
-	}
-	ids := service.ServableClientFacingIDs(ctx, service.PlatformAntigravity, nil, nil)
-	sort.SliceStable(ids, func(i, j int) bool {
-		if ids[i] == service.AntigravityDefaultTestModelID {
-			return true
-		}
-		if ids[j] == service.AntigravityDefaultTestModelID {
-			return false
-		}
-		return ids[i] < ids[j]
-	})
-	out := make([]dto.AccountModelOption, 0, len(ids))
-	for _, id := range ids {
-		if account != nil && service.MapAntigravityModel(account, id) == "" {
-			continue
-		}
-		if m, ok := byID[id]; ok {
-			out = append(out, dto.AccountModelOption{ID: id, DisplayName: m.DisplayName})
-			continue
-		}
-		out = append(out, dto.AccountModelOption{ID: id, DisplayName: id})
-	}
-	return out
-}
-
-func tkClaudeModelsToAdminOptions(models []claude.Model, ids []string) []dto.AccountModelOption {
-	out := tkAdminModelOptions(models, func(model claude.Model) (string, string) {
-		return model.ID, model.DisplayName
-	})
-	if len(ids) == len(out) {
-		for i := range out {
-			out[i].ID = ids[i]
-		}
-	}
-	return out
-}
-
-func tkClaudeAdminModelsForIDs(ids []string) []dto.AccountModelOption {
-	return tkClaudeModelsToAdminOptions(claude.ModelsForIDs(ids), ids)
-}
-
-func tkClaudeAdminDefaultModels(ctx context.Context) []dto.AccountModelOption {
-	ids := service.ServableClientFacingIDs(ctx, service.PlatformAnthropic, nil, nil)
-	return tkClaudeModelsToAdminOptions(claude.ModelsForIDs(ids), nil)
 }
 
 // SyncUpstreamModels handles syncing live supported models from an account's upstream.

--- a/backend/internal/handler/admin/account_handler_tk_available_models.go
+++ b/backend/internal/handler/admin/account_handler_tk_available_models.go
@@ -1,0 +1,205 @@
+package admin
+
+import (
+	"context"
+	"sort"
+
+	"github.com/Wei-Shaw/sub2api/internal/handler/dto"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/geminicli"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+// Admin available-models always crosses the HTTP boundary as one minimal DTO;
+// platform package model types remain internal metadata sources.
+func tkAdminModelOptions[T any](models []T, fields func(T) (string, string)) []dto.AccountModelOption {
+	out := make([]dto.AccountModelOption, 0, len(models))
+	for _, model := range models {
+		id, displayName := fields(model)
+		if displayName == "" {
+			displayName = id
+		}
+		out = append(out, dto.AccountModelOption{ID: id, DisplayName: displayName})
+	}
+	return out
+}
+
+func tkAdminModelOptionsForIDs(ids []string) []dto.AccountModelOption {
+	out := make([]dto.AccountModelOption, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, dto.AccountModelOption{ID: id, DisplayName: id})
+	}
+	return out
+}
+
+func sortedModelMappingKeys(mapping map[string]string) []string {
+	ids := make([]string, 0, len(mapping))
+	for id := range mapping {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func tkOpenAIAdminModelsForIDs(ids []string) []dto.AccountModelOption {
+	return tkAdminModelOptions(openai.ModelsForIDs(ids), func(model openai.Model) (string, string) {
+		return model.ID, model.DisplayName
+	})
+}
+
+func tkOpenAIAdminDefaultModels(ctx context.Context) []dto.AccountModelOption {
+	ids := service.ServableClientFacingIDs(ctx, service.PlatformOpenAI, nil, nil)
+	defaultModelID := openai.DefaultModels[0].ID
+	sort.SliceStable(ids, func(i, j int) bool {
+		if ids[i] == defaultModelID || ids[j] == defaultModelID {
+			return ids[i] == defaultModelID && ids[j] != defaultModelID
+		}
+		return ids[i] < ids[j]
+	})
+	return tkOpenAIAdminModelsForIDs(ids)
+}
+
+func tkGrokAdminModelsForIDs(ids []string) []dto.AccountModelOption {
+	return tkAdminModelOptions(xai.ModelsForIDs(ids), func(model xai.Model) (string, string) {
+		return model.ID, model.DisplayName
+	})
+}
+
+func tkGrokAdminDefaultModels(ctx context.Context) []dto.AccountModelOption {
+	ids := service.ServableClientFacingIDs(ctx, service.PlatformGrok, nil, nil)
+	sort.SliceStable(ids, func(i, j int) bool {
+		if ids[i] == service.GrokDefaultTestModelID {
+			return true
+		}
+		if ids[j] == service.GrokDefaultTestModelID {
+			return false
+		}
+		return ids[i] < ids[j]
+	})
+	return tkGrokAdminModelsForIDs(ids)
+}
+
+func accountHasExplicitModelMapping(account *service.Account) bool {
+	if account == nil {
+		return false
+	}
+	switch rawMapping := account.Credentials["model_mapping"].(type) {
+	case map[string]any:
+		return len(rawMapping) > 0
+	case map[string]string:
+		return len(rawMapping) > 0
+	default:
+		return false
+	}
+}
+
+func tkGeminiAdminModelsForIDs(ids []string) []dto.AccountModelOption {
+	return tkAdminModelOptions(geminicli.ModelsForIDs(ids), func(model geminicli.Model) (string, string) {
+		return model.ID, model.DisplayName
+	})
+}
+
+func tkGeminiAdminDefaultModels(ctx context.Context) []dto.AccountModelOption {
+	return tkGeminiAdminModelsForIDs(
+		service.ServableClientFacingIDs(ctx, service.PlatformGemini, nil, nil),
+	)
+}
+
+func tkGeminiAdminAvailableModels(ctx context.Context, account *service.Account) []dto.AccountModelOption {
+	mapping := account.GetModelMapping()
+	if len(mapping) == 0 {
+		return tkGeminiAdminDefaultModels(ctx)
+	}
+	// Google One mapping is already a conservative whitelist; do not intersect
+	// with the global servable catalog (gemini-2.0-flash may be menu-hidden).
+	if account.IsGeminiGoogleOne() {
+		ids := make([]string, 0, len(mapping))
+		for requestedModel := range mapping {
+			ids = append(ids, requestedModel)
+		}
+		sort.Strings(ids)
+		return tkGeminiAdminModelsForIDs(ids)
+	}
+	return tkGeminiAdminModelsForMapping(ctx, mapping)
+}
+
+func tkGeminiAdminModelsForMapping(ctx context.Context, mapping map[string]string) []dto.AccountModelOption {
+	if len(mapping) == 0 {
+		return tkGeminiAdminDefaultModels(ctx)
+	}
+
+	servable := service.ServableClientFacingIDs(ctx, service.PlatformGemini, nil, nil)
+	servableSet := make(map[string]struct{}, len(servable))
+	for _, id := range servable {
+		servableSet[id] = struct{}{}
+	}
+
+	ids := make([]string, 0, len(mapping))
+	for requestedModel := range mapping {
+		if len(servableSet) > 0 {
+			if _, ok := servableSet[requestedModel]; !ok {
+				continue
+			}
+		}
+		ids = append(ids, requestedModel)
+	}
+	sort.Strings(ids)
+	return tkGeminiAdminModelsForIDs(ids)
+}
+
+// tkAntigravityAdminDefaultModels returns admin account-test models from the unified
+// antigravity servable set, intersected with the account whitelist (mapAntigravityModel).
+// Matches gateway tkAntigravityDefaultModels; DefaultModels only supplies display metadata.
+func tkAntigravityAdminDefaultModels(ctx context.Context, account *service.Account) []dto.AccountModelOption {
+	defaults := antigravity.DefaultModels()
+	byID := make(map[string]antigravity.ClaudeModel, len(defaults))
+	for _, m := range defaults {
+		byID[m.ID] = m
+	}
+	ids := service.ServableClientFacingIDs(ctx, service.PlatformAntigravity, nil, nil)
+	sort.SliceStable(ids, func(i, j int) bool {
+		if ids[i] == service.AntigravityDefaultTestModelID {
+			return true
+		}
+		if ids[j] == service.AntigravityDefaultTestModelID {
+			return false
+		}
+		return ids[i] < ids[j]
+	})
+	out := make([]dto.AccountModelOption, 0, len(ids))
+	for _, id := range ids {
+		if account != nil && service.MapAntigravityModel(account, id) == "" {
+			continue
+		}
+		if m, ok := byID[id]; ok {
+			out = append(out, dto.AccountModelOption{ID: id, DisplayName: m.DisplayName})
+			continue
+		}
+		out = append(out, dto.AccountModelOption{ID: id, DisplayName: id})
+	}
+	return out
+}
+
+func tkClaudeModelsToAdminOptions(models []claude.Model, ids []string) []dto.AccountModelOption {
+	out := tkAdminModelOptions(models, func(model claude.Model) (string, string) {
+		return model.ID, model.DisplayName
+	})
+	if len(ids) == len(out) {
+		for i := range out {
+			out[i].ID = ids[i]
+		}
+	}
+	return out
+}
+
+func tkClaudeAdminModelsForIDs(ids []string) []dto.AccountModelOption {
+	return tkClaudeModelsToAdminOptions(claude.ModelsForIDs(ids), ids)
+}
+
+func tkClaudeAdminDefaultModels(ctx context.Context) []dto.AccountModelOption {
+	ids := service.ServableClientFacingIDs(ctx, service.PlatformAnthropic, nil, nil)
+	return tkClaudeModelsToAdminOptions(claude.ModelsForIDs(ids), nil)
+}

--- a/backend/internal/handler/admin/account_handler_tk_list.go
+++ b/backend/internal/handler/admin/account_handler_tk_list.go
@@ -1,0 +1,133 @@
+package admin
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/handler/dto"
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+func parseAccountListChannelTypeQuery(raw string) (int, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, nil
+	}
+	parsed, err := strconv.Atoi(raw)
+	if err != nil || parsed < 0 {
+		return 0, infraerrors.BadRequest("INVALID_CHANNEL_TYPE_FILTER", "invalid channel_type filter")
+	}
+	return parsed, nil
+}
+
+func buildAccountsListETag(
+	items []AccountWithConcurrency,
+	total int64,
+	page, pageSize int,
+	platform, accountType, status, search string,
+	channelType int,
+	lite bool,
+) string {
+	payload := struct {
+		Total       int64                    `json:"total"`
+		Page        int                      `json:"page"`
+		PageSize    int                      `json:"page_size"`
+		Platform    string                   `json:"platform"`
+		AccountType string                   `json:"type"`
+		Status      string                   `json:"status"`
+		Search      string                   `json:"search"`
+		ChannelType int                      `json:"channel_type"`
+		Lite        bool                     `json:"lite"`
+		Items       []AccountWithConcurrency `json:"items"`
+	}{
+		Total:       total,
+		Page:        page,
+		PageSize:    pageSize,
+		Platform:    platform,
+		AccountType: accountType,
+		Status:      status,
+		Search:      search,
+		ChannelType: channelType,
+		Lite:        lite,
+		Items:       items,
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(raw)
+	return "\"" + hex.EncodeToString(sum[:]) + "\""
+}
+
+func ifNoneMatchMatched(ifNoneMatch, etag string) bool {
+	if etag == "" || ifNoneMatch == "" {
+		return false
+	}
+	for _, token := range strings.Split(ifNoneMatch, ",") {
+		candidate := strings.TrimSpace(token)
+		if candidate == "*" {
+			return true
+		}
+		if candidate == etag {
+			return true
+		}
+		if strings.HasPrefix(candidate, "W/") && strings.TrimPrefix(candidate, "W/") == etag {
+			return true
+		}
+	}
+	return false
+}
+
+// tkBuildAccountListRow projects one service.Account into the list DTO with lite
+// shallow mapping, concurrency/RPM/session gauges, and TK mirror-stub EdgeID.
+func (h *AccountHandler) tkBuildAccountListRow(
+	acc *service.Account,
+	lite bool,
+	concurrencyCounts map[int64]int,
+	schedulerScores map[int64]*AccountSchedulerScore,
+	schedulerGroupScores map[int64][]AccountSchedulerGroupScore,
+	activeSessions map[int64]int,
+	rpmCounts map[int64]int,
+) AccountWithConcurrency {
+	// In lite mode (list view) use the shallow mapper, which keeps GroupIDs but
+	// omits the fully-embedded Groups/AccountGroups objects. Those dominate the
+	// list payload (~3.1KB of ~4.5KB per row — the same group definitions are
+	// duplicated across every account row), and the list resolves group chips
+	// client-side from group_ids + the already-loaded groups list. The full
+	// payload (with embedded Groups) is still served for non-lite callers and
+	// for single-account detail/edit fetches.
+	accountDTO := dto.AccountFromService(acc)
+	if lite {
+		accountDTO = dto.AccountFromServiceShallow(acc)
+	}
+	accountDTO = h.enrichAccountResponse(accountDTO)
+	item := AccountWithConcurrency{
+		Account:            accountDTO,
+		CurrentConcurrency: concurrencyCounts[acc.ID],
+		SchedulerScore:     schedulerScores[acc.ID],
+		SchedulerScores:    schedulerGroupScores[acc.ID],
+		// TK: tag anthropic mirror-stub rows with their edge id so the accounts
+		// UI can expand them into that edge's accounts inline ("" for non-stubs).
+		EdgeID: service.MirrorStubEdgeID(acc),
+	}
+
+	// 添加活跃会话数（仅当启用时）
+	if activeSessions != nil {
+		if count, ok := activeSessions[acc.ID]; ok {
+			item.ActiveSessions = &count
+		}
+	}
+
+	// 添加 RPM 计数（仅当启用时）
+	if rpmCounts != nil {
+		if rpm, ok := rpmCounts[acc.ID]; ok {
+			item.CurrentRPM = &rpm
+		}
+	}
+
+	return item
+}

--- a/backend/internal/handler/admin/account_handler_tk_protocol_probe.go
+++ b/backend/internal/handler/admin/account_handler_tk_protocol_probe.go
@@ -1,0 +1,147 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/response"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+type protocolCapabilityProbeScheduler interface {
+	ProbeAccountProtocolCapabilitiesBatch(ctx context.Context, accountIDs []int64)
+}
+
+type protocolCapabilityProbeRunner interface {
+	ProbeAccountProtocolCapabilitiesNow(ctx context.Context, accountID int64) (service.ProtocolProbeRunResult, error)
+}
+
+type protocolCapabilityProbeResponse struct {
+	CapabilityKey        string     `json:"capability_key"`
+	SupportedProtocols   []string   `json:"supported_protocols"`
+	Revision             int64      `json:"revision"`
+	LastProbedAt         *time.Time `json:"last_probed_at"`
+	AffectedAccountCount int        `json:"affected_account_count"`
+}
+
+func protocolCapabilityProbeProjection(result service.ProtocolProbeRunResult) *protocolCapabilityProbeResponse {
+	if result.Capability == nil {
+		return nil
+	}
+	protocols, err := service.NormalizeSupportedProtocols(result.Capability.SupportedProtocols)
+	if err != nil {
+		protocols = nil
+	}
+	supportedProtocols := make([]string, len(protocols))
+	for i, protocol := range protocols {
+		supportedProtocols[i] = string(protocol)
+	}
+	return &protocolCapabilityProbeResponse{
+		CapabilityKey:        result.Capability.CapabilityKey,
+		SupportedProtocols:   supportedProtocols,
+		Revision:             result.Capability.Revision,
+		LastProbedAt:         result.Capability.LastProbedAt,
+		AffectedAccountCount: result.AffectedAccountCount,
+	}
+}
+
+func (h *AccountHandler) scheduleProtocolCapabilityProbes(account *service.Account) {
+	if account == nil {
+		return
+	}
+	if h.protocolProbeScheduler == nil {
+		return
+	}
+	if len(service.ProtocolProbeCandidates(account)) == 0 {
+		return
+	}
+	h.scheduleProtocolCapabilityProbeBatch([]int64{account.ID})
+}
+
+func (h *AccountHandler) scheduleProtocolCapabilityProbeBatch(accountIDs []int64) {
+	if h == nil || h.protocolProbeScheduler == nil || len(accountIDs) == 0 {
+		return
+	}
+	ids := append([]int64(nil), accountIDs...)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("protocol_capability_probe_panic", "account_count", len(ids), "recover", r)
+			}
+		}()
+		h.protocolProbeScheduler.ProbeAccountProtocolCapabilitiesBatch(context.Background(), ids)
+	}()
+}
+
+func protocolCapabilityProbeRequiredForUpdate(req UpdateAccountRequest) bool {
+	if req.Type != "" || req.ChannelType != nil || len(req.Credentials) > 0 {
+		return true
+	}
+	return protocolCapabilityExtraChanged(req.Extra)
+}
+
+func protocolCapabilityExtraChanged(extra map[string]any) bool {
+	if len(extra) == 0 {
+		return false
+	}
+	_, customBaseURLChanged := extra["custom_base_url"]
+	_, customBaseURLEnabledChanged := extra["custom_base_url_enabled"]
+	return customBaseURLChanged || customBaseURLEnabledChanged
+}
+
+// ProbeProtocols synchronously re-tests the native text protocols for one
+// account and returns the refreshed account snapshot.
+// POST /api/v1/admin/accounts/:id/protocol-probe
+func (h *AccountHandler) ProbeProtocols(c *gin.Context) {
+	accountID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		response.BadRequest(c, "Invalid account ID")
+		return
+	}
+
+	account, err := h.adminService.GetAccount(c.Request.Context(), accountID)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	if h.protocolProbeScheduler == nil {
+		response.ErrorWithDetails(c, http.StatusServiceUnavailable, "Protocol probe unavailable", "protocol_probe_unavailable", nil)
+		return
+	}
+	if len(service.ProtocolProbeCandidates(account)) == 0 {
+		response.Success(c, gin.H{
+			"account": h.buildAccountResponseWithRuntime(c.Request.Context(), account),
+			"outcome": service.ProtocolProbeRunNotApplicable,
+			"reason":  "no_protocol_probe_candidates",
+		})
+		return
+	}
+	runner, ok := h.protocolProbeScheduler.(protocolCapabilityProbeRunner)
+	if !ok {
+		response.ErrorWithDetails(c, http.StatusServiceUnavailable, "Protocol probe unavailable", "protocol_probe_unavailable", nil)
+		return
+	}
+	result, err := runner.ProbeAccountProtocolCapabilitiesNow(c.Request.Context(), accountID)
+	if err != nil {
+		response.ErrorFrom(c, fmt.Errorf("protocol probe account %d: %w", accountID, err))
+		return
+	}
+	account, err = h.adminService.GetAccount(c.Request.Context(), accountID)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+
+	response.Success(c, gin.H{
+		"account":    h.buildAccountResponseWithRuntime(c.Request.Context(), account),
+		"capability": protocolCapabilityProbeProjection(result),
+		"outcome":    result.Outcome,
+		"reason":     result.Reason,
+	})
+}

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
-	"golang.org/x/sync/errgroup"
 )
 
 const gatewayCompatibilityMetricsLogInterval = 1024
@@ -130,32 +129,6 @@ func NewGatewayHandler(
 	}
 }
 
-func prepareGatewayMessagesExecution(
-	c *gin.Context,
-	gatewayService *service.GatewayService,
-	account *service.Account,
-	groupID *int64,
-	parsed *service.ParsedRequest,
-	mapping service.ChannelMappingResult,
-	request protocolrouter.CanonicalRequest,
-) (*service.ParsedRequest, []byte, error) {
-	executionParsed := *parsed
-	if err := executionParsed.ReplaceBody(request.Body()); err != nil {
-		return nil, nil, err
-	}
-	if mapping.Mapped {
-		executionParsed.Model = mapping.MappedModel
-		if err := executionParsed.ReplaceBody(gatewayService.ReplaceModelInBody(executionParsed.Body.Bytes(), mapping.MappedModel)); err != nil {
-			return nil, nil, err
-		}
-	}
-	if err := executionParsed.ReplaceBody(gatewayService.ApplyBedrockCCCompat(c, executionParsed.Body.Bytes(), executionParsed.Model, account, groupID)); err != nil {
-		return nil, nil, err
-	}
-	c.Set("parsed_request", &executionParsed)
-	return &executionParsed, executionParsed.Body.Bytes(), nil
-}
-
 // Messages handles Claude API compatible messages endpoint
 // POST /v1/messages
 func (h *GatewayHandler) Messages(c *gin.Context) {
@@ -247,18 +220,10 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "model is required")
 		return
 	}
-	canonicalRequest, err := newCanonicalProtocolRequest(
-		protocolrouter.ProtocolMessages,
-		protocolrouter.ResponsesPathNone,
-		reqModel,
-		reqStream,
-		body,
-	)
-	if err != nil {
+	if err := h.tkAttachMessagesProtocolRouting(c, reqModel, reqStream, body); err != nil {
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
 		return
 	}
-	c.Request = c.Request.WithContext(service.WithProtocolRouting(c.Request.Context(), h.protocolRouter, canonicalRequest))
 	if !compositeTargetPlatformResolved(c, apiKey, reqModel) {
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Model is not supported by composite groups")
 		return
@@ -357,20 +322,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 	}
 	// 判断是否真的绑定了粘性会话：有 sessionKey 且已经绑定到某个账号
 	hasBoundSession := sessionKey != "" && sessionBoundAccountID > 0
-	var recoveryExcludedAccountID int64
-	if platform == service.PlatformKiro && sessionKey != "" {
-		var recoveryErr error
-		recoveryExcludedAccountID, recoveryErr = h.gatewayService.ConsumeKiroSessionRecovery(c.Request.Context(), apiKey.GroupID, sessionKey)
-		if recoveryErr != nil {
-			reqLog.Warn("gateway.kiro_session_recovery_consume_failed", zap.Error(recoveryErr))
-			recoveryExcludedAccountID = 0
-		}
-		if recoveryExcludedAccountID > 0 {
-			reqLog.Warn("gateway.kiro_session_recovery_excluding_account",
-				zap.Int64("account_id", recoveryExcludedAccountID),
-			)
-		}
-	}
+	recoveryExcludedAccountID := h.tkConsumeKiroSessionRecovery(c.Request.Context(), reqLog, platform, apiKey.GroupID, sessionKey)
 
 	if platform == service.PlatformAnthropic {
 		if h.tkWriteDeprecatedAnthropicModelAtIngress(c, reqModel, reqLog) {
@@ -700,10 +652,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 
 	for {
 		fs := NewFailoverState(h.maxAccountSwitches, hasBoundSession)
-		if recoveryExcludedAccountID > 0 {
-			fs.FailedAccountIDs[recoveryExcludedAccountID] = struct{}{}
-			recoveryExcludedAccountID = 0
-		}
+		tkSeedFailoverExcludedAccount(fs, &recoveryExcludedAccountID)
 		retryWithFallback := false
 
 		for {
@@ -918,72 +867,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			// 记录 Forward 前已写入字节数，Forward 后若增加则说明 SSE 内容已发，禁止 failover
 			writerSizeBeforeForward := c.Writer.Size()
 			forwardStart := time.Now()
-			value, executeErr := service.ExecuteSelectedProtocol(
-				requestCtx,
-				h.protocolRouter,
-				selection,
-				account,
-				h.gatewayService.ValidateProtocolEndpoint,
-				h.gatewayService.LoadProtocolExecutionAccount,
-				service.ProtocolExecutors{
-					NonGoverned: func(executionCtx context.Context, account *service.Account, _ protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
-						executionParsedReq, attemptBody, prepareErr := prepareGatewayMessagesExecution(c, h.gatewayService, account, apiKey.GroupID, attemptParsedReq, channelMapping, request)
-						if prepareErr != nil {
-							return nil, prepareErr
-						}
-						if account.Platform == service.PlatformAntigravity && account.Type != service.AccountTypeAPIKey {
-							return h.antigravityGatewayService.Forward(executionCtx, c, account, attemptBody, hasBoundSession)
-						}
-						return h.gatewayService.Forward(executionCtx, c, account, executionParsedReq)
-					},
-					MessagesIdentity: func(executionCtx context.Context, account *service.Account, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
-						executionParsedReq, _, prepareErr := prepareGatewayMessagesExecution(c, h.gatewayService, account, apiKey.GroupID, attemptParsedReq, channelMapping, request)
-						if prepareErr != nil {
-							return nil, prepareErr
-						}
-						setActualUpstreamEndpoint(c, protocolPlanEndpoint(plan.Endpoint()))
-						return h.gatewayService.Forward(executionCtx, c, account, executionParsedReq)
-					},
-					MessagesToResponses: func(executionCtx context.Context, account *service.Account, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
-						_, attemptBody, prepareErr := prepareGatewayMessagesExecution(c, h.gatewayService, account, apiKey.GroupID, attemptParsedReq, channelMapping, request)
-						if prepareErr != nil {
-							return nil, prepareErr
-						}
-						setActualUpstreamEndpoint(c, protocolPlanEndpoint(plan.Endpoint()))
-						openAIResult, forwardErr := h.openAIGatewayService.ForwardAsAnthropic(executionCtx, c, account, attemptBody, "", channelMapping.MappedModel)
-						return service.ForwardResultFromOpenAI(openAIResult), forwardErr
-					},
-					MessagesToChat: func(executionCtx context.Context, account *service.Account, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
-						_, attemptBody, prepareErr := prepareGatewayMessagesExecution(c, h.gatewayService, account, apiKey.GroupID, attemptParsedReq, channelMapping, request)
-						if prepareErr != nil {
-							return nil, prepareErr
-						}
-						setActualUpstreamEndpoint(c, protocolPlanEndpoint(plan.Endpoint()))
-						openAIResult, forwardErr := h.openAIGatewayService.ForwardAsAnthropicDispatched(executionCtx, c, account, attemptBody, "", channelMapping.MappedModel)
-						return service.ForwardResultFromOpenAI(openAIResult), forwardErr
-					},
-					MessagesToGemini: func(executionCtx context.Context, account *service.Account, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
-						_, attemptBody, prepareErr := prepareGatewayMessagesExecution(c, h.gatewayService, account, apiKey.GroupID, attemptParsedReq, channelMapping, request)
-						if prepareErr != nil {
-							return nil, prepareErr
-						}
-						setActualUpstreamEndpoint(c, protocolPlanEndpoint(plan.Endpoint()))
-						return service.ExecuteGeminiProtocolProfile(
-							plan.GeminiProfile(),
-							func() (*service.ForwardResult, error) {
-								return h.antigravityGatewayService.Forward(executionCtx, c, account, attemptBody, hasBoundSession)
-							},
-							func() (*service.ForwardResult, error) {
-								return h.geminiCompatService.Forward(executionCtx, c, account, attemptBody)
-							},
-						)
-					},
-				},
-			)
-			err = executeErr
-			if value != nil {
-				result, _ = value.(*service.ForwardResult)
-			}
+			result, err = h.executeMessagesSelectedProtocol(c, requestCtx, selection, account, apiKey, attemptParsedReq, channelMapping, hasBoundSession)
 			tkRecordForwardResponseTail(c, forwardStart)
 
 			// 兜底释放串行锁（正常情况已通过回调提前释放）
@@ -1059,21 +943,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			}
 
 			if err != nil {
-				if service.IsKiroPostOutputStreamDisconnect(err) && sessionKey != "" {
-					recoveryCtx, cancelRecovery := context.WithTimeout(context.WithoutCancel(c.Request.Context()), 2*time.Second)
-					recoveryErr := h.gatewayService.RememberKiroSessionRecovery(recoveryCtx, currentAPIKey.GroupID, sessionKey, account.ID)
-					cancelRecovery()
-					if recoveryErr != nil {
-						reqLog.Warn("gateway.kiro_session_recovery_record_failed",
-							zap.Int64("account_id", account.ID),
-							zap.Error(recoveryErr),
-						)
-					} else {
-						reqLog.Warn("gateway.kiro_session_recovery_recorded",
-							zap.Int64("account_id", account.ID),
-						)
-					}
-				}
+				h.tkRememberKiroSessionRecoveryOnDisconnect(c, reqLog, currentAPIKey.GroupID, sessionKey, account.ID, err)
 				// Beta policy block: return 400 immediately, no failover
 				var betaBlockedErr *service.BetaBlockedError
 				if errors.As(err, &betaBlockedErr) {
@@ -1082,41 +952,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 					return
 				}
 
-				if h.handleKiroContentFilteredError(c, err) {
-					return
-				}
-
-				// Kiro upstream rejected the model (HTTP 400 INVALID_MODEL_ID):
-				// return 400 immediately with a clear message, no failover (every
-				// Kiro account rejects the same unknown model identically).
-				var kiroInvalidModelErr *service.KiroInvalidModelError
-				if errors.As(err, &kiroInvalidModelErr) {
-					h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", kiroInvalidModelErr.ClientMessage())
-					return
-				}
-
-				var kiroInvalidRequestErr *service.KiroInvalidRequestError
-				if errors.As(err, &kiroInvalidRequestErr) {
-					h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", kiroInvalidRequestErr.ClientMessage())
-					return
-				}
-
-				var kiroQuotaErr *service.KiroEndpointQuotaExhaustedError
-				if errors.As(err, &kiroQuotaErr) {
-					c.Header("Retry-After", strconv.Itoa(service.KiroEndpointQuotaExhaustedRetryAfterSeconds()))
-					h.errorResponse(c, http.StatusTooManyRequests, "rate_limit_error", kiroQuotaErr.ClientMessage())
-					return
-				}
-
-				// TK canonical-OAuth ingress UA reject: 403 immediately, no failover.
-				// Local policy denial, not account/provider health — mark it
-				// business-limited so strict-mode canary reject volume stays out of
-				// error-rate dashboards (mirrors the BetaBlockedError branch above).
-				// See gateway_service_tk_canonical_oauth_guard.go.
-				var canonicalUARejectErr *service.CanonicalIngressUARejectedError
-				if errors.As(err, &canonicalUARejectErr) {
-					service.MarkOpsClientPolicyDenied(c, service.OpsClientPolicyDeniedReasonLocalPolicyDenied)
-					h.errorResponse(c, http.StatusForbidden, "permission_error", canonicalUARejectErr.Error())
+				if h.tkHandleMessagesNonFailoverForwardError(c, err) {
 					return
 				}
 
@@ -1273,27 +1109,7 @@ func (h *GatewayHandler) Models(c *gin.Context) {
 		platform = forcedPlatform
 	}
 
-	if apiKey != nil && apiKey.IsUniversal() && groupID == nil {
-		protocol := service.UniversalProtocolOpenAI
-		if isAnthropicModelsRequest(c) {
-			protocol = service.UniversalProtocolAnthropic
-		}
-		capabilities, err := h.universalCapabilities(c.Request.Context(), apiKey, protocol)
-		if err != nil {
-			requestLogger(c, "gateway.models", zap.String("protocol", string(protocol))).Warn("capability_discovery_failed", zap.Error(err))
-			if protocol == service.UniversalProtocolAnthropic {
-				h.errorResponse(c, http.StatusInternalServerError, "api_error", "Model discovery unavailable")
-			} else {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"type": "api_error", "message": "Model discovery unavailable"}})
-			}
-			return
-		}
-		ids := capabilityModelIDs(capabilities, "")
-		if protocol == service.UniversalProtocolAnthropic {
-			c.JSON(http.StatusOK, gin.H{"object": "list", "data": claude.ModelsForIDs(ids)})
-		} else {
-			c.JSON(http.StatusOK, gin.H{"object": "list", "data": openai.ModelsForIDs(ids)})
-		}
+	if h.tryServeUniversalModels(c, apiKey, groupID) {
 		return
 	}
 
@@ -1576,17 +1392,6 @@ func customModelsListAllowsModel(availablePatterns []string, model string) bool 
 	return false
 }
 
-func customModelsListComparableModel(model string) string {
-	model = strings.TrimSpace(model)
-	if model == "" || !strings.HasPrefix(model, "claude-") {
-		return model
-	}
-	if base, ok := strings.CutSuffix(model, "-thinking"); ok {
-		model = base
-	}
-	return claude.DenormalizeModelID(model)
-}
-
 func defaultModelIDsForPlatform(platform string) []string {
 	switch platform {
 	case service.PlatformOpenAI:
@@ -1659,33 +1464,7 @@ func mergeModelIDs(primary, secondary []string) []string {
 // AntigravityModels 返回 Antigravity 支持的全部模型
 // GET /antigravity/models
 func (h *GatewayHandler) AntigravityModels(c *gin.Context) {
-	if apiKey, ok := middleware2.GetAPIKeyFromContext(c); ok && apiKey != nil && apiKey.IsUniversal() && apiKey.Group == nil {
-		capabilities, err := h.universalCapabilities(c.Request.Context(), apiKey, service.UniversalProtocolAntigravity)
-		if err != nil {
-			requestLogger(c, "gateway.antigravity_models", zap.String("protocol", string(service.UniversalProtocolAntigravity))).Warn("capability_discovery_failed", zap.Error(err))
-			c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"type": "api_error", "message": "Model discovery unavailable"}})
-			return
-		}
-		models := antigravityModelsForCapabilityIDs(capabilityModelIDs(capabilities, ""))
-		c.JSON(http.StatusOK, gin.H{"object": "list", "data": models})
-		return
-	}
-	// TK: §5.x override-default — filter antigravity.DefaultModels() by pricing +
-	// availability. Candidate set is always the antigravity-specific list (not the
-	// full cross-platform catalog). Response shape is always []antigravity.ClaudeModel.
-	// Goal 2 / R-003; shape/scope regression fix from review-20260507 R-001/R-002.
-	models := h.tkAntigravityDefaultModels(c.Request.Context())
-	// TK: enforce the group's supported_model_scopes on the advertised list, so a
-	// narrow antigravity group without the claude scope hides Claude here. Empty
-	// scopes = unrestricted; canonical scopes (claude + gemini_text + gemini_image)
-	// are enforced only after an operator-reviewed apply-accounts run.
-	if apiKey, ok := middleware2.GetAPIKeyFromContext(c); ok && apiKey != nil && apiKey.Group != nil {
-		models = tkAntigravityFilterModelsByGroupScopes(apiKey.Group.SupportedModelScopes, models)
-	}
-	c.JSON(http.StatusOK, gin.H{
-		"object": "list",
-		"data":   models,
-	})
+	h.serveAntigravityModels(c)
 }
 
 func cloneAPIKeyWithGroup(apiKey *service.APIKey, group *service.Group) *service.APIKey {
@@ -1728,21 +1507,7 @@ func (h *GatewayHandler) Usage(c *gin.Context) {
 		return
 	}
 
-	var usageData gin.H
-	var dailyUsage any
-	var modelStats any
-	g, gctx := errgroup.WithContext(ctx)
-	g.Go(func() error { usageData = h.buildUsageData(gctx, apiKey.ID); return nil })
-	g.Go(func() error { dailyUsage = h.buildAPIKeyDailyUsage(c, subject.UserID, apiKey.ID, days); return nil })
-	g.Go(func() error {
-		if h.usageService != nil {
-			if stats, err := h.usageService.GetAPIKeyModelStats(gctx, apiKey.ID, startTime, endTime); err == nil && len(stats) > 0 {
-				modelStats = stats
-			}
-		}
-		return nil
-	})
-	_ = g.Wait()
+	usageData, dailyUsage, modelStats := h.tkLoadUsageAggregates(c, ctx, subject.UserID, apiKey.ID, days, startTime, endTime)
 
 	// 判断模式: key 有总额度或速率限制 → quota_limited，否则 → unrestricted
 	isQuotaLimited := apiKey.Quota > 0 || apiKey.HasRateLimits()
@@ -2046,22 +1811,9 @@ func (h *GatewayHandler) handleFailoverExhausted(c *gin.Context, failoverErr *se
 	}
 
 	if failoverErr.ClientStatusCode > 0 {
-		// 记录原始上游状态码，以便 ops 错误日志捕获真实的上游错误。
-		upstreamMsg := service.ExtractUpstreamErrorMessage(responseBody)
-		service.SetOpsUpstreamError(c, statusCode, upstreamMsg, "")
-		if retryAfter := failoverErr.ResponseHeaders.Get("Retry-After"); retryAfter != "" {
-			c.Header("Retry-After", retryAfter)
+		if h.tkHandleFailoverClientStatus(c, failoverErr, statusCode, responseBody, streamStarted) {
+			return
 		}
-		message := failoverErr.ClientMessage
-		if message == "" {
-			message = service.GatewayFailoverClientMessage(failoverErr.ClientStatusCode)
-		}
-		errType := strings.TrimSpace(failoverErr.ClientErrorType)
-		if errType == "" {
-			errType = "api_error"
-		}
-		h.handleStreamingAwareError(c, failoverErr.ClientStatusCode, errType, message, streamStarted)
-		return
 	}
 
 	// 先检查透传规则
@@ -2094,24 +1846,14 @@ func (h *GatewayHandler) handleFailoverExhausted(c *gin.Context, failoverErr *se
 
 	// 使用默认的错误映射
 	status, errType, errMsg := h.mapUpstreamError(statusCode)
-	if statusCode == http.StatusForbidden {
-		errMsg = service.TkEnrichForbiddenMessage(c, errMsg)
-	}
-	if platform == service.PlatformAnthropic {
-		if msg := service.ExtractUpstreamErrorMessage(responseBody); msg != "" {
-			errMsg = msg
-		}
-		errMsg = service.TkEnrichClaudeIncidentMessage(errMsg, statusCode)
-	}
+	errMsg = h.tkEnrichMappedUpstreamErrorMessage(c, platform, statusCode, responseBody, errMsg)
 	h.handleStreamingAwareError(c, status, errType, errMsg, streamStarted)
 }
 
 // handleFailoverExhaustedSimple 简化版本，用于没有响应体的情况
 func (h *GatewayHandler) handleFailoverExhaustedSimple(c *gin.Context, statusCode int, streamStarted bool) {
 	status, errType, errMsg := h.mapUpstreamError(statusCode)
-	if statusCode == http.StatusForbidden {
-		errMsg = service.TkEnrichForbiddenMessage(c, errMsg)
-	}
+	errMsg = h.tkEnrichMappedUpstreamErrorMessage(c, "", statusCode, nil, errMsg)
 	service.SetOpsUpstreamError(c, statusCode, errMsg, "")
 	h.handleStreamingAwareError(c, status, errType, errMsg, streamStarted)
 }
@@ -2172,28 +1914,6 @@ func (h *GatewayHandler) handleStreamingAwareError(c *gin.Context, status int, e
 // 否则下游收到的就是 silent EOF。
 func (h *GatewayHandler) ensureForwardErrorResponse(c *gin.Context, streamStarted bool) bool {
 	return h.ensureForwardErrorResponseForError(c, nil, streamStarted)
-}
-
-func (h *GatewayHandler) ensureForwardErrorResponseForError(c *gin.Context, err error, streamStarted bool) bool {
-	if c == nil || c.Writer == nil {
-		return false
-	}
-	// A canceled inbound request means the caller has already gone away. Writing a
-	// generic 502 here only corrupts access/ops semantics; there is no client left
-	// to receive it. Keep the established 499 classification used by failover and
-	// concurrency cancellation paths.
-	if isClientClosedRequest(c, err) {
-		markClientClosedForwardRequest(c)
-		return false
-	}
-	if service.IsResponseCommitted(c) {
-		return false
-	}
-	if c.Writer.Written() {
-		streamStarted = true
-	}
-	h.handleStreamingAwareError(c, http.StatusBadGateway, "upstream_error", "Upstream request failed", streamStarted)
-	return true
 }
 
 // gatewayForwardErrorAlreadyCommunicated reports whether a Forward implementation
@@ -2274,17 +1994,6 @@ func (h *GatewayHandler) errorResponse(c *gin.Context, status int, errType, mess
 			"message": message,
 		},
 	})
-}
-
-func (h *GatewayHandler) handleKiroContentFilteredError(c *gin.Context, err error) bool {
-	var contentFilteredErr *service.KiroContentFilteredError
-	if !errors.As(err, &contentFilteredErr) {
-		return false
-	}
-	service.MarkOpsClientContentFiltered(c)
-	c.Header(service.KiroOutcomeHeader, service.KiroContentFilteredOutcome)
-	h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", service.KiroContentFilteredClientMessage())
-	return true
 }
 
 // CountTokens handles token counting endpoint

--- a/backend/internal/handler/gateway_handler_tk_forward_error.go
+++ b/backend/internal/handler/gateway_handler_tk_forward_error.go
@@ -26,8 +26,12 @@ package handler
 import (
 	"context"
 	"errors"
+	"net/http"
+	"strings"
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
+
+	"github.com/gin-gonic/gin"
 )
 
 // TkRecordFailureFromErr is the single tap helper used by every gateway
@@ -82,4 +86,73 @@ func TkRecordFailureFromErr(
 	}
 
 	svc.TKRecordForwardFailure(ctx, platform, model, accountID, statusCode, body, network)
+}
+
+func (h *GatewayHandler) tkHandleFailoverClientStatus(
+	c *gin.Context,
+	failoverErr *service.UpstreamFailoverError,
+	statusCode int,
+	responseBody []byte,
+	streamStarted bool,
+) bool {
+	if failoverErr == nil || failoverErr.ClientStatusCode <= 0 {
+		return false
+	}
+	// 记录原始上游状态码，以便 ops 错误日志捕获真实的上游错误。
+	upstreamMsg := service.ExtractUpstreamErrorMessage(responseBody)
+	service.SetOpsUpstreamError(c, statusCode, upstreamMsg, "")
+	if retryAfter := failoverErr.ResponseHeaders.Get("Retry-After"); retryAfter != "" {
+		c.Header("Retry-After", retryAfter)
+	}
+	message := failoverErr.ClientMessage
+	if message == "" {
+		message = service.GatewayFailoverClientMessage(failoverErr.ClientStatusCode)
+	}
+	errType := strings.TrimSpace(failoverErr.ClientErrorType)
+	if errType == "" {
+		errType = "api_error"
+	}
+	h.handleStreamingAwareError(c, failoverErr.ClientStatusCode, errType, message, streamStarted)
+	return true
+}
+
+func (h *GatewayHandler) tkEnrichMappedUpstreamErrorMessage(
+	c *gin.Context,
+	platform string,
+	statusCode int,
+	responseBody []byte,
+	errMsg string,
+) string {
+	if statusCode == http.StatusForbidden {
+		errMsg = service.TkEnrichForbiddenMessage(c, errMsg)
+	}
+	if platform == service.PlatformAnthropic {
+		if msg := service.ExtractUpstreamErrorMessage(responseBody); msg != "" {
+			errMsg = msg
+		}
+		errMsg = service.TkEnrichClaudeIncidentMessage(errMsg, statusCode)
+	}
+	return errMsg
+}
+
+func (h *GatewayHandler) ensureForwardErrorResponseForError(c *gin.Context, err error, streamStarted bool) bool {
+	if c == nil || c.Writer == nil {
+		return false
+	}
+	// A canceled inbound request means the caller has already gone away. Writing a
+	// generic 502 here only corrupts access/ops semantics; there is no client left
+	// to receive it. Keep the established 499 classification used by failover and
+	// concurrency cancellation paths.
+	if isClientClosedRequest(c, err) {
+		markClientClosedForwardRequest(c)
+		return false
+	}
+	if service.IsResponseCommitted(c) {
+		return false
+	}
+	if c.Writer.Written() {
+		streamStarted = true
+	}
+	h.handleStreamingAwareError(c, http.StatusBadGateway, "upstream_error", "Upstream request failed", streamStarted)
+	return true
 }

--- a/backend/internal/handler/gateway_handler_tk_kiro.go
+++ b/backend/internal/handler/gateway_handler_tk_kiro.go
@@ -1,0 +1,114 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+func (h *GatewayHandler) handleKiroContentFilteredError(c *gin.Context, err error) bool {
+	var contentFilteredErr *service.KiroContentFilteredError
+	if !errors.As(err, &contentFilteredErr) {
+		return false
+	}
+	service.MarkOpsClientContentFiltered(c)
+	c.Header(service.KiroOutcomeHeader, service.KiroContentFilteredOutcome)
+	h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", service.KiroContentFilteredClientMessage())
+	return true
+}
+
+// tkHandleMessagesNonFailoverForwardError handles Messages-path forward errors that
+// must return immediately without failover (Kiro content-filter / invalid model /
+// invalid request / quota + TK canonical ingress UA reject).
+func (h *GatewayHandler) tkHandleMessagesNonFailoverForwardError(c *gin.Context, err error) bool {
+	if h.handleKiroContentFilteredError(c, err) {
+		return true
+	}
+
+	// Kiro upstream rejected the model (HTTP 400 INVALID_MODEL_ID):
+	// return 400 immediately with a clear message, no failover (every
+	// Kiro account rejects the same unknown model identically).
+	var kiroInvalidModelErr *service.KiroInvalidModelError
+	if errors.As(err, &kiroInvalidModelErr) {
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", kiroInvalidModelErr.ClientMessage())
+		return true
+	}
+
+	var kiroInvalidRequestErr *service.KiroInvalidRequestError
+	if errors.As(err, &kiroInvalidRequestErr) {
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", kiroInvalidRequestErr.ClientMessage())
+		return true
+	}
+
+	var kiroQuotaErr *service.KiroEndpointQuotaExhaustedError
+	if errors.As(err, &kiroQuotaErr) {
+		c.Header("Retry-After", strconv.Itoa(service.KiroEndpointQuotaExhaustedRetryAfterSeconds()))
+		h.errorResponse(c, http.StatusTooManyRequests, "rate_limit_error", kiroQuotaErr.ClientMessage())
+		return true
+	}
+
+	// TK canonical-OAuth ingress UA reject: 403 immediately, no failover.
+	// Local policy denial, not account/provider health — mark it
+	// business-limited so strict-mode canary reject volume stays out of
+	// error-rate dashboards (mirrors the BetaBlockedError branch above).
+	// See gateway_service_tk_canonical_oauth_guard.go.
+	var canonicalUARejectErr *service.CanonicalIngressUARejectedError
+	if errors.As(err, &canonicalUARejectErr) {
+		service.MarkOpsClientPolicyDenied(c, service.OpsClientPolicyDeniedReasonLocalPolicyDenied)
+		h.errorResponse(c, http.StatusForbidden, "permission_error", canonicalUARejectErr.Error())
+		return true
+	}
+
+	return false
+}
+
+func (h *GatewayHandler) tkConsumeKiroSessionRecovery(ctx context.Context, reqLog *zap.Logger, platform string, groupID *int64, sessionKey string) int64 {
+	if platform != service.PlatformKiro || sessionKey == "" {
+		return 0
+	}
+	recoveryExcludedAccountID, recoveryErr := h.gatewayService.ConsumeKiroSessionRecovery(ctx, groupID, sessionKey)
+	if recoveryErr != nil {
+		reqLog.Warn("gateway.kiro_session_recovery_consume_failed", zap.Error(recoveryErr))
+		return 0
+	}
+	if recoveryExcludedAccountID > 0 {
+		reqLog.Warn("gateway.kiro_session_recovery_excluding_account",
+			zap.Int64("account_id", recoveryExcludedAccountID),
+		)
+	}
+	return recoveryExcludedAccountID
+}
+
+func tkSeedFailoverExcludedAccount(fs *FailoverState, excludedID *int64) {
+	if fs == nil || excludedID == nil || *excludedID <= 0 {
+		return
+	}
+	fs.FailedAccountIDs[*excludedID] = struct{}{}
+	*excludedID = 0
+}
+
+func (h *GatewayHandler) tkRememberKiroSessionRecoveryOnDisconnect(c *gin.Context, reqLog *zap.Logger, groupID *int64, sessionKey string, accountID int64, err error) {
+	if !service.IsKiroPostOutputStreamDisconnect(err) || sessionKey == "" {
+		return
+	}
+	recoveryCtx, cancelRecovery := context.WithTimeout(context.WithoutCancel(c.Request.Context()), 2*time.Second)
+	recoveryErr := h.gatewayService.RememberKiroSessionRecovery(recoveryCtx, groupID, sessionKey, accountID)
+	cancelRecovery()
+	if recoveryErr != nil {
+		reqLog.Warn("gateway.kiro_session_recovery_record_failed",
+			zap.Int64("account_id", accountID),
+			zap.Error(recoveryErr),
+		)
+	} else {
+		reqLog.Warn("gateway.kiro_session_recovery_recorded",
+			zap.Int64("account_id", accountID),
+		)
+	}
+}

--- a/backend/internal/handler/gateway_handler_tk_kiro_non_failover_test.go
+++ b/backend/internal/handler/gateway_handler_tk_kiro_non_failover_test.go
@@ -1,0 +1,78 @@
+//go:build unit
+
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// Companion extraction of Messages-path non-failover errors must preserve the
+// same status codes / no-failover early returns as the prior inline chain.
+func TestTkHandleMessagesNonFailoverForwardError_Matrix(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &GatewayHandler{}
+
+	t.Run("content_filtered", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		require.True(t, h.tkHandleMessagesNonFailoverForwardError(c, &service.KiroContentFilteredError{}))
+		require.Equal(t, http.StatusBadRequest, rec.Code)
+		require.Equal(t, service.KiroContentFilteredOutcome, rec.Header().Get(service.KiroOutcomeHeader))
+		require.Equal(t, "invalid_request_error", gjson.GetBytes(rec.Body.Bytes(), "error.type").String())
+	})
+
+	t.Run("invalid_model", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		err := &service.KiroInvalidModelError{Model: "no-such-model"}
+		require.True(t, h.tkHandleMessagesNonFailoverForwardError(c, err))
+		require.Equal(t, http.StatusBadRequest, rec.Code)
+		require.Equal(t, "invalid_request_error", gjson.GetBytes(rec.Body.Bytes(), "error.type").String())
+		require.Equal(t, err.ClientMessage(), gjson.GetBytes(rec.Body.Bytes(), "error.message").String())
+	})
+
+	t.Run("invalid_request", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		err := &service.KiroInvalidRequestError{Message: "bad tools"}
+		require.True(t, h.tkHandleMessagesNonFailoverForwardError(c, err))
+		require.Equal(t, http.StatusBadRequest, rec.Code)
+		require.Equal(t, err.ClientMessage(), gjson.GetBytes(rec.Body.Bytes(), "error.message").String())
+	})
+
+	t.Run("quota_exhausted", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		err := &service.KiroEndpointQuotaExhaustedError{}
+		require.True(t, h.tkHandleMessagesNonFailoverForwardError(c, err))
+		require.Equal(t, http.StatusTooManyRequests, rec.Code)
+		require.Equal(t, "rate_limit_error", gjson.GetBytes(rec.Body.Bytes(), "error.type").String())
+		require.NotEmpty(t, rec.Header().Get("Retry-After"))
+	})
+
+	t.Run("canonical_ua_reject", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		err := &service.CanonicalIngressUARejectedError{IngressUA: "curl/8"}
+		require.True(t, h.tkHandleMessagesNonFailoverForwardError(c, err))
+		require.Equal(t, http.StatusForbidden, rec.Code)
+		require.Equal(t, "permission_error", gjson.GetBytes(rec.Body.Bytes(), "error.type").String())
+		require.True(t, service.HasOpsClientPolicyDenied(c))
+	})
+
+	t.Run("other_error_not_handled", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		require.False(t, h.tkHandleMessagesNonFailoverForwardError(c, errors.New("transport timeout")))
+		require.Empty(t, rec.Body.String())
+		require.Equal(t, 200, rec.Code) // gin default; handler must not write
+	})
+}

--- a/backend/internal/handler/gateway_handler_tk_model_list.go
+++ b/backend/internal/handler/gateway_handler_tk_model_list.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"net/http"
 	"strings"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
@@ -9,8 +10,10 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/gemini"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/geminicli"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
+	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 )
 
 // SetModelListFilter wires the optional client model-list filter into
@@ -36,6 +39,76 @@ func (h *OpenAIGatewayHandler) SetUniversalCapabilityService(capabilities *servi
 	if h != nil {
 		h.tkCapabilities = capabilities
 	}
+}
+
+// tryServeUniversalModels serves /v1/models for universal keys with no group.
+// Returns true when the request was handled (success or error response written).
+func (h *GatewayHandler) tryServeUniversalModels(c *gin.Context, apiKey *service.APIKey, groupID *int64) bool {
+	if apiKey == nil || !apiKey.IsUniversal() || groupID != nil {
+		return false
+	}
+	protocol := service.UniversalProtocolOpenAI
+	if isAnthropicModelsRequest(c) {
+		protocol = service.UniversalProtocolAnthropic
+	}
+	capabilities, err := h.universalCapabilities(c.Request.Context(), apiKey, protocol)
+	if err != nil {
+		requestLogger(c, "gateway.models", zap.String("protocol", string(protocol))).Warn("capability_discovery_failed", zap.Error(err))
+		if protocol == service.UniversalProtocolAnthropic {
+			h.errorResponse(c, http.StatusInternalServerError, "api_error", "Model discovery unavailable")
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"type": "api_error", "message": "Model discovery unavailable"}})
+		}
+		return true
+	}
+	ids := capabilityModelIDs(capabilities, "")
+	if protocol == service.UniversalProtocolAnthropic {
+		c.JSON(http.StatusOK, gin.H{"object": "list", "data": claude.ModelsForIDs(ids)})
+	} else {
+		c.JSON(http.StatusOK, gin.H{"object": "list", "data": openai.ModelsForIDs(ids)})
+	}
+	return true
+}
+
+func (h *GatewayHandler) serveAntigravityModels(c *gin.Context) {
+	if apiKey, ok := middleware2.GetAPIKeyFromContext(c); ok && apiKey != nil && apiKey.IsUniversal() && apiKey.Group == nil {
+		capabilities, err := h.universalCapabilities(c.Request.Context(), apiKey, service.UniversalProtocolAntigravity)
+		if err != nil {
+			requestLogger(c, "gateway.antigravity_models", zap.String("protocol", string(service.UniversalProtocolAntigravity))).Warn("capability_discovery_failed", zap.Error(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"type": "api_error", "message": "Model discovery unavailable"}})
+			return
+		}
+		models := antigravityModelsForCapabilityIDs(capabilityModelIDs(capabilities, ""))
+		c.JSON(http.StatusOK, gin.H{"object": "list", "data": models})
+		return
+	}
+	// TK: §5.x override-default — filter antigravity.DefaultModels() by pricing +
+	// availability. Candidate set is always the antigravity-specific list (not the
+	// full cross-platform catalog). Response shape is always []antigravity.ClaudeModel.
+	// Goal 2 / R-003; shape/scope regression fix from review-20260507 R-001/R-002.
+	models := h.tkAntigravityDefaultModels(c.Request.Context())
+	// TK: enforce the group's supported_model_scopes on the advertised list, so a
+	// narrow antigravity group without the claude scope hides Claude here. Empty
+	// scopes = unrestricted; canonical scopes (claude + gemini_text + gemini_image)
+	// are enforced only after an operator-reviewed apply-accounts run.
+	if apiKey, ok := middleware2.GetAPIKeyFromContext(c); ok && apiKey != nil && apiKey.Group != nil {
+		models = tkAntigravityFilterModelsByGroupScopes(apiKey.Group.SupportedModelScopes, models)
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"object": "list",
+		"data":   models,
+	})
+}
+
+func customModelsListComparableModel(model string) string {
+	model = strings.TrimSpace(model)
+	if model == "" || !strings.HasPrefix(model, "claude-") {
+		return model
+	}
+	if base, ok := strings.CutSuffix(model, "-thinking"); ok {
+		model = base
+	}
+	return claude.DenormalizeModelID(model)
 }
 
 func (h *GatewayHandler) universalCapabilities(ctx context.Context, apiKey *service.APIKey, protocol service.UniversalProtocol) ([]service.UniversalCapability, error) {

--- a/backend/internal/handler/gateway_handler_tk_protocol_execute.go
+++ b/backend/internal/handler/gateway_handler_tk_protocol_execute.go
@@ -1,0 +1,130 @@
+package handler
+
+import (
+	"context"
+
+	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+func prepareGatewayMessagesExecution(
+	c *gin.Context,
+	gatewayService *service.GatewayService,
+	account *service.Account,
+	groupID *int64,
+	parsed *service.ParsedRequest,
+	mapping service.ChannelMappingResult,
+	request protocolrouter.CanonicalRequest,
+) (*service.ParsedRequest, []byte, error) {
+	executionParsed := *parsed
+	if err := executionParsed.ReplaceBody(request.Body()); err != nil {
+		return nil, nil, err
+	}
+	if mapping.Mapped {
+		executionParsed.Model = mapping.MappedModel
+		if err := executionParsed.ReplaceBody(gatewayService.ReplaceModelInBody(executionParsed.Body.Bytes(), mapping.MappedModel)); err != nil {
+			return nil, nil, err
+		}
+	}
+	if err := executionParsed.ReplaceBody(gatewayService.ApplyBedrockCCCompat(c, executionParsed.Body.Bytes(), executionParsed.Model, account, groupID)); err != nil {
+		return nil, nil, err
+	}
+	c.Set("parsed_request", &executionParsed)
+	return &executionParsed, executionParsed.Body.Bytes(), nil
+}
+
+func (h *GatewayHandler) tkAttachMessagesProtocolRouting(c *gin.Context, model string, stream bool, body []byte) error {
+	canonicalRequest, err := newCanonicalProtocolRequest(
+		protocolrouter.ProtocolMessages,
+		protocolrouter.ResponsesPathNone,
+		model,
+		stream,
+		body,
+	)
+	if err != nil {
+		return err
+	}
+	c.Request = c.Request.WithContext(service.WithProtocolRouting(c.Request.Context(), h.protocolRouter, canonicalRequest))
+	return nil
+}
+
+func (h *GatewayHandler) executeMessagesSelectedProtocol(
+	c *gin.Context,
+	requestCtx context.Context,
+	selection *service.AccountSelectionResult,
+	account *service.Account,
+	apiKey *service.APIKey,
+	attemptParsedReq *service.ParsedRequest,
+	channelMapping service.ChannelMappingResult,
+	hasBoundSession bool,
+) (*service.ForwardResult, error) {
+	value, executeErr := service.ExecuteSelectedProtocol(
+		requestCtx,
+		h.protocolRouter,
+		selection,
+		account,
+		h.gatewayService.ValidateProtocolEndpoint,
+		h.gatewayService.LoadProtocolExecutionAccount,
+		service.ProtocolExecutors{
+			NonGoverned: func(executionCtx context.Context, account *service.Account, _ protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
+				executionParsedReq, attemptBody, prepareErr := prepareGatewayMessagesExecution(c, h.gatewayService, account, apiKey.GroupID, attemptParsedReq, channelMapping, request)
+				if prepareErr != nil {
+					return nil, prepareErr
+				}
+				if account.Platform == service.PlatformAntigravity && account.Type != service.AccountTypeAPIKey {
+					return h.antigravityGatewayService.Forward(executionCtx, c, account, attemptBody, hasBoundSession)
+				}
+				return h.gatewayService.Forward(executionCtx, c, account, executionParsedReq)
+			},
+			MessagesIdentity: func(executionCtx context.Context, account *service.Account, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
+				executionParsedReq, _, prepareErr := prepareGatewayMessagesExecution(c, h.gatewayService, account, apiKey.GroupID, attemptParsedReq, channelMapping, request)
+				if prepareErr != nil {
+					return nil, prepareErr
+				}
+				setActualUpstreamEndpoint(c, protocolPlanEndpoint(plan.Endpoint()))
+				return h.gatewayService.Forward(executionCtx, c, account, executionParsedReq)
+			},
+			MessagesToResponses: func(executionCtx context.Context, account *service.Account, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
+				_, attemptBody, prepareErr := prepareGatewayMessagesExecution(c, h.gatewayService, account, apiKey.GroupID, attemptParsedReq, channelMapping, request)
+				if prepareErr != nil {
+					return nil, prepareErr
+				}
+				setActualUpstreamEndpoint(c, protocolPlanEndpoint(plan.Endpoint()))
+				openAIResult, forwardErr := h.openAIGatewayService.ForwardAsAnthropic(executionCtx, c, account, attemptBody, "", channelMapping.MappedModel)
+				return service.ForwardResultFromOpenAI(openAIResult), forwardErr
+			},
+			MessagesToChat: func(executionCtx context.Context, account *service.Account, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
+				_, attemptBody, prepareErr := prepareGatewayMessagesExecution(c, h.gatewayService, account, apiKey.GroupID, attemptParsedReq, channelMapping, request)
+				if prepareErr != nil {
+					return nil, prepareErr
+				}
+				setActualUpstreamEndpoint(c, protocolPlanEndpoint(plan.Endpoint()))
+				openAIResult, forwardErr := h.openAIGatewayService.ForwardAsAnthropicDispatched(executionCtx, c, account, attemptBody, "", channelMapping.MappedModel)
+				return service.ForwardResultFromOpenAI(openAIResult), forwardErr
+			},
+			MessagesToGemini: func(executionCtx context.Context, account *service.Account, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
+				_, attemptBody, prepareErr := prepareGatewayMessagesExecution(c, h.gatewayService, account, apiKey.GroupID, attemptParsedReq, channelMapping, request)
+				if prepareErr != nil {
+					return nil, prepareErr
+				}
+				setActualUpstreamEndpoint(c, protocolPlanEndpoint(plan.Endpoint()))
+				return service.ExecuteGeminiProtocolProfile(
+					plan.GeminiProfile(),
+					func() (*service.ForwardResult, error) {
+						return h.antigravityGatewayService.Forward(executionCtx, c, account, attemptBody, hasBoundSession)
+					},
+					func() (*service.ForwardResult, error) {
+						return h.geminiCompatService.Forward(executionCtx, c, account, attemptBody)
+					},
+				)
+			},
+		},
+	)
+	var result *service.ForwardResult
+	if value != nil {
+		result, _ = value.(*service.ForwardResult)
+	}
+	return result, executeErr
+}

--- a/backend/internal/handler/gateway_handler_tk_usage.go
+++ b/backend/internal/handler/gateway_handler_tk_usage.go
@@ -8,7 +8,30 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 )
+
+func (h *GatewayHandler) tkLoadUsageAggregates(
+	c *gin.Context,
+	ctx context.Context,
+	userID, apiKeyID int64,
+	days int,
+	startTime, endTime time.Time,
+) (usageData gin.H, dailyUsage any, modelStats any) {
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error { usageData = h.buildUsageData(gctx, apiKeyID); return nil })
+	g.Go(func() error { dailyUsage = h.buildAPIKeyDailyUsage(c, userID, apiKeyID, days); return nil })
+	g.Go(func() error {
+		if h.usageService != nil {
+			if stats, err := h.usageService.GetAPIKeyModelStats(gctx, apiKeyID, startTime, endTime); err == nil && len(stats) > 0 {
+				modelStats = stats
+			}
+		}
+		return nil
+	})
+	_ = g.Wait()
+	return usageData, dailyUsage, modelStats
+}
 
 func (h *GatewayHandler) usageWalletBalance(c *gin.Context, ctx context.Context, apiKey *service.APIKey, userID int64) float64 {
 	fallback := 0.0

--- a/backend/internal/service/admin_account.go
+++ b/backend/internal/service/admin_account.go
@@ -9,13 +9,11 @@ import (
 	"log/slog"
 	"maps"
 	"net/http"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
-	kiro "github.com/Wei-Shaw/sub2api/internal/pkg/kiro"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 )
@@ -357,13 +355,6 @@ func normalizeAccountConcurrency(platform, accountType string, concurrency int) 
 	return concurrency
 }
 
-func normalizeAccountPriority(platform string, priority int) int {
-	if platform == PlatformKiro && priority <= 0 {
-		return kiro.DefaultKiroAccountPriority
-	}
-	return priority
-}
-
 // ValidateOpenAILongContextBillingExtra validates the OpenAI account billing flag when present.
 func ValidateOpenAILongContextBillingExtra(platform string, extra map[string]any) error {
 	if platform != PlatformOpenAI {
@@ -484,11 +475,6 @@ func buildAccountForCreate(input *CreateAccountInput, accountExtra map[string]an
 	return account, nil
 }
 
-type accountCreateOptions struct {
-	allowSupplierReservedExtra bool
-	initialSchedulable         *bool
-}
-
 func (s *adminServiceImpl) CreateAccount(ctx context.Context, input *CreateAccountInput) (*Account, error) {
 	if input == nil {
 		return nil, ErrAccountNilInput
@@ -499,490 +485,17 @@ func (s *adminServiceImpl) CreateAccount(ctx context.Context, input *CreateAccou
 	return s.createAccount(ctx, input, accountCreateOptions{})
 }
 
-func (s *adminServiceImpl) createAccount(ctx context.Context, input *CreateAccountInput, options accountCreateOptions) (*Account, error) {
-	if input == nil {
-		return nil, ErrAccountNilInput
-	}
-	if !options.allowSupplierReservedExtra {
-		if err := ValidateSupplierReservedAccountExtra(input.Extra); err != nil {
-			return nil, err
-		}
-	}
-	if strings.TrimSpace(input.AccountEmail) != "" {
-		var err error
-		input.Extra, input.Credentials, err = ApplyAccountEmail(input.Extra, input.Credentials, input.AccountEmail)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	accountExtra, err := normalizeOpenAILongContextBillingExtra(input.Platform, input.Extra)
-	if err != nil {
-		return nil, err
-	}
-	accountExtra, err = normalizeGrokMediaEligibilityExtra(input.Platform, accountExtra)
-	if err != nil {
-		return nil, err
-	}
-
-	groupIDs := input.GroupIDs
-	if len(groupIDs) == 0 && !input.SkipDefaultGroupBind {
-		defaultGroupName := input.Platform + "-default"
-		groups, listErr := s.groupRepo.ListActiveByPlatform(ctx, input.Platform)
-		if listErr == nil {
-			for _, group := range groups {
-				if group.Name == defaultGroupName {
-					groupIDs = []int64{group.ID}
-					break
-				}
-			}
-		}
-	}
-	if len(groupIDs) > 0 && !input.SkipMixedChannelCheck {
-		if err := s.checkMixedChannelRisk(ctx, 0, input.Platform, groupIDs); err != nil {
-			return nil, err
-		}
-	}
-	if len(groupIDs) > 0 {
-		if err := s.checkPublicGroupAggregatorChannelPolicy(ctx, 0, input.Name, input.Platform, input.ChannelType, input.Credentials, groupIDs); err != nil {
-			return nil, err
-		}
-	}
-	if err := NormalizeHeaderOverrideCredentials(input.Credentials); err != nil {
-		return nil, err
-	}
-	// Never persist ephemeral SSO/password secrets after OAuth conversion.
-	input.Credentials = SanitizeStoredCredentials(input.Platform, input.Credentials)
-	input.Credentials = FinalizeAccountCredentials(input.Credentials, input.ChannelType)
-
-	account, err := buildAccountForCreate(input, accountExtra)
-	if err != nil {
-		return nil, err
-	}
-	if options.initialSchedulable != nil {
-		account.Schedulable = *options.initialSchedulable
-	}
-	if err := resolveNewAPIMoonshotBaseURLOnSave(ctx, account); err != nil {
-		return nil, err
-	}
-	if err := resolveGrokTokenOnSave(ctx, account); err != nil {
-		return nil, err
-	}
-	SeedOfficialSupportedProtocols(account)
-	if err := s.accountRepo.Create(ctx, account); err != nil {
-		return nil, err
-	}
-
-	// 绑定分组
-	if len(groupIDs) > 0 {
-		if err := s.accountRepo.BindGroups(ctx, account.ID, groupIDs); err != nil {
-			return nil, err
-		}
-		account.GroupIDs = append([]int64(nil), groupIDs...)
-	}
-
-	// OAuth 账号：创建后异步设置隐私。
-	// 使用 Ensure（幂等）而非 Force：新建账号 Extra 为空时效果相同，但更安全。
-	if account.Type == AccountTypeOAuth {
-		switch account.Platform {
-		case PlatformOpenAI:
-			go func() {
-				defer func() {
-					if r := recover(); r != nil {
-						slog.Error("create_account_openai_privacy_panic", "account_id", account.ID, "recover", r)
-					}
-				}()
-				s.EnsureOpenAIPrivacy(context.Background(), account)
-			}()
-		case PlatformAntigravity:
-			go func() {
-				defer func() {
-					if r := recover(); r != nil {
-						slog.Error("create_account_antigravity_privacy_panic", "account_id", account.ID, "recover", r)
-					}
-				}()
-				s.EnsureAntigravityPrivacy(context.Background(), account)
-			}()
-		}
-	}
-
-	return account, nil
-}
-
-func upstreamBillingProbeIdentity(account *Account) map[string]any {
-	if account == nil {
-		return nil
-	}
-	identity := map[string]any{"platform": account.Platform, "type": account.Type, "proxy_id": nil}
-	if account.ProxyID != nil {
-		identity["proxy_id"] = *account.ProxyID
-	}
-	for _, key := range []string{"api_key", "base_url", credKeyHeaderOverrideEnabled, credKeyHeaderOverrides} {
-		if value, ok := account.Credentials[key]; ok {
-			identity[key] = value
-		}
-	}
-	return identity
-}
-
 func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *UpdateAccountInput) (*Account, error) {
 	account, err := s.accountRepo.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	if IsSupplierManagedAccount(account) {
-		if input.Extra != nil {
-			input.Extra = StripSupplierReservedAccountExtra(input.Extra)
-		}
-	} else if err := ValidateSupplierReservedAccountExtra(input.Extra); err != nil {
+	if err := s.tkApplyUpdateAccountTKFields(ctx, account, input); err != nil {
 		return nil, err
 	}
-	var normalizedExtra map[string]any
-	if input.Extra != nil {
-		normalizedExtra, err = normalizeOpenAILongContextBillingUpdateExtra(account, input)
-		if err != nil {
-			return nil, err
-		}
-		normalizedExtra, err = normalizeGrokMediaEligibilityUpdateExtra(account, input, normalizedExtra)
-		if err != nil {
-			return nil, err
-		}
-	}
-	previousProbeIdentity := upstreamBillingProbeIdentity(account)
-	previousOllamaUsageIdentity := ollamaCloudUsageIdentity(account)
-	// 安全/身份不变量(影子账号):通用更新路径被 edit/re-auth/refresh/batch 共用,
-	// 必须在此守住,否则仅在创建时的保证可被这些路径绕过。
-	if account.IsCredentialShadow() {
-		// 影子绝不持有凭据(凭据只在母账号)——外审 F5。
-		if !isAllowedSparkShadowCredentialsUpdate(input.Credentials) {
-			return nil, infraerrors.Newf(http.StatusBadRequest, "SPARK_SHADOW_NO_CREDENTIALS",
-				"spark shadow accounts do not hold auth credentials; only model mapping can be configured on the shadow account")
-		}
-		// 影子 type 不可变——很多上游逻辑按 account.Type 分支(OAuth transform / ChatGPT
-		// header 注入 / WS OAuth 决策),改成 apikey 会让 spark 影子被选中后按错误协议转发(外审 G7)。
-		if input.Type != "" && input.Type != account.Type {
-			return nil, infraerrors.Newf(http.StatusBadRequest, "SPARK_SHADOW_IMMUTABLE_TYPE",
-				"spark shadow account type cannot be changed; it must remain an OpenAI OAuth shadow")
-		}
-	} else if input.Type != "" && input.Type != account.Type && input.Type != AccountTypeOAuth {
-		// 母账号守卫(外审 D/P1):有 spark 影子的账号不能把 type 改出 OpenAI OAuth——影子读透母
-		// 凭据,母变成 apikey/setup_token 会让影子被调度后按错协议失败(resolveCredentialAccount
-		// 必报错)。须先删影子再改 type。
-		shadows, serr := s.accountRepo.ListShadowsByParent(ctx, id)
-		if serr != nil {
-			return nil, serr
-		}
-		if len(shadows) > 0 {
-			return nil, infraerrors.New(http.StatusBadRequest, "SPARK_SHADOW_PARENT_IMMUTABLE_TYPE",
-				"cannot change account type while it has a spark shadow; delete the shadow first")
-		}
-	}
-	wasOveragesEnabled := account.IsOveragesEnabled()
-
-	if input.Name != "" {
-		account.Name = input.Name
-	}
-	if input.Type != "" {
-		account.Type = input.Type
-	}
-	if input.ChannelType != nil {
-		account.ChannelType = *input.ChannelType
-	}
-	if input.Notes != nil {
-		account.Notes = normalizeAccountNotes(input.Notes)
-	}
-	if account.IsCredentialShadow() && input.Credentials != nil {
-		account.Credentials = sanitizeSparkShadowCredentials(input.Credentials)
-	} else if len(input.Credentials) > 0 {
-		// SSOT credential merge: sensitive preserve-when-omitted + never inherit
-		// stale protocol identity (api_base_urls / protocol_endpoints_exclusive).
-		account.Credentials = MergeAccountCredentials(
-			account.Credentials, input.Credentials, account.ChannelType, CredentialMergeAdmin,
-		)
-		// 校验并规范化请求头覆写配置（header 名小写化、格式检查）
-		if err := NormalizeHeaderOverrideCredentials(account.Credentials); err != nil {
-			return nil, err
-		}
-		// Strip SSO/password residue that must never sit next to OAuth tokens.
-		account.Credentials = SanitizeStoredCredentials(account.Platform, account.Credentials)
-		account.Credentials = FinalizeAccountCredentials(account.Credentials, account.ChannelType)
-	}
-	// Extra 使用 map：需要区分“未提供(nil)”与“显式清空({})”。
-	// 关闭配额限制时前端会删除 quota_* 键并提交 extra:{}，此时也必须落库。
-	requestedProbeEnabledUpdate := input.ProbeEnabled
-	requestedRateSyncEnabledUpdate := input.RateSyncEnabled
-	if input.Extra != nil {
-		delete(normalizedExtra, SupportedProtocolsExtraKey)
-		requestedProbeEnabled, hasRequestedProbeEnabled := normalizedExtra[UpstreamBillingProbeEnabledExtraKey]
-		if hasRequestedProbeEnabled {
-			enabled, ok := requestedProbeEnabled.(bool)
-			if !ok {
-				return nil, infraerrors.BadRequest("INVALID_UPSTREAM_BILLING_PROBE_ENABLED", "upstream_billing_probe_enabled must be a boolean")
-			}
-			if requestedProbeEnabledUpdate != nil && *requestedProbeEnabledUpdate != enabled {
-				return nil, infraerrors.BadRequest("CONFLICTING_UPSTREAM_BILLING_PROBE_ENABLED", "conflicting upstream_billing_probe_enabled values")
-			}
-			requestedProbeEnabledUpdate = &enabled
-		}
-		delete(normalizedExtra, UpstreamBillingProbeEnabledExtraKey)
-		delete(normalizedExtra, UpstreamBillingRateSyncEnabledExtraKey)
-		delete(normalizedExtra, UpstreamBillingProbeExtraKey)
-		delete(normalizedExtra, OllamaCloudUsageSessionExtraKey)
-		delete(normalizedExtra, OllamaCloudUsageAutoRefreshExtraKey)
-		delete(normalizedExtra, OllamaCloudUsageSnapshotExtraKey)
-		// 保留配额用量和专用服务受管字段，防止普通账号编辑意外覆盖。
-		for _, key := range []string{
-			SupportedProtocolsExtraKey,
-			"quota_used",
-			"quota_daily_used",
-			"quota_daily_start",
-			"quota_weekly_used",
-			"quota_weekly_start",
-			grokBillingExtraKey,
-			UpstreamBillingProbeEnabledExtraKey,
-			UpstreamBillingRateSyncEnabledExtraKey,
-			UpstreamBillingProbeExtraKey,
-			OllamaCloudUsageSessionExtraKey,
-			OllamaCloudUsageAutoRefreshExtraKey,
-			OllamaCloudUsageSnapshotExtraKey,
-			SupplierSourceIDExtraKey,
-			SupplierDiscountBandExtraKey,
-		} {
-			if v, ok := account.Extra[key]; ok {
-				normalizedExtra[key] = v
-			}
-		}
-		normalizedExtra = prepareCodexFingerprintExtraForUpdate(account, normalizedExtra)
-		account.Extra = PreserveSupplierManagedExtraKeys(account, normalizedExtra)
-		if account.Platform == PlatformAntigravity && wasOveragesEnabled && !account.IsOveragesEnabled() {
-			delete(account.Extra, "antigravity_credits_overages") // 清理旧版 overages 运行态
-			// 清除 AICredits 限流 key
-			if rawLimits, ok := account.Extra[modelRateLimitsKey].(map[string]any); ok {
-				delete(rawLimits, creditsExhaustedKey)
-			}
-		}
-		if account.Platform == PlatformAntigravity && !wasOveragesEnabled && account.IsOveragesEnabled() {
-			delete(account.Extra, modelRateLimitsKey)
-			delete(account.Extra, "antigravity_credits_overages") // 清理旧版 overages 运行态
-		}
-		// 校验并预计算固定时间重置的下次重置时间
-		if err := ValidateQuotaResetConfig(account.Extra); err != nil {
-			return nil, err
-		}
-		ComputeQuotaResetAt(account.Extra)
-		NormalizeFixedQuotaWindows(account.Extra)
-	}
-	if input.AccountEmail != nil {
-		var err error
-		account.Extra, account.Credentials, err = ApplyAccountEmail(account.Extra, account.Credentials, *input.AccountEmail)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if input.Extra == nil {
-		account.Extra = prepareCodexFingerprintExtraForUpdate(account, account.Extra)
-	}
-	if requestedRateSyncEnabledUpdate != nil && *requestedRateSyncEnabledUpdate {
-		if requestedProbeEnabledUpdate != nil && !*requestedProbeEnabledUpdate {
-			return nil, infraerrors.BadRequest(
-				"UPSTREAM_BILLING_RATE_SYNC_REQUIRES_PROBE",
-				"upstream billing rate sync requires upstream billing probe",
-			)
-		}
-		enabled := true
-		requestedProbeEnabledUpdate = &enabled
-	}
-	if requestedProbeEnabledUpdate != nil && !*requestedProbeEnabledUpdate {
-		disabled := false
-		requestedRateSyncEnabledUpdate = &disabled
-	}
-	if (requestedProbeEnabledUpdate != nil && *requestedProbeEnabledUpdate) ||
-		(requestedRateSyncEnabledUpdate != nil && *requestedRateSyncEnabledUpdate) {
-		if !isUpstreamBillingProbeAccount(account) {
-			return nil, ErrUpstreamBillingProbeAccountInvalid
-		}
-		if requestedProbeEnabledUpdate != nil && *requestedProbeEnabledUpdate && !upstreamBillingProbeSupportsSub2APIBilling(account) {
-			return nil, ErrUpstreamBillingProbeAccountInvalid
-		}
-	}
-	if account.Extra == nil && (requestedProbeEnabledUpdate != nil || requestedRateSyncEnabledUpdate != nil) {
-		account.Extra = make(map[string]any)
-	}
-	if requestedProbeEnabledUpdate != nil {
-		account.Extra[UpstreamBillingProbeEnabledExtraKey] = *requestedProbeEnabledUpdate
-	}
-	if requestedRateSyncEnabledUpdate != nil {
-		account.Extra[UpstreamBillingRateSyncEnabledExtraKey] = *requestedRateSyncEnabledUpdate
-	}
-	// 影子代理恒继承母账号(由 propagateProxyToShadows 同步),不接受独立编辑——外审 B/P1;
-	// 否则要等母账号下次改 proxy 才被覆盖,期间影子会出现"有时继承、有时独立"的漂移。
-	if input.ProxyID != nil && !account.IsCredentialShadow() {
-		// 0 表示清除代理（前端发送 0 而不是 null 来表达清除意图）
-		if *input.ProxyID == 0 {
-			account.ProxyID = nil
-		} else {
-			account.ProxyID = input.ProxyID
-		}
-		account.Proxy = nil // 清除关联对象，防止 GORM Save 时根据 Proxy.ID 覆盖 ProxyID
-	}
-	if !reflect.DeepEqual(previousProbeIdentity, upstreamBillingProbeIdentity(account)) && account.Extra != nil {
-		delete(account.Extra, UpstreamBillingProbeExtraKey)
-		if !isUpstreamBillingProbeAccount(account) {
-			delete(account.Extra, UpstreamBillingProbeEnabledExtraKey)
-			delete(account.Extra, UpstreamBillingRateSyncEnabledExtraKey)
-		}
-	}
-	if account.Extra != nil {
-		if !IsOllamaCloudUsageAccount(account) {
-			delete(account.Extra, OllamaCloudUsageSessionExtraKey)
-			delete(account.Extra, OllamaCloudUsageAutoRefreshExtraKey)
-			delete(account.Extra, OllamaCloudUsageSnapshotExtraKey)
-		} else if !reflect.DeepEqual(previousOllamaUsageIdentity, ollamaCloudUsageIdentity(account)) {
-			delete(account.Extra, OllamaCloudUsageSessionExtraKey)
-			delete(account.Extra, OllamaCloudUsageAutoRefreshExtraKey)
-			delete(account.Extra, OllamaCloudUsageSnapshotExtraKey)
-		}
-	}
-	// 只在指针非 nil 时更新 Concurrency（支持设置为 0）
-	if input.Concurrency != nil {
-		account.Concurrency = normalizeAccountConcurrency(account.Platform, account.Type, *input.Concurrency)
-	}
-	// 只在指针非 nil 时更新 Priority（支持设置为 0）
-	if input.Priority != nil {
-		account.Priority = *input.Priority
-	}
-	if input.RateMultiplier != nil {
-		if *input.RateMultiplier < 0 {
-			return nil, errors.New("rate_multiplier must be >= 0")
-		}
-		// 同步开启时倍率归上游所有，手工值活不过下一次成功探测（表现为"改了又自己
-		// 变回去"），与批量路径一样直接拒绝。判断的是本次请求生效后的状态：上面
-		// 已把请求携带的两个开关落进 account.Extra，所以"同一请求关闭同步 + 改倍率"
-		// （用户显式收回所有权）会走到这里时读到 false，正常放行。
-		if upstreamBillingRateSyncEnabled(account) {
-			return nil, ErrUpstreamBillingRateSyncConflict
-		}
-		account.RateMultiplier = input.RateMultiplier
-	}
-	if input.TierID != nil {
-		if *input.TierID <= 0 {
-			account.TierID = nil
-		} else {
-			account.TierID = input.TierID
-		}
-	}
-	if input.LoadFactor != nil {
-		if *input.LoadFactor <= 0 {
-			account.LoadFactor = nil // 0 或负数表示清除
-		} else if *input.LoadFactor > 10000 {
-			return nil, errors.New("load_factor must be <= 10000")
-		} else {
-			account.LoadFactor = input.LoadFactor
-		}
-	}
-	if input.Status != "" {
-		account.Status = input.Status
-	}
-	if input.ExpiresAt != nil {
-		if *input.ExpiresAt <= 0 {
-			account.ExpiresAt = nil
-		} else {
-			expiresAt := time.Unix(*input.ExpiresAt, 0)
-			account.ExpiresAt = &expiresAt
-		}
-	}
-	if input.AutoPauseOnExpired != nil {
-		account.AutoPauseOnExpired = *input.AutoPauseOnExpired
-	}
-
-	// 先验证分组是否存在（在任何写操作之前）
-	if input.GroupIDs != nil {
-		if err := s.validateGroupIDsExist(ctx, *input.GroupIDs); err != nil {
-			return nil, err
-		}
-
-		// 检查混合渠道风险（除非用户已确认）
-		if !input.SkipMixedChannelCheck {
-			if err := s.checkMixedChannelRisk(ctx, account.ID, account.Platform, *input.GroupIDs); err != nil {
-				return nil, err
-			}
-		}
-	}
-	if err := resolveNewAPIMoonshotBaseURLOnSave(ctx, account); err != nil {
+	if err := s.tkFinalizeUpdateAccountSave(ctx, account, input); err != nil {
 		return nil, err
 	}
-	if account.Platform == PlatformGrok &&
-		tkInputHasNonEmptyCredential(input.Credentials, "refresh_token") {
-		if err := resolveGrokTokenOnSave(ctx, account); err != nil {
-			return nil, err
-		}
-	}
-	SeedOfficialSupportedProtocols(account)
-
-	billingSettingsAppliedAtomically := false
-	updater := s.accountBillingRepo
-	if updater == nil {
-		// Unit tests and narrow internal callers may construct adminServiceImpl
-		// directly; production wiring requires this capability through
-		// AdminAccountRepository.
-		updater, _ = s.accountRepo.(AccountBillingSettingsRepository)
-	}
-	if updater != nil {
-		if err := updater.UpdateWithAccountBillingSettings(
-			ctx,
-			account,
-			requestedProbeEnabledUpdate,
-			requestedRateSyncEnabledUpdate,
-			input.RateMultiplier,
-		); err != nil {
-			return nil, err
-		}
-		billingSettingsAppliedAtomically = true
-	}
-	if !billingSettingsAppliedAtomically {
-		if err := s.accountRepo.Update(ctx, account); err != nil {
-			return nil, err
-		}
-		if (requestedProbeEnabledUpdate != nil || requestedRateSyncEnabledUpdate != nil) &&
-			isUpstreamBillingProbeAccount(account) {
-			settings := make(map[string]any, 2)
-			if requestedProbeEnabledUpdate != nil {
-				settings[UpstreamBillingProbeEnabledExtraKey] = *requestedProbeEnabledUpdate
-			}
-			if requestedRateSyncEnabledUpdate != nil {
-				settings[UpstreamBillingRateSyncEnabledExtraKey] = *requestedRateSyncEnabledUpdate
-			}
-			if err := s.accountRepo.UpdateExtra(ctx, account.ID, settings); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	// 将 proxy 变更传播到 spark 影子账号（同步；Update 内部已触发调度快照）。
-	// 影子自身 proxy 不可独立编辑(见上),故对影子的更新不触发传播。
-	if input.ProxyID != nil && !account.IsCredentialShadow() {
-		if err := s.propagateProxyToShadows(ctx, id, account.ProxyID); err != nil {
-			return nil, err
-		}
-	}
-
-	// 绑定分组
-	effectiveGroupIDs := account.GroupIDs
-	if input.GroupIDs != nil {
-		effectiveGroupIDs = *input.GroupIDs
-	}
-	if len(effectiveGroupIDs) > 0 {
-		if err := s.checkPublicGroupAggregatorChannelPolicy(ctx, account.ID, account.Name, account.Platform, account.ChannelType, account.Credentials, effectiveGroupIDs); err != nil {
-			return nil, err
-		}
-	}
-	if input.GroupIDs != nil {
-		if err := s.accountRepo.BindGroups(ctx, account.ID, *input.GroupIDs); err != nil {
-			return nil, err
-		}
-	}
-
-	// 重新查询以确保返回完整数据（包括正确的 Proxy 关联对象）
 	updated, err := s.accountRepo.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
@@ -1077,16 +590,7 @@ func (s *adminServiceImpl) BulkUpdateAccounts(ctx context.Context, input *BulkUp
 			targetsByID[account.ID] = account
 		}
 	}
-	hasManaged := false
-	for _, account := range cachedTargets {
-		if IsSupplierManagedAccount(account) {
-			hasManaged = true
-			break
-		}
-	}
-	if hasManaged {
-		input.Extra = StripSupplierReservedAccountExtra(input.Extra)
-	} else if err := ValidateSupplierReservedAccountExtra(input.Extra); err != nil {
+	if err := s.tkPrepareBulkUpdateExtras(input, cachedTargets); err != nil {
 		return nil, err
 	}
 
@@ -1096,20 +600,6 @@ func (s *adminServiceImpl) BulkUpdateAccounts(ctx context.Context, input *BulkUp
 			return nil, err
 		}
 		result.LongContextInheritedCount = inheritedCount
-	}
-	if input.ProbeEnabled != nil {
-		for _, accountID := range input.AccountIDs {
-			account, ok := targetsByID[accountID]
-			if !ok {
-				return nil, ErrAccountNotFound
-			}
-			if !isUpstreamBillingProbeAccount(account) {
-				return nil, ErrUpstreamBillingProbeAccountInvalid
-			}
-			if *input.ProbeEnabled && !upstreamBillingProbeSupportsSub2APIBilling(account) {
-				return nil, ErrUpstreamBillingProbeAccountInvalid
-			}
-		}
 	}
 	// 影子账号绝不持有凭据:批量更新携带凭据时,目标中不得含影子(外审 G5,与单账号
 	// UpdateAccount 守卫对齐)。覆盖显式 IDs 与 filter 解析出的 IDs(此处 AccountIDs 已解析完成)。
@@ -1158,16 +648,8 @@ func (s *adminServiceImpl) BulkUpdateAccounts(ctx context.Context, input *BulkUp
 			}
 		}
 	}
-	if needPublicGroupAggregatorCheck {
-		for _, accountID := range input.AccountIDs {
-			account := accountByID[accountID]
-			if account == nil {
-				continue
-			}
-			if err := s.checkPublicGroupAggregatorChannelPolicy(ctx, account.ID, account.Name, account.Platform, account.ChannelType, account.Credentials, *input.GroupIDs); err != nil {
-				return nil, err
-			}
-		}
+	if err := s.tkBulkUpdatePublicGroupChecks(ctx, input, accountByID); err != nil {
+		return nil, err
 	}
 
 	if input.RateMultiplier != nil {
@@ -1294,10 +776,8 @@ func (s *adminServiceImpl) BulkUpdateAccounts(ctx context.Context, input *BulkUp
 		result.Results = append(result.Results, entry)
 	}
 
-	if result.Success > 0 && s.userRepo != nil {
-		if err := SyncAnthropicOperatorConcurrency(ctx, s.accountRepo, s.userRepo); err != nil {
-			return nil, err
-		}
+	if err := s.tkFinalizeBulkUpdateAccounts(ctx, result); err != nil {
+		return nil, err
 	}
 
 	return result, nil
@@ -1310,6 +790,22 @@ func updatesUpstreamBillingProbeIdentity(credentials map[string]any) bool {
 		}
 	}
 	return false
+}
+
+func upstreamBillingProbeIdentity(account *Account) map[string]any {
+	if account == nil {
+		return nil
+	}
+	identity := map[string]any{"platform": account.Platform, "type": account.Type, "proxy_id": nil}
+	if account.ProxyID != nil {
+		identity["proxy_id"] = *account.ProxyID
+	}
+	for _, key := range []string{"api_key", "base_url", credKeyHeaderOverrideEnabled, credKeyHeaderOverrides} {
+		if value, ok := account.Credentials[key]; ok {
+			identity[key] = value
+		}
+	}
+	return identity
 }
 
 func (s *adminServiceImpl) resolveBulkUpdateTargetIDs(ctx context.Context, filters *BulkUpdateAccountFilters) ([]int64, error) {

--- a/backend/internal/service/admin_account.go
+++ b/backend/internal/service/admin_account.go
@@ -601,6 +601,9 @@ func (s *adminServiceImpl) BulkUpdateAccounts(ctx context.Context, input *BulkUp
 		}
 		result.LongContextInheritedCount = inheritedCount
 	}
+	if err := s.tkValidateBulkProbeEnabled(input, targetsByID); err != nil {
+		return nil, err
+	}
 	// 影子账号绝不持有凭据:批量更新携带凭据时,目标中不得含影子(外审 G5,与单账号
 	// UpdateAccount 守卫对齐)。覆盖显式 IDs 与 filter 解析出的 IDs(此处 AccountIDs 已解析完成)。
 	if len(input.Credentials) > 0 {

--- a/backend/internal/service/admin_account_tk_billing_probe.go
+++ b/backend/internal/service/admin_account_tk_billing_probe.go
@@ -1,0 +1,12 @@
+package service
+
+import (
+	kiro "github.com/Wei-Shaw/sub2api/internal/pkg/kiro"
+)
+
+func normalizeAccountPriority(platform string, priority int) int {
+	if platform == PlatformKiro && priority <= 0 {
+		return kiro.DefaultKiroAccountPriority
+	}
+	return priority
+}

--- a/backend/internal/service/admin_account_tk_bulk_update.go
+++ b/backend/internal/service/admin_account_tk_bulk_update.go
@@ -4,8 +4,10 @@ import (
 	"context"
 )
 
-// tkPrepareBulkUpdateExtras applies TokenKey bulk-update Extra guards and
-// upstream-billing probe eligibility checks against the hydrated target set.
+// tkPrepareBulkUpdateExtras applies TokenKey bulk-update Extra guards against
+// the hydrated target set. ProbeEnabled eligibility stays AFTER OpenAI settings
+// validation in BulkUpdateAccounts so dual-failure error priority matches the
+// pre-companion order (supplier → OpenAI settings → probe).
 func (s *adminServiceImpl) tkPrepareBulkUpdateExtras(input *BulkUpdateAccountsInput, cachedTargets []*Account) error {
 	hasManaged := false
 	for _, account := range cachedTargets {
@@ -19,25 +21,25 @@ func (s *adminServiceImpl) tkPrepareBulkUpdateExtras(input *BulkUpdateAccountsIn
 	} else if err := ValidateSupplierReservedAccountExtra(input.Extra); err != nil {
 		return err
 	}
+	return nil
+}
 
-	if input.ProbeEnabled != nil {
-		targetsByID := make(map[int64]*Account, len(cachedTargets))
-		for _, account := range cachedTargets {
-			if account != nil {
-				targetsByID[account.ID] = account
-			}
+// tkValidateBulkProbeEnabled enforces upstream-billing probe eligibility after
+// OpenAI settings validation (same relative order as origin/main BulkUpdate).
+func (s *adminServiceImpl) tkValidateBulkProbeEnabled(input *BulkUpdateAccountsInput, targetsByID map[int64]*Account) error {
+	if input == nil || input.ProbeEnabled == nil {
+		return nil
+	}
+	for _, accountID := range input.AccountIDs {
+		account, ok := targetsByID[accountID]
+		if !ok {
+			return ErrAccountNotFound
 		}
-		for _, accountID := range input.AccountIDs {
-			account, ok := targetsByID[accountID]
-			if !ok {
-				return ErrAccountNotFound
-			}
-			if !isUpstreamBillingProbeAccount(account) {
-				return ErrUpstreamBillingProbeAccountInvalid
-			}
-			if *input.ProbeEnabled && !upstreamBillingProbeSupportsSub2APIBilling(account) {
-				return ErrUpstreamBillingProbeAccountInvalid
-			}
+		if !isUpstreamBillingProbeAccount(account) {
+			return ErrUpstreamBillingProbeAccountInvalid
+		}
+		if *input.ProbeEnabled && !upstreamBillingProbeSupportsSub2APIBilling(account) {
+			return ErrUpstreamBillingProbeAccountInvalid
 		}
 	}
 	return nil

--- a/backend/internal/service/admin_account_tk_bulk_update.go
+++ b/backend/internal/service/admin_account_tk_bulk_update.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"context"
+)
+
+// tkPrepareBulkUpdateExtras applies TokenKey bulk-update Extra guards and
+// upstream-billing probe eligibility checks against the hydrated target set.
+func (s *adminServiceImpl) tkPrepareBulkUpdateExtras(input *BulkUpdateAccountsInput, cachedTargets []*Account) error {
+	hasManaged := false
+	for _, account := range cachedTargets {
+		if IsSupplierManagedAccount(account) {
+			hasManaged = true
+			break
+		}
+	}
+	if hasManaged {
+		input.Extra = StripSupplierReservedAccountExtra(input.Extra)
+	} else if err := ValidateSupplierReservedAccountExtra(input.Extra); err != nil {
+		return err
+	}
+
+	if input.ProbeEnabled != nil {
+		targetsByID := make(map[int64]*Account, len(cachedTargets))
+		for _, account := range cachedTargets {
+			if account != nil {
+				targetsByID[account.ID] = account
+			}
+		}
+		for _, accountID := range input.AccountIDs {
+			account, ok := targetsByID[accountID]
+			if !ok {
+				return ErrAccountNotFound
+			}
+			if !isUpstreamBillingProbeAccount(account) {
+				return ErrUpstreamBillingProbeAccountInvalid
+			}
+			if *input.ProbeEnabled && !upstreamBillingProbeSupportsSub2APIBilling(account) {
+				return ErrUpstreamBillingProbeAccountInvalid
+			}
+		}
+	}
+	return nil
+}
+
+// tkBulkUpdatePublicGroupChecks enforces scheme-C public-group aggregator policy
+// before any bulk write that rebinds groups.
+func (s *adminServiceImpl) tkBulkUpdatePublicGroupChecks(ctx context.Context, input *BulkUpdateAccountsInput, accountByID map[int64]*Account) error {
+	if input.GroupIDs == nil {
+		return nil
+	}
+	for _, accountID := range input.AccountIDs {
+		account := accountByID[accountID]
+		if account == nil {
+			continue
+		}
+		if err := s.checkPublicGroupAggregatorChannelPolicy(ctx, account.ID, account.Name, account.Platform, account.ChannelType, account.Credentials, *input.GroupIDs); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// tkFinalizeBulkUpdateAccounts runs TokenKey post-bulk side effects.
+func (s *adminServiceImpl) tkFinalizeBulkUpdateAccounts(ctx context.Context, result *BulkUpdateAccountsResult) error {
+	if result.Success > 0 && s.userRepo != nil {
+		if err := SyncAnthropicOperatorConcurrency(ctx, s.accountRepo, s.userRepo); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/backend/internal/service/admin_account_tk_bulk_update_test.go
+++ b/backend/internal/service/admin_account_tk_bulk_update_test.go
@@ -1,0 +1,73 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ProbeEnabled eligibility must run AFTER OpenAI settings validation so a
+// dual-failure BulkUpdate prefers OPENAI_BULK_TARGET_INVALID (pre-companion
+// order). A Kiro OAuth account fails both gates.
+func TestBulkUpdateAccounts_OpenAISettingsBeforeProbeEnabled(t *testing.T) {
+	repo := &accountRepoStubForBulkUpdate{getByIDsAccounts: []*Account{
+		{ID: 1, Platform: PlatformKiro, Type: AccountTypeOAuth},
+	}}
+	svc := &adminServiceImpl{accountRepo: repo}
+	enabled := true
+
+	_, err := svc.BulkUpdateAccounts(context.Background(), &BulkUpdateAccountsInput{
+		AccountIDs:   []int64{1},
+		ProbeEnabled: &enabled,
+		Extra:        map[string]any{openAILongContextBillingEnabledKey: true},
+	})
+
+	require.Error(t, err)
+	requireApplicationErrorReason(t, err, "OPENAI_BULK_TARGET_INVALID")
+	require.False(t, errors.Is(err, ErrUpstreamBillingProbeAccountInvalid),
+		"probe must not win over OpenAI settings when both would fail")
+	require.Zero(t, repo.bulkUpdateCalls)
+}
+
+func TestTkValidateBulkProbeEnabled_RejectsNonProbeAccount(t *testing.T) {
+	svc := &adminServiceImpl{}
+	enabled := true
+	err := svc.tkValidateBulkProbeEnabled(&BulkUpdateAccountsInput{
+		AccountIDs:   []int64{9},
+		ProbeEnabled: &enabled,
+	}, map[int64]*Account{
+		9: {ID: 9, Platform: PlatformKiro, Type: AccountTypeOAuth},
+	})
+	require.ErrorIs(t, err, ErrUpstreamBillingProbeAccountInvalid)
+}
+
+func TestTkValidateBulkProbeEnabled_AcceptsProbeAccount(t *testing.T) {
+	svc := &adminServiceImpl{}
+	enabled := true
+	err := svc.tkValidateBulkProbeEnabled(&BulkUpdateAccountsInput{
+		AccountIDs:   []int64{3},
+		ProbeEnabled: &enabled,
+	}, map[int64]*Account{
+		3: {ID: 3, Platform: PlatformAnthropic, Type: AccountTypeAPIKey},
+	})
+	require.NoError(t, err)
+}
+
+func TestTkPrepareBulkUpdateExtras_DoesNotValidateProbe(t *testing.T) {
+	svc := &adminServiceImpl{}
+	enabled := true
+	input := &BulkUpdateAccountsInput{
+		AccountIDs:   []int64{1},
+		ProbeEnabled: &enabled,
+		Extra:        map[string]any{"note": "ok"},
+	}
+	// Kiro OAuth would fail probe validation — prepare must ignore ProbeEnabled.
+	err := svc.tkPrepareBulkUpdateExtras(input, []*Account{
+		{ID: 1, Platform: PlatformKiro, Type: AccountTypeOAuth},
+	})
+	require.NoError(t, err)
+}

--- a/backend/internal/service/admin_account_tk_create.go
+++ b/backend/internal/service/admin_account_tk_create.go
@@ -1,0 +1,122 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+)
+
+type accountCreateOptions struct {
+	allowSupplierReservedExtra bool
+	initialSchedulable         *bool
+}
+
+func (s *adminServiceImpl) createAccount(ctx context.Context, input *CreateAccountInput, options accountCreateOptions) (*Account, error) {
+	if input == nil {
+		return nil, ErrAccountNilInput
+	}
+	if !options.allowSupplierReservedExtra {
+		if err := ValidateSupplierReservedAccountExtra(input.Extra); err != nil {
+			return nil, err
+		}
+	}
+	if strings.TrimSpace(input.AccountEmail) != "" {
+		var err error
+		input.Extra, input.Credentials, err = ApplyAccountEmail(input.Extra, input.Credentials, input.AccountEmail)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	accountExtra, err := normalizeOpenAILongContextBillingExtra(input.Platform, input.Extra)
+	if err != nil {
+		return nil, err
+	}
+	accountExtra, err = normalizeGrokMediaEligibilityExtra(input.Platform, accountExtra)
+	if err != nil {
+		return nil, err
+	}
+
+	groupIDs := input.GroupIDs
+	if len(groupIDs) == 0 && !input.SkipDefaultGroupBind {
+		defaultGroupName := input.Platform + "-default"
+		groups, listErr := s.groupRepo.ListActiveByPlatform(ctx, input.Platform)
+		if listErr == nil {
+			for _, group := range groups {
+				if group.Name == defaultGroupName {
+					groupIDs = []int64{group.ID}
+					break
+				}
+			}
+		}
+	}
+	if len(groupIDs) > 0 && !input.SkipMixedChannelCheck {
+		if err := s.checkMixedChannelRisk(ctx, 0, input.Platform, groupIDs); err != nil {
+			return nil, err
+		}
+	}
+	if len(groupIDs) > 0 {
+		if err := s.checkPublicGroupAggregatorChannelPolicy(ctx, 0, input.Name, input.Platform, input.ChannelType, input.Credentials, groupIDs); err != nil {
+			return nil, err
+		}
+	}
+	if err := NormalizeHeaderOverrideCredentials(input.Credentials); err != nil {
+		return nil, err
+	}
+	// Never persist ephemeral SSO/password secrets after OAuth conversion.
+	input.Credentials = SanitizeStoredCredentials(input.Platform, input.Credentials)
+	input.Credentials = FinalizeAccountCredentials(input.Credentials, input.ChannelType)
+
+	account, err := buildAccountForCreate(input, accountExtra)
+	if err != nil {
+		return nil, err
+	}
+	if options.initialSchedulable != nil {
+		account.Schedulable = *options.initialSchedulable
+	}
+	if err := resolveNewAPIMoonshotBaseURLOnSave(ctx, account); err != nil {
+		return nil, err
+	}
+	if err := resolveGrokTokenOnSave(ctx, account); err != nil {
+		return nil, err
+	}
+	SeedOfficialSupportedProtocols(account)
+	if err := s.accountRepo.Create(ctx, account); err != nil {
+		return nil, err
+	}
+
+	// 绑定分组
+	if len(groupIDs) > 0 {
+		if err := s.accountRepo.BindGroups(ctx, account.ID, groupIDs); err != nil {
+			return nil, err
+		}
+		account.GroupIDs = append([]int64(nil), groupIDs...)
+	}
+
+	// OAuth 账号：创建后异步设置隐私。
+	// 使用 Ensure（幂等）而非 Force：新建账号 Extra 为空时效果相同，但更安全。
+	if account.Type == AccountTypeOAuth {
+		switch account.Platform {
+		case PlatformOpenAI:
+			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						slog.Error("create_account_openai_privacy_panic", "account_id", account.ID, "recover", r)
+					}
+				}()
+				s.EnsureOpenAIPrivacy(context.Background(), account)
+			}()
+		case PlatformAntigravity:
+			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						slog.Error("create_account_antigravity_privacy_panic", "account_id", account.ID, "recover", r)
+					}
+				}()
+				s.EnsureAntigravityPrivacy(context.Background(), account)
+			}()
+		}
+	}
+
+	return account, nil
+}

--- a/backend/internal/service/admin_account_tk_update.go
+++ b/backend/internal/service/admin_account_tk_update.go
@@ -1,0 +1,376 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"time"
+
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+)
+
+// tkApplyUpdateAccountTKFields applies TokenKey account-update mutations and
+// persists the account (including upstream billing settings). Call
+// tkFinalizeUpdateAccountSave afterward for post-save side effects.
+func (s *adminServiceImpl) tkApplyUpdateAccountTKFields(ctx context.Context, account *Account, input *UpdateAccountInput) error {
+	var err error
+	if IsSupplierManagedAccount(account) {
+		if input.Extra != nil {
+			input.Extra = StripSupplierReservedAccountExtra(input.Extra)
+		}
+	} else if err := ValidateSupplierReservedAccountExtra(input.Extra); err != nil {
+		return err
+	}
+	var normalizedExtra map[string]any
+	if input.Extra != nil {
+		normalizedExtra, err = normalizeOpenAILongContextBillingUpdateExtra(account, input)
+		if err != nil {
+			return err
+		}
+		normalizedExtra, err = normalizeGrokMediaEligibilityUpdateExtra(account, input, normalizedExtra)
+		if err != nil {
+			return err
+		}
+	}
+	previousProbeIdentity := upstreamBillingProbeIdentity(account)
+	previousOllamaUsageIdentity := ollamaCloudUsageIdentity(account)
+	// 安全/身份不变量(影子账号):通用更新路径被 edit/re-auth/refresh/batch 共用,
+	// 必须在此守住,否则仅在创建时的保证可被这些路径绕过。
+	if account.IsCredentialShadow() {
+		// 影子绝不持有凭据(凭据只在母账号)——外审 F5。
+		if !isAllowedSparkShadowCredentialsUpdate(input.Credentials) {
+			return infraerrors.Newf(http.StatusBadRequest, "SPARK_SHADOW_NO_CREDENTIALS",
+				"spark shadow accounts do not hold auth credentials; only model mapping can be configured on the shadow account")
+		}
+		// 影子 type 不可变——很多上游逻辑按 account.Type 分支(OAuth transform / ChatGPT
+		// header 注入 / WS OAuth 决策),改成 apikey 会让 spark 影子被选中后按错误协议转发(外审 G7)。
+		if input.Type != "" && input.Type != account.Type {
+			return infraerrors.Newf(http.StatusBadRequest, "SPARK_SHADOW_IMMUTABLE_TYPE",
+				"spark shadow account type cannot be changed; it must remain an OpenAI OAuth shadow")
+		}
+	} else if input.Type != "" && input.Type != account.Type && input.Type != AccountTypeOAuth {
+		// 母账号守卫(外审 D/P1):有 spark 影子的账号不能把 type 改出 OpenAI OAuth——影子读透母
+		// 凭据,母变成 apikey/setup_token 会让影子被调度后按错协议失败(resolveCredentialAccount
+		// 必报错)。须先删影子再改 type。
+		shadows, serr := s.accountRepo.ListShadowsByParent(ctx, account.ID)
+		if serr != nil {
+			return serr
+		}
+		if len(shadows) > 0 {
+			return infraerrors.New(http.StatusBadRequest, "SPARK_SHADOW_PARENT_IMMUTABLE_TYPE",
+				"cannot change account type while it has a spark shadow; delete the shadow first")
+		}
+	}
+	wasOveragesEnabled := account.IsOveragesEnabled()
+
+	if input.Name != "" {
+		account.Name = input.Name
+	}
+	if input.Type != "" {
+		account.Type = input.Type
+	}
+	if input.ChannelType != nil {
+		account.ChannelType = *input.ChannelType
+	}
+	if input.Notes != nil {
+		account.Notes = normalizeAccountNotes(input.Notes)
+	}
+	if account.IsCredentialShadow() && input.Credentials != nil {
+		account.Credentials = sanitizeSparkShadowCredentials(input.Credentials)
+	} else if len(input.Credentials) > 0 {
+		// SSOT credential merge: sensitive preserve-when-omitted + never inherit
+		// stale protocol identity (api_base_urls / protocol_endpoints_exclusive).
+		account.Credentials = MergeAccountCredentials(
+			account.Credentials, input.Credentials, account.ChannelType, CredentialMergeAdmin,
+		)
+		// 校验并规范化请求头覆写配置（header 名小写化、格式检查）
+		if err := NormalizeHeaderOverrideCredentials(account.Credentials); err != nil {
+			return err
+		}
+		// Strip SSO/password residue that must never sit next to OAuth tokens.
+		account.Credentials = SanitizeStoredCredentials(account.Platform, account.Credentials)
+		account.Credentials = FinalizeAccountCredentials(account.Credentials, account.ChannelType)
+	}
+	// Extra 使用 map：需要区分“未提供(nil)”与“显式清空({})”。
+	// 关闭配额限制时前端会删除 quota_* 键并提交 extra:{}，此时也必须落库。
+	requestedProbeEnabledUpdate := input.ProbeEnabled
+	requestedRateSyncEnabledUpdate := input.RateSyncEnabled
+	if input.Extra != nil {
+		delete(normalizedExtra, SupportedProtocolsExtraKey)
+		requestedProbeEnabled, hasRequestedProbeEnabled := normalizedExtra[UpstreamBillingProbeEnabledExtraKey]
+		if hasRequestedProbeEnabled {
+			enabled, ok := requestedProbeEnabled.(bool)
+			if !ok {
+				return infraerrors.BadRequest("INVALID_UPSTREAM_BILLING_PROBE_ENABLED", "upstream_billing_probe_enabled must be a boolean")
+			}
+			if requestedProbeEnabledUpdate != nil && *requestedProbeEnabledUpdate != enabled {
+				return infraerrors.BadRequest("CONFLICTING_UPSTREAM_BILLING_PROBE_ENABLED", "conflicting upstream_billing_probe_enabled values")
+			}
+			requestedProbeEnabledUpdate = &enabled
+		}
+		delete(normalizedExtra, UpstreamBillingProbeEnabledExtraKey)
+		delete(normalizedExtra, UpstreamBillingRateSyncEnabledExtraKey)
+		delete(normalizedExtra, UpstreamBillingProbeExtraKey)
+		delete(normalizedExtra, OllamaCloudUsageSessionExtraKey)
+		delete(normalizedExtra, OllamaCloudUsageAutoRefreshExtraKey)
+		delete(normalizedExtra, OllamaCloudUsageSnapshotExtraKey)
+		// 保留配额用量和专用服务受管字段，防止普通账号编辑意外覆盖。
+		for _, key := range []string{
+			SupportedProtocolsExtraKey,
+			"quota_used",
+			"quota_daily_used",
+			"quota_daily_start",
+			"quota_weekly_used",
+			"quota_weekly_start",
+			grokBillingExtraKey,
+			UpstreamBillingProbeEnabledExtraKey,
+			UpstreamBillingRateSyncEnabledExtraKey,
+			UpstreamBillingProbeExtraKey,
+			OllamaCloudUsageSessionExtraKey,
+			OllamaCloudUsageAutoRefreshExtraKey,
+			OllamaCloudUsageSnapshotExtraKey,
+			SupplierSourceIDExtraKey,
+			SupplierDiscountBandExtraKey,
+		} {
+			if v, ok := account.Extra[key]; ok {
+				normalizedExtra[key] = v
+			}
+		}
+		normalizedExtra = prepareCodexFingerprintExtraForUpdate(account, normalizedExtra)
+		account.Extra = PreserveSupplierManagedExtraKeys(account, normalizedExtra)
+		if account.Platform == PlatformAntigravity && wasOveragesEnabled && !account.IsOveragesEnabled() {
+			delete(account.Extra, "antigravity_credits_overages") // 清理旧版 overages 运行态
+			// 清除 AICredits 限流 key
+			if rawLimits, ok := account.Extra[modelRateLimitsKey].(map[string]any); ok {
+				delete(rawLimits, creditsExhaustedKey)
+			}
+		}
+		if account.Platform == PlatformAntigravity && !wasOveragesEnabled && account.IsOveragesEnabled() {
+			delete(account.Extra, modelRateLimitsKey)
+			delete(account.Extra, "antigravity_credits_overages") // 清理旧版 overages 运行态
+		}
+		// 校验并预计算固定时间重置的下次重置时间
+		if err := ValidateQuotaResetConfig(account.Extra); err != nil {
+			return err
+		}
+		ComputeQuotaResetAt(account.Extra)
+		NormalizeFixedQuotaWindows(account.Extra)
+	}
+	if input.AccountEmail != nil {
+		var err error
+		account.Extra, account.Credentials, err = ApplyAccountEmail(account.Extra, account.Credentials, *input.AccountEmail)
+		if err != nil {
+			return err
+		}
+	}
+	if input.Extra == nil {
+		account.Extra = prepareCodexFingerprintExtraForUpdate(account, account.Extra)
+	}
+	if requestedRateSyncEnabledUpdate != nil && *requestedRateSyncEnabledUpdate {
+		if requestedProbeEnabledUpdate != nil && !*requestedProbeEnabledUpdate {
+			return infraerrors.BadRequest(
+				"UPSTREAM_BILLING_RATE_SYNC_REQUIRES_PROBE",
+				"upstream billing rate sync requires upstream billing probe",
+			)
+		}
+		enabled := true
+		requestedProbeEnabledUpdate = &enabled
+	}
+	if requestedProbeEnabledUpdate != nil && !*requestedProbeEnabledUpdate {
+		disabled := false
+		requestedRateSyncEnabledUpdate = &disabled
+	}
+	if (requestedProbeEnabledUpdate != nil && *requestedProbeEnabledUpdate) ||
+		(requestedRateSyncEnabledUpdate != nil && *requestedRateSyncEnabledUpdate) {
+		if !isUpstreamBillingProbeAccount(account) {
+			return ErrUpstreamBillingProbeAccountInvalid
+		}
+		if requestedProbeEnabledUpdate != nil && *requestedProbeEnabledUpdate && !upstreamBillingProbeSupportsSub2APIBilling(account) {
+			return ErrUpstreamBillingProbeAccountInvalid
+		}
+	}
+	if account.Extra == nil && (requestedProbeEnabledUpdate != nil || requestedRateSyncEnabledUpdate != nil) {
+		account.Extra = make(map[string]any)
+	}
+	if requestedProbeEnabledUpdate != nil {
+		account.Extra[UpstreamBillingProbeEnabledExtraKey] = *requestedProbeEnabledUpdate
+	}
+	if requestedRateSyncEnabledUpdate != nil {
+		account.Extra[UpstreamBillingRateSyncEnabledExtraKey] = *requestedRateSyncEnabledUpdate
+	}
+	// 影子代理恒继承母账号(由 propagateProxyToShadows 同步),不接受独立编辑——外审 B/P1;
+	// 否则要等母账号下次改 proxy 才被覆盖,期间影子会出现"有时继承、有时独立"的漂移。
+	if input.ProxyID != nil && !account.IsCredentialShadow() {
+		// 0 表示清除代理（前端发送 0 而不是 null 来表达清除意图）
+		if *input.ProxyID == 0 {
+			account.ProxyID = nil
+		} else {
+			account.ProxyID = input.ProxyID
+		}
+		account.Proxy = nil // 清除关联对象，防止 GORM Save 时根据 Proxy.ID 覆盖 ProxyID
+	}
+	if !reflect.DeepEqual(previousProbeIdentity, upstreamBillingProbeIdentity(account)) && account.Extra != nil {
+		delete(account.Extra, UpstreamBillingProbeExtraKey)
+		if !isUpstreamBillingProbeAccount(account) {
+			delete(account.Extra, UpstreamBillingProbeEnabledExtraKey)
+			delete(account.Extra, UpstreamBillingRateSyncEnabledExtraKey)
+		}
+	}
+	if account.Extra != nil {
+		if !IsOllamaCloudUsageAccount(account) {
+			delete(account.Extra, OllamaCloudUsageSessionExtraKey)
+			delete(account.Extra, OllamaCloudUsageAutoRefreshExtraKey)
+			delete(account.Extra, OllamaCloudUsageSnapshotExtraKey)
+		} else if !reflect.DeepEqual(previousOllamaUsageIdentity, ollamaCloudUsageIdentity(account)) {
+			delete(account.Extra, OllamaCloudUsageSessionExtraKey)
+			delete(account.Extra, OllamaCloudUsageAutoRefreshExtraKey)
+			delete(account.Extra, OllamaCloudUsageSnapshotExtraKey)
+		}
+	}
+	// 只在指针非 nil 时更新 Concurrency（支持设置为 0）
+	if input.Concurrency != nil {
+		account.Concurrency = normalizeAccountConcurrency(account.Platform, account.Type, *input.Concurrency)
+	}
+	// 只在指针非 nil 时更新 Priority（支持设置为 0）
+	if input.Priority != nil {
+		account.Priority = *input.Priority
+	}
+	if input.RateMultiplier != nil {
+		if *input.RateMultiplier < 0 {
+			return errors.New("rate_multiplier must be >= 0")
+		}
+		// 同步开启时倍率归上游所有，手工值活不过下一次成功探测（表现为"改了又自己
+		// 变回去"），与批量路径一样直接拒绝。判断的是本次请求生效后的状态：上面
+		// 已把请求携带的两个开关落进 account.Extra，所以"同一请求关闭同步 + 改倍率"
+		// （用户显式收回所有权）会走到这里时读到 false，正常放行。
+		if upstreamBillingRateSyncEnabled(account) {
+			return ErrUpstreamBillingRateSyncConflict
+		}
+		account.RateMultiplier = input.RateMultiplier
+	}
+	if input.TierID != nil {
+		if *input.TierID <= 0 {
+			account.TierID = nil
+		} else {
+			account.TierID = input.TierID
+		}
+	}
+	if input.LoadFactor != nil {
+		if *input.LoadFactor <= 0 {
+			account.LoadFactor = nil // 0 或负数表示清除
+		} else if *input.LoadFactor > 10000 {
+			return errors.New("load_factor must be <= 10000")
+		} else {
+			account.LoadFactor = input.LoadFactor
+		}
+	}
+	if input.Status != "" {
+		account.Status = input.Status
+	}
+	if input.ExpiresAt != nil {
+		if *input.ExpiresAt <= 0 {
+			account.ExpiresAt = nil
+		} else {
+			expiresAt := time.Unix(*input.ExpiresAt, 0)
+			account.ExpiresAt = &expiresAt
+		}
+	}
+	if input.AutoPauseOnExpired != nil {
+		account.AutoPauseOnExpired = *input.AutoPauseOnExpired
+	}
+
+	// 先验证分组是否存在（在任何写操作之前）
+	if input.GroupIDs != nil {
+		if err := s.validateGroupIDsExist(ctx, *input.GroupIDs); err != nil {
+			return err
+		}
+
+		// 检查混合渠道风险（除非用户已确认）
+		if !input.SkipMixedChannelCheck {
+			if err := s.checkMixedChannelRisk(ctx, account.ID, account.Platform, *input.GroupIDs); err != nil {
+				return err
+			}
+		}
+	}
+	if err := resolveNewAPIMoonshotBaseURLOnSave(ctx, account); err != nil {
+		return err
+	}
+	if account.Platform == PlatformGrok &&
+		tkInputHasNonEmptyCredential(input.Credentials, "refresh_token") {
+		if err := resolveGrokTokenOnSave(ctx, account); err != nil {
+			return err
+		}
+	}
+	SeedOfficialSupportedProtocols(account)
+
+	billingSettingsAppliedAtomically := false
+	updater := s.accountBillingRepo
+	if updater == nil {
+		// Unit tests and narrow internal callers may construct adminServiceImpl
+		// directly; production wiring requires this capability through
+		// AdminAccountRepository.
+		updater, _ = s.accountRepo.(AccountBillingSettingsRepository)
+	}
+	if updater != nil {
+		if err := updater.UpdateWithAccountBillingSettings(
+			ctx,
+			account,
+			requestedProbeEnabledUpdate,
+			requestedRateSyncEnabledUpdate,
+			input.RateMultiplier,
+		); err != nil {
+			return err
+		}
+		billingSettingsAppliedAtomically = true
+	}
+	if !billingSettingsAppliedAtomically {
+		if err := s.accountRepo.Update(ctx, account); err != nil {
+			return err
+		}
+		if (requestedProbeEnabledUpdate != nil || requestedRateSyncEnabledUpdate != nil) &&
+			isUpstreamBillingProbeAccount(account) {
+			settings := make(map[string]any, 2)
+			if requestedProbeEnabledUpdate != nil {
+				settings[UpstreamBillingProbeEnabledExtraKey] = *requestedProbeEnabledUpdate
+			}
+			if requestedRateSyncEnabledUpdate != nil {
+				settings[UpstreamBillingRateSyncEnabledExtraKey] = *requestedRateSyncEnabledUpdate
+			}
+			if err := s.accountRepo.UpdateExtra(ctx, account.ID, settings); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// tkFinalizeUpdateAccountSave runs post-persist UpdateAccount side effects:
+// proxy propagation to spark shadows, public-group aggregator policy, and
+// group rebinding.
+func (s *adminServiceImpl) tkFinalizeUpdateAccountSave(ctx context.Context, account *Account, input *UpdateAccountInput) error {
+	// 将 proxy 变更传播到 spark 影子账号（同步；Update 内部已触发调度快照）。
+	// 影子自身 proxy 不可独立编辑(见上),故对影子的更新不触发传播。
+	if input.ProxyID != nil && !account.IsCredentialShadow() {
+		if err := s.propagateProxyToShadows(ctx, account.ID, account.ProxyID); err != nil {
+			return err
+		}
+	}
+
+	// 绑定分组
+	effectiveGroupIDs := account.GroupIDs
+	if input.GroupIDs != nil {
+		effectiveGroupIDs = *input.GroupIDs
+	}
+	if len(effectiveGroupIDs) > 0 {
+		if err := s.checkPublicGroupAggregatorChannelPolicy(ctx, account.ID, account.Name, account.Platform, account.ChannelType, account.Credentials, effectiveGroupIDs); err != nil {
+			return err
+		}
+	}
+	if input.GroupIDs != nil {
+		if err := s.accountRepo.BindGroups(ctx, account.ID, *input.GroupIDs); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -1050,45 +1050,6 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 	return nil
 }
 
-func tkModelPricingFromLiteLLM(p *LiteLLMModelPricing) *ModelPricing {
-	if p == nil || p.TokenPricingAbsent || tkIsEffectivelyUnpriced(p) {
-		return nil
-	}
-	price5m := p.CacheCreationInputTokenCost
-	price1h := p.CacheCreationInputTokenCostAbove1hr
-	return &ModelPricing{
-		InputPricePerToken:                 p.InputCostPerToken,
-		InputPricePerTokenPriority:         p.InputCostPerTokenPriority,
-		OutputPricePerToken:                p.OutputCostPerToken,
-		OutputPricePerTokenPriority:        p.OutputCostPerTokenPriority,
-		ThinkingOutputPricePerToken:        p.ThinkingOutputCostPerToken,
-		CacheCreationPricePerToken:         p.CacheCreationInputTokenCost,
-		CacheCreationPricePerTokenPriority: p.CacheCreationInputTokenCostPriority,
-		CacheReadPricePerToken:             p.CacheReadInputTokenCost,
-		CacheReadPricePerTokenPriority:     p.CacheReadInputTokenCostPriority,
-		CacheCreation5mPrice:               price5m,
-		CacheCreation1hPrice:               price1h,
-		SupportsCacheBreakdown:             price1h > 0 && price1h > price5m,
-		LongContextInputThreshold:          p.LongContextInputTokenThreshold,
-		LongContextThresholdInclusive:      p.LongContextThresholdInclusive,
-		LongContextInputMultiplier:         p.LongContextInputCostMultiplier,
-		LongContextOutputMultiplier:        p.LongContextOutputCostMultiplier,
-		ImageInputPricePerToken:            p.InputCostPerImageToken,
-		ImageOutputPricePerToken:           p.OutputCostPerImageToken,
-		Intervals:                          p.Intervals,
-		registrySnapshot:                   p.registrySnapshot,
-	}
-}
-
-func tkOverlayModelPricing(model string) *ModelPricing {
-	owner := strings.ToLower(strings.TrimSpace(model))
-	pricing := tkModelPricingFromLiteLLM(loadTKPricingOverlay()[owner])
-	if pricing != nil {
-		pricing.registryOwner = owner
-	}
-	return pricing
-}
-
 // IsServedViaFamilyFloor reports whether `model` has no direct active-registry owner but resolves
 // through a compatibility alias to another registry owner. It is retained as the convergence
 // signal for served_at_fallback alerts; the returned dimensions are still registry-owned, never
@@ -2139,27 +2100,7 @@ func (s *BillingService) getDefaultImagePrice(model string, imageSize string) fl
 	if basePrice <= 0 {
 		return 0
 	}
-
-	// TK: Imagen bills at its FLAT official per-image price. Google prices Imagen
-	// as a single $/image per quality variant with NO 1K/2K/4K generation tier, so
-	// the size-tier multiplier below (real only for genuine pixel-size tiers such
-	// as Seedream) must not apply. Imagen requests carry ratio codes (no size) and
-	// default to "2K", which silently marked them up ×1.5 — this exemption removes
-	// that. Routes through the same function as the pre-flight HOLD, so settle and
-	// hold stay consistent. See tkIsFlatPerImageModel (billing_service_tk_flat_image.go).
-	if tkIsFlatPerImageModel(model) {
-		return basePrice
-	}
-
-	// 2K 尺寸 1.5 倍，4K 尺寸翻倍
-	if imageSize == "2K" {
-		return basePrice * 1.5
-	}
-	if imageSize == "4K" {
-		return basePrice * 2
-	}
-
-	return basePrice
+	return tkApplyDefaultImageSizeMultiplier(model, imageSize, basePrice)
 }
 
 func (s *BillingService) getDefaultVideoPrice(model string, resolution string) float64 {

--- a/backend/internal/service/billing_service_tk_flat_image.go
+++ b/backend/internal/service/billing_service_tk_flat_image.go
@@ -22,3 +22,25 @@ import "strings"
 func tkIsFlatPerImageModel(model string) bool {
 	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(model)), "imagen-")
 }
+
+// tkApplyDefaultImageSizeMultiplier applies Seedream-style 2K/4K size tiers,
+// except for flat-priced Imagen which must return basePrice unchanged.
+func tkApplyDefaultImageSizeMultiplier(model string, imageSize string, basePrice float64) float64 {
+	// TK: Imagen bills at its FLAT official per-image price. Google prices Imagen
+	// as a single $/image per quality variant with NO 1K/2K/4K generation tier, so
+	// the size-tier multiplier below (real only for genuine pixel-size tiers such
+	// as Seedream) must not apply. Imagen requests carry ratio codes (no size) and
+	// default to "2K", which silently marked them up ×1.5 — this exemption removes
+	// that. Routes through the same function as the pre-flight HOLD, so settle and
+	// hold stay consistent. See tkIsFlatPerImageModel.
+	if tkIsFlatPerImageModel(model) {
+		return basePrice
+	}
+	if imageSize == "2K" {
+		return basePrice * 1.5
+	}
+	if imageSize == "4K" {
+		return basePrice * 2
+	}
+	return basePrice
+}

--- a/backend/internal/service/billing_service_tk_registry_alias.go
+++ b/backend/internal/service/billing_service_tk_registry_alias.go
@@ -20,6 +20,45 @@ func tkRegistryAliasOwnerPricing(owner string) *ModelPricing {
 	return pricing
 }
 
+func tkModelPricingFromLiteLLM(p *LiteLLMModelPricing) *ModelPricing {
+	if p == nil || p.TokenPricingAbsent || tkIsEffectivelyUnpriced(p) {
+		return nil
+	}
+	price5m := p.CacheCreationInputTokenCost
+	price1h := p.CacheCreationInputTokenCostAbove1hr
+	return &ModelPricing{
+		InputPricePerToken:                 p.InputCostPerToken,
+		InputPricePerTokenPriority:         p.InputCostPerTokenPriority,
+		OutputPricePerToken:                p.OutputCostPerToken,
+		OutputPricePerTokenPriority:        p.OutputCostPerTokenPriority,
+		ThinkingOutputPricePerToken:        p.ThinkingOutputCostPerToken,
+		CacheCreationPricePerToken:         p.CacheCreationInputTokenCost,
+		CacheCreationPricePerTokenPriority: p.CacheCreationInputTokenCostPriority,
+		CacheReadPricePerToken:             p.CacheReadInputTokenCost,
+		CacheReadPricePerTokenPriority:     p.CacheReadInputTokenCostPriority,
+		CacheCreation5mPrice:               price5m,
+		CacheCreation1hPrice:               price1h,
+		SupportsCacheBreakdown:             price1h > 0 && price1h > price5m,
+		LongContextInputThreshold:          p.LongContextInputTokenThreshold,
+		LongContextThresholdInclusive:      p.LongContextThresholdInclusive,
+		LongContextInputMultiplier:         p.LongContextInputCostMultiplier,
+		LongContextOutputMultiplier:        p.LongContextOutputCostMultiplier,
+		ImageInputPricePerToken:            p.InputCostPerImageToken,
+		ImageOutputPricePerToken:           p.OutputCostPerImageToken,
+		Intervals:                          p.Intervals,
+		registrySnapshot:                   p.registrySnapshot,
+	}
+}
+
+func tkOverlayModelPricing(model string) *ModelPricing {
+	owner := strings.ToLower(strings.TrimSpace(model))
+	pricing := tkModelPricingFromLiteLLM(loadTKPricingOverlay()[owner])
+	if pricing != nil {
+		pricing.registryOwner = owner
+	}
+	return pricing
+}
+
 func tkPricingRegistryAliasOwner(model string) (string, bool) {
 	model = strings.ToLower(strings.TrimSpace(model))
 	snapshot := loadTKPricingOverlaySnapshot()

--- a/backend/internal/service/gateway_anthropic_passthrough.go
+++ b/backend/internal/service/gateway_anthropic_passthrough.go
@@ -20,7 +20,6 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
 	"github.com/tidwall/gjson"
-	"github.com/tidwall/sjson"
 
 	"github.com/gin-gonic/gin"
 )
@@ -32,18 +31,6 @@ type anthropicPassthroughForwardInput struct {
 	OriginalModel string
 	RequestStream bool
 	StartTime     time.Time
-}
-
-func classifyAnthropicResponseInputAsCacheRead(body []byte, usage *ClaudeUsage) ([]byte, error) {
-	classified, err := sjson.SetBytes(body, "usage.input_tokens", 0)
-	if err != nil {
-		return nil, fmt.Errorf("classify forced cache billing input tokens: %w", err)
-	}
-	classified, err = sjson.SetBytes(classified, "usage.cache_read_input_tokens", usage.CacheReadInputTokens+usage.InputTokens)
-	if err != nil {
-		return nil, fmt.Errorf("classify forced cache billing cache read tokens: %w", err)
-	}
-	return classified, nil
 }
 
 func (s *GatewayService) forwardAnthropicAPIKeyPassthrough(
@@ -106,73 +93,8 @@ func (s *GatewayService) forwardAnthropicPassthroughWithInput(
 	if c != nil {
 		c.Set("anthropic_passthrough", true)
 	}
-	// TK: strip Claude Code context-window aliases on passthrough before
-	// billing/quota and upstream forward see the bracketed id.
-	if bare, aliased := tkStripContextWindowModelAlias(input.RequestModel); aliased {
-		input.Body = s.replaceModelInBody(input.Body, bare)
-		input.RequestModel = bare
-		input.OriginalModel = bare
-		if input.Parsed != nil {
-			input.Parsed.Model = bare
-		}
-		logger.LegacyPrintf("service.gateway",
-			"TK context-window alias stripped on APIKey passthrough (claude-code #60913): -> %s account=%d", bare, account.ID)
-	}
-	// Pre-filter: sanitize invalid UTF-8 / lone surrogate escapes, strip empty
-	// text blocks, drop explicit disabled thinking for Fable, and strip fields
-	// rejected by newer Anthropic models.
-	input.Body = tkApplyAnthropicRequestCompatibilityRules(account, tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account))))
-	if input.Parsed != nil {
-		if err := input.Parsed.ReplaceBody(input.Body); err != nil {
-			return nil, err
-		}
-	}
-	// TK: CC prompt-surface normalize; passthrough skips the full normalize hook.
-	if s != nil && s.settingService != nil && s.settingService.IsAnthropicRequestNormalizeEnabled(ctx) {
-		var changes []tkAnthropicNormalizeChange
-		input.Body, changes = tkApplyAnthropicCCPromptSurfaceNormalize(ctx, c, account, input.Body)
-		if len(changes) > 0 && input.Parsed != nil {
-			if err := input.Parsed.ReplaceBody(input.Body); err != nil {
-				return nil, err
-			}
-		}
-	}
-	// Pre-filter: strip web-search history blocks the upstream cannot accept
-	// (emulation-synthesized ones always; genuine ones additionally for
-	// passback-required third-party upstreams such as GLM/Kimi/DeepSeek,
-	// which reject server_tool_use with 400). input.RequestModel 已是映射后的模型 ID。
-	input.Body = FilterWebSearchHistoryBlocks(input.Body, input.RequestModel)
-	// TK: ToolSearch + stale signed thinking pre-filter.
-	input.Body = TkPrefilterToolSearchHistoricalThinking(input.Body, input.RequestModel)
-	if account.Platform == PlatformAnthropic {
-		input.Body = s.applySigPreemptIfArmed(ctx, c, account, input.Body, input.RequestModel)
-	}
-	if account.Platform == PlatformAnthropic {
-		if err := s.tkRejectInvalidAnthropicToolContext(ctx, c, account, input.Body, s.tkRequiresClaudeCodeSystemSurface(ctx, c, account), true); err != nil {
-			return nil, err
-		}
-	}
-	metadataUserID := ""
-	if input.Parsed != nil {
-		metadataUserID = input.Parsed.MetadataUserID
-	}
-	if metadataUserID == "" {
-		metadataUserID = gjson.GetBytes(input.Body, "metadata.user_id").String()
-	}
-	userAgent := ""
-	if c != nil && c.Request != nil {
-		userAgent = c.GetHeader("User-Agent")
-	}
-	isClaudeCode := IsClaudeCodeClient(ctx) || isClaudeCodeClient(userAgent, metadataUserID)
-	input.Body, _, err = applyStickyToAnthropicMessagesBody(ctx, c, s.settingService, account, input.Body, input.RequestModel, isClaudeCode)
-	if err != nil {
+	if err := s.tkPrepareAnthropicPassthroughBody(ctx, c, account, &input); err != nil {
 		return nil, err
-	}
-	if input.Parsed != nil {
-		// 透传分支也会改写实际 wire body，成功 usage hash 依赖这里同步当前 body。
-		if err := input.Parsed.ReplaceBody(input.Body); err != nil {
-			return nil, err
-		}
 	}
 
 	var resp *http.Response
@@ -228,53 +150,13 @@ func (s *GatewayService) forwardAnthropicPassthroughWithInput(
 		}
 
 		if resp.StatusCode == http.StatusBadRequest {
-			respBody, readErr := s.readUpstreamErrorBody(resp)
-			if readErr == nil {
-				_ = resp.Body.Close()
-				retryBody, retryKind, shouldRetry := s.rectifyAnthropicPassthrough400(ctx, account, input.Body, input.RequestModel, respBody)
-				if shouldRetry && time.Since(retryStart) < maxRetryElapsed {
-					if retryKind == "signature_retry_thinking" {
-						s.armSigPreemptOnError(ctx, c, account)
-					}
-					retryCtx, releaseRetryCtx := detachStreamUpstreamContext(ctx, input.RequestStream)
-					retryReq, retryWireBody, buildErr := s.buildAnthropicPassthroughUpstreamRequest(retryCtx, c, account, retryBody, token, authKind)
-					releaseRetryCtx()
-					if buildErr == nil {
-						retryResp, retryErr := s.httpUpstream.DoWithTLS(retryReq, proxyURL, account.ID, account.Concurrency, s.tlsFPProfileService.ResolveTLSProfile(account))
-						if retryErr == nil {
-							appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
-								Platform:           account.Platform,
-								AccountID:          account.ID,
-								AccountName:        account.Name,
-								UpstreamStatusCode: resp.StatusCode,
-								UpstreamRequestID:  resp.Header.Get("x-request-id"),
-								UpstreamURL:        safeUpstreamURL(upstreamReq.URL.String()),
-								Passthrough:        true,
-								Kind:               retryKind,
-								Message:            extractUpstreamErrorMessage(respBody),
-							})
-							if retryResp.StatusCode < 400 {
-								input.Body = retryWireBody
-								setOpsUpstreamRequestBody(c, retryWireBody)
-								if input.Parsed != nil {
-									if err := input.Parsed.ReplaceBody(retryWireBody); err != nil {
-										_ = retryResp.Body.Close()
-										return nil, err
-									}
-								}
-							}
-							resp = retryResp
-							break
-						}
-						if retryResp != nil && retryResp.Body != nil {
-							_ = retryResp.Body.Close()
-						}
-						logger.LegacyPrintf("service.gateway", "Anthropic passthrough account %d: 400 rectifier retry failed: %v", account.ID, retryErr)
-					} else {
-						logger.LegacyPrintf("service.gateway", "Anthropic passthrough account %d: 400 rectifier retry build failed: %v", account.ID, buildErr)
-					}
-				}
-				resp.Body = io.NopCloser(bytes.NewReader(respBody))
+			var retried bool
+			resp, retried, err = s.tkMaybeRetryAnthropicPassthrough400(ctx, c, account, &input, resp, upstreamReq, proxyURL, token, authKind, retryStart)
+			if err != nil {
+				return nil, err
+			}
+			if retried {
+				break
 			}
 		}
 
@@ -415,14 +297,7 @@ func (s *GatewayService) forwardAnthropicPassthroughWithInput(
 	if input.RequestStream {
 		streamResult, err := s.handleStreamingResponseAnthropicAPIKeyPassthrough(ctx, resp, c, account, input.StartTime, input.RequestModel)
 		if err != nil {
-			var sseErr *sseStreamErrorEventError
-			if errors.As(err, &sseErr) {
-				// The error frame has already been forwarded as the terminal client
-				// outcome. Reuse the canonical recorder for ops evidence, but keep
-				// the non-failover error shape so the handler does not append a
-				// second generic SSE error after semantic output was committed.
-				_ = s.sseStreamErrorFailover(c, account, resp, sseErr, http.StatusBadGateway)
-			}
+			s.tkRecordAnthropicPassthroughStreamTerminalError(c, account, resp, err)
 			// 流中断时保留已观测到的 usage 与错误一起返回，避免上游已计量的请求
 			// 完全漏记漏计费（issue #5148）。
 			if partial := partialStreamUsageResult(c, resp, streamResult, input.OriginalModel, input.RequestModel, input.StartTime, err); partial != nil {
@@ -520,35 +395,6 @@ func (s *GatewayService) buildUpstreamRequestAnthropicAPIKeyPassthrough(
 	account.ApplyHeaderOverrides(req.Header)
 
 	return req, body, nil
-}
-
-func (s *GatewayService) rectifyAnthropicPassthrough400(ctx context.Context, account *Account, body []byte, model string, respBody []byte) ([]byte, string, bool) {
-	if _, ok := tkRecordAnthropicSamplingParamRuleFrom400(account, model, body, http.StatusBadRequest, respBody); ok {
-		if rectified := tkStripDeprecatedSamplingParamsForAccount(account, body); !bytes.Equal(rectified, body) {
-			return rectified, "sampling_param_retry", true
-		}
-	}
-
-	if s.shouldRectifySignatureError(ctx, account, respBody, model) {
-		return FilterThinkingBlocksForRetry(body, model), "signature_retry_thinking", true
-	}
-
-	errMsg := extractUpstreamErrorMessage(respBody)
-	if isThinkingTypeAdaptiveRequiredError(errMsg) {
-		tkRecordAnthropicThinkingRuleFrom400(account, model, body, http.StatusBadRequest, respBody)
-		if rectified, ok := RectifyThinkingTypeAdaptive(body); ok {
-			return rectified, "thinking_adaptive_retry", true
-		}
-	}
-	if isThinkingBudgetConstraintError(errMsg) {
-		if s.settingService != nil && !s.settingService.IsBudgetRectifierEnabled(ctx) {
-			return body, "", false
-		}
-		if rectified, ok := RectifyThinkingBudget(body, model); ok {
-			return rectified, "budget_constraint_retry", true
-		}
-	}
-	return body, "", false
 }
 
 func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(

--- a/backend/internal/service/gateway_anthropic_passthrough_tk.go
+++ b/backend/internal/service/gateway_anthropic_passthrough_tk.go
@@ -1,0 +1,230 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/gin-gonic/gin"
+)
+
+func classifyAnthropicResponseInputAsCacheRead(body []byte, usage *ClaudeUsage) ([]byte, error) {
+	classified, err := sjson.SetBytes(body, "usage.input_tokens", 0)
+	if err != nil {
+		return nil, fmt.Errorf("classify forced cache billing input tokens: %w", err)
+	}
+	classified, err = sjson.SetBytes(classified, "usage.cache_read_input_tokens", usage.CacheReadInputTokens+usage.InputTokens)
+	if err != nil {
+		return nil, fmt.Errorf("classify forced cache billing cache read tokens: %w", err)
+	}
+	return classified, nil
+}
+
+// tkPrepareAnthropicPassthroughBody applies TokenKey request prep before the
+// upstream passthrough hop: context-window alias strip, compatibility
+// sanitize, CC prompt-surface normalize, web-search history filter,
+// ToolSearch thinking prefilter, sig-preempt, tool-context reject, sticky.
+func (s *GatewayService) tkPrepareAnthropicPassthroughBody(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	input *anthropicPassthroughForwardInput,
+) error {
+	// TK: strip Claude Code context-window aliases on passthrough before
+	// billing/quota and upstream forward see the bracketed id.
+	if bare, aliased := tkStripContextWindowModelAlias(input.RequestModel); aliased {
+		input.Body = s.replaceModelInBody(input.Body, bare)
+		input.RequestModel = bare
+		input.OriginalModel = bare
+		if input.Parsed != nil {
+			input.Parsed.Model = bare
+		}
+		logger.LegacyPrintf("service.gateway",
+			"TK context-window alias stripped on APIKey passthrough (claude-code #60913): -> %s account=%d", bare, account.ID)
+	}
+	// Pre-filter: sanitize invalid UTF-8 / lone surrogate escapes, strip empty
+	// text blocks, drop explicit disabled thinking for Fable, and strip fields
+	// rejected by newer Anthropic models.
+	input.Body = tkApplyAnthropicRequestCompatibilityRules(account, tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account))))
+	if input.Parsed != nil {
+		if err := input.Parsed.ReplaceBody(input.Body); err != nil {
+			return err
+		}
+	}
+	// TK: CC prompt-surface normalize; passthrough skips the full normalize hook.
+	if s != nil && s.settingService != nil && s.settingService.IsAnthropicRequestNormalizeEnabled(ctx) {
+		var changes []tkAnthropicNormalizeChange
+		input.Body, changes = tkApplyAnthropicCCPromptSurfaceNormalize(ctx, c, account, input.Body)
+		if len(changes) > 0 && input.Parsed != nil {
+			if err := input.Parsed.ReplaceBody(input.Body); err != nil {
+				return err
+			}
+		}
+	}
+	// Pre-filter: strip web-search history blocks the upstream cannot accept
+	// (emulation-synthesized ones always; genuine ones additionally for
+	// passback-required third-party upstreams such as GLM/Kimi/DeepSeek,
+	// which reject server_tool_use with 400). input.RequestModel 已是映射后的模型 ID。
+	input.Body = FilterWebSearchHistoryBlocks(input.Body, input.RequestModel)
+	// TK: ToolSearch + stale signed thinking pre-filter.
+	input.Body = TkPrefilterToolSearchHistoricalThinking(input.Body, input.RequestModel)
+	if account.Platform == PlatformAnthropic {
+		input.Body = s.applySigPreemptIfArmed(ctx, c, account, input.Body, input.RequestModel)
+	}
+	if account.Platform == PlatformAnthropic {
+		if err := s.tkRejectInvalidAnthropicToolContext(ctx, c, account, input.Body, s.tkRequiresClaudeCodeSystemSurface(ctx, c, account), true); err != nil {
+			return err
+		}
+	}
+	metadataUserID := ""
+	if input.Parsed != nil {
+		metadataUserID = input.Parsed.MetadataUserID
+	}
+	if metadataUserID == "" {
+		metadataUserID = gjson.GetBytes(input.Body, "metadata.user_id").String()
+	}
+	userAgent := ""
+	if c != nil && c.Request != nil {
+		userAgent = c.GetHeader("User-Agent")
+	}
+	isClaudeCode := IsClaudeCodeClient(ctx) || isClaudeCodeClient(userAgent, metadataUserID)
+	var err error
+	input.Body, _, err = applyStickyToAnthropicMessagesBody(ctx, c, s.settingService, account, input.Body, input.RequestModel, isClaudeCode)
+	if err != nil {
+		return err
+	}
+	if input.Parsed != nil {
+		// 透传分支也会改写实际 wire body，成功 usage hash 依赖这里同步当前 body。
+		if err := input.Parsed.ReplaceBody(input.Body); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// tkMaybeRetryAnthropicPassthrough400 runs the TokenKey 400 rectifier once and
+// returns the response to continue with. When retried is true the caller must
+// break out of the upstream attempt loop (matching the prior inline control
+// flow). On a successful rectifier hop it may replace resp and update
+// input.Body; otherwise it restores resp.Body from the buffered 400 body when
+// the original body was consumed.
+func (s *GatewayService) tkMaybeRetryAnthropicPassthrough400(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	input *anthropicPassthroughForwardInput,
+	resp *http.Response,
+	upstreamReq *http.Request,
+	proxyURL string,
+	token string,
+	authKind anthropicPassthroughAuthKind,
+	retryStart time.Time,
+) (out *http.Response, retried bool, err error) {
+	if resp == nil || resp.StatusCode != http.StatusBadRequest {
+		return resp, false, nil
+	}
+	respBody, readErr := s.readUpstreamErrorBody(resp)
+	if readErr != nil {
+		return resp, false, nil
+	}
+	_ = resp.Body.Close()
+	retryBody, retryKind, shouldRetry := s.rectifyAnthropicPassthrough400(ctx, account, input.Body, input.RequestModel, respBody)
+	if shouldRetry && time.Since(retryStart) < maxRetryElapsed {
+		if retryKind == "signature_retry_thinking" {
+			s.armSigPreemptOnError(ctx, c, account)
+		}
+		retryCtx, releaseRetryCtx := detachStreamUpstreamContext(ctx, input.RequestStream)
+		retryReq, retryWireBody, buildErr := s.buildAnthropicPassthroughUpstreamRequest(retryCtx, c, account, retryBody, token, authKind)
+		releaseRetryCtx()
+		if buildErr == nil {
+			retryResp, retryErr := s.httpUpstream.DoWithTLS(retryReq, proxyURL, account.ID, account.Concurrency, s.tlsFPProfileService.ResolveTLSProfile(account))
+			if retryErr == nil {
+				appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+					Platform:           account.Platform,
+					AccountID:          account.ID,
+					AccountName:        account.Name,
+					UpstreamStatusCode: resp.StatusCode,
+					UpstreamRequestID:  resp.Header.Get("x-request-id"),
+					UpstreamURL:        safeUpstreamURL(upstreamReq.URL.String()),
+					Passthrough:        true,
+					Kind:               retryKind,
+					Message:            extractUpstreamErrorMessage(respBody),
+				})
+				if retryResp.StatusCode < 400 {
+					input.Body = retryWireBody
+					setOpsUpstreamRequestBody(c, retryWireBody)
+					if input.Parsed != nil {
+						if err := input.Parsed.ReplaceBody(retryWireBody); err != nil {
+							_ = retryResp.Body.Close()
+							return nil, true, err
+						}
+					}
+				}
+				return retryResp, true, nil
+			}
+			if retryResp != nil && retryResp.Body != nil {
+				_ = retryResp.Body.Close()
+			}
+			logger.LegacyPrintf("service.gateway", "Anthropic passthrough account %d: 400 rectifier retry failed: %v", account.ID, retryErr)
+		} else {
+			logger.LegacyPrintf("service.gateway", "Anthropic passthrough account %d: 400 rectifier retry build failed: %v", account.ID, buildErr)
+		}
+	}
+	resp.Body = io.NopCloser(bytes.NewReader(respBody))
+	return resp, false, nil
+}
+
+func (s *GatewayService) rectifyAnthropicPassthrough400(ctx context.Context, account *Account, body []byte, model string, respBody []byte) ([]byte, string, bool) {
+	if _, ok := tkRecordAnthropicSamplingParamRuleFrom400(account, model, body, http.StatusBadRequest, respBody); ok {
+		if rectified := tkStripDeprecatedSamplingParamsForAccount(account, body); !bytes.Equal(rectified, body) {
+			return rectified, "sampling_param_retry", true
+		}
+	}
+
+	if s.shouldRectifySignatureError(ctx, account, respBody, model) {
+		return FilterThinkingBlocksForRetry(body, model), "signature_retry_thinking", true
+	}
+
+	errMsg := extractUpstreamErrorMessage(respBody)
+	if isThinkingTypeAdaptiveRequiredError(errMsg) {
+		tkRecordAnthropicThinkingRuleFrom400(account, model, body, http.StatusBadRequest, respBody)
+		if rectified, ok := RectifyThinkingTypeAdaptive(body); ok {
+			return rectified, "thinking_adaptive_retry", true
+		}
+	}
+	if isThinkingBudgetConstraintError(errMsg) {
+		if s.settingService != nil && !s.settingService.IsBudgetRectifierEnabled(ctx) {
+			return body, "", false
+		}
+		if rectified, ok := RectifyThinkingBudget(body, model); ok {
+			return rectified, "budget_constraint_retry", true
+		}
+	}
+	return body, "", false
+}
+
+// tkRecordAnthropicPassthroughStreamTerminalError records ops evidence for an
+// already-forwarded SSE error frame without appending a second client error.
+func (s *GatewayService) tkRecordAnthropicPassthroughStreamTerminalError(
+	c *gin.Context,
+	account *Account,
+	resp *http.Response,
+	err error,
+) {
+	var sseErr *sseStreamErrorEventError
+	if errors.As(err, &sseErr) {
+		// The error frame has already been forwarded as the terminal client
+		// outcome. Reuse the canonical recorder for ops evidence, but keep
+		// the non-failover error shape so the handler does not append a
+		// second generic SSE error after semantic output was committed.
+		_ = s.sseStreamErrorFailover(c, account, resp, sseErr, http.StatusBadGateway)
+	}
+}

--- a/backend/internal/service/gateway_anthropic_passthrough_tk_retry_test.go
+++ b/backend/internal/service/gateway_anthropic_passthrough_tk_retry_test.go
@@ -1,0 +1,64 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTkMaybeRetryAnthropicPassthrough400_Non400Passthrough(t *testing.T) {
+	svc := &GatewayService{}
+	resp := &http.Response{StatusCode: http.StatusTooManyRequests, Body: io.NopCloser(strings.NewReader(`rate`))}
+	out, retried, err := svc.tkMaybeRetryAnthropicPassthrough400(
+		context.Background(), nil, &Account{ID: 1, Platform: PlatformAnthropic},
+		&anthropicPassthroughForwardInput{Body: []byte(`{}`)},
+		resp, nil, "", "", anthropicPassthroughAuthAPIKey, time.Now(),
+	)
+	require.NoError(t, err)
+	require.False(t, retried)
+	require.Same(t, resp, out)
+}
+
+func TestTkMaybeRetryAnthropicPassthrough400_NoRectifierRestoresBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &GatewayService{}
+	account := &Account{ID: 82, Platform: PlatformAnthropic}
+	origBody := []byte(`{"model":"claude-sonnet-4-5","messages":[]}`)
+	errJSON := `{"type":"error","error":{"type":"invalid_request_error","message":"unrelated validation failure"}}`
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(errJSON)),
+	}
+	input := &anthropicPassthroughForwardInput{Body: origBody, RequestModel: "claude-sonnet-4-5"}
+
+	out, retried, err := svc.tkMaybeRetryAnthropicPassthrough400(
+		context.Background(), nil, account, input, resp, &http.Request{URL: mustParseURL("https://api.anthropic.com/v1/messages")},
+		"", "token", anthropicPassthroughAuthAPIKey, time.Now(),
+	)
+	require.NoError(t, err)
+	require.False(t, retried, "unrectifiable 400 must not break the attempt loop")
+	require.NotNil(t, out)
+	restored, readErr := io.ReadAll(out.Body)
+	require.NoError(t, readErr)
+	require.JSONEq(t, errJSON, string(restored))
+	require.True(t, bytes.Equal(origBody, input.Body))
+}
+
+func mustParseURL(raw string) *url.URL {
+	u, err := url.ParseRequestURI(raw)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}

--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -173,12 +173,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		bindPreContentStreamKeepalive(c, hwka)
 		result, err := s.kiroGateway.Forward(ctx, c, account, parsed, startTime)
 		stopPreContentStreamKeepalive(c)
-		if err != nil && s.rateLimitService != nil {
-			var failoverErr *UpstreamFailoverError
-			if errors.As(err, &failoverErr) {
-				s.rateLimitService.HandleUpstreamError(ctx, account, failoverErr.StatusCode, failoverErr.ResponseHeaders, failoverErr.ResponseBody)
-			}
-		}
+		s.tkHandleKiroForwardUpstreamError(ctx, account, err)
 		return result, err
 	}
 
@@ -204,46 +199,16 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		body = parsed.Body.Bytes()
 		return nil
 	}
+	getBody := func() []byte { return body }
 	reqModel := parsed.Model
 	reqStream := parsed.Stream
 	originalModel := reqModel
 
-	// TK: strip the Claude Code 1M-context model alias suffix before model
-	// mapping / scheduling / pricing. See gateway_anthropic_context_window_alias_tk.go.
-	if account.Platform == PlatformAnthropic {
-		if bare, aliased := tkStripContextWindowModelAlias(reqModel); aliased {
-			if err := replaceBody(s.replaceModelInBody(body, bare)); err != nil {
-				return nil, err
-			}
-			logger.LegacyPrintf("service.gateway",
-				"TK context-window alias stripped before forward (prevents Anthropic 404 + silent 200K fallback, claude-code #60913): %s -> %s account=%d",
-				reqModel, bare, account.ID)
-			reqModel, parsed.Model, originalModel = bare, bare, bare
-		}
-	}
-
-	// TK canonical-OAuth ingress gates. cc_only=false groups admit non-CC
-	// traffic and complete the disguise on egress via haiku mimicry below.
-	groupAdmitsNonCC := s.tkGroupAdmitsNonCC(ctx, parsed)
-	if c != nil && c.Request != nil && s.isCanonicalAnthropicOAuth(account) {
-		if s.settingService.IsAnthropicCanonicalIngressStrictEnabled(ctx) {
-			if err := checkCanonicalIngressUAStrict(c.Request.Header); err != nil {
-				return nil, err
-			}
-		} else if !groupAdmitsNonCC {
-			if err := checkCanonicalIngressUA(c.Request.Header); err != nil {
-				return nil, err
-			}
-		}
-		if newModel, remapped := remapDeprecatedOpusOnCanonical(reqModel); remapped {
-			if err := replaceBody(s.replaceModelInBody(body, newModel)); err != nil {
-				return nil, err
-			}
-			logger.LegacyPrintf("service.gateway",
-				"Canonical OAuth model remap: %s -> %s (account: %s)",
-				reqModel, newModel, account.Name)
-			reqModel, parsed.Model = newModel, newModel
-		}
+	var groupAdmitsNonCC bool
+	var prepErr error
+	reqModel, originalModel, groupAdmitsNonCC, prepErr = s.tkPrepareAnthropicForwardIngress(ctx, c, account, parsed, reqModel, originalModel, getBody, replaceBody)
+	if prepErr != nil {
+		return nil, prepErr
 	}
 
 	// === DEBUG: 打印客户端原始请求（headers + body 摘要）===
@@ -412,19 +377,8 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		parsed.Model = mappedModel
 		logger.LegacyPrintf("service.gateway", "Model mapping applied: %s -> %s (account: %s, source=%s)", originalModel, mappedModel, account.Name, mappingSource)
 	}
-	if account.Platform == PlatformAnthropic {
-		if replacement, deprecated := tkIsDeprecatedAnthropicModel(mappedModel); deprecated {
-			TkWriteAnthropicDeprecatedModelError(c, mappedModel, replacement)
-			return nil, fmt.Errorf("anthropic model %q is retired (suggest %q)", mappedModel, replacement)
-		}
-	}
-
-	if !s.tkPricedServingGate(ctx, c, tkGateWireAnthropic, account.Platform, originalModel, originalModel) {
-		return nil, fmt.Errorf("priced serving gate: model %q not priced for platform %q", originalModel, account.Platform)
-	}
-
-	if handled, ncErr := s.tkModelNotFoundShortCircuit(c, account, mappedModel); handled {
-		return nil, ncErr
+	if err := s.tkApplyAnthropicForwardPostMappingGates(ctx, c, account, originalModel, mappedModel); err != nil {
+		return nil, err
 	}
 
 	if s.shouldInjectAnthropicCacheTTL1h(ctx, account) {
@@ -456,7 +410,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	// Pre-filter: sanitize invalid UTF-8 / lone surrogate escapes, strip empty
 	// text blocks, drop explicit disabled thinking for Fable, and strip fields
 	// rejected by newer Anthropic models before upstream.
-	if err := replaceBody(tkApplyAnthropicRequestCompatibilityRules(account, tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))))); err != nil {
+	if err := s.tkSanitizeAnthropicForwardBody(account, getBody, replaceBody); err != nil {
 		return nil, err
 	}
 	// Pre-filter: strip web-search history blocks the upstream cannot accept
@@ -494,22 +448,8 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 			logger.LegacyPrintf("service.gateway", "Account %d: rewrote thinking.type for %s (Anthropic-SDK default 'enabled' -> vendor-specific)", account.ID, reqModel)
 		}
 	}
-	if account.Platform == PlatformAnthropic {
-		body = s.applySigPreemptIfArmed(ctx, c, account, body, reqModel)
-	}
-	if account.Platform == PlatformAnthropic {
-		if err := s.tkRejectInvalidAnthropicToolContext(ctx, c, account, body, s.tkRequiresClaudeCodeSystemSurface(ctx, c, account), false); err != nil {
-			return nil, err
-		}
-	}
-	if account.Platform == PlatformAnthropic {
-		stickyBody, _, err := applyStickyToAnthropicMessagesBody(ctx, c, s.settingService, account, body, reqModel, isClaudeCode)
-		if err != nil {
-			return nil, err
-		}
-		if err := replaceBody(stickyBody); err != nil {
-			return nil, err
-		}
+	if err := s.tkApplyAnthropicForwardPreSendGuards(ctx, c, account, reqModel, isClaudeCode, getBody, replaceBody); err != nil {
+		return nil, err
 	}
 	setOpsUpstreamRequestBody(c, body)
 

--- a/backend/internal/service/gateway_forward_tk.go
+++ b/backend/internal/service/gateway_forward_tk.go
@@ -1,0 +1,139 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/gin-gonic/gin"
+)
+
+// tkPrepareAnthropicForwardIngress applies TokenKey early Forward prep:
+// context-window alias strip and canonical-OAuth ingress UA / Opus remap.
+// getBody/replaceBody must share the caller's body view (same as Forward).
+func (s *GatewayService) tkPrepareAnthropicForwardIngress(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	parsed *ParsedRequest,
+	reqModel string,
+	originalModel string,
+	getBody func() []byte,
+	replaceBody func([]byte) error,
+) (newReqModel, newOriginalModel string, groupAdmitsNonCC bool, err error) {
+	newReqModel, newOriginalModel = reqModel, originalModel
+
+	// TK: strip the Claude Code 1M-context model alias suffix before model
+	// mapping / scheduling / pricing. See gateway_anthropic_context_window_alias_tk.go.
+	if account.Platform == PlatformAnthropic {
+		if bare, aliased := tkStripContextWindowModelAlias(reqModel); aliased {
+			if err := replaceBody(s.replaceModelInBody(getBody(), bare)); err != nil {
+				return newReqModel, newOriginalModel, false, err
+			}
+			logger.LegacyPrintf("service.gateway",
+				"TK context-window alias stripped before forward (prevents Anthropic 404 + silent 200K fallback, claude-code #60913): %s -> %s account=%d",
+				reqModel, bare, account.ID)
+			newReqModel, parsed.Model, newOriginalModel = bare, bare, bare
+			reqModel = bare
+		}
+	}
+
+	// TK canonical-OAuth ingress gates. cc_only=false groups admit non-CC
+	// traffic and complete the disguise on egress via haiku mimicry below.
+	groupAdmitsNonCC = s.tkGroupAdmitsNonCC(ctx, parsed)
+	if c != nil && c.Request != nil && s.isCanonicalAnthropicOAuth(account) {
+		if s.settingService.IsAnthropicCanonicalIngressStrictEnabled(ctx) {
+			if err := checkCanonicalIngressUAStrict(c.Request.Header); err != nil {
+				return newReqModel, newOriginalModel, groupAdmitsNonCC, err
+			}
+		} else if !groupAdmitsNonCC {
+			if err := checkCanonicalIngressUA(c.Request.Header); err != nil {
+				return newReqModel, newOriginalModel, groupAdmitsNonCC, err
+			}
+		}
+		if newModel, remapped := remapDeprecatedOpusOnCanonical(reqModel); remapped {
+			if err := replaceBody(s.replaceModelInBody(getBody(), newModel)); err != nil {
+				return newReqModel, newOriginalModel, groupAdmitsNonCC, err
+			}
+			logger.LegacyPrintf("service.gateway",
+				"Canonical OAuth model remap: %s -> %s (account: %s)",
+				reqModel, newModel, account.Name)
+			newReqModel, parsed.Model = newModel, newModel
+		}
+	}
+	return newReqModel, newOriginalModel, groupAdmitsNonCC, nil
+}
+
+// tkSanitizeAnthropicForwardBody applies the TokenKey sanitize wrap around the
+// upstream StripEmptyTextBlocks pre-filter (UTF-8 / fable / sampling compat).
+func (s *GatewayService) tkSanitizeAnthropicForwardBody(
+	account *Account,
+	getBody func() []byte,
+	replaceBody func([]byte) error,
+) error {
+	return replaceBody(tkApplyAnthropicRequestCompatibilityRules(account, tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(getBody(), account)))))
+}
+
+// tkApplyAnthropicForwardPreSendGuards applies signature preempt, tool-context
+// reject, and sticky injection after ToolSearch + upstream thinking filters.
+// Sig-preempt updates a local body view without replaceBody until sticky,
+// matching the prior inline order.
+func (s *GatewayService) tkApplyAnthropicForwardPreSendGuards(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	reqModel string,
+	isClaudeCode bool,
+	getBody func() []byte,
+	replaceBody func([]byte) error,
+) error {
+	if account.Platform != PlatformAnthropic {
+		return nil
+	}
+	body := s.applySigPreemptIfArmed(ctx, c, account, getBody(), reqModel)
+	if err := s.tkRejectInvalidAnthropicToolContext(ctx, c, account, body, s.tkRequiresClaudeCodeSystemSurface(ctx, c, account), false); err != nil {
+		return err
+	}
+	stickyBody, _, err := applyStickyToAnthropicMessagesBody(ctx, c, s.settingService, account, body, reqModel, isClaudeCode)
+	if err != nil {
+		return err
+	}
+	return replaceBody(stickyBody)
+}
+
+// tkHandleKiroForwardUpstreamError records rate-limit side effects for a Kiro
+// UpstreamFailoverError after kiroGateway.Forward returns.
+func (s *GatewayService) tkHandleKiroForwardUpstreamError(ctx context.Context, account *Account, err error) {
+	if err == nil || s.rateLimitService == nil {
+		return
+	}
+	var failoverErr *UpstreamFailoverError
+	if errors.As(err, &failoverErr) {
+		s.rateLimitService.HandleUpstreamError(ctx, account, failoverErr.StatusCode, failoverErr.ResponseHeaders, failoverErr.ResponseBody)
+	}
+}
+
+// tkApplyAnthropicForwardPostMappingGates runs deprecated-model, priced-serving,
+// and model-not-found short-circuits after channel mapping.
+func (s *GatewayService) tkApplyAnthropicForwardPostMappingGates(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	originalModel string,
+	mappedModel string,
+) error {
+	if account.Platform == PlatformAnthropic {
+		if replacement, deprecated := tkIsDeprecatedAnthropicModel(mappedModel); deprecated {
+			TkWriteAnthropicDeprecatedModelError(c, mappedModel, replacement)
+			return fmt.Errorf("anthropic model %q is retired (suggest %q)", mappedModel, replacement)
+		}
+	}
+	if !s.tkPricedServingGate(ctx, c, tkGateWireAnthropic, account.Platform, originalModel, originalModel) {
+		return fmt.Errorf("priced serving gate: model %q not priced for platform %q", originalModel, account.Platform)
+	}
+	if handled, ncErr := s.tkModelNotFoundShortCircuit(c, account, mappedModel); handled {
+		return ncErr
+	}
+	return nil
+}

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -608,27 +608,12 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 	}
 
 	originalModel := req.Model
-	// TK: 分组级 Claude→Gemini 模型映射 (gemini_messages_dispatch_tk.go)。
-	// handler 通过 gin.Context 透传 *Group；resolver 仅当 group 非空且
-	// 配置了映射规则、且 req.Model 不是 gemini-* 形态时才改写 req.Model。
-	if g := tkGroupFromGinContext(c); g != nil {
-		if mapped := g.TKResolveGeminiDispatchModel(req.Model); mapped != "" {
-			req.Model = mapped
-		}
+	var prepErr error
+	req.Model, prepErr = s.tkPrepareGeminiMessagesForward(ctx, c, account, originalModel, req.Model)
+	if prepErr != nil {
+		return nil, prepErr
 	}
 	mappedModel, requestModel := resolveGeminiForwardModels(account, req.Model)
-	// TK priced-serving gate (docs/approved/priced-or-it-doesnt-ship.md): reject
-	// unpriced models with a 404 BEFORE forward / stream start (SSE pre-flight).
-	// No-op unless account.Platform is in the enabled set (gemini ships first).
-	// Forward serves an Anthropic /v1/messages ingress (writeClaudeError elsewhere),
-	// so the 404 body must be the ANTHROPIC envelope (BLOCKER4: byte-align to the
-	// client's wire protocol, not account.Platform). Judge originalModel — billing
-	// records on result.Model=originalModel here (forwardResultBillingModel), so the
-	// gate must use the exact key billing charges (BLOCKER1). See
-	// gateway_priced_serving_gate_tk.go.
-	if !s.tkPricedServingGate(ctx, c, tkGateWireAnthropic, account.Platform, originalModel, originalModel) {
-		return nil, fmt.Errorf("priced serving gate: model %q not priced for platform %q", originalModel, account.Platform)
-	}
 	ctx = withGeminiCodeAssistMappedModel(ctx, mappedModel)
 
 	geminiReq, err := convertClaudeMessagesToGeminiGenerateContent(body)
@@ -1201,17 +1186,8 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 	body = ensureGeminiFunctionCallThoughtSignatures(body)
 
 	mappedModel, requestModel := resolveGeminiForwardModels(account, originalModel)
-	// TK priced-serving gate (docs/approved/priced-or-it-doesnt-ship.md): reject unpriced
-	// models with a 404 BEFORE forward / stream start (SSE pre-flight). Native Gemini ingress
-	// (generateContent/streamGenerateContent) → Gemini 404 envelope. countTokens is EXEMPT
-	// (docs §4, BLOCKER5): it is zero-billing (Usage{}) and a never-hard-fail pre-flight, so
-	// gating it breaks that contract for no leak benefit. Judge originalModel — billing records
-	// result.Model=originalModel here, so the gate must use billing's exact key (BLOCKER1).
-	// No-op unless account.Platform is in the enabled set. See gateway_priced_serving_gate_tk.go.
-	if action != "countTokens" {
-		if !s.tkPricedServingGate(ctx, c, tkGateWireGemini, account.Platform, originalModel, originalModel) {
-			return nil, fmt.Errorf("priced serving gate: model %q not priced for platform %q", originalModel, account.Platform)
-		}
+	if err := s.tkPrepareGeminiNativeForward(ctx, c, account, originalModel, action); err != nil {
+		return nil, err
 	}
 	ctx = withGeminiCodeAssistMappedModel(ctx, mappedModel)
 
@@ -3114,33 +3090,7 @@ func (s *GeminiMessagesCompatService) handleGeminiUpstreamError(ctx context.Cont
 
 	resetAt := ParseGeminiRateLimitResetTime(body)
 	if resetAt == nil {
-		// 根据账号类型使用不同的默认重置时间。
-		//
-		// TK: See upstream Wei-Shaw/sub2api#641 —— 反代 Gemini CLI 的
-		// google_one OAuth 账号收到 429（无 quotaResetDelay/retryDelay）时，
-		// upstream 旧逻辑直接封禁到 PST 午夜，完全忽略 tier 上的 Cooldown
-		// 配置（如 google_ai_pro 的 5min）。所有 OAuth 账号（含 google_one /
-		// aistudio OAuth / code_assist）都应走 tier cooldown；只有非 OAuth
-		// 的 AI Studio API Key 才用 PST 午夜兜底。
-		var ra time.Time
-		if account.Type == AccountTypeOAuth {
-			cooldown := geminiCooldownForTier(tierID)
-			if s.rateLimitService != nil {
-				cooldown = s.rateLimitService.GeminiCooldown(ctx, account)
-			}
-			ra = time.Now().Add(cooldown)
-			logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Account %d (OAuth oauth_type=%s, tier=%s, project=%s, code_assist=%v) rate limited, cooldown=%v", account.ID, oauthType, tierID, projectID, isCodeAssist, time.Until(ra).Truncate(time.Second))
-		} else {
-			// API Key (AI Studio): PST 午夜
-			if ts := nextGeminiDailyResetUnix(); ts != nil {
-				ra = time.Unix(*ts, 0)
-				logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Account %d (API Key, type=%s) rate limited, reset at PST midnight (%v)", account.ID, account.Type, ra)
-			} else {
-				// 兜底：5 分钟
-				ra = time.Now().Add(5 * time.Minute)
-				logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Account %d rate limited, fallback to 5min", account.ID)
-			}
-		}
+		ra := s.tkGeminiDefaultRateLimitResetAt(ctx, account, oauthType, tierID, projectID, isCodeAssist)
 		_ = s.accountRepo.SetRateLimited(ctx, account.ID, ra)
 		return
 	}

--- a/backend/internal/service/gemini_messages_compat_service_tk_oauth_cooldown.go
+++ b/backend/internal/service/gemini_messages_compat_service_tk_oauth_cooldown.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+)
+
+// tkGeminiDefaultRateLimitResetAt chooses the TokenKey default 429 reset time
+// when ParseGeminiRateLimitResetTime finds no explicit delay: OAuth (including
+// google_one) uses tier cooldown; API keys use PST midnight (upstream #641).
+func (s *GeminiMessagesCompatService) tkGeminiDefaultRateLimitResetAt(
+	ctx context.Context,
+	account *Account,
+	oauthType, tierID, projectID string,
+	isCodeAssist bool,
+) time.Time {
+	// TK: See upstream Wei-Shaw/sub2api#641 —— 反代 Gemini CLI 的
+	// google_one OAuth 账号收到 429（无 quotaResetDelay/retryDelay）时，
+	// upstream 旧逻辑直接封禁到 PST 午夜，完全忽略 tier 上的 Cooldown
+	// 配置（如 google_ai_pro 的 5min）。所有 OAuth 账号（含 google_one /
+	// aistudio OAuth / code_assist）都应走 tier cooldown；只有非 OAuth
+	// 的 AI Studio API Key 才用 PST 午夜兜底。
+	if account.Type == AccountTypeOAuth {
+		cooldown := geminiCooldownForTier(tierID)
+		if s.rateLimitService != nil {
+			cooldown = s.rateLimitService.GeminiCooldown(ctx, account)
+		}
+		ra := time.Now().Add(cooldown)
+		logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Account %d (OAuth oauth_type=%s, tier=%s, project=%s, code_assist=%v) rate limited, cooldown=%v", account.ID, oauthType, tierID, projectID, isCodeAssist, time.Until(ra).Truncate(time.Second))
+		return ra
+	}
+	// API Key (AI Studio): PST 午夜
+	if ts := nextGeminiDailyResetUnix(); ts != nil {
+		ra := time.Unix(*ts, 0)
+		logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Account %d (API Key, type=%s) rate limited, reset at PST midnight (%v)", account.ID, account.Type, ra)
+		return ra
+	}
+	// 兜底：5 分钟
+	ra := time.Now().Add(5 * time.Minute)
+	logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Account %d rate limited, fallback to 5min", account.ID)
+	return ra
+}

--- a/backend/internal/service/gemini_messages_compat_service_tk_prepare.go
+++ b/backend/internal/service/gemini_messages_compat_service_tk_prepare.go
@@ -1,0 +1,63 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+)
+
+// tkPrepareGeminiMessagesForward applies TokenKey group Claude→Gemini dispatch
+// mapping and the priced-serving gate before convert/forward.
+func (s *GeminiMessagesCompatService) tkPrepareGeminiMessagesForward(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	originalModel string,
+	reqModel string,
+) (mappedReqModel string, err error) {
+	mappedReqModel = reqModel
+	// TK: 分组级 Claude→Gemini 模型映射 (gemini_messages_dispatch_tk.go)。
+	// handler 通过 gin.Context 透传 *Group；resolver 仅当 group 非空且
+	// 配置了映射规则、且 req.Model 不是 gemini-* 形态时才改写 req.Model。
+	if g := tkGroupFromGinContext(c); g != nil {
+		if mapped := g.TKResolveGeminiDispatchModel(mappedReqModel); mapped != "" {
+			mappedReqModel = mapped
+		}
+	}
+	// TK priced-serving gate (docs/approved/priced-or-it-doesnt-ship.md): reject
+	// unpriced models with a 404 BEFORE forward / stream start (SSE pre-flight).
+	// No-op unless account.Platform is in the enabled set (gemini ships first).
+	// Forward serves an Anthropic /v1/messages ingress (writeClaudeError elsewhere),
+	// so the 404 body must be the ANTHROPIC envelope (BLOCKER4: byte-align to the
+	// client's wire protocol, not account.Platform). Judge originalModel — billing
+	// records on result.Model=originalModel here (forwardResultBillingModel), so the
+	// gate must use the exact key billing charges (BLOCKER1). See
+	// gateway_priced_serving_gate_tk.go.
+	if !s.tkPricedServingGate(ctx, c, tkGateWireAnthropic, account.Platform, originalModel, originalModel) {
+		return mappedReqModel, fmt.Errorf("priced serving gate: model %q not priced for platform %q", originalModel, account.Platform)
+	}
+	return mappedReqModel, nil
+}
+
+// tkPrepareGeminiNativeForward runs the priced-serving gate for native Gemini
+// wire (Gemini error envelope) before ForwardNative continues. countTokens is
+// exempt (docs §4, BLOCKER5): zero-billing pre-flight must not 404.
+func (s *GeminiMessagesCompatService) tkPrepareGeminiNativeForward(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	originalModel string,
+	action string,
+) error {
+	if action == "countTokens" {
+		return nil
+	}
+	// TK priced-serving gate (docs/approved/priced-or-it-doesnt-ship.md): reject unpriced
+	// models before native forward. No-op unless account.Platform is in the enabled set.
+	// See gateway_priced_serving_gate_tk.go.
+	if !s.tkPricedServingGate(ctx, c, tkGateWireGemini, account.Platform, originalModel, originalModel) {
+		return fmt.Errorf("priced serving gate: model %q not priced for platform %q", originalModel, account.Platform)
+	}
+	return nil
+}

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -460,36 +460,12 @@ func (s *defaultOpenAIAccountScheduler) Select(
 		decision.SelectedAccountType = sel.Account.Type
 	}
 
-	var stickySel *AccountSelectionResult
-	stickyWaitPlan := false
-	if !req.StickyWeighted {
-		var escapedSticky bool
-		var escapedStickyAccountID int64
-		var err error
-		stickySel, escapedSticky, escapedStickyAccountID, err = s.selectBySessionHash(ctx, req)
-		if err != nil {
-			return nil, decision, err
-		}
-		if stickySel != nil && stickySel.Acquired {
-			markStickyHit(stickySel)
-			return stickySel, decision, nil
-		}
-
-		stickyWaitPlan = stickySel != nil && stickySel.Account != nil
-		if stickyWaitPlan && !s.stickySlotFullEscapeEnabled(ctx) {
-			markStickyHit(stickySel)
-			return stickySel, decision, nil
-		}
-		if escapedSticky {
-			req.PreserveStickyBinding = true
-			if escapedStickyAccountID > 0 {
-				req.ExcludedIDs = cloneExcludedAccountIDs(req.ExcludedIDs)
-				if req.ExcludedIDs == nil {
-					req.ExcludedIDs = make(map[int64]struct{})
-				}
-				req.ExcludedIDs[escapedStickyAccountID] = struct{}{}
-			}
-		}
+	stickySel, stickyWaitPlan, earlySticky, err := s.tkSelectStickySessionPhase(ctx, &req, markStickyHit)
+	if err != nil {
+		return nil, decision, err
+	}
+	if earlySticky != nil {
+		return earlySticky, decision, nil
 	}
 
 	selection, candidateCount, topK, loadSkew, err := s.selectByLoadBalance(ctx, req)
@@ -530,22 +506,6 @@ func (s *defaultOpenAIAccountScheduler) Select(
 		}
 	}
 	return selection, decision, nil
-}
-
-func (s *defaultOpenAIAccountScheduler) stickySlotFullEscapeEnabled(ctx context.Context) bool {
-	if s == nil || s.service == nil {
-		return true
-	}
-	if s.service.settingService == nil {
-		if s.service.cfg != nil {
-			cfg := s.service.cfg.Gateway.OpenAIScheduler
-			if !cfg.StickyEscapeEnabled && (cfg.StickyEscapeTTFTMs > 0 || cfg.StickyEscapeErrorRate > 0) {
-				return false
-			}
-		}
-		return true
-	}
-	return s.service.settingService.IsStickySlotFullEscapeEnabled(ctx)
 }
 
 func (s *defaultOpenAIAccountScheduler) selectBySessionHash(
@@ -2537,13 +2497,7 @@ func accountSupportsOpenAICapabilities(account *Account, requiredCapability Open
 	if account == nil {
 		return false
 	}
-	// TK fifth platform: upstream gates on IsOpenAI() and would fail-closed
-	// every newapi account. Apply endpoint-capability only to native OpenAI.
-	if account.IsOpenAI() && !account.SupportsOpenAIEndpointCapability(requiredCapability) {
-		return false
-	}
-	if account.IsGrok() && requiredCapability == OpenAIEndpointCapabilityGrokMediaGeneration &&
-		!account.SupportsOpenAIEndpointCapability(requiredCapability) {
+	if !tkOpenAICompatEndpointCapabilityAllows(account, requiredCapability) {
 		return false
 	}
 	return account.SupportsOpenAIImageCapability(requiredImageCapability)

--- a/backend/internal/service/openai_account_scheduler_tk_slot_full_escape.go
+++ b/backend/internal/service/openai_account_scheduler_tk_slot_full_escape.go
@@ -1,0 +1,78 @@
+package service
+
+import "context"
+
+func (s *defaultOpenAIAccountScheduler) stickySlotFullEscapeEnabled(ctx context.Context) bool {
+	if s == nil || s.service == nil {
+		return true
+	}
+	if s.service.settingService == nil {
+		if s.service.cfg != nil {
+			cfg := s.service.cfg.Gateway.OpenAIScheduler
+			if !cfg.StickyEscapeEnabled && (cfg.StickyEscapeTTFTMs > 0 || cfg.StickyEscapeErrorRate > 0) {
+				return false
+			}
+		}
+		return true
+	}
+	return s.service.settingService.IsStickySlotFullEscapeEnabled(ctx)
+}
+
+// tkSelectStickySessionPhase runs TokenKey sticky session selection with
+// slot-full escape (#2859). When early is non-nil the caller must return it;
+// otherwise stickyWaitPlan may be true so a later load-balance miss falls back
+// to waiting on the sticky account.
+func (s *defaultOpenAIAccountScheduler) tkSelectStickySessionPhase(
+	ctx context.Context,
+	req *OpenAIAccountScheduleRequest,
+	markStickyHit func(*AccountSelectionResult),
+) (stickySel *AccountSelectionResult, stickyWaitPlan bool, early *AccountSelectionResult, err error) {
+	if req.StickyWeighted {
+		return nil, false, nil, nil
+	}
+	var escapedSticky bool
+	var escapedStickyAccountID int64
+	stickySel, escapedSticky, escapedStickyAccountID, err = s.selectBySessionHash(ctx, *req)
+	if err != nil {
+		return nil, false, nil, err
+	}
+	if stickySel != nil && stickySel.Acquired {
+		markStickyHit(stickySel)
+		return stickySel, false, stickySel, nil
+	}
+
+	stickyWaitPlan = stickySel != nil && stickySel.Account != nil
+	if stickyWaitPlan && !s.stickySlotFullEscapeEnabled(ctx) {
+		markStickyHit(stickySel)
+		return stickySel, stickyWaitPlan, stickySel, nil
+	}
+	if escapedSticky {
+		req.PreserveStickyBinding = true
+		if escapedStickyAccountID > 0 {
+			req.ExcludedIDs = cloneExcludedAccountIDs(req.ExcludedIDs)
+			if req.ExcludedIDs == nil {
+				req.ExcludedIDs = make(map[int64]struct{})
+			}
+			req.ExcludedIDs[escapedStickyAccountID] = struct{}{}
+		}
+	}
+	return stickySel, stickyWaitPlan, nil, nil
+}
+
+// tkOpenAICompatEndpointCapabilityAllows is the TokenKey fifth-platform gate for
+// accountSupportsOpenAICapabilities: upstream IsOpenAI()-only checks would
+// fail-closed every newapi account, so endpoint capability applies to native
+// OpenAI (and Grok media) only.
+func tkOpenAICompatEndpointCapabilityAllows(account *Account, requiredCapability OpenAIEndpointCapability) bool {
+	if account == nil {
+		return false
+	}
+	if account.IsOpenAI() && !account.SupportsOpenAIEndpointCapability(requiredCapability) {
+		return false
+	}
+	if account.IsGrok() && requiredCapability == OpenAIEndpointCapabilityGrokMediaGeneration &&
+		!account.SupportsOpenAIEndpointCapability(requiredCapability) {
+		return false
+	}
+	return true
+}

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -83,57 +83,18 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	upstreamModel = protocolExecutionResolvedModel(ctx, upstreamModel)
 	promptCacheKey = strings.TrimSpace(promptCacheKey)
 	apiKeyID := getAPIKeyIDFromContext(c)
-	anthropicDigestChain := ""
-	anthropicMatchedDigestChain := ""
-	compatPromptCacheInjected := false
-	// Grok is outside the gpt-5/codex compat injector, but Claude Code still
-	// carries a stable session id. Prefer that as the Grok prompt-cache seed so
-	// multi-turn /v1/messages traffic can hit xAI's server-side cache.
-	if promptCacheKey == "" && account.Platform == PlatformGrok {
-		if seededKey, injected := tkResolveAnthropicCompatPromptCacheKey(c, account, body, &anthropicReq, upstreamModel, promptCacheKey); injected {
-			promptCacheKey = seededKey
-			compatPromptCacheInjected = true
-		}
-	}
-	if promptCacheKey == "" && shouldAutoInjectPromptCacheKeyForCompat(upstreamModel) {
-		promptCacheKey = promptCacheKeyFromAnthropicMetadataSession(&anthropicReq)
-		if promptCacheKey == "" {
-			promptCacheKey = deriveAnthropicCacheControlPromptCacheKey(&anthropicReq)
-		}
-		if promptCacheKey == "" {
-			anthropicDigestChain = buildOpenAICompatAnthropicDigestChain(anthropicDigestReq)
-			if reusedKey, matchedChain := s.findOpenAICompatAnthropicDigestPromptCacheKey(account, apiKeyID, anthropicDigestChain); reusedKey != "" {
-				promptCacheKey = reusedKey
-				anthropicMatchedDigestChain = matchedChain
-			} else {
-				promptCacheKey = promptCacheKeyFromAnthropicDigest(anthropicDigestChain)
-			}
-		}
-		compatPromptCacheInjected = promptCacheKey != ""
-	}
-	compatReplayTrimmed := false
-	compatReplayTrimmedByPolicy := false
-	compatReplayGuardEnabled := shouldAutoInjectPromptCacheKeyForCompat(upstreamModel)
-	compatCompactionPolicy := resolveOpenAICompatMessagesCompactionPolicy(account, apiKeyGroup(getAPIKeyFromContext(c)))
-	compatContinuationEnabled := openAICompatContinuationEnabled(account, upstreamModel)
-	previousResponseID := ""
-	if compatContinuationEnabled {
-		previousResponseID = s.getOpenAICompatSessionResponseID(ctx, c, account, promptCacheKey)
-	}
-	compatContinuationDisabled := compatContinuationEnabled &&
-		s.isOpenAICompatSessionContinuationDisabled(ctx, c, account, promptCacheKey)
-	compatTurnState := ""
-	if compatReplayGuardEnabled && shouldEvaluateOpenAICompatMessagesCompactionForAccount(account, previousResponseID, compatContinuationDisabled) {
-		if shouldApplyOpenAICompatMessagesCompaction(compatCompactionPolicy, &anthropicReq) {
-			compatReplayTrimmed = applyOpenAICompatMessagesCompaction(account, &anthropicReq)
-			compatReplayTrimmedByPolicy = compatReplayTrimmed
-		}
-	}
-	SetOpenAICompatMessagesOpsContext(c, OpenAICompatMessagesOpsSnapshot{
-		PreviousResponseIDAttached: previousResponseID != "",
-		MessagesCompactionApplied:  compatReplayTrimmedByPolicy,
-		EstimatedInputTokens:       estimateAnthropicRequestInputTokens(&anthropicReq),
-	})
+	sessionPrep := s.tkPrepareOpenAICompatMessagesSession(ctx, c, account, body, &anthropicReq, anthropicDigestReq, upstreamModel, promptCacheKey, apiKeyID)
+	promptCacheKey = sessionPrep.promptCacheKey
+	compatPromptCacheInjected := sessionPrep.compatPromptCacheInjected
+	anthropicDigestChain := sessionPrep.anthropicDigestChain
+	anthropicMatchedDigestChain := sessionPrep.anthropicMatchedDigestChain
+	compatReplayTrimmed := sessionPrep.compatReplayTrimmed
+	compatReplayTrimmedByPolicy := sessionPrep.compatReplayTrimmedByPolicy
+	compatReplayGuardEnabled := sessionPrep.compatReplayGuardEnabled
+	compatCompactionPolicy := sessionPrep.compatCompactionPolicy
+	compatContinuationEnabled := sessionPrep.compatContinuationEnabled
+	previousResponseID := sessionPrep.previousResponseID
+	compatTurnState := sessionPrep.compatTurnState
 
 	// 3. Convert Anthropic → Responses after compatibility-only replay guard.
 	responsesReq, err := apicompat.AnthropicToResponses(&anthropicReq)
@@ -683,18 +644,6 @@ func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 		}
 	}
 	return result, nil
-}
-
-func isOpenAICompatResponsesTerminalEvent(eventType string) bool {
-	switch strings.TrimSpace(eventType) {
-	// TK: align with openAIStreamEventIsTerminal so cancelled/canceled close
-	// the streaming loop instead of falling through. See Wei-Shaw/sub2api#1322.
-	case "response.completed", "response.done", "response.incomplete", "response.failed",
-		"response.cancelled", "response.canceled":
-		return true
-	default:
-		return false
-	}
 }
 
 func (s *OpenAIGatewayService) recordOpenAIMessagesStreamUpstreamError(c *gin.Context, account *Account, upstreamRequestID, kind, message string) {

--- a/backend/internal/service/openai_gateway_messages_tk.go
+++ b/backend/internal/service/openai_gateway_messages_tk.go
@@ -207,3 +207,94 @@ func tkResolveAnthropicCompatPromptCacheKey(
 	}
 	return promptCacheKey, false
 }
+
+type tkOpenAICompatMessagesSessionPrep struct {
+	promptCacheKey              string
+	compatPromptCacheInjected   bool
+	anthropicDigestChain        string
+	anthropicMatchedDigestChain string
+	compatReplayTrimmed         bool
+	compatReplayTrimmedByPolicy bool
+	compatReplayGuardEnabled    bool
+	compatCompactionPolicy      openAICompatMessagesCompactionPolicy
+	compatContinuationEnabled   bool
+	previousResponseID          string
+	compatContinuationDisabled  bool
+	compatTurnState             string
+}
+
+// tkPrepareOpenAICompatMessagesSession applies TokenKey prompt-cache seeding,
+// continuation lookup, and messages-compaction replay guard before Anthropic→
+// Responses conversion.
+func (s *OpenAIGatewayService) tkPrepareOpenAICompatMessagesSession(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	anthropicReq *apicompat.AnthropicRequest,
+	anthropicDigestReq *apicompat.AnthropicRequest,
+	upstreamModel string,
+	promptCacheKey string,
+	apiKeyID int64,
+) tkOpenAICompatMessagesSessionPrep {
+	out := tkOpenAICompatMessagesSessionPrep{promptCacheKey: strings.TrimSpace(promptCacheKey)}
+	// Grok is outside the gpt-5/codex compat injector, but Claude Code still
+	// carries a stable session id. Prefer that as the Grok prompt-cache seed so
+	// multi-turn /v1/messages traffic can hit xAI's server-side cache.
+	if out.promptCacheKey == "" && account.Platform == PlatformGrok {
+		if seededKey, injected := tkResolveAnthropicCompatPromptCacheKey(c, account, body, anthropicReq, upstreamModel, out.promptCacheKey); injected {
+			out.promptCacheKey = seededKey
+			out.compatPromptCacheInjected = true
+		}
+	}
+	if out.promptCacheKey == "" && shouldAutoInjectPromptCacheKeyForCompat(upstreamModel) {
+		out.promptCacheKey = promptCacheKeyFromAnthropicMetadataSession(anthropicReq)
+		if out.promptCacheKey == "" {
+			out.promptCacheKey = deriveAnthropicCacheControlPromptCacheKey(anthropicReq)
+		}
+		if out.promptCacheKey == "" {
+			out.anthropicDigestChain = buildOpenAICompatAnthropicDigestChain(anthropicDigestReq)
+			if reusedKey, matchedChain := s.findOpenAICompatAnthropicDigestPromptCacheKey(account, apiKeyID, out.anthropicDigestChain); reusedKey != "" {
+				out.promptCacheKey = reusedKey
+				out.anthropicMatchedDigestChain = matchedChain
+			} else {
+				out.promptCacheKey = promptCacheKeyFromAnthropicDigest(out.anthropicDigestChain)
+			}
+		}
+		out.compatPromptCacheInjected = out.promptCacheKey != ""
+	}
+	out.compatReplayGuardEnabled = shouldAutoInjectPromptCacheKeyForCompat(upstreamModel)
+	out.compatCompactionPolicy = resolveOpenAICompatMessagesCompactionPolicy(account, apiKeyGroup(getAPIKeyFromContext(c)))
+	out.compatContinuationEnabled = openAICompatContinuationEnabled(account, upstreamModel)
+	if out.compatContinuationEnabled {
+		out.previousResponseID = s.getOpenAICompatSessionResponseID(ctx, c, account, out.promptCacheKey)
+	}
+	out.compatContinuationDisabled = out.compatContinuationEnabled &&
+		s.isOpenAICompatSessionContinuationDisabled(ctx, c, account, out.promptCacheKey)
+	if out.compatReplayGuardEnabled && shouldEvaluateOpenAICompatMessagesCompactionForAccount(account, out.previousResponseID, out.compatContinuationDisabled) {
+		if shouldApplyOpenAICompatMessagesCompaction(out.compatCompactionPolicy, anthropicReq) {
+			out.compatReplayTrimmed = applyOpenAICompatMessagesCompaction(account, anthropicReq)
+			out.compatReplayTrimmedByPolicy = out.compatReplayTrimmed
+		}
+	}
+	SetOpenAICompatMessagesOpsContext(c, OpenAICompatMessagesOpsSnapshot{
+		PreviousResponseIDAttached: out.previousResponseID != "",
+		MessagesCompactionApplied:  out.compatReplayTrimmedByPolicy,
+		EstimatedInputTokens:       estimateAnthropicRequestInputTokens(anthropicReq),
+	})
+	return out
+}
+
+// isOpenAICompatResponsesTerminalEvent reports whether an OpenAI Responses SSE
+// event type should close the Anthropic-compat streaming loop.
+func isOpenAICompatResponsesTerminalEvent(eventType string) bool {
+	switch strings.TrimSpace(eventType) {
+	// TK: align with openAIStreamEventIsTerminal so cancelled/canceled close
+	// the streaming loop instead of falling through. See Wei-Shaw/sub2api#1322.
+	case "response.completed", "response.done", "response.incomplete", "response.failed",
+		"response.cancelled", "response.canceled":
+		return true
+	default:
+		return false
+	}
+}

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -378,41 +378,12 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 	s.maybeHandleOpenAITeamLinkedError(ctx, account, statusCode, responseBody)
 	customErrorCodesEnabled := account.IsCustomErrorCodesEnabled()
 
-	if IsForeignCredentialOfficialOpenAIReject(account, statusCode, responseBody) {
-		slog.Error("foreign_credential_official_openai_reject_skip_penalty",
-			"account_id", account.ID,
-			"platform", account.Platform,
-			"channel_type", account.ChannelType,
-			"status_code", statusCode,
-			"expected_base_url", nativeOpenAIBaseURLForAccount(account))
-		return false
+	if handled, disable := s.tkTryHandleUpstreamErrorPrelude(ctx, account, statusCode, headers, responseBody, firstRequestedModel(requestedModel)); handled {
+		return disable
 	}
-
-	if s.handleOpenAICompatDownstreamCapacityPenalty(ctx, account, statusCode, responseBody) {
-		return true
-	}
-
-	// CloudWise model pools are independent. Handle their model-balance 402
-	// before pool-mode and custom-error-code early exits so every CloudWise
-	// account shape persists the same exact-model five-hour cooldown. If the
-	// model scope cannot be persisted, bypass those early exits and retain the
-	// conservative account-level 402 fallback.
+	// Recompute for pool-mode / custom-error carve-outs (predicate is cheap;
+	// prelude already applied the CloudWise cooldown early returns above).
 	cloudwiseModelBalance402 := tkIsCloudwiseModelBalance402Response(account, statusCode, responseBody)
-	if cloudwiseModelBalance402 && s.tkTryCloudwiseModelBalanceCooldown(ctx, account, statusCode, responseBody, firstRequestedModel(requestedModel)) {
-		return true
-	}
-	if s.tkTryCloudwiseProvider424Cooldown(ctx, account, statusCode, responseBody, firstRequestedModel(requestedModel)) {
-		return true
-	}
-
-	// Account-standing prepaid/balance exhaustion (tokensea 用户额度不足, 402
-	// Insufficient Balance, Anthropic credit balance, …) is the same SSOT as
-	// newapi_arrears: SetError + immediate Feishu P0. Must beat pool-mode skip
-	// and tryTempUnschedulable so a generic 403 rule cannot flap a dead prepaid
-	// account (prod 2026-08-30 tokensea-cc #93).
-	if s.tkTryHandleStandingBilling(ctx, account, statusCode, responseBody) {
-		return true
-	}
 
 	// 池模式默认不标记本地账号状态；但管理员显式配置的临时不可调度规则优先。
 	// 401 保留现有认证错误语义，不在这里改变池模式的认证处理。
@@ -499,157 +470,7 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 		}
 		// 其他 400 错误（如参数问题）不处理，不禁用账号
 	case 401:
-		if tkSkipDownstreamKiroOAuthAuthRejectPenalty(account, statusCode, upstreamMsg, responseBody) {
-			slog.Info("anthropic_downstream_kiro_oauth_401_skip_penalty",
-				"account_id", account.ID,
-				"status_code", statusCode)
-			s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "kiro_oauth_401")
-			return true
-		}
-		if tkIsCapabilityScope401(statusCode, responseBody) {
-			slog.Info("capability_scope_401_skip_penalty",
-				"account_id", account.ID, "platform", account.Platform, "message", upstreamMsg)
-			return false
-		}
-		if account.Platform == PlatformNewAPI && IsOpenAICompatModelNotFound404(responseBody, upstreamMsg) {
-			slog.Info("newapi_model_not_found_401_skip_auth_penalty",
-				"account_id", account.ID,
-				"channel_type", account.ChannelType,
-				"message", upstreamMsg)
-			return false
-		}
-		// 外审第9轮:Spark 影子无独立凭据,401 是母账号 token 问题——失效缓存 / refresh_token 判断 /
-		// 永久禁用 / 临时不可调度都必须落到凭据 owner(母账号),否则影子(无 refresh_token)必中
-		// "refresh_token missing"永久禁用分支、母账号 token cache 也不会被清,把母账号可恢复的 token
-		// 问题变成影子永久死亡。母账号被标记 temp-unschedulable 后由 parentHealthyForShadow 级联排除影子。
-		// 非影子时 resolveCredentialAccount 返回自身;母账号缺失/损坏(orphan 影子,罕见)时回退到原 account。
-		authAccount := account
-		if resolved, rerr := resolveCredentialAccount(ctx, s.accountRepo, account); rerr == nil && resolved != nil {
-			authAccount = resolved
-		}
-		if authAccount.Platform == PlatformOpenAI && tkIsPermanentOpenAIAuth401(responseBody) {
-			openai401Code := extractUpstreamErrorCode(responseBody)
-			msg := "Unauthorized (401): account authentication failed permanently"
-			if openai401Code == "token_invalidated" || openai401Code == "token_revoked" {
-				msg = "Token revoked (401): account authentication permanently revoked"
-			}
-			if upstreamMsg != "" {
-				if openai401Code == "token_invalidated" || openai401Code == "token_revoked" {
-					msg = "Token revoked (401): " + upstreamMsg
-				} else {
-					msg = "Unauthorized (401): " + upstreamMsg
-				}
-			}
-			s.handleAuthError(ctx, authAccount, msg)
-			shouldDisable = true
-			break
-		}
-		if account.Platform == PlatformAnthropic && account.Type == AccountTypeOAuth {
-			if s.tokenCacheInvalidator != nil {
-				if err := s.tokenCacheInvalidator.InvalidateToken(ctx, account); err != nil {
-					slog.Warn("oauth_401_invalidate_cache_failed", "account_id", account.ID, "error", err)
-				}
-			}
-			msg := "OAuth 401 — manual re-authorization required (re-login via account management)"
-			if upstreamMsg != "" {
-				msg = "OAuth 401: " + upstreamMsg
-			}
-			slog.Warn("oauth_401_immediate_disable",
-				"account_id", account.ID, "platform", account.Platform)
-			s.handleAuthError(ctx, account, msg)
-			shouldDisable = true
-			break
-		}
-		// OpenAI: token_invalidated / token_revoked 表示 token 被永久作废（非过期），直接标记 error
-		openai401Code := extractUpstreamErrorCode(responseBody)
-		if authAccount.Platform == PlatformOpenAI && (openai401Code == "token_invalidated" || openai401Code == "token_revoked") {
-			msg := "Token revoked (401): account authentication permanently revoked"
-			if upstreamMsg != "" {
-				msg = "Token revoked (401): " + upstreamMsg
-			}
-			s.handleAuthError(ctx, authAccount, msg)
-			shouldDisable = true
-			break
-		}
-		// OpenAI: {"detail":"Unauthorized"} 表示 token 完全无效（非标准 OpenAI 错误格式），直接标记 error
-		if authAccount.Platform == PlatformOpenAI && gjson.GetBytes(responseBody, "detail").String() == "Unauthorized" {
-			msg := "Unauthorized (401): account authentication failed permanently"
-			if upstreamMsg != "" {
-				msg = "Unauthorized (401): " + upstreamMsg
-			}
-			s.handleAuthError(ctx, authAccount, msg)
-			shouldDisable = true
-			break
-		}
-		// OAuth 账号在 401 错误时临时不可调度（给 token 刷新窗口）；非 OAuth 账号保持原有 SetError 行为。
-		if authAccount.Type == AccountTypeOAuth {
-			// 1. 失效缓存
-			if s.tokenCacheInvalidator != nil {
-				if err := s.tokenCacheInvalidator.InvalidateToken(ctx, authAccount); err != nil {
-					slog.Warn("oauth_401_invalidate_cache_failed", "account_id", authAccount.ID, "error", err)
-				}
-			}
-			// 缺少 refresh_token 的 OAuth 账号无法在冷却期内自愈（后台刷新服务也会跳过），
-			// 直接走 SetError 永久禁用，避免冷却结束后再被选中产生一发无意义的 502。
-			if strings.TrimSpace(authAccount.GetCredential("refresh_token")) == "" {
-				msg := "Authentication failed (401): refresh_token missing, cannot recover"
-				if upstreamMsg != "" {
-					msg = "OAuth 401 (no refresh_token): " + upstreamMsg
-				}
-				s.handleAuthError(ctx, authAccount, msg)
-				shouldDisable = true
-				break
-			}
-			// 2. 临时不可调度，替代 SetError（保持 status=active 让刷新服务能拾取）
-			// 注意：此处不再写回 account.Credentials/expires_at。
-			// 原实现使用请求开始时的 account 快照整列覆盖 credentials JSONB（见
-			// persistAccountCredentials → accountRepository.UpdateCredentials → SetCredentials），
-			// 在另一个 worker 刚刷新完 refresh_token 的窄窗口内会把新 refresh_token 回滚为旧值，
-			// 导致下一周期用旧 refresh_token 调上游拿到 invalid_grant 后，
-			// tryRecoverFromRefreshRace 重读 DB 发现 currentRT == usedRT 也救不回来，账号被错误 disable。
-			// 这里仅依赖 InvalidateToken + SetTempUnschedulable 让账号在冷却期内不被调度，
-			// 冷却结束后由 token_provider 的 NeedsRefresh / token_refresh_service 走带分布式锁的正路刷新。
-			if s.tkDisableIfOAuth401OnValidToken(ctx, authAccount, upstreamMsg) {
-				shouldDisable = true
-				break
-			}
-			msg := "Authentication failed (401): invalid or expired credentials"
-			if upstreamMsg != "" {
-				msg = "OAuth 401: " + upstreamMsg
-			}
-			if authAccount.Platform == PlatformAntigravity {
-				extraUpdates := antigravityForceTokenRefreshExtra("401_invalid")
-				if err := s.accountRepo.UpdateExtra(ctx, authAccount.ID, extraUpdates); err != nil {
-					slog.Warn("antigravity_401_force_refresh_mark_failed", "account_id", authAccount.ID, "error", err)
-				} else {
-					if authAccount.Extra == nil {
-						authAccount.Extra = make(map[string]any, len(extraUpdates))
-					}
-					for k, v := range extraUpdates {
-						authAccount.Extra[k] = v
-					}
-					slog.Info("antigravity_401_force_refresh_marked", "account_id", authAccount.ID)
-				}
-			}
-			cooldownMinutes := s.cfg.RateLimit.OAuth401CooldownMinutes
-			if cooldownMinutes <= 0 {
-				cooldownMinutes = 10
-			}
-			until := time.Now().Add(time.Duration(cooldownMinutes) * time.Minute)
-			s.notifyAccountSchedulingBlocked(authAccount, until, "oauth_401")
-			if err := s.accountRepo.SetTempUnschedulable(ctx, authAccount.ID, until, msg); err != nil {
-				slog.Warn("oauth_401_set_temp_unschedulable_failed", "account_id", authAccount.ID, "error", err)
-			}
-			shouldDisable = true
-		} else {
-			// 非 OAuth：保持 SetError 行为
-			msg := "Authentication failed (401): invalid or expired credentials"
-			if upstreamMsg != "" {
-				msg = "Authentication failed (401): " + upstreamMsg
-			}
-			s.handleAuthError(ctx, authAccount, msg)
-			shouldDisable = true
-		}
+		shouldDisable = s.tkHandleAuth401(ctx, account, upstreamMsg, responseBody)
 	case 402:
 		// 国产供应商：余额不足是可恢复状态（充值/检测恢复后由周期任务自动解除），
 		// 不能走 handleAuthError 永久置 status=error。改为可恢复的临时停调。
@@ -698,37 +519,8 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 				"status_code", statusCode)
 		}
 	case 429:
-		if account.Platform == PlatformAnthropic && tkIsAnthropicRequestOwned429Message(upstreamMsg, responseBody) {
-			slog.Info("anthropic_request_owned_429_skip_penalty",
-				"account_id", account.ID,
-				"status_code", statusCode)
-			return true
-		}
-		if account.Platform == PlatformAnthropic && tkSkipDownstreamNoAvailableAccountsPenalty(statusCode, upstreamMsg, responseBody) {
-			slog.Info("anthropic_downstream_no_available_accounts_skip_penalty",
-				"account_id", account.ID,
-				"status_code", statusCode)
-			s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "no_available_accounts")
-			return true
-		}
-		if account.Platform == PlatformAnthropic && tkSkipDownstreamFailoverExhaustedPenalty(statusCode, upstreamMsg, responseBody) {
-			slog.Info("anthropic_downstream_failover_exhausted_skip_penalty",
-				"account_id", account.ID,
-				"status_code", statusCode)
-			s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "all_available_accounts_exhausted")
-			return true
-		}
-		if tkSkipDownstreamKiroServiceUnavailablePenalty(account, statusCode, upstreamMsg, responseBody) {
-			slog.Info("anthropic_downstream_kiro_service_unavailable_skip_penalty",
-				"account_id", account.ID,
-				"status_code", statusCode)
-			s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "kiro_service_unavailable")
-			return true
-		}
-		if account.Platform == PlatformAnthropic && tkIsAnthropicNonAuthoritative429(headers, responseBody) {
-			tkLogAnthropicNonAuthoritative429Skip(account, statusCode)
-			s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "non_authoritative_429")
-			return true
+		if handled, disable := s.tkTryHandle429Extras(ctx, account, statusCode, headers, upstreamMsg, responseBody); handled {
+			return disable
 		}
 		rateLimitSet := s.handle429(ctx, account, headers, responseBody, requestedModel...)
 		if account.Platform == PlatformAnthropic && tkAnthropicStubHealthFuseEligible(statusCode, rateLimitSet) {
@@ -1198,99 +990,12 @@ func (s *RateLimitService) handle403(ctx context.Context, account *Account, upst
 		}
 		return s.handleOpenAI403(ctx, account, upstreamMsg, responseBody)
 	}
-	if s.tkMaybeRefreshKiroInvalidBearer403(ctx, account, upstreamMsg, responseBody) {
-		return true
-	}
-	if account.Platform == PlatformAnthropic {
-		if tkSkipDownstreamKiroOAuthAuthRejectPenalty(account, http.StatusForbidden, upstreamMsg, responseBody) {
-			slog.Info("anthropic_downstream_kiro_oauth_403_skip_penalty",
-				"account_id", account.ID,
-				"status_code", http.StatusForbidden)
-			s.recordAnthropicStubSaturation(ctx, account.ID, http.StatusForbidden, "kiro_oauth_403")
-			return true
-		}
-		if tkSkipRelayedCanonicalIngressRejectPenalty(http.StatusForbidden, upstreamMsg, responseBody) {
-			slog.Info("anthropic_downstream_canonical_ingress_reject_skip_penalty",
-				"account_id", account.ID)
-			return true
-		}
-		if s.tkTryDisableAnthropicOrgBan403(ctx, account, upstreamMsg, responseBody) {
-			return true
-		}
-		if s.tkTryDisableAnthropicTLSFingerprint403(ctx, account, upstreamMsg, responseBody) {
-			return true
-		}
-		if s.tkTryEscalatePersistentBodyless403(ctx, account, upstreamMsg, responseBody) {
-			return true
-		}
-		if tkIsAnthropicAccountAuthFatal403(upstreamMsg, responseBody) {
-			msg := buildForbiddenErrorMessage(
-				"Access forbidden (403):",
-				upstreamMsg,
-				responseBody,
-				"account may be suspended or lack permissions",
-			)
-			s.handleAuthError(ctx, account, msg)
-			return true
-		}
-		s.recordAnthropicStubSaturation(ctx, account.ID, http.StatusForbidden, "permission_failover")
-		return true
-	}
-	// 非 Antigravity 平台：保持原有行为
-	msg := buildForbiddenErrorMessage(
-		"Access forbidden (403):",
-		upstreamMsg,
-		responseBody,
-		"account may be suspended or lack permissions",
-	)
-	s.handleAuthError(ctx, account, msg)
-	return true
+	return s.tkHandleNonOpenAI403(ctx, account, upstreamMsg, responseBody)
 }
 
 func (s *RateLimitService) handleOpenAI403(ctx context.Context, account *Account, upstreamMsg string, responseBody []byte) (shouldDisable bool) {
-	if matched := matchTempUnschedKeyword(strings.ToLower(string(responseBody)), openAICloudflareChallengeKeywords); matched != "" {
-		slog.Warn(
-			"openai_403_cf_challenge_skip_cooldown",
-			"account_id", account.ID,
-			"matched_keyword", matched,
-			"upstream_msg", upstreamMsg,
-		)
-		return true
-	}
-	if matched := tkIsOpenAIClientInducedCapability403(upstreamMsg, responseBody); matched != "" {
-		slog.Info("openai_403_client_induced_capability_skip_cooldown",
-			"account_id", account.ID,
-			"matched", matched)
-		return true
-	}
-	if openAIIsHTMLBody(responseBody) {
-		slog.Warn(
-			"openai_403_html_body_skip_cooldown",
-			"account_id", account.ID,
-			"upstream_msg", upstreamMsg,
-		)
-		return true
-	}
-	// 上游代理 / CDN 在请求到达 OpenAI API 之前就拦下时，回的是 HTML 403 页面而不是
-	// {"error":{...}} 结构化错误。这类响应描述的是「这条链路 / 这个端点被挡了」，
-	// 不构成账号凭据或权限失效的证据——例如无效的 /v1/responses 子路径（#5334）。
-	//
-	// 据此写账号状态会把请求级错误放大成账号级处罚：首次即 temp-unschedulable，
-	// 连续 openAI403DisableThreshold 次直接永久禁用；而 403 又在 failover 状态集里，
-	// 同一个坏请求会被逐个账号重放，足以把整组账号打下线。
-	//
-	// 与既有口径一致：count_tokens 路径的 isOpenAIOAuthInputTokensUnsupported 已把
-	// 「HTML 403 page without a structured error」按端点级响应处理；
-	// shouldApplyOpenAIAlphaSearchAccountErrorSideEffects 的不变式也是端点级错误
-	// 只换号、不写账号错误状态。这里只跳过账号处罚，不改变 failover 行为——
-	// 换个走不同代理的账号仍有可能成功。
-	if isHTMLResponse(responseBody) {
-		slog.Warn(
-			"openai_403_html_body_skips_account_penalty",
-			"account_id", account.ID,
-			"upstream_message", upstreamMsg,
-		)
-		return false
+	if handled, disable := s.tkOpenAI403PrePenaltyGates(account, upstreamMsg, responseBody); handled {
+		return disable
 	}
 
 	msg := buildForbiddenErrorMessage(

--- a/backend/internal/service/ratelimit_service_tk_auth401.go
+++ b/backend/internal/service/ratelimit_service_tk_auth401.go
@@ -1,0 +1,169 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/tidwall/gjson"
+)
+
+// tkHandleAuth401 collapses HandleUpstreamError case 401 into one companion.
+// Behavior (order inclusive) matches the prior inline body exactly.
+func (s *RateLimitService) tkHandleAuth401(
+	ctx context.Context,
+	account *Account,
+	upstreamMsg string,
+	responseBody []byte,
+) (shouldDisable bool) {
+	if s == nil || account == nil {
+		return false
+	}
+	statusCode := 401
+
+	if tkSkipDownstreamKiroOAuthAuthRejectPenalty(account, statusCode, upstreamMsg, responseBody) {
+		slog.Info("anthropic_downstream_kiro_oauth_401_skip_penalty",
+			"account_id", account.ID,
+			"status_code", statusCode)
+		s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "kiro_oauth_401")
+		return true
+	}
+	if tkIsCapabilityScope401(statusCode, responseBody) {
+		slog.Info("capability_scope_401_skip_penalty",
+			"account_id", account.ID, "platform", account.Platform, "message", upstreamMsg)
+		return false
+	}
+	if account.Platform == PlatformNewAPI && IsOpenAICompatModelNotFound404(responseBody, upstreamMsg) {
+		slog.Info("newapi_model_not_found_401_skip_auth_penalty",
+			"account_id", account.ID,
+			"channel_type", account.ChannelType,
+			"message", upstreamMsg)
+		return false
+	}
+	// 外审第9轮:Spark 影子无独立凭据,401 是母账号 token 问题——失效缓存 / refresh_token 判断 /
+	// 永久禁用 / 临时不可调度都必须落到凭据 owner(母账号),否则影子(无 refresh_token)必中
+	// "refresh_token missing"永久禁用分支、母账号 token cache 也不会被清,把母账号可恢复的 token
+	// 问题变成影子永久死亡。母账号被标记 temp-unschedulable 后由 parentHealthyForShadow 级联排除影子。
+	// 非影子时 resolveCredentialAccount 返回自身;母账号缺失/损坏(orphan 影子,罕见)时回退到原 account。
+	authAccount := account
+	if resolved, rerr := resolveCredentialAccount(ctx, s.accountRepo, account); rerr == nil && resolved != nil {
+		authAccount = resolved
+	}
+	if authAccount.Platform == PlatformOpenAI && tkIsPermanentOpenAIAuth401(responseBody) {
+		openai401Code := extractUpstreamErrorCode(responseBody)
+		msg := "Unauthorized (401): account authentication failed permanently"
+		if openai401Code == "token_invalidated" || openai401Code == "token_revoked" {
+			msg = "Token revoked (401): account authentication permanently revoked"
+		}
+		if upstreamMsg != "" {
+			if openai401Code == "token_invalidated" || openai401Code == "token_revoked" {
+				msg = "Token revoked (401): " + upstreamMsg
+			} else {
+				msg = "Unauthorized (401): " + upstreamMsg
+			}
+		}
+		s.handleAuthError(ctx, authAccount, msg)
+		return true
+	}
+	if account.Platform == PlatformAnthropic && account.Type == AccountTypeOAuth {
+		if s.tokenCacheInvalidator != nil {
+			if err := s.tokenCacheInvalidator.InvalidateToken(ctx, account); err != nil {
+				slog.Warn("oauth_401_invalidate_cache_failed", "account_id", account.ID, "error", err)
+			}
+		}
+		msg := "OAuth 401 — manual re-authorization required (re-login via account management)"
+		if upstreamMsg != "" {
+			msg = "OAuth 401: " + upstreamMsg
+		}
+		slog.Warn("oauth_401_immediate_disable",
+			"account_id", account.ID, "platform", account.Platform)
+		s.handleAuthError(ctx, account, msg)
+		return true
+	}
+	// OpenAI: token_invalidated / token_revoked 表示 token 被永久作废（非过期），直接标记 error
+	openai401Code := extractUpstreamErrorCode(responseBody)
+	if authAccount.Platform == PlatformOpenAI && (openai401Code == "token_invalidated" || openai401Code == "token_revoked") {
+		msg := "Token revoked (401): account authentication permanently revoked"
+		if upstreamMsg != "" {
+			msg = "Token revoked (401): " + upstreamMsg
+		}
+		s.handleAuthError(ctx, authAccount, msg)
+		return true
+	}
+	// OpenAI: {"detail":"Unauthorized"} 表示 token 完全无效（非标准 OpenAI 错误格式），直接标记 error
+	if authAccount.Platform == PlatformOpenAI && gjson.GetBytes(responseBody, "detail").String() == "Unauthorized" {
+		msg := "Unauthorized (401): account authentication failed permanently"
+		if upstreamMsg != "" {
+			msg = "Unauthorized (401): " + upstreamMsg
+		}
+		s.handleAuthError(ctx, authAccount, msg)
+		return true
+	}
+	// OAuth 账号在 401 错误时临时不可调度（给 token 刷新窗口）；非 OAuth 账号保持原有 SetError 行为。
+	if authAccount.Type == AccountTypeOAuth {
+		// 1. 失效缓存
+		if s.tokenCacheInvalidator != nil {
+			if err := s.tokenCacheInvalidator.InvalidateToken(ctx, authAccount); err != nil {
+				slog.Warn("oauth_401_invalidate_cache_failed", "account_id", authAccount.ID, "error", err)
+			}
+		}
+		// 缺少 refresh_token 的 OAuth 账号无法在冷却期内自愈（后台刷新服务也会跳过），
+		// 直接走 SetError 永久禁用，避免冷却结束后再被选中产生一发无意义的 502。
+		if strings.TrimSpace(authAccount.GetCredential("refresh_token")) == "" {
+			msg := "Authentication failed (401): refresh_token missing, cannot recover"
+			if upstreamMsg != "" {
+				msg = "OAuth 401 (no refresh_token): " + upstreamMsg
+			}
+			s.handleAuthError(ctx, authAccount, msg)
+			return true
+		}
+		// 2. 临时不可调度，替代 SetError（保持 status=active 让刷新服务能拾取）
+		// 注意：此处不再写回 account.Credentials/expires_at。
+		// 原实现使用请求开始时的 account 快照整列覆盖 credentials JSONB（见
+		// persistAccountCredentials → accountRepository.UpdateCredentials → SetCredentials），
+		// 在另一个 worker 刚刷新完 refresh_token 的窄窗口内会把新 refresh_token 回滚为旧值，
+		// 导致下一周期用旧 refresh_token 调上游拿到 invalid_grant 后，
+		// tryRecoverFromRefreshRace 重读 DB 发现 currentRT == usedRT 也救不回来，账号被错误 disable。
+		// 这里仅依赖 InvalidateToken + SetTempUnschedulable 让账号在冷却期内不被调度，
+		// 冷却结束后由 token_provider 的 NeedsRefresh / token_refresh_service 走带分布式锁的正路刷新。
+		if s.tkDisableIfOAuth401OnValidToken(ctx, authAccount, upstreamMsg) {
+			return true
+		}
+		msg := "Authentication failed (401): invalid or expired credentials"
+		if upstreamMsg != "" {
+			msg = "OAuth 401: " + upstreamMsg
+		}
+		if authAccount.Platform == PlatformAntigravity {
+			extraUpdates := antigravityForceTokenRefreshExtra("401_invalid")
+			if err := s.accountRepo.UpdateExtra(ctx, authAccount.ID, extraUpdates); err != nil {
+				slog.Warn("antigravity_401_force_refresh_mark_failed", "account_id", authAccount.ID, "error", err)
+			} else {
+				if authAccount.Extra == nil {
+					authAccount.Extra = make(map[string]any, len(extraUpdates))
+				}
+				for k, v := range extraUpdates {
+					authAccount.Extra[k] = v
+				}
+				slog.Info("antigravity_401_force_refresh_marked", "account_id", authAccount.ID)
+			}
+		}
+		cooldownMinutes := s.cfg.RateLimit.OAuth401CooldownMinutes
+		if cooldownMinutes <= 0 {
+			cooldownMinutes = 10
+		}
+		until := time.Now().Add(time.Duration(cooldownMinutes) * time.Minute)
+		s.notifyAccountSchedulingBlocked(authAccount, until, "oauth_401")
+		if err := s.accountRepo.SetTempUnschedulable(ctx, authAccount.ID, until, msg); err != nil {
+			slog.Warn("oauth_401_set_temp_unschedulable_failed", "account_id", authAccount.ID, "error", err)
+		}
+		return true
+	}
+	// 非 OAuth：保持 SetError 行为
+	msg := "Authentication failed (401): invalid or expired credentials"
+	if upstreamMsg != "" {
+		msg = "Authentication failed (401): " + upstreamMsg
+	}
+	s.handleAuthError(ctx, authAccount, msg)
+	return true
+}

--- a/backend/internal/service/ratelimit_service_tk_companion_orchestration_test.go
+++ b/backend/internal/service/ratelimit_service_tk_companion_orchestration_test.go
@@ -1,0 +1,118 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// Pins the OpenAI 403 pre-penalty gate polarity that must stay identical to
+// the pre-companion inline chain: CF / client-induced / openAIIsHTMLBody all
+// return shouldDisable=true (failover without account penalty path); when
+// none of those match, handled=false so the consecutive-403 counter runs.
+func TestTkOpenAI403PrePenaltyGates_PolarityMatrix(t *testing.T) {
+	svc := NewRateLimitService(&rateLimitAccountRepoStub{}, nil, &config.Config{}, nil, nil)
+	account := &Account{ID: 4031, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+
+	t.Run("cf_challenge_disables_request", func(t *testing.T) {
+		body := []byte(`just a moment... challenge-platform cf-browser-verification`)
+		handled, disable := svc.tkOpenAI403PrePenaltyGates(account, "", body)
+		require.True(t, handled)
+		require.True(t, disable)
+	})
+
+	t.Run("client_induced_capability_disables_request", func(t *testing.T) {
+		msg := "You are not allowed to generate embeddings from this model"
+		handled, disable := svc.tkOpenAI403PrePenaltyGates(account, msg, []byte(`{"error":{"message":"`+msg+`"}}`))
+		require.True(t, handled)
+		require.True(t, disable)
+	})
+
+	t.Run("openai_html_body_disables_request_not_account", func(t *testing.T) {
+		handled, disable := svc.tkOpenAI403PrePenaltyGates(account, "", []byte(openAIAccessDeniedHTMLSample))
+		require.True(t, handled)
+		require.True(t, disable, "openAIIsHTMLBody branch must keep shouldDisable=true (skip cooldown, still failover)")
+	})
+
+	t.Run("structured_account_403_unhandled", func(t *testing.T) {
+		body := []byte(`{"error":{"code":"access_terminated","message":"Your account has been disabled"}}`)
+		handled, disable := svc.tkOpenAI403PrePenaltyGates(account, "Your account has been disabled", body)
+		require.False(t, handled)
+		require.False(t, disable)
+	})
+
+	// Dead-ish on typical HTML (openAIIsHTMLBody is broader), but the polarity
+	// must stay: isHTMLResponse-only → shouldDisable=false (skip account
+	// penalty AND do not force request failover via this gate).
+	t.Run("is_html_response_only_skips_without_disable", func(t *testing.T) {
+		body := []byte(`prefix <html><body>blocked</body></html>`)
+		require.False(t, openAIIsHTMLBody(body))
+		require.True(t, isHTMLResponse(body))
+		handled, disable := svc.tkOpenAI403PrePenaltyGates(account, "", body)
+		require.True(t, handled)
+		require.False(t, disable)
+	})
+
+	t.Run("nil_account", func(t *testing.T) {
+		handled, disable := svc.tkOpenAI403PrePenaltyGates(nil, "", nil)
+		require.True(t, handled)
+		require.False(t, disable)
+	})
+}
+
+func TestTkTryHandle429Extras_RequestOwnedBeforeDownstream(t *testing.T) {
+	svc := NewRateLimitService(&rateLimitAccountRepoStub{}, nil, &config.Config{}, nil, nil)
+	account := &Account{ID: 4291, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+
+	handled, disable := svc.tkTryHandle429Extras(
+		context.Background(),
+		account,
+		http.StatusTooManyRequests,
+		http.Header{},
+		"Usage credits are required for long context requests.",
+		nil,
+	)
+	require.True(t, handled)
+	require.True(t, disable)
+
+	handled, disable = svc.tkTryHandle429Extras(
+		context.Background(),
+		account,
+		http.StatusTooManyRequests,
+		http.Header{"Anthropic-Ratelimit-Unified-5h-Reset": {"9999999999"}},
+		"Number of request tokens has exceeded your per-minute rate limit",
+		[]byte(`{"type":"error","error":{"type":"rate_limit_error","message":"rpm"}}`),
+	)
+	require.False(t, handled, "authoritative anthropic 429 must fall through to handle429")
+	require.False(t, disable)
+}
+
+func TestTkHandleAuth401_CapabilityScopeDoesNotDisable(t *testing.T) {
+	svc := NewRateLimitService(&rateLimitAccountRepoStub{}, nil, &config.Config{}, nil, nil)
+	account := &Account{ID: 4011, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	body := []byte(tkCapabilityScope401IncidentBody)
+
+	require.False(t, svc.tkHandleAuth401(context.Background(), account, "capability", body),
+		"capability-scope 401 must not disable the account")
+}
+
+func TestTkHandleAuth401_NilGuards(t *testing.T) {
+	var svc *RateLimitService
+	require.False(t, svc.tkHandleAuth401(context.Background(), &Account{ID: 1}, "", nil))
+	svc = NewRateLimitService(&rateLimitAccountRepoStub{}, nil, &config.Config{}, nil, nil)
+	require.False(t, svc.tkHandleAuth401(context.Background(), nil, "", nil))
+}
+
+func TestTkHandleNonOpenAI403_GenericPlatformDisables(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	account := &Account{ID: 55, Platform: PlatformGemini, Type: AccountTypeAPIKey}
+
+	require.True(t, svc.tkHandleNonOpenAI403(context.Background(), account, "forbidden", []byte(`{"error":"no"}`)))
+	require.Equal(t, 1, repo.setErrorCalls)
+}

--- a/backend/internal/service/ratelimit_service_tk_handle403.go
+++ b/backend/internal/service/ratelimit_service_tk_handle403.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+)
+
+// tkHandleNonOpenAI403 owns the non-OpenAI/CN 403 chain that runs after
+// handle403 returns from Antigravity / OpenAI / CN providers.
+func (s *RateLimitService) tkHandleNonOpenAI403(
+	ctx context.Context,
+	account *Account,
+	upstreamMsg string,
+	responseBody []byte,
+) (shouldDisable bool) {
+	if s == nil || account == nil {
+		return false
+	}
+	if s.tkMaybeRefreshKiroInvalidBearer403(ctx, account, upstreamMsg, responseBody) {
+		return true
+	}
+	if account.Platform == PlatformAnthropic {
+		if tkSkipDownstreamKiroOAuthAuthRejectPenalty(account, http.StatusForbidden, upstreamMsg, responseBody) {
+			slog.Info("anthropic_downstream_kiro_oauth_403_skip_penalty",
+				"account_id", account.ID,
+				"status_code", http.StatusForbidden)
+			s.recordAnthropicStubSaturation(ctx, account.ID, http.StatusForbidden, "kiro_oauth_403")
+			return true
+		}
+		if tkSkipRelayedCanonicalIngressRejectPenalty(http.StatusForbidden, upstreamMsg, responseBody) {
+			slog.Info("anthropic_downstream_canonical_ingress_reject_skip_penalty",
+				"account_id", account.ID)
+			return true
+		}
+		if s.tkTryDisableAnthropicOrgBan403(ctx, account, upstreamMsg, responseBody) {
+			return true
+		}
+		if s.tkTryDisableAnthropicTLSFingerprint403(ctx, account, upstreamMsg, responseBody) {
+			return true
+		}
+		if s.tkTryEscalatePersistentBodyless403(ctx, account, upstreamMsg, responseBody) {
+			return true
+		}
+		if tkIsAnthropicAccountAuthFatal403(upstreamMsg, responseBody) {
+			msg := buildForbiddenErrorMessage(
+				"Access forbidden (403):",
+				upstreamMsg,
+				responseBody,
+				"account may be suspended or lack permissions",
+			)
+			s.handleAuthError(ctx, account, msg)
+			return true
+		}
+		s.recordAnthropicStubSaturation(ctx, account.ID, http.StatusForbidden, "permission_failover")
+		return true
+	}
+	// 非 Antigravity 平台：保持原有行为
+	msg := buildForbiddenErrorMessage(
+		"Access forbidden (403):",
+		upstreamMsg,
+		responseBody,
+		"account may be suspended or lack permissions",
+	)
+	s.handleAuthError(ctx, account, msg)
+	return true
+}

--- a/backend/internal/service/ratelimit_service_tk_handle429_extras.go
+++ b/backend/internal/service/ratelimit_service_tk_handle429_extras.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+)
+
+// tkTryHandle429Extras collapses the TokenKey-only early-return chain at the
+// top of HandleUpstreamError case 429 (request-owned / downstream capacity /
+// non-authoritative envelope skips) into one companion call site.
+//
+// When handled is false the caller continues into handle429 + stub-health fuse.
+func (s *RateLimitService) tkTryHandle429Extras(
+	ctx context.Context,
+	account *Account,
+	statusCode int,
+	headers http.Header,
+	upstreamMsg string,
+	responseBody []byte,
+) (handled, shouldDisable bool) {
+	if s == nil || account == nil {
+		return true, false
+	}
+	if account.Platform == PlatformAnthropic && tkIsAnthropicRequestOwned429Message(upstreamMsg, responseBody) {
+		slog.Info("anthropic_request_owned_429_skip_penalty",
+			"account_id", account.ID,
+			"status_code", statusCode)
+		return true, true
+	}
+	if account.Platform == PlatformAnthropic && tkSkipDownstreamNoAvailableAccountsPenalty(statusCode, upstreamMsg, responseBody) {
+		slog.Info("anthropic_downstream_no_available_accounts_skip_penalty",
+			"account_id", account.ID,
+			"status_code", statusCode)
+		s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "no_available_accounts")
+		return true, true
+	}
+	if account.Platform == PlatformAnthropic && tkSkipDownstreamFailoverExhaustedPenalty(statusCode, upstreamMsg, responseBody) {
+		slog.Info("anthropic_downstream_failover_exhausted_skip_penalty",
+			"account_id", account.ID,
+			"status_code", statusCode)
+		s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "all_available_accounts_exhausted")
+		return true, true
+	}
+	if tkSkipDownstreamKiroServiceUnavailablePenalty(account, statusCode, upstreamMsg, responseBody) {
+		slog.Info("anthropic_downstream_kiro_service_unavailable_skip_penalty",
+			"account_id", account.ID,
+			"status_code", statusCode)
+		s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "kiro_service_unavailable")
+		return true, true
+	}
+	if account.Platform == PlatformAnthropic && tkIsAnthropicNonAuthoritative429(headers, responseBody) {
+		tkLogAnthropicNonAuthoritative429Skip(account, statusCode)
+		s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "non_authoritative_429")
+		return true, true
+	}
+	return false, false
+}

--- a/backend/internal/service/ratelimit_service_tk_openai_403_gate.go
+++ b/backend/internal/service/ratelimit_service_tk_openai_403_gate.go
@@ -1,0 +1,65 @@
+package service
+
+import (
+	"log/slog"
+	"strings"
+)
+
+// tkOpenAI403PrePenaltyGates collapses the request-level OpenAI 403 short-circuits
+// that must run before the consecutive-403 counter / temp_unschedulable path.
+//
+// Returns handled=true when the caller must return immediately with shouldDisable.
+func (s *RateLimitService) tkOpenAI403PrePenaltyGates(
+	account *Account,
+	upstreamMsg string,
+	responseBody []byte,
+) (handled, shouldDisable bool) {
+	if account == nil {
+		return true, false
+	}
+	if matched := matchTempUnschedKeyword(strings.ToLower(string(responseBody)), openAICloudflareChallengeKeywords); matched != "" {
+		slog.Warn(
+			"openai_403_cf_challenge_skip_cooldown",
+			"account_id", account.ID,
+			"matched_keyword", matched,
+			"upstream_msg", upstreamMsg,
+		)
+		return true, true
+	}
+	if matched := tkIsOpenAIClientInducedCapability403(upstreamMsg, responseBody); matched != "" {
+		slog.Info("openai_403_client_induced_capability_skip_cooldown",
+			"account_id", account.ID,
+			"matched", matched)
+		return true, true
+	}
+	if openAIIsHTMLBody(responseBody) {
+		slog.Warn(
+			"openai_403_html_body_skip_cooldown",
+			"account_id", account.ID,
+			"upstream_msg", upstreamMsg,
+		)
+		return true, true
+	}
+	// 上游代理 / CDN 在请求到达 OpenAI API 之前就拦下时，回的是 HTML 403 页面而不是
+	// {"error":{...}} 结构化错误。这类响应描述的是「这条链路 / 这个端点被挡了」，
+	// 不构成账号凭据或权限失效的证据——例如无效的 /v1/responses 子路径（#5334）。
+	//
+	// 据此写账号状态会把请求级错误放大成账号级处罚：首次即 temp-unschedulable，
+	// 连续 openAI403DisableThreshold 次直接永久禁用；而 403 又在 failover 状态集里，
+	// 同一个坏请求会被逐个账号重放，足以把整组账号打下线。
+	//
+	// 与既有口径一致：count_tokens 路径的 isOpenAIOAuthInputTokensUnsupported 已把
+	// 「HTML 403 page without a structured error」按端点级响应处理；
+	// shouldApplyOpenAIAlphaSearchAccountErrorSideEffects 的不变式也是端点级错误
+	// 只换号、不写账号错误状态。这里只跳过账号处罚，不改变 failover 行为——
+	// 换个走不同代理的账号仍有可能成功。
+	if isHTMLResponse(responseBody) {
+		slog.Warn(
+			"openai_403_html_body_skips_account_penalty",
+			"account_id", account.ID,
+			"upstream_message", upstreamMsg,
+		)
+		return true, false
+	}
+	return false, false
+}

--- a/backend/internal/service/ratelimit_service_tk_upstream_error_prelude.go
+++ b/backend/internal/service/ratelimit_service_tk_upstream_error_prelude.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+)
+
+// tkTryHandleUpstreamErrorPrelude collapses the TokenKey-only early-return chain
+// at the top of HandleUpstreamError into one companion call site.
+//
+// Order is load-bearing and must stay identical to the prior inline chain:
+// foreign-credential official-OpenAI reject → OpenAI-compat downstream capacity
+// → CloudWise model-balance 402 → CloudWise provider 424 → standing billing.
+//
+// When handled is false the caller continues the upstream-shaped pool-mode /
+// custom-error / temp-unschedulable path. cloudwiseModelBalance402 is recomputed
+// by the caller for those carve-outs (cheap predicate).
+func (s *RateLimitService) tkTryHandleUpstreamErrorPrelude(
+	ctx context.Context,
+	account *Account,
+	statusCode int,
+	_ http.Header,
+	responseBody []byte,
+	requestedModel string,
+) (handled, shouldDisable bool) {
+	if s == nil || account == nil {
+		return true, false
+	}
+
+	if IsForeignCredentialOfficialOpenAIReject(account, statusCode, responseBody) {
+		slog.Error("foreign_credential_official_openai_reject_skip_penalty",
+			"account_id", account.ID,
+			"platform", account.Platform,
+			"channel_type", account.ChannelType,
+			"status_code", statusCode,
+			"expected_base_url", nativeOpenAIBaseURLForAccount(account))
+		return true, false
+	}
+
+	if s.handleOpenAICompatDownstreamCapacityPenalty(ctx, account, statusCode, responseBody) {
+		return true, true
+	}
+
+	// CloudWise model pools are independent. Handle their model-balance 402
+	// before pool-mode and custom-error-code early exits so every CloudWise
+	// account shape persists the same exact-model five-hour cooldown. If the
+	// model scope cannot be persisted, bypass those early exits and retain the
+	// conservative account-level 402 fallback.
+	cloudwiseModelBalance402 := tkIsCloudwiseModelBalance402Response(account, statusCode, responseBody)
+	if cloudwiseModelBalance402 && s.tkTryCloudwiseModelBalanceCooldown(ctx, account, statusCode, responseBody, requestedModel) {
+		return true, true
+	}
+	if s.tkTryCloudwiseProvider424Cooldown(ctx, account, statusCode, responseBody, requestedModel) {
+		return true, true
+	}
+
+	// Account-standing prepaid/balance exhaustion (tokensea 用户额度不足, 402
+	// Insufficient Balance, Anthropic credit balance, …) is the same SSOT as
+	// newapi_arrears: SetError + immediate Feishu P0. Must beat pool-mode skip
+	// and tryTempUnschedulable so a generic 403 rule cannot flap a dead prepaid
+	// account (prod 2026-08-30 tokensea-cc #93).
+	if s.tkTryHandleStandingBilling(ctx, account, statusCode, responseBody) {
+		return true, true
+	}
+
+	return false, false
+}

--- a/backend/internal/service/ratelimit_service_tk_upstream_error_prelude_test.go
+++ b/backend/internal/service/ratelimit_service_tk_upstream_error_prelude_test.go
@@ -1,0 +1,76 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// Official OpenAI help-page 401 on a foreign (non-official) credential must
+// short-circuit without disabling — same contract as the pre-companion inline
+// chain in HandleUpstreamError.
+func TestTkTryHandleUpstreamErrorPrelude_ForeignCredentialSkipsDisable(t *testing.T) {
+	svc := NewRateLimitService(&rateLimitAccountRepoStub{}, nil, &config.Config{}, nil, nil)
+	account := &Account{
+		ID:       91,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+		},
+	}
+	body := []byte(`Incorrect API key provided: sk-****. You can find your API key at https://platform.openai.com/account/api-keys.`)
+
+	handled, shouldDisable := svc.tkTryHandleUpstreamErrorPrelude(
+		context.Background(), account, http.StatusUnauthorized, nil, body, "")
+	require.True(t, handled)
+	require.False(t, shouldDisable)
+}
+
+// Mirror-stub "no available accounts" capacity must be handled by the prelude
+// (and still return shouldDisable=true for request failover) without writing
+// account error / temp-unschedulable state.
+func TestTkTryHandleUpstreamErrorPrelude_OpenAIDownstreamCapacity(t *testing.T) {
+	sat := &fakeOpenAISaturationCounterRL{}
+	repo := &rateLimitAccountRepoStub{}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	svc.SetOpenAISaturationCounter(sat)
+	body := []byte(`{"type":"error","error":{"type":"api_error","message":"No available accounts: no available accounts"}}`)
+
+	handled, shouldDisable := svc.tkTryHandleUpstreamErrorPrelude(
+		context.Background(), openAIEdgeStub(63), http.StatusTooManyRequests, nil, body, "")
+	require.True(t, handled)
+	require.True(t, shouldDisable)
+	require.Equal(t, []int64{63}, sat.incrementIDs)
+	require.Zero(t, repo.setErrorCalls)
+	require.Zero(t, repo.tempCalls)
+}
+
+func TestTkTryHandleUpstreamErrorPrelude_UnhandledContinues(t *testing.T) {
+	svc := NewRateLimitService(&rateLimitAccountRepoStub{}, nil, &config.Config{}, nil, nil)
+	account := &Account{ID: 7, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+
+	handled, shouldDisable := svc.tkTryHandleUpstreamErrorPrelude(
+		context.Background(), account, http.StatusBadGateway, nil, []byte(`upstream boom`), "")
+	require.False(t, handled)
+	require.False(t, shouldDisable)
+}
+
+func TestTkTryHandleUpstreamErrorPrelude_NilGuards(t *testing.T) {
+	var svc *RateLimitService
+	handled, shouldDisable := svc.tkTryHandleUpstreamErrorPrelude(
+		context.Background(), &Account{ID: 1}, http.StatusInternalServerError, nil, nil, "")
+	require.True(t, handled)
+	require.False(t, shouldDisable)
+
+	svc = NewRateLimitService(&rateLimitAccountRepoStub{}, nil, &config.Config{}, nil, nil)
+	handled, shouldDisable = svc.tkTryHandleUpstreamErrorPrelude(
+		context.Background(), nil, http.StatusInternalServerError, nil, nil, "")
+	require.True(t, handled)
+	require.False(t, shouldDisable)
+}

--- a/scripts/checks/protocol-routing-ssot.py
+++ b/scripts/checks/protocol-routing-ssot.py
@@ -894,8 +894,14 @@ def check(root: Path) -> list[str]:
         ):
             errors.append("protocol routing is missing the scheduler authorization regression test")
 
-    account_handler = root / "backend/internal/handler/admin/account_handler.go"
-    if account_handler.is_file():
+    # Probe scheduling lives in the TK companion so account_handler.go stays
+    # upstream-shaped; accept either path as long as one owner has the bodies.
+    account_handler_probe_owners = (
+        root / "backend/internal/handler/admin/account_handler_tk_protocol_probe.go",
+        root / "backend/internal/handler/admin/account_handler.go",
+    )
+    account_handler = next((path for path in account_handler_probe_owners if path.is_file()), None)
+    if account_handler is not None:
         source = strip_go_comments_and_literals(account_handler.read_text(encoding="utf-8"))
         bodies = function_bodies(source, "scheduleProtocolCapabilityProbes")
         if not bodies:

--- a/scripts/checks/protocol-routing-ssot.py
+++ b/scripts/checks/protocol-routing-ssot.py
@@ -59,7 +59,7 @@ OWNER_FILES = (
 )
 
 GOVERNED_HANDLERS = (
-    "backend/internal/handler/gateway_handler.go",
+    "backend/internal/handler/gateway_handler_tk_protocol_execute.go",
     "backend/internal/handler/gateway_handler_chat_completions.go",
     "backend/internal/handler/gateway_handler_responses.go",
     "backend/internal/handler/openai_gateway_handler.go",
@@ -68,7 +68,7 @@ GOVERNED_HANDLERS = (
 )
 
 HANDLER_GEMINI_EXECUTORS = {
-    "backend/internal/handler/gateway_handler.go": ("MessagesToGemini",),
+    "backend/internal/handler/gateway_handler_tk_protocol_execute.go": ("MessagesToGemini",),
     "backend/internal/handler/gateway_handler_chat_completions.go": ("ChatToGemini",),
     "backend/internal/handler/gateway_handler_responses.go": ("ResponsesToGemini",),
     "backend/internal/handler/openai_gateway_handler.go": (
@@ -117,7 +117,7 @@ TARGET_BOUNDARIES = {
 }
 
 FORWARD_BOUNDARIES = {
-    "backend/internal/handler/gateway_handler.go": (
+    "backend/internal/handler/gateway_handler_tk_protocol_execute.go": (
         r"\bh\.gatewayService\.Forward\s*\(",
     ),
     "backend/internal/handler/gateway_handler_chat_completions.go": (

--- a/scripts/checks/public-group-aggregator-channel.py
+++ b/scripts/checks/public-group-aggregator-channel.py
@@ -20,6 +20,13 @@ import sys
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 POLICY_GO = REPO_ROOT / "backend/internal/service/openrouter_provider_tk_policy.go"
 ADMIN_ACCOUNT_GO = REPO_ROOT / "backend/internal/service/admin_account.go"
+# Policy call sites may live in TK companions after OPC extraction.
+ADMIN_ACCOUNT_POLICY_OWNERS = (
+    REPO_ROOT / "backend/internal/service/admin_account.go",
+    REPO_ROOT / "backend/internal/service/admin_account_tk_create.go",
+    REPO_ROOT / "backend/internal/service/admin_account_tk_update.go",
+    REPO_ROOT / "backend/internal/service/admin_account_tk_bulk_update.go",
+)
 ROUTE_GO = REPO_ROOT / "backend/internal/server/routes/gateway.go"
 CONFIG_EXAMPLE = REPO_ROOT / "ops/pricing/examples/openrouter-provider-config.example.json"
 
@@ -94,12 +101,13 @@ def main() -> int:
             if marker not in text:
                 return _fail(f"{path.name} missing marker {marker!r}")
 
-    if not ADMIN_ACCOUNT_GO.is_file():
+    admin_owners = [path for path in ADMIN_ACCOUNT_POLICY_OWNERS if path.is_file()]
+    if not admin_owners:
         return _fail(f"missing admin account owner: {ADMIN_ACCOUNT_GO}")
-    admin_text = ADMIN_ACCOUNT_GO.read_text(encoding="utf-8")
+    admin_text = "\n".join(path.read_text(encoding="utf-8") for path in admin_owners)
     for marker in REQUIRED_ADMIN_ACCOUNT_MARKERS:
         if marker not in admin_text:
-            return _fail(f"admin_account.go missing policy call site {marker!r}")
+            return _fail(f"admin account owners missing policy call site {marker!r}")
 
     return 0
 

--- a/scripts/checks/test_protocol_routing_ssot.py
+++ b/scripts/checks/test_protocol_routing_ssot.py
@@ -24,7 +24,7 @@ class ProtocolRoutingSSOTTest(unittest.TestCase):
             path = root / relative
             path.parent.mkdir(parents=True, exist_ok=True)
             gemini_executors = {
-                "backend/internal/handler/gateway_handler.go": "MessagesToGemini",
+                "backend/internal/handler/gateway_handler_tk_protocol_execute.go": "MessagesToGemini",
                 "backend/internal/handler/gateway_handler_chat_completions.go": "ChatToGemini",
                 "backend/internal/handler/gateway_handler_responses.go": "ResponsesToGemini",
                 "backend/internal/handler/openai_gateway_handler.go": "MessagesToGemini: route, ResponsesToGemini",

--- a/scripts/sentinels/engine-facade.json
+++ b/scripts/sentinels/engine-facade.json
@@ -58,8 +58,6 @@
       "name": "openai_compat_continuation_injection",
       "source": "backend/internal/service/openai_gateway_messages.go",
       "required_literals": [
-        "compatContinuationEnabled := openAICompatContinuationEnabled(account, upstreamModel)",
-        "previousResponseID = s.getOpenAICompatSessionResponseID(ctx, c, account, promptCacheKey)",
         "s.bindOpenAICompatSessionResponseID(ctx, c, account, promptCacheKey, result.ResponseID)",
         "openAICompatShouldTrimForContinuation(account)"
       ]
@@ -88,10 +86,6 @@
       "name": "openai_compat_messages_compaction_injection",
       "source": "backend/internal/service/openai_gateway_messages.go",
       "required_literals": [
-        "compatCompactionPolicy := resolveOpenAICompatMessagesCompactionPolicy(account, apiKeyGroup(getAPIKeyFromContext(c)))",
-        "shouldEvaluateOpenAICompatMessagesCompactionForAccount(account, previousResponseID, compatContinuationDisabled)",
-        "if shouldApplyOpenAICompatMessagesCompaction(compatCompactionPolicy, &anthropicReq) {",
-        "compatReplayTrimmed = applyOpenAICompatMessagesCompaction(account, &anthropicReq)",
         "zap.Bool(\"compat_messages_compaction_applied\", true)",
         "zap.Int(\"compat_messages_compaction_input_tokens_threshold\", compatCompactionPolicy.inputTokenLimit)"
       ]
@@ -154,6 +148,31 @@
       "source": "backend/internal/pkg/apicompat/chatcompletions_to_responses.go",
       "required_literals": [
         "if _, ok := parsed.(map[string]any); !ok {"
+      ]
+    },
+    {
+      "name": "openai_compat_messages_session_prep_companion",
+      "source": "backend/internal/service/openai_gateway_messages_tk.go",
+      "required_literals": [
+        "out.compatContinuationEnabled = openAICompatContinuationEnabled(account, upstreamModel)",
+        "out.previousResponseID = s.getOpenAICompatSessionResponseID(ctx, c, account, out.promptCacheKey)"
+      ]
+    },
+    {
+      "name": "openai_compat_messages_session_prep_callsite",
+      "source": "backend/internal/service/openai_gateway_messages.go",
+      "required_literals": [
+        "s.tkPrepareOpenAICompatMessagesSession("
+      ]
+    },
+    {
+      "name": "openai_compat_messages_compaction_companion",
+      "source": "backend/internal/service/openai_gateway_messages_tk.go",
+      "required_literals": [
+        "out.compatCompactionPolicy = resolveOpenAICompatMessagesCompactionPolicy(account, apiKeyGroup(getAPIKeyFromContext(c)))",
+        "shouldEvaluateOpenAICompatMessagesCompactionForAccount(account, out.previousResponseID, out.compatContinuationDisabled)",
+        "if shouldApplyOpenAICompatMessagesCompaction(out.compatCompactionPolicy, anthropicReq) {",
+        "out.compatReplayTrimmed = applyOpenAICompatMessagesCompaction(account, anthropicReq)"
       ]
     }
   ]

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6551,11 +6551,24 @@
       "must_contain": [
         "cachedTargets, err := s.accountRepo.GetByIDs(ctx, input.AccountIDs)",
         "if needMixedChannelCheck || needPublicGroupAggregatorCheck {",
-        "MergeAccountCredentials(\n\t\t\taccount.Credentials, input.Credentials, account.ChannelType, CredentialMergeAdmin,",
-        "PrepareBulkCredentialPatch(input.Credentials)",
-        "FinalizeAccountCredentials(input.Credentials, input.ChannelType)"
+        "PrepareBulkCredentialPatch(input.Credentials)"
       ],
       "rationale": "Bulk edits now hydrate every target once before any write so supplier-managed ownership and the existing public-group aggregator policy share one complete account snapshot. The later map fill remains required for group-only edits with SkipMixedChannelCheck. Admin create/update/bulk must finalize protocol identity credentials. Without these call sites, ordinary NewAPI edits and bulk base_url rotations can keep exclusive urls pointing at a prior supplier."
+    },
+    {
+      "path": "backend/internal/service/admin_account_tk_update.go",
+      "must_contain": [
+        "MergeAccountCredentials(\n\t\t\taccount.Credentials, input.Credentials, account.ChannelType, CredentialMergeAdmin,",
+        "FinalizeAccountCredentials(account.Credentials, account.ChannelType)"
+      ],
+      "rationale": "Bulk edits now hydrate every target once before any write so supplier-managed ownership and the existing public-group aggregator policy share one complete account snapshot. The later map fill remains required for group-only edits with SkipMixedChannelCheck. Admin create/update/bulk must finalize protocol identity credentials. Without these call sites, ordinary NewAPI edits and bulk base_url rotations can keep exclusive urls pointing at a prior supplier. (update companion credential merge/finalize)"
+    },
+    {
+      "path": "backend/internal/service/admin_account_tk_create.go",
+      "must_contain": [
+        "FinalizeAccountCredentials(input.Credentials, input.ChannelType)"
+      ],
+      "rationale": "Bulk edits now hydrate every target once before any write so supplier-managed ownership and the existing public-group aggregator policy share one complete account snapshot. The later map fill remains required for group-only edits with SkipMixedChannelCheck. Admin create/update/bulk must finalize protocol identity credentials. Without these call sites, ordinary NewAPI edits and bulk base_url rotations can keep exclusive urls pointing at a prior supplier. (create companion finalize credentials)"
     },
     {
       "path": "backend/internal/service/openai_gateway_chat_completions.go",
@@ -6776,11 +6789,25 @@
       "rationale": "Scheme C loop prevention: public groups must reject OpenRouter/Coze/Submodel aggregator upstream accounts. Dropping this policy re-opens universal-key routing into OpenRouter relay loops."
     },
     {
-      "path": "backend/internal/service/admin_account.go",
+      "path": "backend/internal/service/admin_account_tk_create.go",
       "must_contain": [
         "checkPublicGroupAggregatorChannelPolicy"
       ],
-      "rationale": "Admin account create/update must invoke scheme C policy at the write boundary; the helper alone does not block bad group bindings."
+      "rationale": "Admin account create/update must invoke scheme C policy at the write boundary; the helper alone does not block bad group bindings. (create companion)"
+    },
+    {
+      "path": "backend/internal/service/admin_account_tk_update.go",
+      "must_contain": [
+        "checkPublicGroupAggregatorChannelPolicy"
+      ],
+      "rationale": "Admin account create/update must invoke scheme C policy at the write boundary; the helper alone does not block bad group bindings. (update companion)"
+    },
+    {
+      "path": "backend/internal/service/admin_account_tk_bulk_update.go",
+      "must_contain": [
+        "checkPublicGroupAggregatorChannelPolicy"
+      ],
+      "rationale": "Admin account create/update must invoke scheme C policy at the write boundary; the helper alone does not block bad group bindings. (bulk companion)"
     },
     {
       "path": "backend/internal/service/openrouter_provider_tk_model.go",
@@ -7630,14 +7657,28 @@
       "path": "backend/internal/service/admin_account.go",
       "must_contain": [
         "ValidateSupplierReservedAccountExtra(input.Extra)",
-        "StripSupplierReservedAccountExtra(input.Extra)",
-        "PreserveSupplierManagedExtraKeys(account, normalizedExtra)",
         "SupplierSourceIDExtraKey:",
         "func (s *adminServiceImpl) RefreshAccountCredentials(ctx context.Context, id int64)",
-        "func (s *adminServiceImpl) CreateShadow(ctx context.Context, parentID int64, opts ShadowOptions)",
-        "if IsSupplierManagedAccount(account) {"
+        "func (s *adminServiceImpl) CreateShadow(ctx context.Context, parentID int64, opts ShadowOptions)"
       ],
       "rationale": "Ordinary account admin writes treat supplier-managed accounts like ordinary accounts. Reserved Extra keys cannot be forged on create/import; managed Extra edits strip/forge-guard reserved keys and PreserveSupplierManagedExtraKeys keeps sync identity; duplicate strips supplier identity keys. Projection field overwrite remains owned by supplier-source sync narrow writes, not by these generic guards."
+    },
+    {
+      "path": "backend/internal/service/admin_account_tk_update.go",
+      "must_contain": [
+        "StripSupplierReservedAccountExtra(input.Extra)",
+        "PreserveSupplierManagedExtraKeys(account, normalizedExtra)",
+        "if IsSupplierManagedAccount(account) {"
+      ],
+      "rationale": "Ordinary account admin writes treat supplier-managed accounts like ordinary accounts. Reserved Extra keys cannot be forged on create/import; managed Extra edits strip/forge-guard reserved keys and PreserveSupplierManagedExtraKeys keeps sync identity; duplicate strips supplier identity keys. Projection field overwrite remains owned by supplier-source sync narrow writes, not by these generic guards. (update companion supplier guards)"
+    },
+    {
+      "path": "backend/internal/service/admin_account_tk_bulk_update.go",
+      "must_contain": [
+        "StripSupplierReservedAccountExtra(input.Extra)",
+        "if IsSupplierManagedAccount(account) {"
+      ],
+      "rationale": "Ordinary account admin writes treat supplier-managed accounts like ordinary accounts. Reserved Extra keys cannot be forged on create/import; managed Extra edits strip/forge-guard reserved keys and PreserveSupplierManagedExtraKeys keeps sync identity; duplicate strips supplier identity keys. Projection field overwrite remains owned by supplier-source sync narrow writes, not by these generic guards. (bulk companion supplier guards)"
     },
     {
       "path": "backend/internal/service/supplier_managed_account_guard_test.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2182,7 +2182,7 @@
       "rationale": "OAuth Claude Code mimicry beta registry: Sonnet/Opus and Haiku sets must stay aligned with real cc CLI traffic (latest cc capture; version single-sourced in deploy/aws/stage0/anthropic-http-mimicry-baselines.json). Dropping thinking-token-count / structured-outputs or reverting Haiku to the legacy claude-code + extended-cache-ttl set re-opens third-party cohort signals on OAuth subscriptions."
     },
     {
-      "path": "backend/internal/handler/gateway_handler.go",
+      "path": "backend/internal/handler/gateway_handler_tk_kiro.go",
       "must_contain": [
         "var canonicalUARejectErr *service.CanonicalIngressUARejectedError",
         "errors.As(err, &canonicalUARejectErr)",
@@ -4087,9 +4087,8 @@
       "rationale": "Focused regressions proving the issue #625 boundary: a status-0 `context canceled` transport error is client-owned; deadline/timeout remains provider-owned; a real final upstream 5xx remains provider-owned; an older failover 5xx followed by terminal cancel is client-owned; the reverse ordering remains provider-owned; and a final 499 remains client-owned even with earlier upstream events. Dropping these lets an upstream merge silently revert the quad-P0 fix or reintroduce failover-history pollution."
     },
     {
-      "path": "backend/internal/handler/gateway_handler.go",
+      "path": "backend/internal/handler/gateway_handler_tk_forward_error.go",
       "must_contain": [
-        "func (h *GatewayHandler) ensureForwardErrorResponse(c *gin.Context, streamStarted bool) bool",
         "func (h *GatewayHandler) ensureForwardErrorResponseForError(c *gin.Context, err error, streamStarted bool) bool",
         "if isClientClosedRequest(c, err) {",
         "markClientClosedForwardRequest(c)"
@@ -6237,9 +6236,9 @@
       "rationale": "TK channel pricing restriction companion: pre-scheduling model restriction checks based on channel-level pricing configuration. Extracted from gateway_service.go to reduce upstream merge surface. Forward and ForwardCountTokens call checkChannelPricingRestriction; dropping the companion breaks compilation."
     },
     {
-      "path": "backend/internal/handler/gateway_handler.go",
+      "path": "backend/internal/handler/gateway_handler_tk_usage.go",
       "must_contain": [
-        "g.Go(func() error { usageData = h.buildUsageData(gctx, apiKey.ID); return nil })"
+        "g.Go(func() error { usageData = h.buildUsageData(gctx, apiKeyID); return nil })"
       ],
       "rationale": "GatewayHandler.Usage (/key-usage) perf fix: three query groups must run concurrently via errgroup. Reverting to sequential best-effort blocks restores prod TTFB with identical response bytes. Sibling perf-query-shape sentinel pins the same shape; this entry satisfies the gateway-tk registry update gate when the upstream-shaped handler is edited with deletions."
     },
@@ -6617,9 +6616,9 @@
       "rationale": "A classified internal relay empty-pool response must preserve request-local exclusions at terminal selection exhaustion; clearing them retries the same relay and can manufacture the three-hit cooldown inside one client request."
     },
     {
-      "path": "backend/internal/handler/gateway_handler.go",
+      "path": "backend/internal/handler/gateway_handler_tk_forward_error.go",
       "must_contain": [
-        "failoverErr.ClientStatusCode > 0",
+        "failoverErr.ClientStatusCode <= 0",
         "failoverErr.ResponseHeaders.Get(\"Retry-After\")",
         "failoverErr.ClientMessage"
       ],
@@ -7152,7 +7151,7 @@
       "rationale": "Codex discovery may reuse an upstream manifest only as a schema template. Automatic keys must return a native empty manifest for a genuine no-capability set, otherwise filter models[] to capability-authorized slugs while preserving unknown manifest fields; removing either projection turns an empty business set into 503 or advertises every upstream model."
     },
     {
-      "path": "backend/internal/handler/gateway_handler.go",
+      "path": "backend/internal/handler/gateway_handler_tk_model_list.go",
       "must_contain": [
         "requestLogger(c, \"gateway.models\", zap.String(\"protocol\", string(protocol))).Warn(\"capability_discovery_failed\", zap.Error(err))",
         "requestLogger(c, \"gateway.antigravity_models\", zap.String(\"protocol\", string(service.UniversalProtocolAntigravity))).Warn(\"capability_discovery_failed\", zap.Error(err))"

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -210,7 +210,7 @@
     },
     {
       "rationale": "Load-bearing wiring for the local Anthropic tool-context guard on both OAuth and API-key passthrough forwarding/count_tokens paths. The companion helper alone is insufficient; if these gateway_service.go call sites are dropped, corrupt user/tool_result continuations will bypass local validation and hit upstream accounts again.",
-      "path": "backend/internal/service/gateway_anthropic_passthrough.go",
+      "path": "backend/internal/service/gateway_anthropic_passthrough_tk.go",
       "must_contain": [
         "s.tkRejectInvalidAnthropicToolContext(ctx, c, account, input.Body, s.tkRequiresClaudeCodeSystemSurface(ctx, c, account), true)"
       ]
@@ -274,11 +274,24 @@
         "tryGeminiCodeAssistApplyModelRateLimit(ctx, account, body)",
         "detail.Get(\"retryDelay\").String()",
         "detail.Get(\"metadata.retryDelay\").String()",
-        "TK: See upstream Wei-Shaw/sub2api#641",
-        "if account.Type == AccountTypeOAuth {",
         "TkEnrichForbiddenMessage("
       ],
       "rationale": "Code Assist 429 fallback-model protection depends on upstream-file hooks plus precise reset-delay extraction. Forwarding must store resolved upstream Gemini model in context, upstream 429 handling must delegate to the TK companion before account-level SetRateLimited, and ParseGeminiRateLimitResetTime must keep structured RetryInfo retryDelay parsing. Dropping any of these reintroduces whole-account long cooldown when upstream already provides a short retry window. The handleGeminiUpstreamError fallback branch must route all Gemini OAuth accounts (google_one + aistudio OAuth + code_assist) through tier cooldown — only API Key accounts may fall through to PST-midnight reset (see upstream #641). Also locks the TkEnrichForbiddenMessage hook in writeGeminiMappedError's case-403 branch so the 403 client message keeps body-size context instead of regressing to the unhelpful default."
+    },
+    {
+      "path": "backend/internal/service/gemini_messages_compat_service_tk_oauth_cooldown.go",
+      "must_contain": [
+        "func (s *GeminiMessagesCompatService) tkGeminiDefaultRateLimitResetAt(",
+        "Wei-Shaw/sub2api#641"
+      ],
+      "rationale": "Code Assist 429 fallback-model protection depends on upstream-file hooks plus precise reset-delay extraction. Forwarding must store resolved upstream Gemini model in context, upstream 429 handling must delegate to the TK companion before account-level SetRateLimited, and ParseGeminiRateLimitResetTime must keep structured RetryInfo retryDelay parsing. Dropping any of these reintroduces whole-account long cooldown when upstream already provides a short retry window. The handleGeminiUpstreamError fallback branch must route all Gemini OAuth accounts (google_one + aistudio OAuth + code_assist) through tier cooldown — only API Key accounts may fall through to PST-midnight reset (see upstream #641). Also locks the TkEnrichForbiddenMessage hook in writeGeminiMappedError's case-403 branch so the 403 client message keeps body-size context instead of regressing to the unhelpful default. (oauth cooldown companion)"
+    },
+    {
+      "path": "backend/internal/service/gemini_messages_compat_service.go",
+      "must_contain": [
+        "s.tkGeminiDefaultRateLimitResetAt("
+      ],
+      "rationale": "Thin Gemini OAuth 429 default-reset call site."
     },
     {
       "path": "backend/internal/service/gemini_relay_model_tk.go",
@@ -497,12 +510,6 @@
         "anthropicCooldownTierLadder",
         "anthropicCooldownTierTTLMinutes",
         "anthropicCooldownTierEscalationsWindowMinutes",
-        "openAICloudflareChallengeKeywords",
-        "openai_403_cf_challenge_skip_cooldown",
-        "openAIIsHTMLBody",
-        "openai_403_html_body_skip_cooldown",
-        "tkIsOpenAIClientInducedCapability403(upstreamMsg, responseBody)",
-        "openai_403_client_induced_capability_skip_cooldown",
         "handleAnthropicUpstreamError(",
         "handleAnthropicUpstreamErrorWithOptions",
         "tkAnthropicStubHealthFuseEligible",
@@ -519,18 +526,95 @@
         "planGatedModel := isOpenAIOAuthAccount(account) && isOpenAICodexPlanGatedModelError(statusCode, responseBody)",
         "if !cloudwiseModelBalance402 && !planGatedModel && !account.ShouldHandleErrorCode(statusCode) && account.Platform != PlatformAnthropic {",
         "s.ResetAnthropicUpstreamErrorCounter(ctx, accountID)",
-        "s.tkDisableIfOAuth401OnValidToken(ctx, authAccount, upstreamMsg)",
-        "oauth_401_immediate_disable",
         "case 413:",
         "anthropic_request_too_large_skip_penalty",
+        "s.notifyAccountRecovered(accountID)",
+        "s.tkTryHandleUpstreamErrorPrelude(",
+        "s.tkHandleAuth401(",
+        "s.tkHandleNonOpenAI403(",
+        "s.tkOpenAI403PrePenaltyGates(",
+        "s.tkTryHandle429Extras("
+      ],
+      "rationale": "Anthropic model-not-found 404s are CLIENT errors (a model name no account serves — Anthropic's catalog is global, not per-account) and must SKIP the account penalty (slog `anthropic_model_not_found_skip_penalty`, return false → shouldDisable=false, no UpstreamFailoverError wrap) so one bad-model client cannot cool accounts and drain a thin edge pool into 'No available accounts' 429s; the gateway then surfaces a 400 'Unsupported model' to the client (path B, prod P0 2026-06-06 edge us5). An upstream merge that re-adds SetModelRateLimit on this 404 path reintroduces the amplifier. Anthropic 429s without reset metadata must use the configurable short cooldown unless the body is the known third-party/extra-usage rejection, otherwise production can repeatedly hit the same account with no local backoff. Anthropic upstream errors must feed the TK short-window counter (anchored by `anthropicUpstreamErrorWindowMinutes` — intentionally short at 1 minute so transient bursts clear quickly) and mark the account temporarily unschedulable after three hits so a single bad Edge/OAuth account cannot produce repeated upstream 400/403/5xx responses before the scheduler removes it. **Pool-mode policy (2026-05-21 revision of PR #333, anchored by `anthropicCooldownTierLadder`)**: the prior PR #333 carve-out (which let pool_mode accounts early-return before the counter via `anthropic_upstream_error_pool_mode_skipped`) is removed. PR #333's blanket immunity left ops with no mechanical signal that a stub was failing, leaving cc-edges (single-member exclusive group) vulnerable to silently routing all traffic to a dead upstream pool. The replacement is **tiered exponential cooldown**: first cooldown in a 30-min window is 30s (transient jitter shrugged off without the 10-min outage that motivated PR #248's reversal), second is 2 min, third+ is 10 min. The two carve-outs on `HandleUpstreamError` entry (`account.Platform != PlatformAnthropic` on both the pool-mode early-return AND the custom-error-codes allowlist guard) MUST stay so Anthropic 4xx/5xx still enter the dispatch — without them an upstream merge that 'simplifies' the early-returns would silently restore PR #333's broken immunity. `IncrementAnthropicCooldownTier` and `ResetAnthropicCooldownTier` are anchored separately because they are the load-bearing seams for tier escalation; a Redis client refactor that drops them would silently collapse the ladder back to a fixed 30s cooldown. The `ResetAnthropicUpstreamErrorCounter` call MUST be invoked from recovery hotpaths (ClearRateLimit, RecoverAccountState, ClearTempUnschedulable, UpdateSessionWindow allowed status) so a healed account does not carry stale strikes OR stale tier escalation. OpenAI burst 429s (Codex headers present but neither 5h nor 7d window at 100% used+with-reset) must call the TK companion TkRecordOpenAI429BurstFallthrough and return nil so handle429 falls back to the short cooldown, otherwise transient throttle surges turn into multi-day 503 windows (upstream #2258). Upstream merges in this large service file can compile cleanly while dropping any of these protections, so the sentinel anchors all policies in the hotspot file. **G1 (413 / request_too_large)**: `case 413:` short-circuits an upstream request_too_large for Anthropic (slog `anthropic_request_too_large_skip_penalty`) so an oversized request that cleared TokenKey's local body-limit but exceeded Anthropic's own cap fails back to the client without advancing the 3/3 ladder — a client looping 300KB+ sessions must not be able to cool a shared OAuth account. Dropping the case lets request_too_large fall into the default 4xx-5xx branch and silently re-arm the amplifier. **G2 (narrow — downstream failover-exhausted)**: `tkSkipDownstreamFailoverExhaustedPenalty` (slog `anthropic_downstream_failover_exhausted_skip_penalty`) extends the no-available skip to TokenKey's own 'all available accounts exhausted' downstream capacity envelope; it matches ONLY that TokenKey-generated phrase, so raw edge-infra 5xx and genuine provider errors still count and keep the PR #333 route-away cooldown. Removing either hook silently regresses the corresponding non-account amplification exemption. **Recovery notify**: `notifyAccountSchedulingBlockCleared`(ClearRateLimit/RecoverAccountState 的账号真实清除汇聚点)末尾调 `s.notifyAccountRecovered(accountID)` 发飞书恢复绿卡(事件驱动)。删掉该行 → 账号恢复无任何飞书通知,恢复链路断裂。 **G3 (non-authoritative 429)**: 无 anthropic-ratelimit-* 头的 429 是 edge 的 header-less capacity/failover 信封('Upstream rate limit exceeded, please retry later' 等),不是真窗口限流(真窗口限流一定带头);case-429 调 `tkIsAnthropicNonAuthoritative429`(无条件,无开关)不冷却不喂阶梯(slog `anthropic_non_authoritative_429_skip_penalty`),泛化 no-available / failover-exhausted 两个 needle 跳过 —— 删掉它会重新点燃把健康镜像(cc-us7,2026-06-13 23:11 tier-0 30s)冷却的放大器。详见 ratelimit_service_tk_nonauthoritative_429.go。 Kiro invalid-bearer 403 handling must stay wired into handle403 before the generic SetError fallback; the companion helper alone is insufficient if this call site is dropped."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_openai_403_gate.go",
+      "must_contain": [
+        "func (s *RateLimitService) tkOpenAI403PrePenaltyGates(",
+        "openAICloudflareChallengeKeywords",
+        "openai_403_cf_challenge_skip_cooldown",
+        "openAIIsHTMLBody",
+        "openai_403_html_body_skip_cooldown",
+        "tkIsOpenAIClientInducedCapability403(upstreamMsg, responseBody)",
+        "openai_403_client_induced_capability_skip_cooldown"
+      ],
+      "rationale": "OpenAI 403 pre-penalty gates companion: CF/Arkose keyword skip, client-induced capability skip, and HTML body skip must stay wired before the consecutive-403 counter. Extracted from handleOpenAI403; thin call site remains in ratelimit_service.go via tkOpenAI403PrePenaltyGates."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_auth401.go",
+      "must_contain": [
+        "func (s *RateLimitService) tkHandleAuth401(",
+        "s.tkDisableIfOAuth401OnValidToken(ctx, authAccount, upstreamMsg)",
+        "oauth_401_immediate_disable",
+        "tkIsPermanentOpenAIAuth401(responseBody)",
+        "tkIsCapabilityScope401(statusCode, responseBody)",
+        "capability_scope_401_skip_penalty",
+        "IsOpenAICompatModelNotFound404(responseBody, upstreamMsg)",
+        "newapi_model_not_found_401_skip_auth_penalty",
+        "tkSkipDownstreamKiroOAuthAuthRejectPenalty(account, statusCode, upstreamMsg, responseBody)",
+        "anthropic_downstream_kiro_oauth_401_skip_penalty",
+        "s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, \"kiro_oauth_401\")"
+      ],
+      "rationale": "HandleUpstreamError case 401 companion. Capability-scope / newapi model-not-found skips, Kiro mirror OAuth 401 skip, Anthropic OAuth immediate disable, permanent OpenAI 401, and valid-token revoke gate must stay ordered before SetError / temp_unschedulable. Thin call site: s.tkHandleAuth401 in ratelimit_service.go."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_handle403.go",
+      "must_contain": [
+        "func (s *RateLimitService) tkHandleNonOpenAI403(",
+        "s.tkMaybeRefreshKiroInvalidBearer403(ctx, account, upstreamMsg, responseBody)",
+        "tkSkipDownstreamKiroOAuthAuthRejectPenalty(account, http.StatusForbidden, upstreamMsg, responseBody)",
+        "anthropic_downstream_kiro_oauth_403_skip_penalty",
+        "s.recordAnthropicStubSaturation(ctx, account.ID, http.StatusForbidden, \"kiro_oauth_403\")",
+        "tkSkipRelayedCanonicalIngressRejectPenalty(http.StatusForbidden, upstreamMsg, responseBody)",
+        "if s.tkTryDisableAnthropicOrgBan403(ctx, account, upstreamMsg, responseBody) {",
+        "if s.tkTryDisableAnthropicTLSFingerprint403(ctx, account, upstreamMsg, responseBody) {",
+        "if s.tkTryEscalatePersistentBodyless403(ctx, account, upstreamMsg, responseBody) {",
+        "if tkIsAnthropicAccountAuthFatal403(upstreamMsg, responseBody) {",
+        "s.recordAnthropicStubSaturation(ctx, account.ID, http.StatusForbidden, \"permission_failover\")"
+      ],
+      "rationale": "Non-OpenAI/CN handle403 companion after OpenAI/CN returns. Kiro invalid-bearer refresh, Kiro mirror OAuth 403 skip, canonical-ingress reject skip, org-ban/TLS/bodyless/fatal Anthropic 403, and permission_failover saturation must stay ordered. Thin call site: s.tkHandleNonOpenAI403."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_handle429_extras.go",
+      "must_contain": [
+        "func (s *RateLimitService) tkTryHandle429Extras(",
         "tkSkipDownstreamFailoverExhaustedPenalty",
         "anthropic_downstream_failover_exhausted_skip_penalty",
         "tkIsAnthropicNonAuthoritative429(headers, responseBody)",
         "tkLogAnthropicNonAuthoritative429Skip(account, statusCode)",
-        "s.notifyAccountRecovered(accountID)",
-        "s.tkMaybeRefreshKiroInvalidBearer403(ctx, account, upstreamMsg, responseBody)"
+        "tkSkipDownstreamNoAvailableAccountsPenalty(statusCode, upstreamMsg, responseBody)",
+        "anthropic_downstream_no_available_accounts_skip_penalty",
+        "anthropic_request_owned_429_skip_penalty",
+        "tkSkipDownstreamKiroServiceUnavailablePenalty(account, statusCode, upstreamMsg, responseBody)",
+        "anthropic_downstream_kiro_service_unavailable_skip_penalty",
+        "s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, \"kiro_service_unavailable\")",
+        "s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, \"no_available_accounts\")",
+        "s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, \"all_available_accounts_exhausted\")",
+        "s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, \"non_authoritative_429\")"
       ],
-      "rationale": "Anthropic model-not-found 404s are CLIENT errors (a model name no account serves — Anthropic's catalog is global, not per-account) and must SKIP the account penalty (slog `anthropic_model_not_found_skip_penalty`, return false → shouldDisable=false, no UpstreamFailoverError wrap) so one bad-model client cannot cool accounts and drain a thin edge pool into 'No available accounts' 429s; the gateway then surfaces a 400 'Unsupported model' to the client (path B, prod P0 2026-06-06 edge us5). An upstream merge that re-adds SetModelRateLimit on this 404 path reintroduces the amplifier. Anthropic 429s without reset metadata must use the configurable short cooldown unless the body is the known third-party/extra-usage rejection, otherwise production can repeatedly hit the same account with no local backoff. Anthropic upstream errors must feed the TK short-window counter (anchored by `anthropicUpstreamErrorWindowMinutes` — intentionally short at 1 minute so transient bursts clear quickly) and mark the account temporarily unschedulable after three hits so a single bad Edge/OAuth account cannot produce repeated upstream 400/403/5xx responses before the scheduler removes it. **Pool-mode policy (2026-05-21 revision of PR #333, anchored by `anthropicCooldownTierLadder`)**: the prior PR #333 carve-out (which let pool_mode accounts early-return before the counter via `anthropic_upstream_error_pool_mode_skipped`) is removed. PR #333's blanket immunity left ops with no mechanical signal that a stub was failing, leaving cc-edges (single-member exclusive group) vulnerable to silently routing all traffic to a dead upstream pool. The replacement is **tiered exponential cooldown**: first cooldown in a 30-min window is 30s (transient jitter shrugged off without the 10-min outage that motivated PR #248's reversal), second is 2 min, third+ is 10 min. The two carve-outs on `HandleUpstreamError` entry (`account.Platform != PlatformAnthropic` on both the pool-mode early-return AND the custom-error-codes allowlist guard) MUST stay so Anthropic 4xx/5xx still enter the dispatch — without them an upstream merge that 'simplifies' the early-returns would silently restore PR #333's broken immunity. `IncrementAnthropicCooldownTier` and `ResetAnthropicCooldownTier` are anchored separately because they are the load-bearing seams for tier escalation; a Redis client refactor that drops them would silently collapse the ladder back to a fixed 30s cooldown. The `ResetAnthropicUpstreamErrorCounter` call MUST be invoked from recovery hotpaths (ClearRateLimit, RecoverAccountState, ClearTempUnschedulable, UpdateSessionWindow allowed status) so a healed account does not carry stale strikes OR stale tier escalation. OpenAI burst 429s (Codex headers present but neither 5h nor 7d window at 100% used+with-reset) must call the TK companion TkRecordOpenAI429BurstFallthrough and return nil so handle429 falls back to the short cooldown, otherwise transient throttle surges turn into multi-day 503 windows (upstream #2258). Upstream merges in this large service file can compile cleanly while dropping any of these protections, so the sentinel anchors all policies in the hotspot file. **G1 (413 / request_too_large)**: `case 413:` short-circuits an upstream request_too_large for Anthropic (slog `anthropic_request_too_large_skip_penalty`) so an oversized request that cleared TokenKey's local body-limit but exceeded Anthropic's own cap fails back to the client without advancing the 3/3 ladder — a client looping 300KB+ sessions must not be able to cool a shared OAuth account. Dropping the case lets request_too_large fall into the default 4xx-5xx branch and silently re-arm the amplifier. **G2 (narrow — downstream failover-exhausted)**: `tkSkipDownstreamFailoverExhaustedPenalty` (slog `anthropic_downstream_failover_exhausted_skip_penalty`) extends the no-available skip to TokenKey's own 'all available accounts exhausted' downstream capacity envelope; it matches ONLY that TokenKey-generated phrase, so raw edge-infra 5xx and genuine provider errors still count and keep the PR #333 route-away cooldown. Removing either hook silently regresses the corresponding non-account amplification exemption. **Recovery notify**: `notifyAccountSchedulingBlockCleared`(ClearRateLimit/RecoverAccountState 的账号真实清除汇聚点)末尾调 `s.notifyAccountRecovered(accountID)` 发飞书恢复绿卡(事件驱动)。删掉该行 → 账号恢复无任何飞书通知,恢复链路断裂。 **G3 (non-authoritative 429)**: 无 anthropic-ratelimit-* 头的 429 是 edge 的 header-less capacity/failover 信封('Upstream rate limit exceeded, please retry later' 等),不是真窗口限流(真窗口限流一定带头);case-429 调 `tkIsAnthropicNonAuthoritative429`(无条件,无开关)不冷却不喂阶梯(slog `anthropic_non_authoritative_429_skip_penalty`),泛化 no-available / failover-exhausted 两个 needle 跳过 —— 删掉它会重新点燃把健康镜像(cc-us7,2026-06-13 23:11 tier-0 30s)冷却的放大器。详见 ratelimit_service_tk_nonauthoritative_429.go。 Kiro invalid-bearer 403 handling must stay wired into handle403 before the generic SetError fallback; the companion helper alone is insufficient if this call site is dropped."
+      "rationale": "HandleUpstreamError case-429 early-skip companion: request-owned, no-available, failover-exhausted, Kiro service-unavailable, and non-authoritative envelope skips must stay before handle429 + stub-health fuse. Thin call site: s.tkTryHandle429Extras."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_upstream_error_prelude.go",
+      "must_contain": [
+        "func (s *RateLimitService) tkTryHandleUpstreamErrorPrelude(",
+        "IsForeignCredentialOfficialOpenAIReject(account, statusCode, responseBody)",
+        "foreign_credential_official_openai_reject_skip_penalty",
+        "s.tkTryCloudwiseModelBalanceCooldown(ctx, account, statusCode, responseBody, requestedModel)",
+        "s.tkTryCloudwiseProvider424Cooldown(ctx, account, statusCode, responseBody, requestedModel)",
+        "tkTryHandleStandingBilling"
+      ],
+      "rationale": "HandleUpstreamError top early-return companion: foreign-credential official-OpenAI reject, OpenAI-compat downstream capacity, CloudWise 402/424, and standing billing must beat pool-mode / custom-error / temp-unschedulable exits. Thin call site: s.tkTryHandleUpstreamErrorPrelude; cloudwiseModelBalance402 is recomputed in ratelimit_service.go for carve-outs."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_nonauthoritative_429.go",
@@ -698,17 +782,11 @@
     {
       "path": "backend/internal/service/ratelimit_service.go",
       "must_contain": [
-        "tkSkipDownstreamKiroOAuthAuthRejectPenalty(account, statusCode, upstreamMsg, responseBody)",
-        "tkSkipDownstreamKiroOAuthAuthRejectPenalty(account, http.StatusForbidden, upstreamMsg, responseBody)",
-        "tkSkipDownstreamKiroServiceUnavailablePenalty(account, statusCode, upstreamMsg, responseBody)",
-        "anthropic_downstream_kiro_oauth_401_skip_penalty",
-        "anthropic_downstream_kiro_oauth_403_skip_penalty",
-        "anthropic_downstream_kiro_service_unavailable_skip_penalty",
-        "s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, \"kiro_oauth_401\")",
-        "s.recordAnthropicStubSaturation(ctx, account.ID, http.StatusForbidden, \"kiro_oauth_403\")",
-        "s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, \"kiro_service_unavailable\")"
+        "s.tkHandleAuth401(",
+        "s.tkHandleNonOpenAI403(",
+        "s.tkTryHandle429Extras("
       ],
-      "rationale": "G5/G6 Kiro mirror downstream-failure injection points. The 401 branch must run before the generic API-key SetError path, the 403 branch before handle403's generic ladder / permanent-disable checks, and the exact service-unavailable 502 branch before handleAnthropicUpstreamError advances the 3/3 fuse. These relayed edge-owned failures must fail over and feed bounded mirror de-prioritization while leaving prod mirror stub health untouched. If an upstream merge rewrites any call site, edge self-heal can clear the real account while prod keeps a stale SetError/ladder cooldown or collapses every Kiro mirror relay."
+      "rationale": "G5/G6 Kiro mirror downstream-failure injection points (call-site anchors). 401/403/502 skip bodies live in ratelimit_service_tk_auth401.go / ratelimit_service_tk_handle403.go / ratelimit_service_tk_handle429_extras.go; these thin call sites in the upstream-shaped file must remain so an upstream merge cannot drop the wiring. Detailed needles are anchored on the companions."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go",
@@ -935,15 +1013,9 @@
       "path": "backend/internal/service/gateway_forward.go",
       "must_contain": [
         "GetOrCreateFingerprint(ctx, account.ID, clientHeaders, resolveTLSProfileNameForAccount(s.tlsFPProfileService, account))",
-        "checkCanonicalIngressUA(c.Request.Header)",
-        "groupAdmitsNonCC := s.tkGroupAdmitsNonCC(ctx, parsed)",
-        "} else if !groupAdmitsNonCC {",
         "IsAnthropicCanonicalHaikuMimicryEnabled(ctx) || groupAdmitsNonCC)",
-        "s.settingService.IsAnthropicCanonicalIngressStrictEnabled(ctx)",
         "s.settingService.IsAnthropicCanonicalHaikuMimicryEnabled(ctx)",
         "shouldRewriteSystemForNonCCMimicry(reqModel, canonicalHaikuMimicry)",
-        "checkCanonicalIngressUAStrict(c.Request.Header)",
-        "remapDeprecatedOpusOnCanonical(reqModel)",
         "filteredBody := FilterThinkingBlocksForRetry(body, reqModel)",
         "parseRejectedAnthropicBetas(respBody)"
       ],
@@ -951,6 +1023,18 @@
         "x-stainless-helper-method"
       ],
       "rationale": "Main gateway upstream builders must invoke unified TK Claude session-header sync after API-key passthrough, OAuth forward, count_tokens forward, and Vertex Anthropic forward paths diverge upstream merge conflicts. Sticky-source sink event emission is also load-bearing for prod request_id/client_request_id evidence correlation. TLS fingerprint profile resolution must pass through the ops helper so upstream_errors JSON records the profile id/name used by failed Anthropic OAuth attempts; otherwise Node24/Node25 candidate canaries cannot be attributed after a profile switch. Claude Code OAuth mimicry must preserve captured real CLI User-Agent/X-Stainless fingerprint values and only fill missing defaults; reverting to unconditional defaults reintroduces version downgrade/header fingerprint drift. API Key passthrough must keep its guarded thinking-shape 400 self-heal retries that record passthrough ops evidence and rewrite the body before surfacing the error; dropping any makes GPT专线 → cc-edges group switches expose Anthropic 400s to clients. Three one-shot guarded retries (each gated by its own attempted-flag): (1) thinking-signature — downgrades stale cross-upstream thinking blocks via FilterThinkingBlocksForRetry; (2) budget-constraint — RectifyThinkingBudget(input.Body, modelForRepair) when isThinkingBudgetConstraintError matches and IsBudgetRectifierEnabled; (3) Opus 4.7+ adaptive-required — RectifyThinkingTypeAdaptive when isThinkingTypeAdaptiveRequiredError matches AND isOpus47OrNewer(modelForRepair), since opus-4.7/4.8 reject thinking.type=enabled with a 400 (CC #61348). (2) and (3) bring the passthrough path to parity with the main Forward() 400-repair ladder; the model gate reads the model from wireBody (the body that actually 400'd). Dropping (2)/(3) silently regresses passthrough opus-4.7 sessions back to hard 400s. The obsolete x-stainless-helper-method header must stay absent because current real Claude Code traffic does not emit it and reintroducing it increases OAuth fingerprint risk. Haiku 4.5 context_management auto-injection must stay exempt (upstream #2506): Anthropic rejects context_management for claude-haiku-4-5-* with HTTP 400 even when thinking.type is enabled, and the body rewrite must mirror the existing Haiku exemption in the anthropic-beta header path. count_tokens forwarding must pre-strip Anthropic-unsupported top-level fields (temperature/top_p/top_k/stop_sequences/max_tokens/stream/metadata/service_tier/context_management) AND must run a second silent strip AFTER normalizeClaudeOAuthRequestBody injects mimic defaults (temperature=1 / max_tokens=128000 / context_management=...); without this second strip, OAuth-account count_tokens still 400s because normalize undoes the early sanitize (2026-05-18 09:10:30 prod trace). The breaker-exempt clause (anchor `tkCountTokensSkipBreaker(resp.StatusCode)`, defined in gateway_service_tk_count_tokens_failover.go) excludes count_tokens 400 AND the capacity statuses 429/529/503 from the anthropic_upstream_error breaker — both ForwardCountTokens and the API-key passthrough variant call it. 400 exemption stops a single client schema bug from accumulating to threshold and tripping `anthropic_upstream_error_temp_unschedulable` (2026-05-18 cc-us1-oauth → group cc-edges incident). 429/529/503 exemption stops a single transient upstream overload on this precheck endpoint from marking the busy account overload_until/temp_unschedulable +10m while an idle schedulable account sits unused (2026-06-02 edge us1: acct1 罚下 / acct4 空闲); 503 (pool stub prod→edge 'no available accounts') is the same transient capacity class and is now aligned with the main /v1/messages path, whose shouldFailoverUpstreamError fails over on >=500 — without the 503 exemption count_tokens would penalize the main account on a downstream pool-exhaustion blip that the failover loop should simply rotate past. Rotation on these statuses is the count_tokens failover loop's job (gateway_handler_tk_count_tokens_failover.go) via the shared tkCountTokensFailoverError helper, not a breaker write — count_tokens returns *UpstreamFailoverError for failover-eligible statuses instead of writing the client response; if tkCountTokensSkipBreaker narrows back below {400,429,529,503}, count_tokens reverts to penalizing the main account on transient overload. OAuth-401-revocation guard: the 401 branch calls `tkDisableIfOAuth401OnValidToken(ctx, account, upstreamMsg)` before the temp_unschedulable cooldown — a 401 on a still-valid (not near-expiry) access token is treated as an upstream grant revocation and SetError'd on the first strike (manual re-authorization), while an expired/near-expiry token 401 falls through to the cooldown + background-refresh self-heal. See the dedicated ratelimit_service_tk_oauth401.go sentinel for the companion logic."
+    },
+    {
+      "path": "backend/internal/service/gateway_forward_tk.go",
+      "must_contain": [
+        "checkCanonicalIngressUA(c.Request.Header)",
+        "groupAdmitsNonCC = s.tkGroupAdmitsNonCC(ctx, parsed)",
+        "} else if !groupAdmitsNonCC {",
+        "s.settingService.IsAnthropicCanonicalIngressStrictEnabled(ctx)",
+        "checkCanonicalIngressUAStrict(c.Request.Header)",
+        "remapDeprecatedOpusOnCanonical(reqModel)"
+      ],
+      "rationale": "Main gateway upstream builders must invoke unified TK Claude session-header sync after API-key passthrough, OAuth forward, count_tokens forward, and Vertex Anthropic forward paths diverge upstream merge conflicts. Sticky-source sink event emission is also load-bearing for prod request_id/client_request_id evidence correlation. TLS fingerprint profile resolution must pass through the ops helper so upstream_errors JSON records the profile id/name used by failed Anthropic OAuth attempts; otherwise Node24/Node25 candidate canaries cannot be attributed after a profile switch. Claude Code OAuth mimicry must preserve captured real CLI User-Agent/X-Stainless fingerprint values and only fill missing defaults; reverting to unconditional defaults reintroduces version downgrade/header fingerprint drift. API Key passthrough must keep its guarded thinking-shape 400 self-heal retries that record passthrough ops evidence and rewrite the body before surfacing the error; dropping any makes GPT专线 → cc-edges group switches expose Anthropic 400s to clients. Three one-shot guarded retries (each gated by its own attempted-flag): (1) thinking-signature — downgrades stale cross-upstream thinking blocks via FilterThinkingBlocksForRetry; (2) budget-constraint — RectifyThinkingBudget(input.Body, modelForRepair) when isThinkingBudgetConstraintError matches and IsBudgetRectifierEnabled; (3) Opus 4.7+ adaptive-required — RectifyThinkingTypeAdaptive when isThinkingTypeAdaptiveRequiredError matches AND isOpus47OrNewer(modelForRepair), since opus-4.7/4.8 reject thinking.type=enabled with a 400 (CC #61348). (2) and (3) bring the passthrough path to parity with the main Forward() 400-repair ladder; the model gate reads the model from wireBody (the body that actually 400'd). Dropping (2)/(3) silently regresses passthrough opus-4.7 sessions back to hard 400s. The obsolete x-stainless-helper-method header must stay absent because current real Claude Code traffic does not emit it and reintroducing it increases OAuth fingerprint risk. Haiku 4.5 context_management auto-injection must stay exempt (upstream #2506): Anthropic rejects context_management for claude-haiku-4-5-* with HTTP 400 even when thinking.type is enabled, and the body rewrite must mirror the existing Haiku exemption in the anthropic-beta header path. count_tokens forwarding must pre-strip Anthropic-unsupported top-level fields (temperature/top_p/top_k/stop_sequences/max_tokens/stream/metadata/service_tier/context_management) AND must run a second silent strip AFTER normalizeClaudeOAuthRequestBody injects mimic defaults (temperature=1 / max_tokens=128000 / context_management=...); without this second strip, OAuth-account count_tokens still 400s because normalize undoes the early sanitize (2026-05-18 09:10:30 prod trace). The breaker-exempt clause (anchor `tkCountTokensSkipBreaker(resp.StatusCode)`, defined in gateway_service_tk_count_tokens_failover.go) excludes count_tokens 400 AND the capacity statuses 429/529/503 from the anthropic_upstream_error breaker — both ForwardCountTokens and the API-key passthrough variant call it. 400 exemption stops a single client schema bug from accumulating to threshold and tripping `anthropic_upstream_error_temp_unschedulable` (2026-05-18 cc-us1-oauth → group cc-edges incident). 429/529/503 exemption stops a single transient upstream overload on this precheck endpoint from marking the busy account overload_until/temp_unschedulable +10m while an idle schedulable account sits unused (2026-06-02 edge us1: acct1 罚下 / acct4 空闲); 503 (pool stub prod→edge 'no available accounts') is the same transient capacity class and is now aligned with the main /v1/messages path, whose shouldFailoverUpstreamError fails over on >=500 — without the 503 exemption count_tokens would penalize the main account on a downstream pool-exhaustion blip that the failover loop should simply rotate past. Rotation on these statuses is the count_tokens failover loop's job (gateway_handler_tk_count_tokens_failover.go) via the shared tkCountTokensFailoverError helper, not a breaker write — count_tokens returns *UpstreamFailoverError for failover-eligible statuses instead of writing the client response; if tkCountTokensSkipBreaker narrows back below {400,429,529,503}, count_tokens reverts to penalizing the main account on transient overload. OAuth-401-revocation guard: the 401 branch calls `tkDisableIfOAuth401OnValidToken(ctx, account, upstreamMsg)` before the temp_unschedulable cooldown — a 401 on a still-valid (not near-expiry) access token is treated as an upstream grant revocation and SetError'd on the first strike (manual re-authorization), while an expired/near-expiry token 401 falls through to the cooldown + background-refresh self-heal. See the dedicated ratelimit_service_tk_oauth401.go sentinel for the companion logic. (moved into gateway_forward_tk.go)"
     },
     {
       "path": "backend/internal/service/gateway_upstream_request.go",
@@ -1154,11 +1238,16 @@
       "must_contain": [
         "Wei-Shaw/sub2api#1311",
         "c.Writer.Header().Set(\"Content-Type\", \"application/json\")",
-        "openAICompatSSEFrameParser",
-        "Wei-Shaw/sub2api#1322",
-        "\"response.cancelled\", \"response.canceled\""
+        "openAICompatSSEFrameParser"
       ],
       "rationale": "Non-stream /v1/messages uses the same buffered Responses SSE -> JSON conversion root cause as /v1/chat/completions; it must also override Content-Type after WriteFilteredHeaders so JSON bodies are not labeled text/event-stream. The buffered terminal reader must use openAICompatSSEFrameParser to recognise typed completion events when the stream closes without a standalone [DONE] (upstream PR #2530). isOpenAICompatResponsesTerminalEvent — used by both the Messages and Chat Completions streaming handlers — must keep response.cancelled / response.canceled in its terminal set so legitimate upstream cancellations close the stream cleanly instead of degenerating to 'stream usage incomplete: missing terminal event' (upstream #1322)."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_messages_tk.go",
+      "must_contain": [
+        "\"response.cancelled\", \"response.canceled\""
+      ],
+      "rationale": "Non-stream /v1/messages uses the same buffered Responses SSE -> JSON conversion root cause as /v1/chat/completions; it must also override Content-Type after WriteFilteredHeaders so JSON bodies are not labeled text/event-stream. The buffered terminal reader must use openAICompatSSEFrameParser to recognise typed completion events when the stream closes without a standalone [DONE] (upstream PR #2530). isOpenAICompatResponsesTerminalEvent — used by both the Messages and Chat Completions streaming handlers — must keep response.cancelled / response.canceled in its terminal set so legitimate upstream cancellations close the stream cleanly instead of degenerating to 'stream usage incomplete: missing terminal event' (upstream #1322). (moved)"
     },
     {
       "path": "backend/internal/service/openai_gateway_messages_tk.go",
@@ -1663,7 +1752,7 @@
     },
     {
       "rationale": "Three call sites in upstream-shaped forwarding code that anchor the signature_error preempt feature: (1) the main Anthropic Forward path (~4583) and (3) ForwardCountTokens (~9060) both call applySigPreemptIfArmed on the working body before the first upstream attempt; (2) the Anthropic API-Key passthrough path (~5105) calls applySigPreemptIfArmed on input.Body. armSigPreemptOnError is invoked from all three signature_error detection branches. The struct-field declaration is pinned so upstream merges cannot drop the setter target. If any of these are silently removed, the feature degrades to no-op and the 12-in-4-min burst symptom on a single OAuth account returns.",
-      "path": "backend/internal/service/gateway_anthropic_passthrough.go",
+      "path": "backend/internal/service/gateway_anthropic_passthrough_tk.go",
       "must_contain": [
         "s.applySigPreemptIfArmed(ctx, c, account, input.Body,",
         "s.armSigPreemptOnError(ctx, c, account)"
@@ -1980,7 +2069,7 @@
       "rationale": "Anchors the customer-facing deprecation gate for retired / soon-to-sunset Anthropic model IDs. PR #329 / #327 removed the IDs from admin dropdowns + default chain but did NOT short-circuit requests; this module turns hardcoded-client requests into a friendly 400 + migration suggestion instead of an opaque upstream not_found_error or routing 429 when selection fails before Forward. ErrDeprecatedAnthropicModel + tkDeprecatedAnthropicSelectionFailure pin the account-selection failure path (mixed model_unsupported + unschedulable stats previously fell through to empty-pool 429). TkSelectionNoAvailableAccountsError pins the load-batch empty-pool returns in SelectAccountWithLoadAwareness (PR #1257 gap after #1255). The table literal IDs are pinned because dropping any silently re-opens the cliff for a specific client population. See /xj-review R-001 (decision path c)."
     },
     {
-      "path": "backend/internal/service/gateway_forward.go",
+      "path": "backend/internal/service/gateway_forward_tk.go",
       "must_contain": [
         "TkWriteAnthropicDeprecatedModelError(c, mappedModel, replacement)"
       ],
@@ -2280,10 +2369,9 @@
         "tkIsAnthropicClientInducedBadRequest(responseBody)",
         "s.tkClampOpenAIRateLimitReset(ctx, account.ID",
         "s.tkClampAnthropicWindowReset(ctx, account.ID",
-        "tkSkipDownstreamNoAvailableAccountsPenalty(statusCode, upstreamMsg, responseBody)",
-        "anthropic_downstream_no_available_accounts_skip_penalty"
+        "s.tkTryHandle429Extras("
       ],
-      "rationale": "TK#2608: client-induced Anthropic 400 invalid_request_error must not advance the per-account cooldown counter (else an external caller can pause a shared OAuth subscription account). TK#1981: opt-in clamp of long OpenAI 429 resets so released accounts are re-probed by traffic instead of idling. Prod incident 2026-05-31 / 2026-06: a downstream 503 or 429 whose body is our own 'no available accounts' pool-exhaustion signal (edge empty pool or thin-pool burst, surfaced through a prod per-edge mirror stub) must fail over to the next stub WITHOUT handle429 cooldown, anthropic_upstream_error counter advance, or Feishu digest '限流冷却（429）' — else intentional edge shutdown or a brief edge burst cools the whole stub and collapses the prod pool."
+      "rationale": "TK#2608: client-induced Anthropic 400 invalid_request_error must not advance the per-account cooldown counter (else an external caller can pause a shared OAuth subscription account). TK#1981: opt-in clamp of long OpenAI 429 resets so released accounts are re-probed by traffic instead of idling. Prod incident 2026-05-31 / 2026-06: a downstream 503 or 429 whose body is our own 'no available accounts' pool-exhaustion signal must fail over WITHOUT handle429 cooldown — that skip body now lives in ratelimit_service_tk_handle429_extras.go; this entry anchors the remaining main-file injections plus the thin s.tkTryHandle429Extras call site."
     },
     {
       "path": "backend/internal/service/openai_gateway_service_tk_implicit_throttle.go",
@@ -3230,14 +3318,26 @@
       "rationale": "把 AccountIncidentNotifier 注入 RateLimitService 的 glue：wire ProvideTKAccountIncidentNotifier 在构造后调 SetAccountIncidentNotifier 回填，挂钩点（ratelimit_service.go）经 notifyAccountIncident 转发。notifyAccountRecovered 是恢复绿卡的转发包装，由 notifyAccountSchedulingBlockCleared(ClearRateLimit/RecoverAccountState 真实清除事件)调用。isWholeAccountRuntimeBlockReason is the SSOT predicate for whether notifyAccountSchedulingBlocked also writes the in-memory whole-account runtime blocker (model-scoped 429 reasons excluded).删掉会让挂钩行编译失败或静默 no-op，账号失效/恢复告警链路断裂。"
     },
     {
-      "path": "backend/internal/service/openai_account_scheduler.go",
+      "path": "backend/internal/service/openai_account_scheduler_tk_slot_full_escape.go",
       "must_contain": [
-        "func (s *defaultOpenAIAccountScheduler) stickySlotFullEscapeEnabled",
-        "if stickySel != nil && stickySel.Acquired {",
-        "if stickyWaitPlan && !s.stickySlotFullEscapeEnabled(ctx) {",
-        "if selection != nil && selection.Acquired && selection.Account != nil {"
+        "if stickySel != nil && stickySel.Acquired {"
       ],
       "rationale": "TK #2859 sticky slot-full escape (OpenAI/newapi advanced scheduler). Upstream selectBySessionHash returns a WaitPlan unconditionally when the sticky-bound account's concurrency slot is full, trapping the user on a busy account even when free accounts exist. The caller now dispatches on result.Acquired: sticky slot acquired -> return sticky (happy path, cache-optimal, zero added cost); slot full -> try load-balance FIRST and escape to a free (Acquired) account; only when the whole pool is full fall back to the sticky WaitPlan (cache still warm). Gated by gateway.sticky_routing.slot_full_escape_enabled (default true, fail-open) for instant rollback. These anchors keep an upstream merge from silently reverting the Acquired-based dispatch back to upstream's immediate-WaitPlan trap. anthropic main gateway path is intentionally NOT changed (it already escapes on wait_queue_full). See docs/approved/sticky-routing.md §11.5."
+    },
+    {
+      "path": "backend/internal/service/openai_account_scheduler.go",
+      "must_contain": [
+        "if selection != nil && selection.Acquired && selection.Account != nil {"
+      ],
+      "rationale": "TK #2859 sticky slot-full escape (OpenAI/newapi advanced scheduler). Upstream selectBySessionHash returns a WaitPlan unconditionally when the sticky-bound account's concurrency slot is full, trapping the user on a busy account even when free accounts exist. The caller now dispatches on result.Acquired: sticky slot acquired -> return sticky (happy path, cache-optimal, zero added cost); slot full -> try load-balance FIRST and escape to a free (Acquired) account; only when the whole pool is full fall back to the sticky WaitPlan (cache still warm). Gated by gateway.sticky_routing.slot_full_escape_enabled (default true, fail-open) for instant rollback. These anchors keep an upstream merge from silently reverting the Acquired-based dispatch back to upstream's immediate-WaitPlan trap. anthropic main gateway path is intentionally NOT changed (it already escapes on wait_queue_full). See docs/approved/sticky-routing.md §11.5. (load-balance Acquired dispatch remains in upstream-shaped Select)"
+    },
+    {
+      "path": "backend/internal/service/openai_account_scheduler_tk_slot_full_escape.go",
+      "must_contain": [
+        "func (s *defaultOpenAIAccountScheduler) stickySlotFullEscapeEnabled(ctx context.Context) bool {",
+        "if stickyWaitPlan && !s.stickySlotFullEscapeEnabled(ctx) {"
+      ],
+      "rationale": "TK #2859 sticky slot-full escape (OpenAI/newapi advanced scheduler). Upstream selectBySessionHash returns a WaitPlan unconditionally when the sticky-bound account's concurrency slot is full, trapping the user on a busy account even when free accounts exist. The caller now dispatches on result.Acquired: sticky slot acquired -> return sticky (happy path, cache-optimal, zero added cost); slot full -> try load-balance FIRST and escape to a free (Acquired) account; only when the whole pool is full fall back to the sticky WaitPlan (cache still warm). Gated by gateway.sticky_routing.slot_full_escape_enabled (default true, fail-open) for instant rollback. These anchors keep an upstream merge from silently reverting the Acquired-based dispatch back to upstream's immediate-WaitPlan trap. anthropic main gateway path is intentionally NOT changed (it already escapes on wait_queue_full). See docs/approved/sticky-routing.md §11.5. (moved)"
     },
     {
       "path": "backend/internal/service/setting_service_tk_sticky_routing.go",
@@ -3271,14 +3371,14 @@
       "rationale": "Main ForwardCountTokens local-estimate short-circuit log for non-standard unsupported count_tokens relays."
     },
     {
-      "path": "backend/internal/service/gateway_forward.go",
+      "path": "backend/internal/service/gateway_forward_tk.go",
       "must_contain": [
-        "StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))"
+        "StripEmptyTextBlocks(TkSanitizeRequestBody(getBody(), account))"
       ],
       "rationale": "UTF-8 / lone-surrogate pre-flight self-heal (claude-code #60168 / #63885 / #64777). TkSanitizeRequestBody is wired as the INNER call of the StripEmptyTextBlocks pre-filter on all three Anthropic forward paths (Forward, APIKey passthrough, ForwardCountTokens) so an unpaired UTF-16 surrogate or invalid raw UTF-8 byte (macOS screenshot drag, truncated pasted rune) is repaired to U+FFFD before the request reaches Anthropic, preventing the hard 'str is not valid UTF-8: surrogate code point' 400 that bricks the session. These are one-line wraps in an upstream-shaped file; an upstream merge could silently drop them and re-break the path with zero compile error. Anchor the wrapped call shape (sanitize INNER, strip OUTER — order matters because StripEmptyTextBlocks parses the body as JSON) so the regression is caught at merge time. See docs/gateway-anthropic-utf8-surrogate-self-heal.md."
     },
     {
-      "path": "backend/internal/service/gateway_anthropic_passthrough.go",
+      "path": "backend/internal/service/gateway_anthropic_passthrough_tk.go",
       "must_contain": [
         "StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account))"
       ],
@@ -3401,7 +3501,7 @@
       "rationale": "TokenKey 默认信任 loopback + 私网代理网段，使 gin c.ClientIP() 在 Caddy/nginx/Docker 反代后解析真实客户端 IP（Wei-Shaw/sub2api#1326 / #2410）。真实逻辑在 http_tk_trusted_proxies.go；http.go 仅薄注入一次 tkResolveTrustedProxies 调用。若上游 merge 把此分支回退为 SetTrustedProxies(nil)，按 IP 分桶的认证端点限流（rate_limiter.go）会塌缩成单一 docker 网桥桶、支付审计 IP 失真——此 sentinel 捕获该回退。"
     },
     {
-      "path": "backend/internal/service/gateway_anthropic_passthrough.go",
+      "path": "backend/internal/service/gateway_anthropic_passthrough_tk.go",
       "must_contain": [
         "TkPrefilterToolSearchHistoricalThinking(input.Body, input.RequestModel)",
         "tkApplyAnthropicCCPromptSurfaceNormalize(ctx, c, account, input.Body)"
@@ -3409,14 +3509,14 @@
       "rationale": "Passthrough ToolSearch historical thinking pre-filter and CC prompt-surface normalize split from gateway_service.go."
     },
     {
-      "path": "backend/internal/service/gateway_forward.go",
+      "path": "backend/internal/service/gateway_forward_tk.go",
       "must_contain": [
         "if bare, aliased := tkStripContextWindowModelAlias(reqModel); aliased {"
       ],
       "rationale": "Wiring of the Claude Code [1m] context-window alias strip (claude-code #60913) into the three Anthropic forward paths — Forward + count_tokens (reqModel) and the APIKey passthrough (input.RequestModel). Each is a one-line hook in an upstream-shaped file that compiles clean if dropped, so an upstream merge could silently revert it and re-expose the 404 + silent 200K downgrade. Anchor both call shapes so the regression is caught at merge time; the pure stripper itself is guarded by the gateway_anthropic_context_window_alias_tk.go sentinel."
     },
     {
-      "path": "backend/internal/service/gateway_anthropic_passthrough.go",
+      "path": "backend/internal/service/gateway_anthropic_passthrough_tk.go",
       "must_contain": [
         "if bare, aliased := tkStripContextWindowModelAlias(input.RequestModel); aliased {"
       ],
@@ -3872,9 +3972,8 @@
     {
       "path": "backend/internal/service/ratelimit_service.go",
       "must_contain": [
+        "s.tkTryHandleUpstreamErrorPrelude(",
         "cloudwiseModelBalance402 := tkIsCloudwiseModelBalance402Response(",
-        "s.tkTryCloudwiseModelBalanceCooldown(ctx, account, statusCode, responseBody, firstRequestedModel(requestedModel))",
-        "s.tkTryCloudwiseProvider424Cooldown(ctx, account, statusCode, responseBody, firstRequestedModel(requestedModel))",
         "account.Platform != PlatformAnthropic && !cloudwiseModelBalance402",
         "if !cloudwiseModelBalance402 && !planGatedModel",
         "if len(requestedModel) > 0 && s.tkTryAnthropicModelScopedCooldown(ctx, account, requestedModel[0], result) {",
@@ -4145,10 +4244,16 @@
         "var pendingStreamError *sseStreamErrorEventError",
         "pendingStreamError = &sseStreamErrorEventError{}",
         "pendingStreamError = &sseStreamErrorEventError{RawData: trimmed}",
-        "_ = s.sseStreamErrorFailover(c, account, resp, sseErr, http.StatusBadGateway)",
         "MarkResponseCommitted(c)"
       ],
       "rationale": "Anthropic passthrough must treat upstream event:error (including an event-only frame) or data type=error as the terminal semantic outcome, forward the original SSE frame exactly once, mark the response committed, and reuse sseStreamErrorFailover only as the canonical ops evidence recorder. Losing these anchors turns real Kiro overload errors into misleading missing-terminal 502s or duplicate generic SSE errors."
+    },
+    {
+      "path": "backend/internal/service/gateway_anthropic_passthrough_tk.go",
+      "must_contain": [
+        "_ = s.sseStreamErrorFailover(c, account, resp, sseErr, http.StatusBadGateway)"
+      ],
+      "rationale": "Anthropic passthrough must treat upstream event:error (including an event-only frame) or data type=error as the terminal semantic outcome, forward the original SSE frame exactly once, mark the response committed, and reuse sseStreamErrorFailover only as the canonical ops evidence recorder. Losing these anchors turns real Kiro overload errors into misleading missing-terminal 502s or duplicate generic SSE errors. (moved into gateway_anthropic_passthrough_tk.go companion)"
     },
     {
       "path": "backend/internal/service/gateway_anthropic_apikey_passthrough_test.go",
@@ -4451,9 +4556,9 @@
       "rationale": "Injection chain for the bare family-name fallback: both Messages and CountTokens call TkApplyBareModelAlias at the handler throat — right after the request model is parsed and BEFORE channel mapping / session hash / scheduling / usage recording — gated to the anthropic path via QuotaPlatform (force-platform first, group platform fallback). This pre-scheduling placement is what keeps billing keys, sticky sessions and account selection consistent on the resolved full id. An upstream merge that drops these call sites recompiles cleanly but silently reverts bare 'opus' to the unsupported-model 400."
     },
     {
-      "path": "backend/internal/service/gateway_forward.go",
+      "path": "backend/internal/service/gateway_forward_tk.go",
       "must_contain": [
-        "replaceBody(tkApplyAnthropicRequestCompatibilityRules(account, tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account)))))"
+        "return replaceBody(tkApplyAnthropicRequestCompatibilityRules(account, tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(getBody(), account)))))"
       ],
       "rationale": "The native Forward pre-send sanitize chain must wrap the StripEmptyTextBlocks(TkSanitizeRequestBody(...)) combo with tkStripFableDisabledThinking and tkApplyAnthropicRequestCompatibilityRules so explicit thinking.type=disabled never reaches fable upstreams, top-level sampling params never reach Opus 4.7+/Sonnet 5+ Anthropic upstreams, and short-cached adaptive-thinking rules apply before the next upstream call. An upstream merge that restores the bare two-function chain silently reverts these fixes and surfaces raw upstream 400s again."
     },
@@ -4465,7 +4570,7 @@
       "rationale": "The count_tokens pre-send sanitize chain must wrap the StripEmptyTextBlocks(TkSanitizeRequestBody(...)) combo with tkStripFableDisabledThinking and tkApplyAnthropicRequestCompatibilityRules so explicit thinking.type=disabled never reaches fable upstreams, top-level sampling params never reach Opus 4.7+/Sonnet 5+ Anthropic upstreams, and short-cached compatibility rules reduce repeated upstream 400s."
     },
     {
-      "path": "backend/internal/service/gateway_anthropic_passthrough.go",
+      "path": "backend/internal/service/gateway_anthropic_passthrough_tk.go",
       "must_contain": [
         "input.Body = tkApplyAnthropicRequestCompatibilityRules(account, tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account))))"
       ],
@@ -4488,7 +4593,7 @@
     },
     {
       "rationale": "The native anthropic Forward path must stash the final (post-rewrite) upstream request body before the retry loop AND re-stash after a successful filtered-thinking / tool-downgrade retry. Two consumers depend on it: ops_error_logs per-attempt body context, and the traj v2 upstream-request divergence capture (qa reads the same gin key for opt-in records; see scripts/sentinels/trajectory.json required_file_hooks). An upstream merge dropping any of these calls silently corrupts exported training pairs instead of failing loudly.",
-      "path": "backend/internal/service/gateway_anthropic_passthrough.go",
+      "path": "backend/internal/service/gateway_anthropic_passthrough_tk.go",
       "must_contain": [
         "setOpsUpstreamRequestBody(c, retryWireBody)"
       ]
@@ -4530,7 +4635,7 @@
       "rationale": "Relayed canonical-ingress strict-403 skip for prod→edge mirror stubs (PR #691 cc-only canary prep). When a strict-mode edge rejects a non-CC / empty-UA client, the prod stub sees a 403 carrying TokenKey's own canonicalIngressRejectNeedle phrase — an end-client identity verdict, not stub/edge health. Without this skip, three rejections within a minute advance the anthropic 3/3 ladder and cool the canary edge's stub for up to 10 minutes: any third-party client probing prod could evict the canary edge from the pool (same amplifier shape as the 2026-05-31 no-available incident). Matches ONLY the TokenKey phrase; genuine Anthropic 403s (org disabled, TLS/bot challenge) still flow through handle403's keyword check and tiered cooldown."
     },
     {
-      "path": "backend/internal/service/ratelimit_service.go",
+      "path": "backend/internal/service/ratelimit_service_tk_handle403.go",
       "must_contain": [
         "tkSkipRelayedCanonicalIngressRejectPenalty(http.StatusForbidden, upstreamMsg, responseBody)"
       ],
@@ -4602,7 +4707,7 @@
     {
       "path": "backend/internal/service/ratelimit_service.go",
       "must_contain": [
-        "anthropic_request_owned_429_skip_penalty",
+        "s.tkTryHandle429Extras(",
         "tkCheckPlatformPoolExhausted",
         "func (s *RateLimitService) handle529(ctx context.Context, account *Account, headers http.Header) bool",
         "cooldown = anthropicCooldownTierLadder[0]",
@@ -4745,7 +4850,7 @@
       "rationale": "Write side of the saturation de-prioritization: increments the per-stub short-window counter ONLY on the downstream-capacity skip-penalty path (no-available / failover-exhausted). The fixed window (90s) self-clears so the preference evaporates ~1.5min after an edge recovers; threshold 3 (see edge_mirror_stub_saturation_tk.go) preserves transient blips. Crucially this NEVER advances the 3/3 ladder / SetTempUnschedulable — it is a preference feed, not a whole-account cooldown."
     },
     {
-      "path": "backend/internal/service/ratelimit_service.go",
+      "path": "backend/internal/service/ratelimit_service_tk_handle429_extras.go",
       "must_contain": [
         "s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, \"no_available_accounts\")",
         "s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, \"all_available_accounts_exhausted\")",
@@ -5016,7 +5121,7 @@
       "rationale": "TK fix (prod P0 2026-06-13, GPT专线 group_id=2): a capability/scope-level upstream 401 (token missing a capability scope, e.g. images Missing scopes: api.model.images.request) must NOT cool the whole account — that drained a thin OpenAI OAuth pool to zero and 429'd ALL models for ~10min (503/429 amplifier, cf. #725). The detector keys on BOTH 'missing scopes' AND 'insufficient permissions for this operation' to distinguish capability-401 from a genuine account-level 401. If an upstream merge drops this file the no-cooldown / no-failover / client-400 guards below silently revert to cooling the account again."
     },
     {
-      "path": "backend/internal/service/ratelimit_service.go",
+      "path": "backend/internal/service/ratelimit_service_tk_auth401.go",
       "must_contain": [
         "tkIsCapabilityScope401(statusCode, responseBody)",
         "capability_scope_401_skip_penalty",
@@ -5139,16 +5244,22 @@
       "rationale": "Anthropic 403 org-ban permanent-disable (2026-06-16 edge us6 account edge-ls-oh-3-d incident). A 403 permission_error 'OAuth authentication is currently not allowed for this organization' is an irrecoverable org-level ban (token refresh keeps succeeding — grant alive, org policy-blocked at request time), but handle403 previously routed it into handleAnthropicUpstreamError's generic 3/3 ladder whose 10-min cooldown AUTO-RECOVERS, so a banned account flapped forever (cool 10m -> re-enter pool -> 403 -> re-cool). The keyword list + the tkTryDisableAnthropicOrgBan403 function + its handleAuthError (SetError, no auto-recovery) call are the whole fix: if an upstream merge or refactor deletes any of them, the org-ban 403 silently falls back to the eternal-flap ladder and the regression is invisible until an operator notices the wasted failover + attribution noise. The extracted pure predicate tkMatchAnthropicOrgBan403Body is the single source of truth shared with the in-place-retry skip (gateway_service_tk_oauth_fatal_403_skip.go) so the breaker and the retry-skip never drift on what counts as an org ban. Pairs with the ratelimit_service.go injection-point sentinel."
     },
     {
-      "path": "backend/internal/service/ratelimit_service.go",
+      "path": "backend/internal/service/ratelimit_service_tk_handle403.go",
       "must_contain": [
         "if s.tkTryDisableAnthropicOrgBan403(ctx, account, upstreamMsg, responseBody) {",
         "if s.tkTryDisableAnthropicTLSFingerprint403(ctx, account, upstreamMsg, responseBody) {",
         "if s.tkTryEscalatePersistentBodyless403(ctx, account, upstreamMsg, responseBody) {",
         "if tkIsAnthropicAccountAuthFatal403(upstreamMsg, responseBody) {",
-        "s.recordAnthropicStubSaturation(ctx, account.ID, http.StatusForbidden, \"permission_failover\")",
-        "s.anthropicUpstreamErrorCounterCache.ResetAnthropicBodyless403Count(ctx, accountID)"
+        "s.recordAnthropicStubSaturation(ctx, account.ID, http.StatusForbidden, \"permission_failover\")"
       ],
       "rationale": "Injection points for Anthropic handle403 after specialist skips. (1) tkTryDisableAnthropicOrgBan403 — structured org-ban (#810). (2) tkTryDisableAnthropicTLSFingerprint403 — TLS/WAF 403 SetError with greppable prefix (bulk recover after profile re-capture). (3) tkTryEscalatePersistentBodyless403 — bodyless episode terminal disable. (4) tkIsAnthropicAccountAuthFatal403 — structured invalid-bearer / lacks-scopes only. (5) permission_failover saturation — default for remaining 403s. (6) ResetAnthropicBodyless403Count on recovery hotpaths."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service.go",
+      "must_contain": [
+        "s.anthropicUpstreamErrorCounterCache.ResetAnthropicBodyless403Count(ctx, accountID)"
+      ],
+      "rationale": "Recovery hotpath must reset the bodyless-403 counter when clearing Anthropic upstream-error state so a healed account does not carry a stale permanent-disable strike. Companion handle403 owns the escalate call site; this anchors the Reset in the upstream-shaped recovery path."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_anthropic_tls_fingerprint_403.go",
@@ -5345,7 +5456,7 @@
       "rationale": "isImageGenerationModel delegates to the canonical antigravity.IsImageModel (single source of truth for gemini-native image detection; #814 R-002 consolidation). antigravity_gateway_service.go is a large gateway file that attracts upstream merges; one that rewrites this helper could silently restore the old hardcoded gemini-image allowlist body, re-forking the predicate into 3 divergent copies and silently failing to bill future gemini image models (imageCount never fires). Pinning the one-line delegation keeps the dedup mechanical. Pairs with the antigravity.IsImageModel definition sentinel (antigravity.json) and the TestIsImageGenerationModel_DelegatesToCanonical behavioral guard."
     },
     {
-      "path": "backend/internal/service/gateway_forward.go",
+      "path": "backend/internal/service/gateway_forward_tk.go",
       "must_contain": [
         "s.tkModelNotFoundShortCircuit(c, account, mappedModel)"
       ],
@@ -7330,10 +7441,10 @@
     {
       "path": "backend/internal/service/ratelimit_service.go",
       "must_contain": [
-        "tkIsPermanentOpenAIAuth401(responseBody)",
-        "HandleOpenAIImageCapabilityLoss400(ctx, account, statusCode, responseBody)"
+        "HandleOpenAIImageCapabilityLoss400(ctx, account, statusCode, responseBody)",
+        "s.tkHandleAuth401("
       ],
-      "rationale": "Upstream-shaped injection: permanent OpenAI 401 and account-level image-capability 400 must keep calling the TokenKey owners. Losing either hook restores whole-account disable or reschedules dead image capability."
+      "rationale": "Upstream-shaped injection: account-level image-capability 400 must keep calling HandleOpenAIImageCapabilityLoss400; permanent OpenAI 401 is owned by ratelimit_service_tk_auth401.go via s.tkHandleAuth401."
     },
     {
       "path": "backend/internal/service/openai_account_runtime_block_fastpath.go",
@@ -8366,6 +8477,87 @@
         "_VERDICT_SEMANTIC_RE"
       ],
       "rationale": "The preflight checker recursively scans backend production Go and must reject future platform/channel-local failover implementations, comment-spoofed delegation, duplicated decision fields/actions and verdict-shaped semantics, including additions in files not yet listed in the sentinel registry."
+    },
+    {
+      "path": "backend/internal/service/gateway_anthropic_passthrough.go",
+      "must_contain": [
+        "s.tkPrepareAnthropicPassthroughBody(ctx, c, account, &input)",
+        "s.tkMaybeRetryAnthropicPassthrough400(",
+        "s.tkRecordAnthropicPassthroughStreamTerminalError(c, account, resp, err)"
+      ],
+      "rationale": "Thin TK companion call sites in Anthropic passthrough forward path; dropping any silently disables prep/400-rectify/stream-terminal recording."
+    },
+    {
+      "path": "backend/internal/service/gateway_anthropic_passthrough_tk.go",
+      "must_contain": [
+        "func classifyAnthropicResponseInputAsCacheRead(body []byte, usage *ClaudeUsage) ([]byte, error) {",
+        "func (s *GatewayService) tkPrepareAnthropicPassthroughBody(",
+        "func (s *GatewayService) tkMaybeRetryAnthropicPassthrough400(",
+        "func (s *GatewayService) rectifyAnthropicPassthrough400(",
+        "func (s *GatewayService) tkRecordAnthropicPassthroughStreamTerminalError("
+      ],
+      "rationale": "Anthropic passthrough TK companion owns forced-cache-read classification, request prep, 400 rectifier retry, and stream terminal ops recording extracted from the upstream-shaped file."
+    },
+    {
+      "path": "backend/internal/service/gateway_forward.go",
+      "must_contain": [
+        "s.tkPrepareAnthropicForwardIngress(",
+        "s.tkSanitizeAnthropicForwardBody(",
+        "s.tkApplyAnthropicForwardPreSendGuards(",
+        "s.tkApplyAnthropicForwardPostMappingGates(",
+        "s.tkHandleKiroForwardUpstreamError("
+      ],
+      "rationale": "Thin TK companion call sites in GatewayService.Forward; dropping any silently disables ingress/sanitize/pre-send/post-mapping/Kiro failover hooks."
+    },
+    {
+      "path": "backend/internal/service/gateway_forward_tk.go",
+      "must_contain": [
+        "func (s *GatewayService) tkPrepareAnthropicForwardIngress(",
+        "func (s *GatewayService) tkSanitizeAnthropicForwardBody(",
+        "func (s *GatewayService) tkApplyAnthropicForwardPreSendGuards(",
+        "func (s *GatewayService) tkApplyAnthropicForwardPostMappingGates(",
+        "func (s *GatewayService) tkHandleKiroForwardUpstreamError("
+      ],
+      "rationale": "Gateway Forward TK companion owns early ingress, sanitize wrap, pre-send guards, post-mapping gates, and Kiro failover side effects extracted from the upstream-shaped file."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_messages.go",
+      "must_contain": [
+        "s.tkPrepareOpenAICompatMessagesSession("
+      ],
+      "rationale": "Thin call site for OpenAI compat messages session prep companion."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_messages_tk.go",
+      "must_contain": [
+        "func (s *OpenAIGatewayService) tkPrepareOpenAICompatMessagesSession(",
+        "func isOpenAICompatResponsesTerminalEvent(eventType string) bool {"
+      ],
+      "rationale": "OpenAI gateway messages TK companion: session prep + terminal event classifier."
+    },
+    {
+      "path": "backend/internal/service/openai_account_scheduler.go",
+      "must_contain": [
+        "s.tkSelectStickySessionPhase(",
+        "tkOpenAICompatEndpointCapabilityAllows(account, requiredCapability)"
+      ],
+      "rationale": "Thin sticky slot-full escape and newapi capability gate call sites."
+    },
+    {
+      "path": "backend/internal/service/openai_account_scheduler_tk_slot_full_escape.go",
+      "must_contain": [
+        "func (s *defaultOpenAIAccountScheduler) stickySlotFullEscapeEnabled(",
+        "func (s *defaultOpenAIAccountScheduler) tkSelectStickySessionPhase(",
+        "func tkOpenAICompatEndpointCapabilityAllows("
+      ],
+      "rationale": "OpenAI scheduler sticky slot-full escape + newapi endpoint capability companion."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_messages_tk.go",
+      "must_contain": [
+        "Wei-Shaw/sub2api#1322"
+      ],
+      "rationale": "Non-stream /v1/messages uses the same buffered Responses SSE -> JSON conversion root cause as /v1/chat/completions; it must also override Content-Type after WriteFilteredHeaders so JSON bodies are not labeled text/event-stream. The buffered terminal reader must use openAICompatSSEFrameParser to recognise typed completion events when the stream closes without a standalone [DONE] (upstream PR #2530). isOpenAICompatResponsesTerminalEvent — used by both the Messages and Chat Completions streaming handlers — must keep response.cancelled / response.canceled in its terminal set so legitimate upstream cancellations close the stream cleanly instead of degenerating to 'stream usage incomplete: missing terminal event' (upstream #1322). (terminal classifier moved to companion)"
     }
   ]
 }

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -254,12 +254,18 @@
       "rationale": "Create-time validate+prime (resolveGrokTokenOnSave): pastes a grok refresh_token, does a live xAI refresh, and either primes the account (access_token/expires_at/token_endpoint) or rejects with the exact upstream reason. tkInputHasNonEmptyCredential gates the UpdateAccount re-validate so an unrelated grok edit isn't blocked by a transient xAI outage. Losing either lets dead grok accounts materialize, or fires an xAI call on every edit."
     },
     {
-      "path": "backend/internal/service/admin_account.go",
+      "path": "backend/internal/service/admin_account_tk_create.go",
+      "rationale": "The Grok validate+prime hook must remain wired at both save boundaries: CreateAccount always validates a newly pasted token before conservative official-profile protocol seeding and persistence, while UpdateAccount revalidates only when that request explicitly supplies a non-empty refresh_token. The distinct surrounding blocks prevent a surviving create call from masking deletion of the update call, prevent protocol seeding from persisting an unvalidated account, and prevent unrelated Grok edits from acquiring a live xAI dependency. (create boundary companion)",
       "must_contain": [
-        "if err := resolveGrokTokenOnSave(ctx, account); err != nil {\n\t\treturn nil, err\n\t}\n\tSeedOfficialSupportedProtocols(account)\n\tif err := s.accountRepo.Create",
+        "if err := resolveGrokTokenOnSave(ctx, account); err != nil {\n\t\treturn nil, err\n\t}\n\tSeedOfficialSupportedProtocols(account)\n\tif err := s.accountRepo.Create"
+      ]
+    },
+    {
+      "path": "backend/internal/service/admin_account_tk_update.go",
+      "rationale": "The Grok validate+prime hook must remain wired at both save boundaries: CreateAccount always validates a newly pasted token before conservative official-profile protocol seeding and persistence, while UpdateAccount revalidates only when that request explicitly supplies a non-empty refresh_token. The distinct surrounding blocks prevent a surviving create call from masking deletion of the update call, prevent protocol seeding from persisting an unvalidated account, and prevent unrelated Grok edits from acquiring a live xAI dependency. (update boundary companion)",
+      "must_contain": [
         "if account.Platform == PlatformGrok &&\n\t\ttkInputHasNonEmptyCredential(input.Credentials, \"refresh_token\") {\n\t\tif err := resolveGrokTokenOnSave(ctx, account); err != nil {"
-      ],
-      "rationale": "The Grok validate+prime hook must remain wired at both save boundaries: CreateAccount always validates a newly pasted token before conservative official-profile protocol seeding and persistence, while UpdateAccount revalidates only when that request explicitly supplies a non-empty refresh_token. The distinct surrounding blocks prevent a surviving create call from masking deletion of the update call, prevent protocol seeding from persisting an unvalidated account, and prevent unrelated Grok edits from acquiring a live xAI dependency."
+      ]
     },
     {
       "path": "backend/internal/service/account_test_service.go",

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -527,9 +527,8 @@
       "rationale": "Registration of KiroTokenRefresher into the background refresh ticker's refreshers[]/executors[]. An upstream merge that rewrites NewTokenRefreshService must preserve this line, or kiro refresh never runs even though the refresher type still exists."
     },
     {
-      "path": "backend/internal/handler/gateway_handler.go",
+      "path": "backend/internal/handler/gateway_handler_tk_kiro.go",
       "must_contain": [
-        "account.IsKiro()",
         "handleKiroContentFilteredError",
         "service.MarkOpsClientContentFiltered(c)",
         "service.KiroInvalidModelError",

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -84,7 +84,7 @@
       "rationale": "Focused request-recorder evidence that streaming and runtime paths stay byte-identical to the canonical CLI identity and that per-account machine metadata cannot alter the wire identity."
     },
     {
-      "path": "backend/internal/service/admin_account.go",
+      "path": "backend/internal/service/admin_account_tk_billing_probe.go",
       "must_contain": [
         "func normalizeAccountPriority",
         "platform == PlatformKiro",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -137,12 +137,18 @@
       "rationale": "TK companion invoked from admin_service.go CreateAccount/UpdateAccount that pins newapi/Moonshot accounts to the regional base_url their API key actually accepts. Without it, admins silently save accounts with the wrong region (api.moonshot.cn vs .ai), and the relay hot path 401s every request because it deliberately does not do per-request region fallback. Build-break alone is insufficient: an upstream merge that simultaneously removes the call sites would silently regress this without compile failure."
     },
     {
-      "path": "backend/internal/service/admin_account.go",
+      "path": "backend/internal/service/admin_account_tk_create.go",
+      "rationale": "CreateAccount and UpdateAccount are separate persistence boundaries and must both invoke the Moonshot regional resolver. The two context-specific anchors distinguish the create call (followed by unconditional Grok create validation) from the update call (followed by conditional Grok refresh validation), so one surviving call cannot mask deletion of the other. (create boundary companion)",
       "must_contain": [
-        "if err := resolveNewAPIMoonshotBaseURLOnSave(ctx, account); err != nil {\n\t\treturn nil, err\n\t}\n\tif err := resolveGrokTokenOnSave",
-        "if err := resolveNewAPIMoonshotBaseURLOnSave(ctx, account); err != nil {\n\t\treturn nil, err\n\t}\n\tif account.Platform == PlatformGrok"
-      ],
-      "rationale": "CreateAccount and UpdateAccount are separate persistence boundaries and must both invoke the Moonshot regional resolver. The two context-specific anchors distinguish the create call (followed by unconditional Grok create validation) from the update call (followed by conditional Grok refresh validation), so one surviving call cannot mask deletion of the other."
+        "if err := resolveNewAPIMoonshotBaseURLOnSave(ctx, account); err != nil {\n\t\treturn nil, err\n\t}\n\tif err := resolveGrokTokenOnSave"
+      ]
+    },
+    {
+      "path": "backend/internal/service/admin_account_tk_update.go",
+      "rationale": "CreateAccount and UpdateAccount are separate persistence boundaries and must both invoke the Moonshot regional resolver. The two context-specific anchors distinguish the create call (followed by unconditional Grok create validation) from the update call (followed by conditional Grok refresh validation), so one surviving call cannot mask deletion of the other. (update boundary companion)",
+      "must_contain": [
+        "if err := resolveNewAPIMoonshotBaseURLOnSave(ctx, account); err != nil {\n\t\treturn err\n\t}\n\tif account.Platform == PlatformGrok"
+      ]
     },
     {
       "path": "backend/internal/integration/newapi/channel_types.go",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -435,10 +435,16 @@
     {
       "path": "backend/internal/service/openai_account_scheduler.go",
       "must_contain": [
-        "func accountSupportsOpenAICapabilities",
-        "account.IsOpenAI() && !account.SupportsOpenAIEndpointCapability"
+        "func accountSupportsOpenAICapabilities"
       ],
       "rationale": "TK reconciliation of upstream endpoint-capability gating onto the fifth-platform scheduler. accountSupportsOpenAICapabilities applies the OpenAI endpoint-capability filter to native `openai` accounts ONLY (`account.IsOpenAI() && !...`), so `newapi` accounts (platform != openai, !IsOpenAI) are never fail-closed out of chat/embeddings scheduling. If a future merge drops the IsOpenAI() guard and applies SupportsOpenAIEndpointCapability unconditionally, every newapi account would be filtered out of the compat pool — a total fifth-platform outage. Must survive future upstream merges."
+    },
+    {
+      "path": "backend/internal/service/openai_account_scheduler_tk_slot_full_escape.go",
+      "must_contain": [
+        "account.IsOpenAI() && !account.SupportsOpenAIEndpointCapability(requiredCapability)"
+      ],
+      "rationale": "TK reconciliation of upstream endpoint-capability gating onto the fifth-platform scheduler. accountSupportsOpenAICapabilities applies the OpenAI endpoint-capability filter to native `openai` accounts ONLY (`account.IsOpenAI() && !...`), so `newapi` accounts (platform != openai, !IsOpenAI) are never fail-closed out of chat/embeddings scheduling. If a future merge drops the IsOpenAI() guard and applies SupportsOpenAIEndpointCapability unconditionally, every newapi account would be filtered out of the compat pool — a total fifth-platform outage. Must survive future upstream merges. (moved)"
     },
     {
       "path": "backend/internal/relay/bridge/context_input.go",
@@ -641,11 +647,12 @@
       "rationale": "Regression for the real vstecscloud 403 insufficient_user_quota response shape plus a marker-outside-message boundary: the bridge must SetError, emit newapi_arrears through the account incident notifier, preserve the upstream detail, and make the same failover decision from the complete envelope."
     },
     {
-      "path": "backend/internal/service/ratelimit_service.go",
+      "path": "backend/internal/service/ratelimit_service_tk_upstream_error_prelude.go",
       "must_contain": [
-        "tkTryHandleStandingBilling"
+        "tkTryHandleStandingBilling",
+        "func (s *RateLimitService) tkTryHandleUpstreamErrorPrelude("
       ],
-      "rationale": "HandleUpstreamError must call tkTryHandleStandingBilling before pool-mode skip and tryTempUnschedulable. Otherwise a generic 403 temp rule or Anthropic stub-saturation fallthrough leaves prepaid-dead accounts (tokensea 用户额度不足) schedulable with no Feishu account-failure card."
+      "rationale": "HandleUpstreamError must call tkTryHandleStandingBilling (via tkTryHandleUpstreamErrorPrelude) before pool-mode skip and tryTempUnschedulable. Otherwise a generic 403 temp rule or Anthropic stub-saturation fallthrough leaves prepaid-dead accounts (tokensea 用户额度不足) schedulable with no Feishu account-failure card."
     },
     {
       "path": "backend/internal/service/openai_gateway_bridge_dispatch.go",
@@ -1026,7 +1033,7 @@
       "rationale": "Native text transports must preserve an omitted configurable OpenAI API-key/upstream base_url as unresolved. Falling through to GetOpenAIBaseURL would synthesize api.openai.com before the fail-closed boundary can distinguish an explicit custom endpoint from an implicit official-host fallback, contradicting docs/approved/protocol-routing-ssot.md section 6. The sibling credential accessor preserves CloudWise and Agent Plan special bindings while using the canonical OpenAI-protocol key accessor for ordinary OpenAI/NewAPI/CN accounts."
     },
     {
-      "path": "backend/internal/service/ratelimit_service.go",
+      "path": "backend/internal/service/ratelimit_service_tk_upstream_error_prelude.go",
       "must_contain": [
         "IsForeignCredentialOfficialOpenAIReject(account, statusCode, responseBody)",
         "foreign_credential_official_openai_reject_skip_penalty"

--- a/scripts/sentinels/perf-query-shape.json
+++ b/scripts/sentinels/perf-query-shape.json
@@ -197,11 +197,11 @@
       "rationale": "ListAffiliateInvite/Rebate/TransferRecords MUST use COUNT(*) OVER() instead of a separate COUNT(*) query before the paginated SELECT. Reverting to dual sequential queries returns byte-identical pagination totals but doubles DB round-trips (~780ms → ~400ms TTFB on /admin/affiliates/transfers). affiliate_repo.go is upstream-shaped and churned; integration tests do not assert query shape, so this substring is the only mechanical guard."
     },
     {
-      "path": "backend/internal/handler/gateway_handler.go",
+      "path": "backend/internal/handler/gateway_handler_tk_usage.go",
       "must_contain": [
-        "g.Go(func() error { usageData = h.buildUsageData(gctx, apiKey.ID); return nil })"
+        "g.Go(func() error { usageData = h.buildUsageData(gctx, apiKeyID); return nil })"
       ],
-      "rationale": "GatewayHandler.Usage (/key-usage) MUST parallelize buildUsageData, buildAPIKeyDailyUsage, and GetAPIKeyModelStats via errgroup.WithContext. Reverting to sequential calls returns byte-identical JSON but restores ~612ms TTFB (~250ms when parallel). gateway_handler.go is upstream-owned; no test asserts concurrency shape, so this call-site substring is the mechanical guard."
+      "rationale": "GatewayHandler.Usage (/key-usage) MUST parallelize buildUsageData, buildAPIKeyDailyUsage, and GetAPIKeyModelStats via errgroup.WithContext. Reverting to sequential calls returns byte-identical JSON but restores ~612ms TTFB (~250ms when parallel). gateway_handler_tk_usage.go owns the errgroup shape after TK companion extraction; no test asserts concurrency shape, so this call-site substring is the mechanical guard."
     }
   ]
 }

--- a/scripts/sentinels/priced-serving-gate.json
+++ b/scripts/sentinels/priced-serving-gate.json
@@ -62,11 +62,25 @@
     {
       "path": "backend/internal/service/gemini_messages_compat_service.go",
       "must_contain": [
-        "if !s.tkPricedServingGate(ctx, c, tkGateWireAnthropic, account.Platform, originalModel, originalModel) {",
-        "if !s.tkPricedServingGate(ctx, c, tkGateWireGemini, account.Platform, originalModel, originalModel) {",
         "tkBillingService         *BillingService"
       ],
       "rationale": "Route hooks 4/6 + 5/6 — gemini compat Forward (Anthropic /v1/messages ingress → tkGateWireAnthropic envelope) AND ForwardNative (native Gemini ingress → tkGateWireGemini envelope; countTokens is exempted just before this call). BOTH judge originalModel (billing's key here — gemini native bills result.Model=originalModel; judging mappedModel was BLOCKER1, the catch-all leak). This is the first-launch enabled platform, so a revert here is the highest-impact. The tkBillingService struct-field anchor proves the gate's oracle dep slot survives (the gemini compat service holds none of its deps on the upstream constructor)."
+    },
+    {
+      "path": "backend/internal/service/gemini_messages_compat_service_tk_prepare.go",
+      "must_contain": [
+        "func (s *GeminiMessagesCompatService) tkPrepareGeminiMessagesForward(",
+        "func (s *GeminiMessagesCompatService) tkPrepareGeminiNativeForward("
+      ],
+      "rationale": "Route hooks 4/6 + 5/6 — gemini compat Forward (Anthropic /v1/messages ingress → tkGateWireAnthropic envelope) AND ForwardNative (native Gemini ingress → tkGateWireGemini envelope; countTokens is exempted just before this call). BOTH judge originalModel (billing's key here — gemini native bills result.Model=originalModel; judging mappedModel was BLOCKER1, the catch-all leak). This is the first-launch enabled platform, so a revert here is the highest-impact. The tkBillingService struct-field anchor proves the gate's oracle dep slot survives (the gemini compat service holds none of its deps on the upstream constructor). (prepare companion)"
+    },
+    {
+      "path": "backend/internal/service/gemini_messages_compat_service.go",
+      "must_contain": [
+        "s.tkPrepareGeminiMessagesForward(",
+        "s.tkPrepareGeminiNativeForward("
+      ],
+      "rationale": "Thin Gemini Forward/Native TK prepare call sites."
     },
     {
       "path": "backend/internal/service/gemini_chat_completions_compat_service.go",
@@ -76,11 +90,19 @@
       "rationale": "Route hook 6/6 — the third gemini ingress (OpenAI /v1/chat/completions onto a gemini account, forwardClaudeBodyAsChatCompletions). This route had NO gate in v1's first cut (BLOCKER2) — an OpenAI-CC client could hit a gemini account with an unpriced model and serve $0 on the launch platform. OpenAI wire envelope; judges originalModel."
     },
     {
+      "path": "backend/internal/service/gemini_messages_compat_service_tk_prepare.go",
+      "must_contain": [
+        "func (s *GeminiMessagesCompatService) tkPrepareGeminiMessagesForward("
+      ],
+      "rationale": "Route hook (native anthropic /v1/messages catch-all). Inserted right after the deprecated-model gate (post-mapping, pre-forward) — the native catch-all (empty model_mapping = allow-all) is the original vulnerability hot spot. anthropic is NOT in the first-launch enabled set but joins per the rollout plan; the hook (on originalModel, billing's key) must survive until then. (prepare companion)"
+    },
+    {
       "path": "backend/internal/service/gemini_messages_compat_service.go",
       "must_contain": [
-        "if !s.tkPricedServingGate(ctx, c, tkGateWireAnthropic, account.Platform, originalModel, originalModel) {"
+        "s.tkPrepareGeminiMessagesForward(",
+        "s.tkPrepareGeminiNativeForward("
       ],
-      "rationale": "Route hook (native anthropic /v1/messages catch-all). Inserted right after the deprecated-model gate (post-mapping, pre-forward) — the native catch-all (empty model_mapping = allow-all) is the original vulnerability hot spot. anthropic is NOT in the first-launch enabled set but joins per the rollout plan; the hook (on originalModel, billing's key) must survive until then."
+      "rationale": "Thin Gemini Forward/Native TK prepare call sites."
     },
     {
       "path": "backend/internal/service/domain_constants.go",

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -7,12 +7,17 @@
       "must_contain": [
         "TkRecordFailureFromErr",
         "tkFilterModelIDs",
-        "tkAntigravityDefaultModels",
         "tkGeminiDefaultModelsList",
-        "TkEvalBodyGuard(",
-        "TkEnrichForbiddenMessage("
+        "TkEvalBodyGuard("
       ],
-      "rationale": "gateway_handler.go has TK injection points across multiple flows: (1) failure taps at the Anthropic /v1/messages + Gemini /v1/messages error paths (TkRecordFailureFromErr), (2) the CatalogPolicy model-list projection on the whitelist path (tkFilterModelIDs), (3) the shape-preserving antigravity model filter (tkAntigravityDefaultModels), (4) the gemini /v1/models fallback re-point to the CatalogPolicy projection (tkGeminiDefaultModelsList) so the list converges with /pricing instead of returning the raw geminicli.DefaultModels (which still carried advertised_dead gemini-2.0-flash) — an upstream merge could silently revert this one-line branch back to the raw list and un-converge gemini /v1/models, (5) the pre-flight body-size guard on Messages + CountTokens entries (TkEvalBodyGuard) that fail-fast oversize requests before forward — see edge:us1 production data where opus-4-7 upstream rejects body >= ~940 KB with raw 403; and (6) the actionable-message enrichment for upstream 403 in handleFailoverExhausted + handleFailoverExhaustedSimple (TkEnrichForbiddenMessage). An upstream merge touching the forward-failed error handlers, the Models/AntigravityModels methods, or the entry hooks could silently drop any of these. If TkRecordFailureFromErr is lost, model_not_found failures from Anthropic and Gemini platforms stop being classified; if TkEvalBodyGuard is lost, claude-cli clients lose the pre-flight rejection and again hit upstream 403; if TkEnrichForbiddenMessage is lost, the 403 response collapses back to 'Upstream access forbidden, please contact administrator' without body-size hint."
+      "rationale": "gateway_handler.go has TK injection points across multiple flows: (1) failure taps at the Anthropic /v1/messages + Gemini /v1/messages error paths (TkRecordFailureFromErr), (2) the CatalogPolicy model-list projection on the whitelist path (tkFilterModelIDs), (3) the gemini /v1/models fallback re-point to the CatalogPolicy projection (tkGeminiDefaultModelsList) so the list converges with /pricing instead of returning the raw geminicli.DefaultModels (which still carried advertised_dead gemini-2.0-flash) — an upstream merge could silently revert this one-line branch back to the raw list and un-converge gemini /v1/models, and (4) the pre-flight body-size guard on Messages + CountTokens entries (TkEvalBodyGuard) that fail-fast oversize requests before forward — see edge:us1 production data where opus-4-7 upstream rejects body >= ~940 KB with raw 403. Antigravity default-model projection and 403 enrichment live in TK companions (gateway_handler_tk_model_list.go / gateway_handler_tk_forward_error.go)."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler_tk_model_list.go",
+      "must_contain": [
+        "tkAntigravityDefaultModels"
+      ],
+      "rationale": "Shape-preserving antigravity model filter owner after TK companion extraction. An upstream merge that drops tkAntigravityDefaultModels un-converges /antigravity/models with CatalogPolicy."
     },
     {
       "path": "backend/internal/handler/gateway_handler_chat_completions.go",
@@ -64,9 +69,10 @@
       "path": "backend/internal/handler/gateway_handler_tk_forward_error.go",
       "must_contain": [
         "TkRecordFailureFromErr",
-        "UpstreamFailoverError"
+        "UpstreamFailoverError",
+        "TkEnrichForbiddenMessage("
       ],
-      "rationale": "This TK companion file is the single implementation of TkRecordFailureFromErr — the helper that extracts upstream HTTP status from UpstreamFailoverError and forwards it to the availability classifier. If this file is lost (e.g. an upstream merge that removes all untracked files), all 5 tap call sites compile against a missing function and the build fails. The file also contains the UpstreamFailoverError unwrap logic that makes model_not_found classification work correctly (R-004 fix from review-20260506)."
+      "rationale": "This TK companion file is the single implementation of TkRecordFailureFromErr — the helper that extracts upstream HTTP status from UpstreamFailoverError and forwards it to the availability classifier. If this file is lost (e.g. an upstream merge that removes all untracked files), all 5 tap call sites compile against a missing function and the build fails. The file also contains the UpstreamFailoverError unwrap logic that makes model_not_found classification work correctly (R-004 fix from review-20260506), plus the Messages-path TkEnrichForbiddenMessage call site for actionable 403 enrichment."
     },
     {
       "path": "backend/internal/handler/pricing_catalog_handler_tk.go",

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -434,17 +434,31 @@
       "path": "backend/internal/handler/admin/account_handler.go",
       "must_contain": [
         "tkGeminiAdminAvailableModels(c.Request.Context(), account)",
+        "tkClaudeAdminModelsForIDs(sortedModelMappingKeys(mapping))",
+        "scheduleProtocolCapabilityProbes"
+      ],
+      "rationale": "Admin GetAvailableModels dispatcher keeps the Gemini/Claude menu call sites and create/update/re-test scheduleProtocolCapabilityProbes injection points after TK companion extraction. Model builders and protocol-probe implementation live in account_handler_tk_available_models.go / account_handler_tk_protocol_probe.go."
+    },
+    {
+      "path": "backend/internal/handler/admin/account_handler_tk_available_models.go",
+      "must_contain": [
         "func tkGeminiAdminAvailableModels(",
         "func tkGeminiAdminModelsForMapping(",
         "service.ServableClientFacingIDs(ctx, service.PlatformGemini, nil, nil)",
         "func tkAdminModelOptions[",
-        "[]dto.AccountModelOption",
-        "tkClaudeAdminModelsForIDs(sortedModelMappingKeys(mapping))",
-        "scheduleProtocolCapabilityProbes",
-        "service.ProtocolProbeCandidates(account)",
-        "ProbeAccountProtocolCapabilities"
+        "[]dto.AccountModelOption"
       ],
-      "rationale": "Admin GET /admin/accounts/:id/models for Gemini routes through tkGeminiAdminAvailableModels (model_mapping SSOT). Non-Google-One accounts still intersect mapping with ServableClientFacingIDs via tkGeminiAdminModelsForMapping; Google One keeps the conservative whitelist from GetModelMapping without servable pruning. Every platform projects package-specific metadata through tkAdminModelOptions into the same []dto.AccountModelOption HTTP contract. Governed custom-account create/update/re-test lifecycle events must schedule one account+revision candidate-set probe job; that job evaluates Chat Completions, Responses, and native Anthropic Messages before one complete-set CAS write."
+      "rationale": "Admin available-models TK builders: Gemini routes through tkGeminiAdminAvailableModels (model_mapping SSOT). Non-Google-One accounts still intersect mapping with ServableClientFacingIDs via tkGeminiAdminModelsForMapping; Google One keeps the conservative whitelist from GetModelMapping without servable pruning. Every platform projects package-specific metadata through tkAdminModelOptions into the same []dto.AccountModelOption HTTP contract."
+    },
+    {
+      "path": "backend/internal/handler/admin/account_handler_tk_protocol_probe.go",
+      "must_contain": [
+        "func (h *AccountHandler) scheduleProtocolCapabilityProbes(",
+        "service.ProtocolProbeCandidates(account)",
+        "ProbeAccountProtocolCapabilities",
+        "func (h *AccountHandler) ProbeProtocols("
+      ],
+      "rationale": "Governed custom-account create/update/re-test lifecycle events schedule one account+revision candidate-set probe job via scheduleProtocolCapabilityProbes; ProbeProtocols is the synchronous admin re-test handler. That job evaluates Chat Completions, Responses, and native Anthropic Messages before one complete-set CAS write."
     },
     {
       "path": "backend/internal/handler/admin/account_handler_available_models_test.go",

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -259,14 +259,8 @@
       "path": "backend/internal/service/billing_service.go",
       "must_contain": [
         "tkIsEffectivelyUnpriced",
-        "func tkModelPricingFromLiteLLM",
-        "ThinkingOutputPricePerToken:        p.ThinkingOutputCostPerToken",
-        "Intervals:                          p.Intervals",
         "pricing.ThinkingOutputPricePerToken",
-        "tkIsFlatPerImageModel(model)",
         "normalizeOpenAIBillingModel",
-        "func tkOverlayModelPricing",
-        "tkModelPricingFromLiteLLM(loadTKPricingOverlay()[owner])",
         "tkOverlayModelPricing(\"deepseek-v4-flash\")",
         "tkApplyDeepSeekPeakValleyPricing",
         "tkOverlayModelPricing(\"glm-5.2\")",
@@ -274,6 +268,28 @@
         "if fallback.registryOwner == \"\""
       ],
       "rationale": "BillingService pricing hooks: unknown zeroes fail closed, interval/thinking/media fields survive conversion, Imagen keeps flat billing, and compatibility aliases normalize. Production alias matching must resolve an active registry owner instead of using the legacy numeric Go fixture table. Not every registry row is a family alias; dropping the scoped hooks reintroduces price drift while broadening them changes fail-closed behavior for unrelated models."
+    },
+    {
+      "path": "backend/internal/service/billing_service_tk_registry_alias.go",
+      "must_contain": [
+        "func tkModelPricingFromLiteLLM",
+        "func tkOverlayModelPricing"
+      ],
+      "rationale": "BillingService pricing hooks: unknown zeroes fail closed, interval/thinking/media fields survive conversion, Imagen keeps flat billing, and compatibility aliases normalize. Production alias matching must resolve an active registry owner instead of using the legacy numeric Go fixture table. Not every registry row is a family alias; dropping the scoped hooks reintroduces price drift while broadening them changes fail-closed behavior for unrelated models. (overlay helpers in companion)"
+    },
+    {
+      "path": "backend/internal/service/billing_service_tk_flat_image.go",
+      "must_contain": [
+        "tkIsFlatPerImageModel(model)"
+      ],
+      "rationale": "BillingService pricing hooks: unknown zeroes fail closed, interval/thinking/media fields survive conversion, Imagen keeps flat billing, and compatibility aliases normalize. Production alias matching must resolve an active registry owner instead of using the legacy numeric Go fixture table. Not every registry row is a family alias; dropping the scoped hooks reintroduces price drift while broadening them changes fail-closed behavior for unrelated models. (flat image multiplier in companion)"
+    },
+    {
+      "path": "backend/internal/service/billing_service.go",
+      "must_contain": [
+        "return tkApplyDefaultImageSizeMultiplier(model, imageSize, basePrice)"
+      ],
+      "rationale": "Thin call site for Imagen flat / size-tier multiplier companion."
     },
     {
       "path": "backend/internal/service/billing_service_tk_registry_alias.go",
@@ -478,6 +494,15 @@
         "return nil, fmt.Errorf(\"read model availability for %s/%s: %w\""
       ],
       "rationale": "Automatic-key discovery fallback uses the same servable catalog as pricing, but unlike storefront rendering it must surface availability repository errors. This strict companion preserves structurally-gone pruning and priced membership without converting an unknown repository state into a successful capability menu."
+    },
+    {
+      "path": "backend/internal/service/billing_service_tk_registry_alias.go",
+      "must_contain": [
+        "ThinkingOutputPricePerToken:        p.ThinkingOutputCostPerToken",
+        "Intervals:                          p.Intervals",
+        "tkModelPricingFromLiteLLM(loadTKPricingOverlay()[owner])"
+      ],
+      "rationale": "BillingService pricing hooks: unknown zeroes fail closed, interval/thinking/media fields survive conversion, Imagen keeps flat billing, and compatibility aliases normalize. Production alias matching must resolve an active registry owner instead of using the legacy numeric Go fixture table. Not every registry row is a family alias; dropping the scoped hooks reintroduces price drift while broadening them changes fail-closed behavior for unrelated models. (LiteLLM/overlay conversion moved to companion)"
     }
   ]
 }

--- a/scripts/sentinels/terminal.json
+++ b/scripts/sentinels/terminal.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "openai_compat_responses_terminal_helper",
-      "source": "backend/internal/service/openai_gateway_messages.go",
+      "source": "backend/internal/service/openai_gateway_messages_tk.go",
       "required_literals": [
         "func isOpenAICompatResponsesTerminalEvent(eventType string) bool {",
         "case \"response.completed\", \"response.done\", \"response.incomplete\", \"response.failed\",",


### PR DESCRIPTION
## 摘要
- 对 P0 上游形热点做行为不变的 `*_tk_*.go` companion 抽取，主文件只留薄调用点
- 覆盖：`gateway_handler`、admin account 面、`ratelimit`、anthropic passthrough、`gateway_forward`、openai messages/scheduler、billing/gemini compat
- 同步 protocol-routing SSOT / public-group aggregator / sentinel 注册表到 companion 路径
- 已 rebase 到含 #1984 的 `origin/main`
- 行为审计：修复 BulkUpdate `ProbeEnabled` 校验顺序；补 companion 编排极性 / Messages 非 failover / passthrough 400 不重试回归钉

## 风险
常规风险。意图为结构收敛、无行为变更。对照 `origin/main` 五类线上风险面均 PASS；唯一曾发现的偏差（BulkUpdate 双失败错误优先权）已修回。no-web-impact

## 验证
- 对照 `origin/main`：Messages/Kiro、Anthropic passthrough、ratelimit prelude/401/403/429、admin Create/Update/Bulk、gateway_forward、billing/gemini — 均行为等价
- 回归：`TestBulkUpdateAccounts_OpenAISettingsBeforeProbeEnabled`、`TestTkTryHandleUpstreamErrorPrelude_*`、`TestTkHandleMessagesNonFailoverForwardError_Matrix`、`TestTkOpenAI403PrePenaltyGates_PolarityMatrix`、`TestTkTryHandle429Extras_*`、`TestTkHandleAuth401_*`、`TestTkMaybeRetryAnthropicPassthrough400_*`
- `./scripts/preflight.sh` PASS

## 提交
```
640781d44 test(ratelimit,gateway): 钉死 companion 编排极性与 passthrough 400 不重试契约
f7159ce36 fix(admin): 恢复 BulkUpdate ProbeEnabled 校验顺序并钉死 companion 回归
f202ab411 chore(sentinel): 锚定 P0 companion 抽取后的 needle 路径
b82125110 refactor(billing,gemini): 抽取 pricing/compat 剩余 TK 内联块
4809418b8 refactor(openai): 继续收薄 messages 与 account scheduler 热点
91f6fcea3 refactor(gateway): 抽取 gateway_forward TK companion
5034ee46c refactor(gateway): 新增 anthropic passthrough TK companion
a78cba03c refactor(ratelimit): 抽取 HandleUpstreamError TK companion 分发器
b9ff97f92 refactor(admin): 抽取 admin_account / account_handler TK companion
3a0e8b51a refactor(handler): 抽取 gateway_handler TK companion，收薄 Messages 热点
```
最新提交：640781d44