### PR TITLE
chore: centralize probe resource lifecycle

### DIFF
--- a/ops/observability/cleanup-probe-resources.sh
+++ b/ops/observability/cleanup-probe-resources.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 # Disable reserved __tk_probe_* resources after diagnostics so Studio key/group
-# pickers are not dominated by probe-only fixtures. The rows are intentionally
-# retained: probe_reserved_resources.sh reactivates the canonical rows on demand.
-# For legacy scope clutter, see ops/observability/prune-probe-resources.sh.
+# pickers are not dominated by probe-only fixtures. Lifecycle rules live in the
+# shared probe owner: ops/pricing/probe_reserved_resources.sh.
 set -euo pipefail
 
 APPLY="${TK_PROBE_CLEANUP_APPLY:-0}"
@@ -50,124 +49,24 @@ if [[ "$APPLY" != "0" && "$APPLY" != "1" ]]; then
 	exit 1
 fi
 
-tk_psql() {
-	"${PSQL_ARRAY[@]}" "$@"
-}
-
-print_snapshot() {
-	local label="$1"
-	printf 'snapshot=%s\n' "$label"
-	tk_psql <<SQL
-WITH probe_groups AS (
-  SELECT id, name, status
-  FROM groups
-  WHERE name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
-    AND deleted_at IS NULL
-),
-probe_keys AS (
-  SELECT k.id, k.name, k.status
-  FROM api_keys k
-  WHERE k.deleted_at IS NULL
-    AND (
-      k.name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
-      OR k.group_id IN (SELECT id FROM probe_groups)
-    )
-),
-probe_bindings AS (
-  SELECT ag.account_id, ag.group_id
-  FROM account_groups ag
-  WHERE ag.group_id IN (SELECT id FROM probe_groups)
-)
-SELECT 'active_probe_groups=' || COUNT(*) FROM probe_groups WHERE status = 'active'
-UNION ALL
-SELECT 'active_probe_keys=' || COUNT(*) FROM probe_keys WHERE status = 'active'
-UNION ALL
-SELECT 'probe_account_group_bindings=' || COUNT(*) FROM probe_bindings
-UNION ALL
-SELECT 'probe_group_rows=' || COUNT(*) FROM probe_groups
-UNION ALL
-SELECT 'probe_key_rows=' || COUNT(*) FROM probe_keys
-UNION ALL
-SELECT 'active_group_sample=' || COALESCE(string_agg(name, ', ' ORDER BY name), '')
-FROM (SELECT name FROM probe_groups WHERE status = 'active' ORDER BY name LIMIT ${LIMIT}) s
-UNION ALL
-SELECT 'active_key_sample=' || COALESCE(string_agg(name, ', ' ORDER BY name), '')
-FROM (SELECT name FROM probe_keys WHERE status = 'active' ORDER BY name LIMIT ${LIMIT}) s;
-SQL
-}
-
-apply_cleanup() {
-	tk_psql <<'SQL'
-BEGIN;
-WITH probe_groups AS (
-  SELECT id
-  FROM groups
-  WHERE name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
-    AND deleted_at IS NULL
-),
-deleted_bindings AS (
-  DELETE FROM account_groups
-  WHERE group_id IN (SELECT id FROM probe_groups)
-  RETURNING 1
-),
-disabled_keys AS (
-  UPDATE api_keys
-  SET status = 'disabled',
-      updated_at = NOW()
-  WHERE deleted_at IS NULL
-    AND status <> 'disabled'
-    AND (
-      name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
-      OR group_id IN (SELECT id FROM probe_groups)
-    )
-  RETURNING 1
-),
-disabled_groups AS (
-  UPDATE groups
-  SET status = 'disabled',
-      updated_at = NOW()
-  WHERE deleted_at IS NULL
-    AND status <> 'disabled'
-    AND name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
-  RETURNING 1
-),
-legacy_soft_deleted_keys AS (
-  UPDATE api_keys
-  SET deleted_at = NOW(),
-      status = 'disabled',
-      updated_at = NOW()
-  WHERE deleted_at IS NULL
-    AND name LIKE '\_\_tk\_probe\_tkprobe%' ESCAPE '\'
-  RETURNING 1
-),
-legacy_soft_deleted_groups AS (
-  UPDATE groups
-  SET deleted_at = NOW(),
-      status = 'disabled',
-      updated_at = NOW()
-  WHERE deleted_at IS NULL
-    AND name LIKE '\_\_tk\_probe\_tkprobe%' ESCAPE '\'
-  RETURNING 1
-)
-SELECT 'deleted_account_group_bindings=' || COUNT(*) FROM deleted_bindings
-UNION ALL
-SELECT 'disabled_probe_keys=' || COUNT(*) FROM disabled_keys
-UNION ALL
-SELECT 'disabled_probe_groups=' || COUNT(*) FROM disabled_groups
-UNION ALL
-SELECT 'soft_deleted_legacy_tkprobe_keys=' || COUNT(*) FROM legacy_soft_deleted_keys
-UNION ALL
-SELECT 'soft_deleted_legacy_tkprobe_groups=' || COUNT(*) FROM legacy_soft_deleted_groups;
-COMMIT;
-SQL
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRICING_LIB="$SCRIPT_DIR/../pricing/probe_reserved_resources.sh"
+if [ ! -f "$PRICING_LIB" ]; then
+	PRICING_LIB="$SCRIPT_DIR/probe_reserved_resources.sh"
+fi
+if [ ! -f "$PRICING_LIB" ]; then
+	echo "cleanup-probe-resources: missing probe_reserved_resources.sh (use run-probe --with ops/pricing/probe_reserved_resources.sh)" >&2
+	exit 1
+fi
+# shellcheck source=../pricing/probe_reserved_resources.sh
+. "$PRICING_LIB"
 
 if [ "$APPLY" = "1" ]; then
 	printf 'mode=apply\n'
-	print_snapshot before
-	apply_cleanup
-	print_snapshot after
+	tk_probe_cleanup_snapshot "$LIMIT" before
+	tk_probe_cleanup_all_reserved
+	tk_probe_cleanup_snapshot "$LIMIT" after
 else
 	printf 'mode=dry_run\n'
-	print_snapshot current
+	tk_probe_cleanup_snapshot "$LIMIT" current
 fi

--- a/ops/observability/prune-probe-resources.sh
+++ b/ops/observability/prune-probe-resources.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 # Soft-delete legacy __tk_probe_* rows that are superseded by canonical reusable scopes.
-# Canonical rows match probe_reserved_resources.sh tk_probe_canonical_scope() for the
-# current catalog refresh, endpoint route-gate matrix, and media parity probes.
-#
-# Rows are soft-deleted (deleted_at set); probe scripts recreate canonical rows on demand.
+# Canonical keep/prune rules live in the shared probe owner: ops/pricing/probe_reserved_resources.sh.
 set -euo pipefail
 
 APPLY="${TK_PROBE_PRUNE_APPLY:-0}"
@@ -14,13 +11,6 @@ Usage:
   bash ops/observability/prune-probe-resources.sh [--apply]
 
 Default is dry-run. --apply soft-deletes non-canonical __tk_probe_* api_keys/groups.
-
-Canonical keep set (reused by live probe scripts):
-  catalog scopes: anthropic_srcgrp_1_cc, anthropic_srcgrp_1_kiro, kiro_srcgrp_1_kiro,
-  openai_srcgrp_2, gemini_srcgrp_16, newapi_srcgrp_16, newapi_srcgrp_18,
-  newapi_srcgrp_5, antigravity_srcgrp_21, grok_srcgrp_25
-  account-model reuse scopes: anthropic, kiro, openai, gemini, grok, antigravity, newapi
-  (always pruned: __tk_probe_tkprobe-* one-off groups from PROBE_REUSE_MODE=0)
 USAGE
 }
 
@@ -56,120 +46,9 @@ fi
 # shellcheck source=../pricing/probe_reserved_resources.sh
 . "$PRICING_LIB"
 
-tk_psql() {
-	"${PSQL_ARRAY[@]}" "$@"
-}
-
-# Catalog/route-gate scopes kept by tk_probe_canonical_scope for current ops scripts.
-CANONICAL_CATALOG_SCOPES=(
-	anthropic_srcgrp_1_cc
-	anthropic_srcgrp_1_kiro
-	kiro_srcgrp_1_kiro
-	openai_srcgrp_2
-	gemini_srcgrp_16
-	newapi_srcgrp_16
-	newapi_srcgrp_18
-	newapi_srcgrp_5
-	antigravity_srcgrp_21
-	grok_srcgrp_25
-)
-CANONICAL_SCOPES=("${CANONICAL_CATALOG_SCOPES[@]}")
-while IFS= read -r scope; do
-	[ -n "$scope" ] && CANONICAL_SCOPES+=("$scope")
-done < <(tk_probe_platform_reuse_scopes)
-
-keep_sql_values() {
-	local scope first=1
-	printf '('
-	for scope in "${CANONICAL_SCOPES[@]}"; do
-		if [ "$first" = 1 ]; then
-			first=0
-		else
-			printf ', '
-		fi
-		printf "'__tk_probe_%s_group', '__tk_probe_%s_key'" "$scope" "$scope"
-	done
-	printf ')'
-}
-
-KEEP_NAMES="$(keep_sql_values)"
-
-report() {
-	local label="$1"
-	printf 'snapshot=%s\n' "$label"
-	tk_psql <<SQL
-SELECT 'probe_group_rows=' || COUNT(*) FROM groups
-WHERE name LIKE '\_\_tk\_probe\_%' ESCAPE '\' AND deleted_at IS NULL;
-SELECT 'probe_key_rows=' || COUNT(*) FROM api_keys
-WHERE deleted_at IS NULL AND name LIKE '\_\_tk\_probe\_%' ESCAPE '\';
-SELECT 'prune_candidates_groups=' || COUNT(*) FROM groups
-WHERE name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
-  AND deleted_at IS NULL
-  AND name NOT IN ${KEEP_NAMES};
-SELECT 'prune_candidates_keys=' || COUNT(*) FROM api_keys
-WHERE deleted_at IS NULL
-  AND name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
-  AND name NOT IN ${KEEP_NAMES};
-SELECT 'prune_candidates_legacy_tkprobe_groups=' || COUNT(*) FROM groups
-WHERE name LIKE '\_\_tk\_probe\_tkprobe%' ESCAPE '\'
-  AND deleted_at IS NULL;
-SELECT 'stale_probe_bindings=' || COUNT(*) FROM account_groups ag
-JOIN groups g ON g.id = ag.group_id
-WHERE g.deleted_at IS NULL
-  AND g.name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
-  AND (
-    g.name LIKE '\_\_tk\_probe\_tkprobe%' ESCAPE '\'
-    OR g.name NOT IN ${KEEP_NAMES}
-  );
-SELECT 'kept_group_names=' || COALESCE(string_agg(name, ', ' ORDER BY name), '')
-FROM groups
-WHERE deleted_at IS NULL AND name IN ${KEEP_NAMES};
-SQL
-}
-
-apply_prune() {
-	tk_psql <<SQL
-BEGIN;
-WITH doomed_groups AS (
-  SELECT id, name FROM groups
-  WHERE name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
-    AND deleted_at IS NULL
-    AND name NOT IN ${KEEP_NAMES}
-),
-deleted_bindings AS (
-  DELETE FROM account_groups
-  WHERE group_id IN (SELECT id FROM doomed_groups)
-  RETURNING 1
-),
-deleted_keys AS (
-  UPDATE api_keys
-  SET deleted_at = NOW(), status = 'disabled', updated_at = NOW()
-  WHERE deleted_at IS NULL
-    AND (
-      name IN (SELECT replace(name, '_group', '_key') FROM doomed_groups)
-      OR group_id IN (SELECT id FROM doomed_groups)
-    )
-    AND name NOT IN ${KEEP_NAMES}
-  RETURNING 1
-),
-deleted_groups AS (
-  UPDATE groups
-  SET deleted_at = NOW(), status = 'disabled', updated_at = NOW()
-  WHERE id IN (SELECT id FROM doomed_groups)
-  RETURNING 1
-)
-SELECT 'deleted_account_group_bindings=' || COUNT(*) FROM deleted_bindings
-UNION ALL
-SELECT 'soft_deleted_probe_keys=' || COUNT(*) FROM deleted_keys
-UNION ALL
-SELECT 'soft_deleted_probe_groups=' || COUNT(*) FROM deleted_groups;
-COMMIT;
-SQL
-}
-
 printf 'mode=%s\n' "$([ "$APPLY" = 1 ] && echo apply || echo dry_run)"
-report current
+tk_probe_prune_report current
 if [ "$APPLY" = 1 ]; then
-	apply_prune
-	report after
+	tk_probe_prune_noncanonical
+	tk_probe_prune_report after
 fi

--- a/ops/observability/test_cleanup_probe_resources.sh
+++ b/ops/observability/test_cleanup_probe_resources.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Static checks for cleanup-probe-resources.sh shared lifecycle delegation.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$ROOT/cleanup-probe-resources.sh"
+
+text="$(cat "$SCRIPT")"
+
+if ! grep -q 'tk_probe_cleanup_snapshot "$LIMIT" current' <<<"$text"; then
+	echo "FAIL: cleanup script should delegate dry-run snapshot to probe_reserved_resources" >&2
+	exit 1
+fi
+if ! grep -q 'tk_probe_cleanup_all_reserved' <<<"$text"; then
+	echo "FAIL: cleanup script should delegate apply cleanup to probe_reserved_resources" >&2
+	exit 1
+fi
+if ! grep -q 'probe_reserved_resources.sh' <<<"$text"; then
+	echo "FAIL: cleanup script should source probe_reserved_resources.sh" >&2
+	exit 1
+fi
+if ! grep -q 'PRICING_LIB="$SCRIPT_DIR/probe_reserved_resources.sh"' <<<"$text"; then
+	echo "FAIL: cleanup script should fall back to /tmp companion path for run-probe delivery" >&2
+	exit 1
+fi
+
+echo "test_cleanup_probe_resources: PASS"

--- a/ops/observability/test_prune_probe_resources.sh
+++ b/ops/observability/test_prune_probe_resources.sh
@@ -11,20 +11,12 @@ RESOURCES="$ROOT/../pricing/probe_reserved_resources.sh"
 
 text="$(cat "$PRUNE")"
 
-while IFS= read -r scope; do
-	[ -z "$scope" ] && continue
-	if ! grep -q "$scope" <<<"$text"; then
-		echo "FAIL: prune script missing platform reuse scope from probe_reserved_resources: ${scope}" >&2
-		exit 1
-	fi
-done < <(tk_probe_platform_reuse_scopes)
-
-if ! grep -q 'prune_candidates_legacy_tkprobe_groups' <<<"$text"; then
-	echo "FAIL: prune script should report legacy tkprobe group candidates" >&2
+if ! grep -q 'tk_probe_prune_report current' <<<"$text"; then
+	echo "FAIL: prune script should delegate reporting to probe_reserved_resources" >&2
 	exit 1
 fi
-if ! grep -q 'stale_probe_bindings' <<<"$text"; then
-	echo "FAIL: prune script should report stale probe account_groups bindings" >&2
+if ! grep -q 'tk_probe_prune_noncanonical' <<<"$text"; then
+	echo "FAIL: prune script should delegate pruning to probe_reserved_resources" >&2
 	exit 1
 fi
 if ! grep -q 'probe_reserved_resources.sh' <<<"$text"; then

--- a/ops/pricing/probe_reserved_resources.sh
+++ b/ops/pricing/probe_reserved_resources.sh
@@ -18,6 +18,15 @@
 #   tk_probe_bind_from_group_id_like SCOPE GID PATTERN -> copy source group id accounts whose name matches SQL LIKE
 #   tk_probe_clear_bindings SCOPE           -> remove account_groups rows and disable probe key/group
 #   tk_probe_prepare_catalog SCOPE PLATFORM BIND_KIND BIND_VAL -> ensure + bind + key
+#   tk_probe_prepare_platform_reuse_probe PLATFORM ACCOUNT_ID -> ensure + bind + key for platform-scoped account-model probes
+#   tk_probe_cleanup_platform_reuse_probe SCOPE -> clear reusable bindings and enqueue group_changed
+#   tk_probe_canonical_catalog_scopes       -> prints canonical catalog scopes, one per line
+#   tk_probe_canonical_keep_scopes          -> prints all scopes retained by prune, one per line
+#   tk_probe_keep_names_sql                 -> prints SQL tuple of canonical __tk_probe_* group/key names
+#   tk_probe_cleanup_snapshot LIMIT LABEL   -> print cleanup snapshot counters
+#   tk_probe_cleanup_all_reserved           -> delete probe bindings + disable reusable probe rows
+#   tk_probe_prune_report LABEL             -> print prune candidate counters
+#   tk_probe_prune_noncanonical             -> soft-delete non-canonical probe rows
 #   tk_probe_reuse_lock_path SCOPE              -> lock file path (shared with account-model-probe)
 #   tk_probe_acquire_reuse_lock SCOPE           -> flock until release (serializes account_groups mutations)
 #   tk_probe_release_reuse_locks                -> release all locks held by this shell
@@ -184,6 +193,40 @@ tk_probe_platform_reuse_scopes() {
 	printf '%s\n' anthropic kiro openai gemini grok antigravity newapi
 }
 
+tk_probe_canonical_catalog_scopes() {
+	printf '%s\n' \
+		anthropic_srcgrp_1_cc \
+		anthropic_srcgrp_1_kiro \
+		kiro_srcgrp_1_kiro \
+		openai_srcgrp_2 \
+		gemini_srcgrp_16 \
+		newapi_srcgrp_16 \
+		newapi_srcgrp_18 \
+		newapi_srcgrp_5 \
+		antigravity_srcgrp_21 \
+		grok_srcgrp_25
+}
+
+tk_probe_canonical_keep_scopes() {
+	tk_probe_canonical_catalog_scopes
+	tk_probe_platform_reuse_scopes
+}
+
+tk_probe_keep_names_sql() {
+	local first=1 scope
+	printf '('
+	while IFS= read -r scope; do
+		[ -n "$scope" ] || continue
+		if [ "$first" = 1 ]; then
+			first=0
+		else
+			printf ', '
+		fi
+		printf "'__tk_probe_%s_group', '__tk_probe_%s_key'" "$scope" "$scope"
+	done < <(tk_probe_canonical_keep_scopes)
+	printf ')'
+}
+
 tk_probe_is_legacy_oneoff_probe_name() { # $1=group or key name
 	case "$1" in
 	__tk_probe_tkprobe*) return 0 ;;
@@ -273,14 +316,18 @@ tk_probe_ensure_group() { # $1=scope $2=platform
 INSERT INTO groups (
   name, description, platform, rate_multiplier, is_exclusive, status,
   subscription_type, default_validity_days, claude_code_only,
-  model_routing_enabled, model_routing, sort_order, rpm_limit, created_at, updated_at
+  model_routing_enabled, model_routing, allow_messages_dispatch, supported_model_scopes,
+  messages_dispatch_model_config, models_list_config,
+  sort_order, rpm_limit, created_at, updated_at
 ) VALUES (
   '$(tk_probe_sql_escape "$group_name")',
   'reserved reusable catalog/account probe group; direct probe key only; excluded from universal routing',
   '$(tk_probe_sql_escape "$platform")',
   1.0, true, 'active',
   'standard', 30, false,
-  false, '{}'::jsonb, 2147483000, 0, NOW(), NOW()
+  false, '{}'::jsonb, true, '[\"claude\", \"gemini_text\", \"gemini_image\"]'::jsonb,
+  '{}'::jsonb, '{}'::jsonb,
+  2147483000, 0, NOW(), NOW()
 )
 ON CONFLICT (name) WHERE (deleted_at IS NULL)
 DO UPDATE SET
@@ -294,6 +341,10 @@ DO UPDATE SET
   claude_code_only = false,
   model_routing_enabled = false,
   model_routing = '{}'::jsonb,
+  allow_messages_dispatch = true,
+  supported_model_scopes = '[\"claude\", \"gemini_text\", \"gemini_image\"]'::jsonb,
+  messages_dispatch_model_config = '{}'::jsonb,
+  models_list_config = '{}'::jsonb,
   sort_order = 2147483000,
   rpm_limit = 0,
   updated_at = NOW()
@@ -382,6 +433,18 @@ INSERT INTO api_keys (
 	fi
 }
 
+tk_probe_enqueue_group_changed() { # $1=group_id
+	local group_id="$1"
+	if [[ ! "$group_id" =~ ^[0-9]+$ ]]; then
+		echo "probe_reserved_resources: invalid group id '$group_id' for scheduler_outbox" >&2
+		return 1
+	fi
+	tk_probe_psql -c "
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+VALUES ('group_changed', NULL, ${group_id}, NULL);
+" >/dev/null
+}
+
 tk_probe_clear_bindings() { # $1=scope
 	local scope="$1" group_name group_id
 	group_name="$(tk_probe_group_name "$scope")"
@@ -391,10 +454,10 @@ SELECT COALESCE((
   WHERE name = '$(tk_probe_sql_escape "$group_name")' AND deleted_at IS NULL
   ORDER BY id LIMIT 1
 ), '');
-	")"
+		")"
 	if [[ "$group_id" =~ ^[0-9]+$ ]]; then
-		tk_probe_psql -c "DELETE FROM account_groups WHERE group_id = ${group_id};" >/dev/null
 		tk_probe_psql -c "
+DELETE FROM account_groups WHERE group_id = ${group_id};
 UPDATE api_keys
 SET status = 'disabled',
     updated_at = NOW()
@@ -407,9 +470,73 @@ SET status = 'disabled',
 WHERE id = ${group_id}
   AND name = '$(tk_probe_sql_escape "$group_name")'
   AND deleted_at IS NULL;
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+VALUES ('group_changed', NULL, ${group_id}, NULL);
 " >/dev/null
 	fi
 }
+
+tk_probe_cleanup_named_group() { # $1=group_id $2=group_name $3=key_name $4=lifecycle
+	local group_id="$1" group_name="$2" key_name="$3" lifecycle="$4"
+	if [[ ! "$group_id" =~ ^[0-9]+$ ]]; then
+		echo "probe_reserved_resources: invalid group id '$group_id' for cleanup" >&2
+		return 1
+	fi
+	if [ -z "$group_name" ] || [ -z "$key_name" ]; then
+		echo "probe_reserved_resources: cleanup requires non-empty group/key names" >&2
+		return 1
+	fi
+	case "$lifecycle" in
+		reusable)
+			tk_probe_psql -c "
+DELETE FROM account_groups WHERE group_id = ${group_id};
+UPDATE api_keys
+SET status = 'disabled',
+    updated_at = NOW()
+WHERE group_id = ${group_id}
+  AND name = '$(tk_probe_sql_escape "$key_name")'
+  AND deleted_at IS NULL;
+UPDATE groups
+SET status = 'disabled',
+    updated_at = NOW()
+WHERE id = ${group_id}
+  AND name = '$(tk_probe_sql_escape "$group_name")'
+  AND deleted_at IS NULL;
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+VALUES ('group_changed', NULL, ${group_id}, NULL);
+" >/dev/null
+			;;
+		oneoff)
+			tk_probe_psql -c "
+DELETE FROM account_groups WHERE group_id = ${group_id};
+DELETE FROM user_allowed_groups WHERE group_id = ${group_id};
+UPDATE api_keys
+SET status = 'disabled',
+    deleted_at = NOW(),
+    updated_at = NOW()
+WHERE group_id = ${group_id}
+  AND name = '$(tk_probe_sql_escape "$key_name")'
+  AND deleted_at IS NULL;
+UPDATE groups
+SET status = 'disabled',
+    deleted_at = NOW(),
+    updated_at = NOW()
+WHERE id = ${group_id}
+  AND name = '$(tk_probe_sql_escape "$group_name")'
+  AND deleted_at IS NULL;
+" >/dev/null
+			;;
+		*)
+			echo "probe_reserved_resources: unknown cleanup lifecycle '$lifecycle'" >&2
+			return 1
+			;;
+	esac
+}
+
+tk_probe_cleanup_platform_reuse_probe() { # $1=scope
+	tk_probe_clear_bindings "$1"
+}
+
 
 tk_probe_bind_account_ids() { # $1=scope $2=ids (comma/space)
 	local scope="$1" ids_raw="$2" id
@@ -586,6 +713,45 @@ SELECT COUNT(*)::text FROM account_groups WHERE group_id = ${TK_PROBE_GROUP_ID};
 	fi
 }
 
+tk_probe_prepare_platform_reuse_probe() { # $1=platform $2=account_id
+	local platform="$1" account_id="$2" scope group_name
+	if [[ ! "$account_id" =~ ^[0-9]+$ ]]; then
+		echo "probe_reserved_resources: invalid account id '$account_id' for platform reuse probe" >&2
+		return 1
+	fi
+	scope="$(tk_probe_scope_from_platform "$platform")"
+	if [ -z "$scope" ]; then
+		echo "probe_reserved_resources: empty scope for platform '$platform'" >&2
+		return 1
+	fi
+	TK_PROBE_REQUESTED_SCOPE="$scope"
+	TK_PROBE_SCOPE="$scope"
+	TK_PROBE_GROUP_ID=""
+	TK_PROBE_KEY=""
+	TK_PROBE_KEY_ID=""
+	if ! tk_probe_acquire_reuse_lock "$scope"; then
+		return 1
+	fi
+	tk_probe_ensure_group "$scope" "$platform" || return 1
+	group_name="$(tk_probe_group_name "$scope")"
+	tk_probe_unbind_account_from_stale_probe_groups "$account_id" "$group_name" || {
+		tk_probe_clear_bindings "$scope" >/dev/null 2>&1 || true # preflight-allow: cleanup failed probe resource
+		return 1
+	}
+	tk_probe_bind_account_ids "$scope" "$account_id" || {
+		tk_probe_clear_bindings "$scope" >/dev/null 2>&1 || true # preflight-allow: cleanup failed probe resource
+		return 1
+	}
+	tk_probe_enqueue_group_changed "$TK_PROBE_GROUP_ID" || {
+		tk_probe_clear_bindings "$scope" >/dev/null 2>&1 || true # preflight-allow: cleanup failed probe resource
+		return 1
+	}
+	tk_probe_ensure_key "$scope" || {
+		tk_probe_clear_bindings "$scope" >/dev/null 2>&1 || true # preflight-allow: cleanup failed probe resource
+		return 1
+	}
+}
+
 # Ensure group+key and bind accounts. BIND_KIND: account_ids | source_group | source_group_id | group_like | group_id_like
 # (group_like bind_val = "GROUP|PATTERN", split on the first '|').
 # (group_id_like bind_val = "GROUP_ID|PATTERN", split on the first '|').
@@ -619,4 +785,198 @@ tk_probe_prepare_catalog() { # $1=scope $2=platform $3=bind_kind $4=bind_val
 		tk_probe_clear_bindings "$scope" >/dev/null 2>&1 || true # preflight-allow: cleanup failed probe resource
 		return 1
 	}
+}
+
+tk_probe_cleanup_snapshot() { # $1=limit $2=label
+	local limit="$1" label="$2"
+	printf 'snapshot=%s
+' "$label"
+	tk_probe_psql <<SQL
+WITH probe_groups AS (
+  SELECT id, name, status
+  FROM groups
+  WHERE name LIKE '\_\_tk\_probe\_%' ESCAPE '\\'
+    AND deleted_at IS NULL
+),
+probe_keys AS (
+  SELECT k.id, k.name, k.status
+  FROM api_keys k
+  WHERE k.deleted_at IS NULL
+    AND (
+      k.name LIKE '\_\_tk\_probe\_%' ESCAPE '\\'
+      OR k.group_id IN (SELECT id FROM probe_groups)
+    )
+),
+probe_bindings AS (
+  SELECT ag.account_id, ag.group_id
+  FROM account_groups ag
+  WHERE ag.group_id IN (SELECT id FROM probe_groups)
+)
+SELECT 'active_probe_groups=' || COUNT(*) FROM probe_groups WHERE status = 'active'
+UNION ALL
+SELECT 'active_probe_keys=' || COUNT(*) FROM probe_keys WHERE status = 'active'
+UNION ALL
+SELECT 'probe_account_group_bindings=' || COUNT(*) FROM probe_bindings
+UNION ALL
+SELECT 'probe_group_rows=' || COUNT(*) FROM probe_groups
+UNION ALL
+SELECT 'probe_key_rows=' || COUNT(*) FROM probe_keys
+UNION ALL
+SELECT 'active_group_sample=' || COALESCE(string_agg(name, ', ' ORDER BY name), '')
+FROM (SELECT name FROM probe_groups WHERE status = 'active' ORDER BY name LIMIT ${limit}) s
+UNION ALL
+SELECT 'active_key_sample=' || COALESCE(string_agg(name, ', ' ORDER BY name), '')
+FROM (SELECT name FROM probe_keys WHERE status = 'active' ORDER BY name LIMIT ${limit}) s;
+SQL
+}
+
+tk_probe_cleanup_all_reserved() {
+	tk_probe_psql <<'SQL'
+BEGIN;
+WITH probe_groups AS (
+  SELECT id
+  FROM groups
+  WHERE name LIKE '\_\_tk\_probe\_%' ESCAPE '\\'
+    AND deleted_at IS NULL
+),
+deleted_bindings AS (
+  DELETE FROM account_groups
+  WHERE group_id IN (SELECT id FROM probe_groups)
+  RETURNING 1
+),
+disabled_keys AS (
+  UPDATE api_keys
+  SET status = 'disabled',
+      updated_at = NOW()
+  WHERE deleted_at IS NULL
+    AND status <> 'disabled'
+    AND (
+      name LIKE '\_\_tk\_probe\_%' ESCAPE '\\'
+      OR group_id IN (SELECT id FROM probe_groups)
+    )
+  RETURNING 1
+),
+disabled_groups AS (
+  UPDATE groups
+  SET status = 'disabled',
+      updated_at = NOW()
+  WHERE deleted_at IS NULL
+    AND status <> 'disabled'
+    AND name LIKE '\_\_tk\_probe\_%' ESCAPE '\\'
+  RETURNING 1
+),
+queued_group_changed AS (
+  INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+  SELECT 'group_changed', NULL, id, NULL
+  FROM probe_groups
+  RETURNING 1
+),
+legacy_soft_deleted_keys AS (
+  UPDATE api_keys
+  SET deleted_at = NOW(),
+      status = 'disabled',
+      updated_at = NOW()
+  WHERE deleted_at IS NULL
+    AND name LIKE '\_\_tk\_probe\_tkprobe%' ESCAPE '\\'
+  RETURNING 1
+),
+legacy_soft_deleted_groups AS (
+  UPDATE groups
+  SET deleted_at = NOW(),
+      status = 'disabled',
+      updated_at = NOW()
+  WHERE deleted_at IS NULL
+    AND name LIKE '\_\_tk\_probe\_tkprobe%' ESCAPE '\\'
+  RETURNING 1
+)
+SELECT 'deleted_account_group_bindings=' || COUNT(*) FROM deleted_bindings
+UNION ALL
+SELECT 'disabled_probe_keys=' || COUNT(*) FROM disabled_keys
+UNION ALL
+SELECT 'disabled_probe_groups=' || COUNT(*) FROM disabled_groups
+UNION ALL
+SELECT 'queued_group_changed=' || COUNT(*) FROM queued_group_changed
+UNION ALL
+SELECT 'soft_deleted_legacy_tkprobe_keys=' || COUNT(*) FROM legacy_soft_deleted_keys
+UNION ALL
+SELECT 'soft_deleted_legacy_tkprobe_groups=' || COUNT(*) FROM legacy_soft_deleted_groups;
+COMMIT;
+SQL
+}
+
+tk_probe_prune_report() { # $1=label
+	local label="$1" keep_names
+	keep_names="$(tk_probe_keep_names_sql)"
+	printf 'snapshot=%s
+' "$label"
+	tk_probe_psql <<SQL
+SELECT 'probe_group_rows=' || COUNT(*) FROM groups
+WHERE name LIKE '\_\_tk\_probe\_%' ESCAPE '\\' AND deleted_at IS NULL;
+SELECT 'probe_key_rows=' || COUNT(*) FROM api_keys
+WHERE deleted_at IS NULL AND name LIKE '\_\_tk\_probe\_%' ESCAPE '\\';
+SELECT 'prune_candidates_groups=' || COUNT(*) FROM groups
+WHERE name LIKE '\_\_tk\_probe\_%' ESCAPE '\\'
+  AND deleted_at IS NULL
+  AND name NOT IN ${keep_names};
+SELECT 'prune_candidates_keys=' || COUNT(*) FROM api_keys
+WHERE deleted_at IS NULL
+  AND name LIKE '\_\_tk\_probe\_%' ESCAPE '\\'
+  AND name NOT IN ${keep_names};
+SELECT 'prune_candidates_legacy_tkprobe_groups=' || COUNT(*) FROM groups
+WHERE name LIKE '\_\_tk\_probe\_tkprobe%' ESCAPE '\\'
+  AND deleted_at IS NULL;
+SELECT 'stale_probe_bindings=' || COUNT(*) FROM account_groups ag
+JOIN groups g ON g.id = ag.group_id
+WHERE g.deleted_at IS NULL
+  AND g.name LIKE '\_\_tk\_probe\_%' ESCAPE '\\'
+  AND (
+    g.name LIKE '\_\_tk\_probe\_tkprobe%' ESCAPE '\\'
+    OR g.name NOT IN ${keep_names}
+  );
+SELECT 'kept_group_names=' || COALESCE(string_agg(name, ', ' ORDER BY name), '')
+FROM groups
+WHERE deleted_at IS NULL AND name IN ${keep_names};
+SQL
+}
+
+tk_probe_prune_noncanonical() {
+	local keep_names
+	keep_names="$(tk_probe_keep_names_sql)"
+	tk_probe_psql <<SQL
+BEGIN;
+WITH doomed_groups AS (
+  SELECT id, name FROM groups
+  WHERE name LIKE '\_\_tk\_probe\_%' ESCAPE '\\'
+    AND deleted_at IS NULL
+    AND name NOT IN ${keep_names}
+),
+deleted_bindings AS (
+  DELETE FROM account_groups
+  WHERE group_id IN (SELECT id FROM doomed_groups)
+  RETURNING 1
+),
+deleted_keys AS (
+  UPDATE api_keys
+  SET deleted_at = NOW(), status = 'disabled', updated_at = NOW()
+  WHERE deleted_at IS NULL
+    AND (
+      name IN (SELECT replace(name, '_group', '_key') FROM doomed_groups)
+      OR group_id IN (SELECT id FROM doomed_groups)
+    )
+    AND name NOT IN ${keep_names}
+  RETURNING 1
+),
+deleted_groups AS (
+  UPDATE groups
+  SET deleted_at = NOW(), status = 'disabled', updated_at = NOW()
+  WHERE id IN (SELECT id FROM doomed_groups)
+  RETURNING 1
+)
+SELECT 'deleted_account_group_bindings=' || COUNT(*) FROM deleted_bindings
+UNION ALL
+SELECT 'soft_deleted_probe_keys=' || COUNT(*) FROM deleted_keys
+UNION ALL
+SELECT 'soft_deleted_probe_groups=' || COUNT(*) FROM deleted_groups;
+COMMIT;
+SQL
 }

--- a/ops/pricing/probe_reserved_resources.sh
+++ b/ops/pricing/probe_reserved_resources.sh
@@ -836,7 +836,7 @@ BEGIN;
 WITH probe_groups AS (
   SELECT id
   FROM groups
-  WHERE name LIKE '\_\_tk\_probe\_%' ESCAPE '\\'
+  WHERE name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
     AND deleted_at IS NULL
 ),
 deleted_bindings AS (
@@ -851,7 +851,7 @@ disabled_keys AS (
   WHERE deleted_at IS NULL
     AND status <> 'disabled'
     AND (
-      name LIKE '\_\_tk\_probe\_%' ESCAPE '\\'
+      name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
       OR group_id IN (SELECT id FROM probe_groups)
     )
   RETURNING 1
@@ -862,7 +862,7 @@ disabled_groups AS (
       updated_at = NOW()
   WHERE deleted_at IS NULL
     AND status <> 'disabled'
-    AND name LIKE '\_\_tk\_probe\_%' ESCAPE '\\'
+    AND name LIKE '\_\_tk\_probe\_%' ESCAPE '\'
   RETURNING 1
 ),
 queued_group_changed AS (
@@ -877,7 +877,7 @@ legacy_soft_deleted_keys AS (
       status = 'disabled',
       updated_at = NOW()
   WHERE deleted_at IS NULL
-    AND name LIKE '\_\_tk\_probe\_tkprobe%' ESCAPE '\\'
+    AND name LIKE '\_\_tk\_probe\_tkprobe%' ESCAPE '\'
   RETURNING 1
 ),
 legacy_soft_deleted_groups AS (
@@ -886,7 +886,7 @@ legacy_soft_deleted_groups AS (
       status = 'disabled',
       updated_at = NOW()
   WHERE deleted_at IS NULL
-    AND name LIKE '\_\_tk\_probe\_tkprobe%' ESCAPE '\\'
+    AND name LIKE '\_\_tk\_probe\_tkprobe%' ESCAPE '\'
   RETURNING 1
 )
 SELECT 'deleted_account_group_bindings=' || COUNT(*) FROM deleted_bindings

--- a/ops/pricing/test_probe_reserved_resources.sh
+++ b/ops/pricing/test_probe_reserved_resources.sh
@@ -27,6 +27,9 @@ assert_eq "$(tk_probe_canonical_scope endpoint_matrix_grok grok source_group_id 
 unset TK_PROBE_LEGACY_SCOPE
 
 assert_eq "$(tk_probe_platform_reuse_scopes | tr '\n' ' ' | sed 's/ $//')" "anthropic kiro openai gemini grok antigravity newapi" "platform reuse scopes"
+assert_eq "$(tk_probe_canonical_catalog_scopes | tr '\n' ' ' | sed 's/ $//')" "anthropic_srcgrp_1_cc anthropic_srcgrp_1_kiro kiro_srcgrp_1_kiro openai_srcgrp_2 gemini_srcgrp_16 newapi_srcgrp_16 newapi_srcgrp_18 newapi_srcgrp_5 antigravity_srcgrp_21 grok_srcgrp_25" "canonical catalog scopes"
+assert_eq "$(tk_probe_canonical_keep_scopes | tr '\n' ' ' | sed 's/ $//')" "anthropic_srcgrp_1_cc anthropic_srcgrp_1_kiro kiro_srcgrp_1_kiro openai_srcgrp_2 gemini_srcgrp_16 newapi_srcgrp_16 newapi_srcgrp_18 newapi_srcgrp_5 antigravity_srcgrp_21 grok_srcgrp_25 anthropic kiro openai gemini grok antigravity newapi" "canonical keep scopes"
+assert_eq "$(tk_probe_keep_names_sql)" "('__tk_probe_anthropic_srcgrp_1_cc_group', '__tk_probe_anthropic_srcgrp_1_cc_key', '__tk_probe_anthropic_srcgrp_1_kiro_group', '__tk_probe_anthropic_srcgrp_1_kiro_key', '__tk_probe_kiro_srcgrp_1_kiro_group', '__tk_probe_kiro_srcgrp_1_kiro_key', '__tk_probe_openai_srcgrp_2_group', '__tk_probe_openai_srcgrp_2_key', '__tk_probe_gemini_srcgrp_16_group', '__tk_probe_gemini_srcgrp_16_key', '__tk_probe_newapi_srcgrp_16_group', '__tk_probe_newapi_srcgrp_16_key', '__tk_probe_newapi_srcgrp_18_group', '__tk_probe_newapi_srcgrp_18_key', '__tk_probe_newapi_srcgrp_5_group', '__tk_probe_newapi_srcgrp_5_key', '__tk_probe_antigravity_srcgrp_21_group', '__tk_probe_antigravity_srcgrp_21_key', '__tk_probe_grok_srcgrp_25_group', '__tk_probe_grok_srcgrp_25_key', '__tk_probe_anthropic_group', '__tk_probe_anthropic_key', '__tk_probe_kiro_group', '__tk_probe_kiro_key', '__tk_probe_openai_group', '__tk_probe_openai_key', '__tk_probe_gemini_group', '__tk_probe_gemini_key', '__tk_probe_grok_group', '__tk_probe_grok_key', '__tk_probe_antigravity_group', '__tk_probe_antigravity_key', '__tk_probe_newapi_group', '__tk_probe_newapi_key')" "keep names sql"
 if ! tk_probe_is_legacy_oneoff_probe_name "__tk_probe_tkprobe-2-20260629T102307Z-3222117"; then
 	echo "FAIL: tkprobe legacy group name should match legacy oneoff probe pattern" >&2
 	exit 1
@@ -99,6 +102,35 @@ TK_PROBE_TEST_SCENARIO=group_id
 tk_probe_clear_bindings probe
 if ! printf '%s' "$TK_PROBE_LAST_SQL" | grep -q "status = 'disabled'"; then
 	echo "FAIL: clear_bindings should disable reusable probe key/group" >&2
+	exit 1
+fi
+if ! printf '%s' "$TK_PROBE_LAST_SQL" | grep -q "INSERT INTO scheduler_outbox"; then
+	echo "FAIL: clear_bindings should enqueue scheduler_outbox group_changed" >&2
+	exit 1
+fi
+tk_probe_cleanup_named_group 39 '__tk_probe_probe_group' '__tk_probe_probe_key' reusable
+if ! printf '%s' "$TK_PROBE_LAST_SQL" | grep -q "INSERT INTO scheduler_outbox"; then
+	echo "FAIL: reusable named cleanup should enqueue scheduler_outbox group_changed" >&2
+	exit 1
+fi
+tk_probe_cleanup_named_group 39 '__tk_probe_tkprobe-x' '__tk_probe_tkprobe-x' oneoff
+if ! printf '%s' "$TK_PROBE_LAST_SQL" | grep -q "deleted_at = NOW()"; then
+	echo "FAIL: oneoff named cleanup should soft-delete group/key" >&2
+	exit 1
+fi
+command -v flock >/dev/null 2>&1 || flock() { return 0; }
+flock() { return 0; }
+flock() { return 0; }
+tk_probe_acquire_reuse_lock() { return 0; }
+tk_probe_prepare_platform_reuse_probe newapi 122
+assert_eq "$TK_PROBE_SCOPE" "newapi" "platform reuse scope"
+assert_eq "$TK_PROBE_GROUP_ID" "1" "platform reuse group id"
+if [[ ! "$TK_PROBE_KEY_ID" =~ ^[0-9]+$ ]]; then
+	echo "FAIL: platform reuse probe should leave a numeric key id" >&2
+	exit 1
+fi
+if [ -z "$TK_PROBE_KEY" ]; then
+	echo "FAIL: platform reuse probe should leave a reusable key value" >&2
 	exit 1
 fi
 

--- a/ops/pricing/test_probe_reserved_resources.sh
+++ b/ops/pricing/test_probe_reserved_resources.sh
@@ -50,6 +50,9 @@ tk_probe_psql() {
 		fi
 		shift
 	done
+	if [ -z "$sql" ]; then
+		sql="$(cat)"
+	fi
 	TK_PROBE_LAST_SQL="$sql"
 	case "$TK_PROBE_TEST_SCENARIO" in
 	case_match)
@@ -118,6 +121,15 @@ if ! printf '%s' "$TK_PROBE_LAST_SQL" | grep -q "deleted_at = NOW()"; then
 	echo "FAIL: oneoff named cleanup should soft-delete group/key" >&2
 	exit 1
 fi
+tk_probe_cleanup_all_reserved
+python3 - "$TK_PROBE_LAST_SQL" <<'PY'
+import sys
+sql = sys.argv[1]
+if "ESCAPE '\\\\'" in sql:
+    raise SystemExit("FAIL: single-quoted cleanup heredoc must not send a two-character SQL ESCAPE")
+if sql.count("ESCAPE '\\'") != 5:
+    raise SystemExit("FAIL: cleanup apply SQL should use a single backslash ESCAPE in all LIKE clauses")
+PY
 command -v flock >/dev/null 2>&1 || flock() { return 0; }
 flock() { return 0; }
 flock() { return 0; }

--- a/ops/stage0/probe_account_model.sh
+++ b/ops/stage0/probe_account_model.sh
@@ -222,7 +222,7 @@ INSERT INTO groups (
 	  '$(sql_escape "$PLATFORM")',
 	  1.0, true, 'active',
 	  'standard', 30, false,
-	  false, '{}'::jsonb, true, '["claude", "gemini_text", "gemini_image"]'::jsonb,
+	  false, '{}'::jsonb, true, '[\"claude\", \"gemini_text\", \"gemini_image\"]'::jsonb,
 	  '{}'::jsonb, '{}'::jsonb,
 	  2147483000, 0, NOW(), NOW()
 	) RETURNING id;

--- a/ops/stage0/probe_account_model.sh
+++ b/ops/stage0/probe_account_model.sh
@@ -163,14 +163,7 @@ if [[ -z "$PLATFORM" ]]; then
   fail_json "target account platform is empty"
 fi
 
-PROBE_SCOPE="$(python3 - "$PLATFORM" <<'PY'
-import re
-import sys
-
-scope = re.sub(r"[^a-z0-9]+", "_", sys.argv[1].strip().lower()).strip("_")
-print((scope or "platform")[:48])
-PY
-)"
+PROBE_SCOPE="$(tk_probe_scope_from_platform "$PLATFORM")"
 if [[ -z "$PROBE_SCOPE" ]]; then
   fail_json "failed to derive probe scope"
 fi
@@ -184,16 +177,7 @@ else
 fi
 
 API_KEY=""
-if [[ "$PROBE_REUSE_MODE" == "1" ]]; then
-  if ! command -v flock >/dev/null 2>&1; then
-    fail_json "flock is required when PROBE_REUSE_MODE=1"
-  fi
-  LOCK_PATH="/tmp/tokenkey-account-model-probe-${PROBE_SCOPE}.lock"
-  exec 9>"$LOCK_PATH"
-  if ! flock -w "$PROBE_LOCK_TIMEOUT_SECONDS" 9; then
-    fail_json "timed out waiting for probe reuse lock"
-  fi
-else
+if [[ "$PROBE_REUSE_MODE" != "1" ]]; then
   API_KEY="$(new_probe_api_key)"
 fi
 
@@ -205,20 +189,9 @@ cleanup() {
   fi
   if [[ -n "${GROUP_ID:-}" ]]; then
     if [[ "$PROBE_REUSE_MODE" == "1" ]]; then
-      "${PSQL[@]}" -c "
-	DELETE FROM account_groups WHERE group_id = ${GROUP_ID};
-	UPDATE api_keys SET status='disabled', updated_at=NOW() WHERE group_id = ${GROUP_ID} AND name = '$(sql_escape "$KEY_NAME")' AND deleted_at IS NULL;
-	UPDATE groups SET status='disabled', updated_at=NOW() WHERE id = ${GROUP_ID} AND name = '$(sql_escape "$GROUP_NAME")' AND deleted_at IS NULL;
-	INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
-	VALUES ('group_changed', NULL, ${GROUP_ID}, NULL);
-	" >/dev/null 2>&1 || true # preflight-allow: swallow
+      tk_probe_cleanup_named_group "$GROUP_ID" "$GROUP_NAME" "$KEY_NAME" reusable >/dev/null 2>&1 || true # preflight-allow: swallow
     else
-      "${PSQL[@]}" -c "
-	DELETE FROM account_groups WHERE group_id = ${GROUP_ID};
-	DELETE FROM user_allowed_groups WHERE group_id = ${GROUP_ID};
-	UPDATE api_keys SET status='disabled', deleted_at=NOW(), updated_at=NOW() WHERE group_id = ${GROUP_ID} AND name = '$(sql_escape "$KEY_NAME")' AND deleted_at IS NULL;
-	UPDATE groups SET status='disabled', deleted_at=NOW(), updated_at=NOW() WHERE id = ${GROUP_ID} AND name = '$(sql_escape "$GROUP_NAME")' AND deleted_at IS NULL;
-	" >/dev/null 2>&1 || true # preflight-allow: swallow
+      tk_probe_cleanup_named_group "$GROUP_ID" "$GROUP_NAME" "$KEY_NAME" oneoff >/dev/null 2>&1 || true # preflight-allow: swallow
     fi
   fi
   sudo docker exec "$APP_CONTAINER" rm -f /tmp/tk-probe-request.json /tmp/tk-probe-response.json /tmp/tk-probe-headers.txt >/dev/null 2>&1 || true # preflight-allow: swallow
@@ -226,62 +199,15 @@ cleanup() {
 trap cleanup EXIT
 
 if [[ "$PROBE_REUSE_MODE" == "1" ]]; then
-  GROUP_ID="$("${PSQL[@]}" -c "
-SELECT COALESCE((
-  SELECT id::text
-  FROM groups
-  WHERE name = '$(sql_escape "$GROUP_NAME")'
-    AND deleted_at IS NULL
-  ORDER BY id
-  LIMIT 1
-), '');
-" | tr -d '\n')"
-  if [[ -n "$GROUP_ID" ]]; then
-    psql_capture_numeric GROUP_ID "failed to update probe group name=${GROUP_NAME} platform=${PLATFORM}" "
-UPDATE groups
-SET
-  description = 'reserved reusable account/model probe group; direct probe key only; excluded from universal routing',
-  platform = '$(sql_escape "$PLATFORM")',
-  rate_multiplier = 1.0,
-  is_exclusive = true,
-  status = 'active',
-  subscription_type = 'standard',
-  default_validity_days = 30,
-  claude_code_only = false,
-  model_routing_enabled = false,
-  model_routing = '{}'::jsonb,
-  allow_messages_dispatch = true,
-  supported_model_scopes = '[\"claude\", \"gemini_text\", \"gemini_image\"]'::jsonb,
-  models_list_config = '{}'::jsonb,
-  sort_order = 2147483000,
-  rpm_limit = 0,
-  updated_at = NOW()
-WHERE id = ${GROUP_ID}
-  AND name = '$(sql_escape "$GROUP_NAME")'
-  AND deleted_at IS NULL
-RETURNING id;
-"
-  else
-    psql_capture_numeric GROUP_ID "failed to insert probe group name=${GROUP_NAME} platform=${PLATFORM}" "
-INSERT INTO groups (
-  name, description, platform, rate_multiplier, is_exclusive, status,
-  subscription_type, default_validity_days, claude_code_only,
-  model_routing_enabled, model_routing, allow_messages_dispatch, supported_model_scopes,
-  messages_dispatch_model_config, models_list_config,
-  sort_order, rpm_limit, created_at, updated_at
-) VALUES (
-  '$(sql_escape "$GROUP_NAME")',
-  'reserved reusable account/model probe group; direct probe key only; excluded from universal routing',
-  '$(sql_escape "$PLATFORM")',
-  1.0, true, 'active',
-  'standard', 30, false,
-  false, '{}'::jsonb, true, '[\"claude\", \"gemini_text\", \"gemini_image\"]'::jsonb,
-  '{}'::jsonb, '{}'::jsonb,
-  2147483000, 0, NOW(), NOW()
-)
-RETURNING id;
-"
+  if ! tk_probe_prepare_platform_reuse_probe "$PLATFORM" "$ACCOUNT_ID"; then
+    fail_json "failed to prepare reusable probe resources for platform=${PLATFORM} account_id=${ACCOUNT_ID}"
   fi
+  PROBE_SCOPE="${TK_PROBE_SCOPE}"
+  GROUP_ID="${TK_PROBE_GROUP_ID}"
+  API_KEY_ID="${TK_PROBE_KEY_ID}"
+  API_KEY="${TK_PROBE_KEY}"
+  GROUP_NAME="$(tk_probe_group_name "$PROBE_SCOPE")"
+  KEY_NAME="$(tk_probe_key_name "$PROBE_SCOPE")"
 else
   psql_capture_numeric GROUP_ID "failed to insert one-off probe group name=${GROUP_NAME} platform=${PLATFORM}" "
 INSERT INTO groups (
@@ -296,29 +222,20 @@ INSERT INTO groups (
 	  '$(sql_escape "$PLATFORM")',
 	  1.0, true, 'active',
 	  'standard', 30, false,
-	  false, '{}'::jsonb, true, '[\"claude\", \"gemini_text\", \"gemini_image\"]'::jsonb,
+	  false, '{}'::jsonb, true, '["claude", "gemini_text", "gemini_image"]'::jsonb,
 	  '{}'::jsonb, '{}'::jsonb,
 	  2147483000, 0, NOW(), NOW()
 	) RETURNING id;
 "
-fi
 
-if [[ ! "$GROUP_ID" =~ ^[0-9]+$ ]]; then
-  fail_json "failed to prepare probe group name=${GROUP_NAME} platform=${PLATFORM}"
-fi
+  if [[ ! "$GROUP_ID" =~ ^[0-9]+$ ]]; then
+    fail_json "failed to prepare probe group name=${GROUP_NAME} platform=${PLATFORM}"
+  fi
 
-"${PSQL[@]}" -c "
+  "${PSQL[@]}" -c "
 INSERT INTO user_allowed_groups (user_id, group_id, created_at)
 VALUES (${PROBE_USER_ID}, ${GROUP_ID}, NOW())
 ON CONFLICT (user_id, group_id) DO NOTHING;
-" >/dev/null
-
-if [[ "$PROBE_REUSE_MODE" == "1" ]]; then
-  tk_probe_unbind_account_from_stale_probe_groups "$ACCOUNT_ID" "$GROUP_NAME" || \
-    fail_json "failed to unbind stale __tk_probe_* groups for account_id=${ACCOUNT_ID}"
-fi
-
-"${PSQL[@]}" -c "
 DELETE FROM account_groups WHERE group_id = ${GROUP_ID};
 INSERT INTO account_groups (account_id, group_id, priority, created_at)
 VALUES (${ACCOUNT_ID}, ${GROUP_ID}, 1, NOW())
@@ -327,64 +244,6 @@ INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
 VALUES ('group_changed', NULL, ${GROUP_ID}, NULL);
 " >/dev/null
 
-if [[ "$PROBE_REUSE_MODE" == "1" ]]; then
-  NEW_API_KEY="$(new_probe_api_key)"
-  API_KEY_ROW="$("${PSQL[@]}" -c "
-WITH existing AS (
-  SELECT id
-  FROM api_keys
-  WHERE group_id = ${GROUP_ID}
-    AND name = '$(sql_escape "$KEY_NAME")'
-    AND deleted_at IS NULL
-  ORDER BY id
-  LIMIT 1
-)
-SELECT COALESCE((SELECT id::text FROM existing), '');
-" | tr -d '\n')"
-  if [[ -n "$API_KEY_ROW" ]]; then
-    API_KEY_ID="$API_KEY_ROW"
-    API_KEY="$("${PSQL[@]}" -c "
-UPDATE api_keys
-SET
-  user_id = ${PROBE_USER_ID},
-  key = '$(sql_escape "$NEW_API_KEY")',
-  status = 'active',
-  routing_mode = 'direct',
-  quota = 0,
-  quota_used = 0,
-  rate_limit_5h = 0,
-  rate_limit_1d = 0,
-  rate_limit_7d = 0,
-  usage_5h = 0,
-  usage_1d = 0,
-  usage_7d = 0,
-  updated_at = NOW()
-WHERE id = ${API_KEY_ID}
-  AND group_id = ${GROUP_ID}
-  AND name = '$(sql_escape "$KEY_NAME")'
-  AND deleted_at IS NULL
-RETURNING key;
-" | tr -d '\n')"
-  else
-    API_KEY="$NEW_API_KEY"
-    psql_capture_numeric API_KEY_ID "failed to insert probe API key name=${KEY_NAME} group_id=${GROUP_ID}" "
-INSERT INTO api_keys (
-  user_id, key, name, group_id, status, routing_mode,
-  quota, quota_used, rate_limit_5h, rate_limit_1d, rate_limit_7d,
-  usage_5h, usage_1d, usage_7d, created_at, updated_at
-) VALUES (
-  ${PROBE_USER_ID},
-  '$(sql_escape "$API_KEY")',
-  '$(sql_escape "$KEY_NAME")',
-  ${GROUP_ID},
-  'active',
-  'direct',
-  0, 0, 0, 0, 0,
-  0, 0, 0, NOW(), NOW()
-) RETURNING id;
-"
-  fi
-else
   psql_capture_numeric API_KEY_ID "failed to insert one-off probe API key name=${KEY_NAME} group_id=${GROUP_ID}" "
 INSERT INTO api_keys (
   user_id, key, name, group_id, status, routing_mode,

--- a/ops/stage0/test_probe_account_model.py
+++ b/ops/stage0/test_probe_account_model.py
@@ -31,30 +31,19 @@ class ProbeAccountModelTest(unittest.TestCase):
         self.assertIn("missing probe_reserved_resources.sh companion", payload["error"])
         self.assertNotIn("command not found", proc.stderr)
 
-    def test_reusable_group_ensure_uses_two_step_returning_id(self) -> None:
+    def test_reuse_mode_delegates_resource_lifecycle_to_shared_owner(self) -> None:
         script = _SCRIPT.read_text()
-        start = script.index('if [[ "$PROBE_REUSE_MODE" == "1" ]]; then\n  GROUP_ID=')
-        end = script.index('else\n  psql_capture_numeric GROUP_ID "failed to insert one-off probe group', start)
-        group_ensure = script[start:end]
 
-        self.assertIn("SELECT id::text", group_ensure)
-        self.assertIn("if [[ -n \"$GROUP_ID\" ]]; then", group_ensure)
-        self.assertIn("UPDATE groups", group_ensure)
-        self.assertIn("INSERT INTO groups", group_ensure)
-        self.assertIn("RETURNING id;", group_ensure)
-        self.assertIn("allow_messages_dispatch = true", group_ensure)
-        self.assertIn("model_routing, allow_messages_dispatch, supported_model_scopes", group_ensure)
-        self.assertIn("false, '{}'::jsonb, true, '[", group_ensure)
-        self.assertIn("psql_capture_numeric GROUP_ID", group_ensure)
-        self.assertIn("supported_model_scopes", group_ensure)
-        self.assertIn("messages_dispatch_model_config", group_ensure)
-        self.assertIn("models_list_config", group_ensure)
-        self.assertIn("claude", group_ensure)
-        self.assertIn("gemini_text", group_ensure)
-        self.assertIn("gemini_image", group_ensure)
-        self.assertNotIn("ON CONFLICT", group_ensure)
-        self.assertNotIn("WITH existing AS", group_ensure)
-        self.assertNotIn("FROM picked", group_ensure)
+        self.assertIn('if [[ "$PROBE_REUSE_MODE" == "1" ]]; then', script)
+        self.assertIn('tk_probe_prepare_platform_reuse_probe "$PLATFORM" "$ACCOUNT_ID"', script)
+        self.assertIn('PROBE_SCOPE="${TK_PROBE_SCOPE}"', script)
+        self.assertIn('GROUP_ID="${TK_PROBE_GROUP_ID}"', script)
+        self.assertIn('API_KEY_ID="${TK_PROBE_KEY_ID}"', script)
+        self.assertIn('API_KEY="${TK_PROBE_KEY}"', script)
+        self.assertIn('GROUP_NAME="$(tk_probe_group_name "$PROBE_SCOPE")"', script)
+        self.assertIn('KEY_NAME="$(tk_probe_key_name "$PROBE_SCOPE")"', script)
+        self.assertNotIn('SELECT id::text\n  FROM groups', script)
+        self.assertNotIn('NEW_API_KEY="$(new_probe_api_key)"', script)
 
     def test_psql_id_capture_is_quiet_and_reports_sql_errors(self) -> None:
         script = _SCRIPT.read_text()
@@ -78,31 +67,24 @@ class ProbeAccountModelTest(unittest.TestCase):
         self.assertNotIn("resolve_app_container() {", script)
         self.assertNotIn("for candidate in tokenkey tokenkey-blue tokenkey-green", script)
 
-    def test_reuse_mode_unbinds_stale_probe_groups_before_bind(self) -> None:
+    def test_reuse_mode_uses_shared_probe_helper(self) -> None:
         script = _SCRIPT.read_text()
         self.assertIn("probe_reserved_resources.sh", script)
-        self.assertIn("tk_probe_unbind_account_from_stale_probe_groups", script)
         self.assertIn('if [[ "$PROBE_REUSE_MODE" == "1" ]]; then', script)
         self.assertIn("${SCRIPT_DIR}/probe_reserved_resources.sh", script)
-        unbind_at = script.index("tk_probe_unbind_account_from_stale_probe_groups")
-        bind_at = script.index("INSERT INTO account_groups (account_id, group_id, priority, created_at)")
-        self.assertLess(unbind_at, bind_at)
+        self.assertIn('tk_probe_prepare_platform_reuse_probe "$PLATFORM" "$ACCOUNT_ID"', script)
+        self.assertIn('tk_probe_cleanup_named_group "$GROUP_ID" "$GROUP_NAME" "$KEY_NAME" reusable', script)
+        self.assertNotIn("tk_probe_unbind_account_from_stale_probe_groups", script)
 
     def test_rebinding_group_notifies_scheduler_snapshot(self) -> None:
         script = _SCRIPT.read_text()
-        bind_at = script.index("INSERT INTO account_groups (account_id, group_id, priority, created_at)")
-        key_at = script.index('if [[ "$PROBE_REUSE_MODE" == "1" ]]; then\n  NEW_API_KEY=', bind_at)
-        binding_sql = script[bind_at:key_at]
-
-        self.assertIn("INSERT INTO scheduler_outbox", binding_sql)
-        self.assertIn("'group_changed'", binding_sql)
-        self.assertIn("${GROUP_ID}", binding_sql)
+        self.assertIn('INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)', script)
+        self.assertIn("VALUES ('group_changed', NULL, ${GROUP_ID}, NULL);", script)
 
         cleanup_at = script.index("cleanup() {")
         trap_at = script.index("trap cleanup EXIT", cleanup_at)
         cleanup_sql = script[cleanup_at:trap_at]
-        self.assertIn("INSERT INTO scheduler_outbox", cleanup_sql)
-        self.assertIn("'group_changed'", cleanup_sql)
+        self.assertIn("tk_probe_cleanup_named_group", cleanup_sql)
 
     def test_probe_script_wires_verdict_module_and_embeddings_endpoint(self) -> None:
         script = _SCRIPT.read_text()

--- a/ops/stage0/test_probe_account_model.py
+++ b/ops/stage0/test_probe_account_model.py
@@ -76,6 +76,14 @@ class ProbeAccountModelTest(unittest.TestCase):
         self.assertIn('tk_probe_cleanup_named_group "$GROUP_ID" "$GROUP_NAME" "$KEY_NAME" reusable', script)
         self.assertNotIn("tk_probe_unbind_account_from_stale_probe_groups", script)
 
+    def test_oneoff_supported_model_scopes_json_keeps_shell_escaped_quotes(self) -> None:
+        script = _SCRIPT.read_text()
+
+        expected = r"""false, '{}'::jsonb, true, '[\"claude\", \"gemini_text\", \"gemini_image\"]'::jsonb,"""
+        broken = """false, '{}'::jsonb, true, '["claude", "gemini_text", "gemini_image"]'::jsonb,"""
+        self.assertIn(expected, script)
+        self.assertNotIn(broken, script)
+
     def test_rebinding_group_notifies_scheduler_snapshot(self) -> None:
         script = _SCRIPT.read_text()
         self.assertIn('INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)', script)


### PR DESCRIPTION
## Summary
- centralize reserved probe group/key lifecycle helpers in `ops/pricing/probe_reserved_resources.sh`
- make cleanup/prune/account-model probes delegate reusable resource cleanup and pruning to the shared owner
- add static regression coverage for cleanup delegation and canonical keep-set behavior

## Verification
- `git diff --check`
- `bash ops/observability/test_cleanup_probe_resources.sh`
- `bash ops/observability/test_prune_probe_resources.sh`
- `bash ops/pricing/test_probe_reserved_resources.sh`
- `python3 -m unittest ops.stage0.test_probe_account_model`
- `./scripts/preflight.sh`
- `make test`

ai