### PR TITLE
fix(admin): 复制账号保留 channel_type

### DIFF
--- a/backend/internal/service/admin_account.go
+++ b/backend/internal/service/admin_account.go
@@ -308,6 +308,7 @@ func (s *adminServiceImpl) DuplicateAccount(ctx context.Context, id int64, actor
 		Notes:                 cloneAccountValuePointer(source.Notes),
 		Platform:              source.Platform,
 		Type:                  source.Type,
+		ChannelType:           source.ChannelType,
 		Credentials:           credentials,
 		Extra:                 extra,
 		ProxyID:               cloneAccountValuePointer(proxyID),

--- a/backend/internal/service/admin_service_duplicate_account_test.go
+++ b/backend/internal/service/admin_service_duplicate_account_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	newapiconstant "github.com/QuantumNous/new-api/constant"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -275,7 +276,7 @@ func TestDuplicateAccountPreservesNewAPIChannelType(t *testing.T) {
 	ctx := context.Background()
 	repo := newDuplicateAccountRepoStub()
 	svc := &adminServiceImpl{accountRepo: repo, accountDuplicateRepo: repo}
-	const volcEngineChannelType = 45
+	const volcEngineChannelType = newapiconstant.ChannelTypeVolcEngine
 	source := &Account{
 		Name:        "volcengine-agent-plan",
 		Platform:    PlatformNewAPI,

--- a/backend/internal/service/admin_service_duplicate_account_test.go
+++ b/backend/internal/service/admin_service_duplicate_account_test.go
@@ -93,6 +93,7 @@ func TestDuplicateAccountCopiesConfigurationAndResetsRuntimeState(t *testing.T) 
 		Notes:                 &notes,
 		Platform:              PlatformAnthropic,
 		Type:                  AccountTypeAPIKey,
+		ChannelType:           17, // non-zero must survive duplicate so edit forms keep the selection
 		ProxyID:               &proxyID,
 		ProxyFallbackOriginID: &originalProxyID,
 		Concurrency:           6,
@@ -153,6 +154,7 @@ func TestDuplicateAccountCopiesConfigurationAndResetsRuntimeState(t *testing.T) 
 	require.Equal(t, "primary (Copy)", duplicate.Name)
 	require.Equal(t, source.Platform, duplicate.Platform)
 	require.Equal(t, source.Type, duplicate.Type)
+	require.Equal(t, source.ChannelType, duplicate.ChannelType)
 	require.Equal(t, source.Concurrency, duplicate.Concurrency)
 	require.Equal(t, source.Priority, duplicate.Priority)
 	require.Equal(t, source.AutoPauseOnExpired, duplicate.AutoPauseOnExpired)
@@ -265,6 +267,39 @@ func TestDuplicateAccountPreservesUngroupedState(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, duplicate.GroupIDs)
 	require.NotContains(t, repo.groupsOf, duplicate.ID)
+}
+
+// Regression: copying a newapi/VolcEngine account dropped channel_type (defaulted to 0),
+// so the admin edit form showed an empty channel selector until the operator re-selected it.
+func TestDuplicateAccountPreservesNewAPIChannelType(t *testing.T) {
+	ctx := context.Background()
+	repo := newDuplicateAccountRepoStub()
+	svc := &adminServiceImpl{accountRepo: repo, accountDuplicateRepo: repo}
+	const volcEngineChannelType = 45
+	source := &Account{
+		Name:        "volcengine-agent-plan",
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: volcEngineChannelType,
+		Credentials: map[string]any{
+			"api_key":  "ark-test",
+			"base_url": "https://ark.cn-beijing.volces.com/api/plan/v3",
+		},
+		Concurrency: 100,
+		Priority:    1,
+		GroupIDs:    []int64{5, 19},
+	}
+	require.NoError(t, repo.Create(ctx, source))
+
+	duplicate, err := svc.DuplicateAccount(ctx, source.ID, "admin:1", "")
+
+	require.NoError(t, err)
+	require.Equal(t, PlatformNewAPI, duplicate.Platform)
+	require.Equal(t, volcEngineChannelType, duplicate.ChannelType,
+		"duplicate must keep channel_type so edit UI does not force re-selection")
+	stored, getErr := repo.GetByID(ctx, duplicate.ID)
+	require.NoError(t, getErr)
+	require.Equal(t, volcEngineChannelType, stored.ChannelType)
 }
 
 func TestDuplicateAccountAtomicCreateFailureLeavesNoOrphan(t *testing.T) {


### PR DESCRIPTION
## 摘要
- 修复 Admin 复制账号时漏传 `channel_type`，副本落库为 0，编辑页需重新选择渠道类型的问题。
- 回归测试改用 `newapiconstant.ChannelTypeVolcEngine` SSOT，避免硬编码 45。

## 风险
- 常规风险：`DuplicateAccount` 仅补齐已有字段拷贝；不影响鉴权与计费。
- Web impact: none（后端落库正确后，既有编辑表单即可显示 channel_type）。

## 验证
- `go test -tags=unit ./internal/service/ -run 'TestDuplicateAccount' -count=1` → PASS

## 提交
```
cd3405975 fix(admin): use ChannelTypeVolcEngine SSOT in duplicate test
041b713e0 fix(admin): preserve channel_type when duplicating accounts
```
最新提交：cd3405975