### PR TITLE
refactor(openrouter): 去掉 legacy group_ids/key id 与鉴权别名

### DIFF
--- a/backend/internal/handler/gateway_handler_tk_openrouter_provider.go
+++ b/backend/internal/handler/gateway_handler_tk_openrouter_provider.go
@@ -33,7 +33,7 @@ func (h *GatewayHandler) serveOpenRouterProviderModels(c *gin.Context) bool {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"message": "load openrouter provider config", "code": 500}})
 		return true
 	}
-	if !cfg.CanAccessCatalog(apiKey.ID, apiKey.UserID) {
+	if !cfg.AllowsSellerAPIKey(apiKey.ID, apiKey.UserID) {
 		c.JSON(http.StatusForbidden, gin.H{"error": gin.H{"message": "api key not authorized for openrouter provider catalog", "code": 403}})
 		return true
 	}
@@ -56,7 +56,7 @@ func (h *GatewayHandler) tryServeOpenRouterProviderModels(c *gin.Context) bool {
 		return false
 	}
 	cfg, err := h.settingService.GetOpenRouterProviderConfig(c.Request.Context())
-	if err != nil || !cfg.CanAccessCatalog(apiKey.ID, apiKey.UserID) {
+	if err != nil || !cfg.AllowsSellerAPIKey(apiKey.ID, apiKey.UserID) {
 		return false
 	}
 	return h.serveOpenRouterProviderModels(c)

--- a/backend/internal/handler/gateway_handler_tk_openrouter_provider_media.go
+++ b/backend/internal/handler/gateway_handler_tk_openrouter_provider_media.go
@@ -77,7 +77,7 @@ func (h *GatewayHandler) authorizeOpenRouterProviderInference(c *gin.Context) (s
 	if apiKey.User != nil && apiKey.User.ID > 0 {
 		userID = apiKey.User.ID
 	}
-	if !cfg.AllowsInferenceAPIKey(apiKey.ID, userID) {
+	if !cfg.AllowsSellerAPIKey(apiKey.ID, userID) {
 		c.JSON(http.StatusForbidden, gin.H{"error": gin.H{"message": "api key not authorized for openrouter provider inference", "code": 403}})
 		return cfg, true
 	}

--- a/backend/internal/service/openrouter_provider_tk_catalog.go
+++ b/backend/internal/service/openrouter_provider_tk_catalog.go
@@ -136,44 +136,27 @@ func (s *GatewayService) openRouterProviderCatalogCandidates(ctx context.Context
 }
 
 // ResolveOpenRouterProviderSupplyGroupIDs returns the seller catalog supply groups.
-// Owner is billing_user_id → user_allowed_groups. Legacy cfg.GroupIDs is only a
-// fallback when BillingUserID is unset (tests / empty config).
+// Owner is billing_user_id → user_allowed_groups (required).
 func (s *GatewayService) ResolveOpenRouterProviderSupplyGroupIDs(
 	ctx context.Context,
 	cfg OpenRouterProviderConfig,
 ) ([]int64, error) {
-	if cfg.BillingUserID > 0 {
-		if s == nil || s.userRepo == nil {
-			return nil, fmt.Errorf("openrouter provider: user repository required to resolve supply groups")
-		}
-		user, err := s.userRepo.GetByID(ctx, cfg.BillingUserID)
-		if err != nil {
-			return nil, fmt.Errorf("openrouter provider billing user %d: %w", cfg.BillingUserID, err)
-		}
-		if user == nil {
-			return nil, fmt.Errorf("openrouter provider billing user %d not found", cfg.BillingUserID)
-		}
-		out := make([]int64, 0, len(user.AllowedGroups))
-		seen := make(map[int64]struct{}, len(user.AllowedGroups))
-		for _, id := range user.AllowedGroups {
-			if id <= 0 {
-				continue
-			}
-			if _, ok := seen[id]; ok {
-				continue
-			}
-			seen[id] = struct{}{}
-			out = append(out, id)
-		}
-		sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
-		if len(out) == 0 {
-			return nil, fmt.Errorf("openrouter provider billing user %d has no allowed groups", cfg.BillingUserID)
-		}
-		return out, nil
+	if cfg.BillingUserID <= 0 {
+		return nil, fmt.Errorf("openrouter provider config: billing_user_id required")
 	}
-	out := make([]int64, 0, len(cfg.GroupIDs))
-	seen := make(map[int64]struct{}, len(cfg.GroupIDs))
-	for _, id := range cfg.GroupIDs {
+	if s == nil || s.userRepo == nil {
+		return nil, fmt.Errorf("openrouter provider: user repository required to resolve supply groups")
+	}
+	user, err := s.userRepo.GetByID(ctx, cfg.BillingUserID)
+	if err != nil {
+		return nil, fmt.Errorf("openrouter provider billing user %d: %w", cfg.BillingUserID, err)
+	}
+	if user == nil {
+		return nil, fmt.Errorf("openrouter provider billing user %d not found", cfg.BillingUserID)
+	}
+	out := make([]int64, 0, len(user.AllowedGroups))
+	seen := make(map[int64]struct{}, len(user.AllowedGroups))
+	for _, id := range user.AllowedGroups {
 		if id <= 0 {
 			continue
 		}
@@ -185,7 +168,7 @@ func (s *GatewayService) ResolveOpenRouterProviderSupplyGroupIDs(
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
 	if len(out) == 0 {
-		return nil, fmt.Errorf("openrouter provider config: billing_user_id or legacy group_ids required")
+		return nil, fmt.Errorf("openrouter provider billing user %d has no allowed groups", cfg.BillingUserID)
 	}
 	return out, nil
 }

--- a/backend/internal/service/openrouter_provider_tk_catalog_test.go
+++ b/backend/internal/service/openrouter_provider_tk_catalog_test.go
@@ -5,6 +5,7 @@ package service
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -16,7 +17,6 @@ func TestResolveOpenRouterProviderSupplyGroupIDs_FromBillingUserAllowedGroups(t 
 	}
 	got, err := svc.ResolveOpenRouterProviderSupplyGroupIDs(context.Background(), OpenRouterProviderConfig{
 		BillingUserID: 32,
-		GroupIDs:      []int64{99, 100}, // legacy must be ignored
 	})
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
@@ -38,23 +38,18 @@ func TestResolveOpenRouterProviderSupplyGroupIDs_BillingUserEmptyGroups(t *testi
 	}
 	_, err := svc.ResolveOpenRouterProviderSupplyGroupIDs(context.Background(), OpenRouterProviderConfig{
 		BillingUserID: 32,
-		GroupIDs:      []int64{1},
 	})
 	if err == nil {
 		t.Fatal("expected error when billing user has no allowed groups")
 	}
 }
 
-func TestResolveOpenRouterProviderSupplyGroupIDs_LegacyFallbackWithoutBillingUser(t *testing.T) {
+func TestResolveOpenRouterProviderSupplyGroupIDs_RequiresBillingUser(t *testing.T) {
+	// Boundary: missing billing_user_id must fail (legacy group_ids fallback removed).
 	svc := &GatewayService{}
-	got, err := svc.ResolveOpenRouterProviderSupplyGroupIDs(context.Background(), OpenRouterProviderConfig{
-		GroupIDs: []int64{2, 1, 2},
-	})
-	if err != nil {
-		t.Fatalf("resolve: %v", err)
-	}
-	if len(got) != 2 || got[0] != 1 || got[1] != 2 {
-		t.Fatalf("got %v", got)
+	_, err := svc.ResolveOpenRouterProviderSupplyGroupIDs(context.Background(), OpenRouterProviderConfig{})
+	if err == nil || !strings.Contains(err.Error(), "billing_user_id required") {
+		t.Fatalf("expected billing_user_id required, got %v", err)
 	}
 }
 

--- a/backend/internal/service/openrouter_provider_tk_config.go
+++ b/backend/internal/service/openrouter_provider_tk_config.go
@@ -17,19 +17,13 @@ const OpenRouterProviderSellerKeyName = "openrouter"
 // Supply groups are NOT stored here: BuildOpenRouterProviderCatalog reads
 // billing_user_id's user_allowed_groups at runtime (single source of truth).
 // Seller auth is billing_user_id ownership (any of that user's API keys).
-// AllowedAPIKeyIDs / MonitorAPIKeyIDs remain optional legacy allowlists and both
-// grant the full seller surface (catalog + inference) during migration.
 // Loop prevention uses scheme C (no aggregator channels on public groups).
-// Legacy JSON field "group_ids" is ignored when billing_user_id is set.
+// Unknown JSON keys (legacy group_ids / key id lists) are ignored on parse.
 type OpenRouterProviderConfig struct {
-	Enabled       bool   `json:"enabled"`
-	ModelIDPrefix string `json:"model_id_prefix"`
-	Slug          string `json:"slug"`
-	// GroupIDs is legacy-only. Prefer billing user allowed groups; ignored when BillingUserID > 0.
-	GroupIDs               []int64          `json:"group_ids,omitempty"`
+	Enabled                bool             `json:"enabled"`
+	ModelIDPrefix          string           `json:"model_id_prefix"`
+	Slug                   string           `json:"slug"`
 	BillingUserID          int64            `json:"billing_user_id"`
-	AllowedAPIKeyIDs       []int64          `json:"allowed_api_key_ids,omitempty"`
-	MonitorAPIKeyIDs       []int64          `json:"monitor_api_key_ids,omitempty"`
 	DefaultContextLen      int              `json:"default_context_length"`
 	CapacityTPM            *int64           `json:"capacity_tpm"`
 	ModelCapacityTPM       map[string]int64 `json:"model_capacity_tpm"`
@@ -159,40 +153,13 @@ func (c OpenRouterProviderConfig) isBillingUser(userID int64) bool {
 	return c.BillingUserID > 0 && c.BillingUserID == userID
 }
 
-// AllowsSellerAPIKey is the single seller-surface allow check: billing-user
-// ownership, or a legacy numeric id allowlist entry.
+// AllowsSellerAPIKey is the single seller-surface allow check: any API key
+// owned by billing_user_id (catalog + inference).
 func (c OpenRouterProviderConfig) AllowsSellerAPIKey(apiKeyID, userID int64) bool {
 	if !c.Enabled || apiKeyID <= 0 {
 		return false
 	}
-	if c.isBillingUser(userID) {
-		return true
-	}
-	for _, id := range c.AllowedAPIKeyIDs {
-		if id == apiKeyID {
-			return true
-		}
-	}
-	for _, id := range c.MonitorAPIKeyIDs {
-		if id == apiKeyID {
-			return true
-		}
-	}
-	return false
-}
-
-// AllowsInferenceAPIKey allows catalog + inference (same seller surface).
-func (c OpenRouterProviderConfig) AllowsInferenceAPIKey(apiKeyID, userID int64) bool {
-	return c.AllowsSellerAPIKey(apiKeyID, userID)
-}
-
-func (c OpenRouterProviderConfig) CanAccessCatalog(apiKeyID, userID int64) bool {
-	return c.AllowsSellerAPIKey(apiKeyID, userID)
-}
-
-// AllowsAPIKey keeps the previous name for catalog/inference allow checks used in tests.
-func (c OpenRouterProviderConfig) AllowsAPIKey(apiKeyID, userID int64) bool {
-	return c.AllowsSellerAPIKey(apiKeyID, userID)
+	return c.isBillingUser(userID)
 }
 
 func (c OpenRouterProviderConfig) PublicModelID(model string) string {
@@ -229,34 +196,26 @@ func (c OpenRouterProviderConfig) InternalModelID(publicID string) (string, bool
 	return internal, true
 }
 
-func (c OpenRouterProviderConfig) CatalogBaseURL(apiBase string) string {
+func openRouterProviderAbsoluteURL(apiBase, path string) string {
 	base := strings.TrimRight(strings.TrimSpace(apiBase), "/")
 	if base == "" {
 		base = "https://api.tokenkey.dev"
 	}
-	return base + "/openrouter/v1/models"
+	return base + path
+}
+
+func (c OpenRouterProviderConfig) CatalogBaseURL(apiBase string) string {
+	return openRouterProviderAbsoluteURL(apiBase, "/openrouter/v1/models")
 }
 
 func (c OpenRouterProviderConfig) InferenceBaseURL(apiBase string) string {
-	base := strings.TrimRight(strings.TrimSpace(apiBase), "/")
-	if base == "" {
-		base = "https://api.tokenkey.dev"
-	}
-	return base + "/v1/chat/completions"
+	return openRouterProviderAbsoluteURL(apiBase, "/v1/chat/completions")
 }
 
 func (c OpenRouterProviderConfig) ImagesBaseURL(apiBase string) string {
-	base := strings.TrimRight(strings.TrimSpace(apiBase), "/")
-	if base == "" {
-		base = "https://api.tokenkey.dev"
-	}
-	return base + "/openrouter/v1/images"
+	return openRouterProviderAbsoluteURL(apiBase, "/openrouter/v1/images")
 }
 
 func (c OpenRouterProviderConfig) VideosBaseURL(apiBase string) string {
-	base := strings.TrimRight(strings.TrimSpace(apiBase), "/")
-	if base == "" {
-		base = "https://api.tokenkey.dev"
-	}
-	return base + "/openrouter/v1/videos"
+	return openRouterProviderAbsoluteURL(apiBase, "/openrouter/v1/videos")
 }

--- a/backend/internal/service/openrouter_provider_tk_config_test.go
+++ b/backend/internal/service/openrouter_provider_tk_config_test.go
@@ -167,24 +167,44 @@ func TestOpenRouterProviderConfig_CatalogAndInferenceURLs(t *testing.T) {
 	}
 }
 
-func TestOpenRouterProviderConfig_AllowsAPIKey(t *testing.T) {
-	cfg := OpenRouterProviderConfig{
-		Enabled:          true,
-		AllowedAPIKeyIDs: []int64{42},
-		BillingUserID:    7,
-	}
-	if !cfg.AllowsAPIKey(42, 99) {
-		t.Fatal("allowed api key id must pass")
-	}
-	if cfg.AllowsAPIKey(43, 99) {
-		t.Fatal("non-allowlisted key must fail when not billing user")
-	}
-	cfg = OpenRouterProviderConfig{Enabled: true, BillingUserID: 7}
-	if !cfg.AllowsAPIKey(100, 7) {
+func TestOpenRouterProviderConfig_AllowsSellerAPIKey(t *testing.T) {
+	cfg := OpenRouterProviderConfig{Enabled: true, BillingUserID: 7}
+	if !cfg.AllowsSellerAPIKey(100, 7) {
 		t.Fatal("any billing-user key must pass")
 	}
-	if cfg.AllowsAPIKey(100, 8) {
+	if cfg.AllowsSellerAPIKey(100, 8) {
 		t.Fatal("other user keys must fail")
+	}
+	if cfg.AllowsSellerAPIKey(0, 7) {
+		t.Fatal("zero api key id must fail")
+	}
+	cfg.Enabled = false
+	if cfg.AllowsSellerAPIKey(100, 7) {
+		t.Fatal("disabled config must fail")
+	}
+}
+
+func TestParseOpenRouterProviderConfig_IgnoresLegacyFields(t *testing.T) {
+	// Boundary: stale settings JSON may still carry group_ids / key id lists.
+	raw := `{
+		"enabled": true,
+		"billing_user_id": 32,
+		"group_ids": [1, 2],
+		"allowed_api_key_ids": [10],
+		"monitor_api_key_ids": [99]
+	}`
+	cfg, err := ParseOpenRouterProviderConfig(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.BillingUserID != 32 || !cfg.Enabled {
+		t.Fatalf("unexpected cfg: %+v", cfg)
+	}
+	if !cfg.AllowsSellerAPIKey(1, 32) {
+		t.Fatal("billing user must authorize after ignoring legacy lists")
+	}
+	if cfg.AllowsSellerAPIKey(10, 0) {
+		t.Fatal("legacy key id lists must not authorize without billing user match")
 	}
 }
 

--- a/backend/internal/service/openrouter_provider_tk_model.go
+++ b/backend/internal/service/openrouter_provider_tk_model.go
@@ -22,7 +22,7 @@ func (s *SettingService) NormalizeOpenRouterProviderChatBody(
 	if err != nil {
 		return body, "", false, err
 	}
-	if !cfg.AllowsInferenceAPIKey(apiKeyID, userID) {
+	if !cfg.AllowsSellerAPIKey(apiKeyID, userID) {
 		return body, "", false, nil
 	}
 	modelResult := gjson.GetBytes(body, "model")

--- a/backend/internal/service/openrouter_provider_tk_model_test.go
+++ b/backend/internal/service/openrouter_provider_tk_model_test.go
@@ -26,43 +26,30 @@ func TestOpenRouterProviderConfig_SellerAuthBillingUser(t *testing.T) {
 	if !cfg.AllowsSellerAPIKey(1, 32) {
 		t.Fatal("any billing-user key must pass seller surface")
 	}
-	if !cfg.AllowsInferenceAPIKey(1, 32) {
-		t.Fatal("billing-user key must infer")
-	}
-	if !cfg.CanAccessCatalog(2, 32) {
-		t.Fatal("billing-user key must read catalog")
+	if !cfg.AllowsSellerAPIKey(2, 32) {
+		t.Fatal("second billing-user key must also pass")
 	}
 	if cfg.AllowsSellerAPIKey(1, 99) {
 		t.Fatal("other user must fail")
 	}
+	if cfg.AllowsSellerAPIKey(0, 32) {
+		t.Fatal("zero api key id must fail")
+	}
 }
 
-func TestOpenRouterProviderConfig_LegacyIDAllowlist(t *testing.T) {
-	cfg := OpenRouterProviderConfig{
-		Enabled:          true,
-		AllowedAPIKeyIDs: []int64{10},
-		MonitorAPIKeyIDs: []int64{99},
-		BillingUserID:    7,
-	}
-	if !cfg.CanAccessCatalog(99, 0) {
-		t.Fatal("legacy monitor id must access full seller surface")
-	}
-	if !cfg.AllowsInferenceAPIKey(99, 0) {
-		t.Fatal("legacy monitor id must also infer after dual-key removal")
-	}
-	if !cfg.AllowsInferenceAPIKey(10, 0) {
-		t.Fatal("legacy inference id must pass")
-	}
-	if cfg.AllowsSellerAPIKey(11, 0) {
-		t.Fatal("unknown id outside billing user must fail")
+func TestOpenRouterProviderConfig_SellerAuthRequiresBillingUser(t *testing.T) {
+	// Boundary: no billing_user_id → no seller access (legacy key-id lists removed).
+	cfg := OpenRouterProviderConfig{Enabled: true}
+	if cfg.AllowsSellerAPIKey(10, 0) {
+		t.Fatal("without billing_user_id seller surface must stay closed")
 	}
 }
 
 func TestNormalizeOpenRouterProviderChatBody_RewritesModel(t *testing.T) {
 	rawCfg := OpenRouterProviderConfig{
-		Enabled:          true,
-		AllowedAPIKeyIDs: []int64{10},
-		ModelIDPrefix:    "tokenkey/",
+		Enabled:       true,
+		BillingUserID: 1,
+		ModelIDPrefix: "tokenkey/",
 	}
 	encoded, err := json.Marshal(rawCfg)
 	if err != nil {

--- a/ops/pricing/manage-openrouter-provider-config.py
+++ b/ops/pricing/manage-openrouter-provider-config.py
@@ -29,8 +29,6 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SETTING_KEY = "tk_openrouter_provider_config"
 BILLING_USER_ID = 32
 SELLER_KEY_NAME = "openrouter"
-# Accepted when looking up an existing key (legacy dual-key names).
-LEGACY_SELLER_KEY_NAMES = ("openrouter", "openrouter-inference", "openrouter-monitor")
 APP_URL = "http://127.0.0.1:8080"
 
 PSQL = "sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1"
@@ -74,7 +72,6 @@ USER_ID = 32
 REQUESTED_GROUP_ID = __GROUP_ID__
 CREATE_GROUP = __CREATE_GROUP__
 SELLER_NAME = "openrouter"
-LEGACY_NAMES = ("openrouter", "openrouter-inference", "openrouter-monitor")
 CONFIG = json.loads("""__CONFIG_JSON__""")
 APP_URL = "http://127.0.0.1:8080"
 APP_CONTAINER = "tokenkey-green"
@@ -178,11 +175,13 @@ group_id = ensure_group_id()
 ensure_user_allowed_group(group_id)
 
 existing = list_user_keys()
-seller_id = 0
-for name in LEGACY_NAMES:
-    seller_id = find_key_id(existing, name)
-    if seller_id > 0:
-        break
+seller_id = find_key_id(existing, SELLER_NAME)
+if seller_id <= 0:
+    for item in existing or []:
+        if (item.get("status") or "") != "disabled":
+            seller_id = int(item.get("id") or 0)
+            if seller_id > 0:
+                break
 if seller_id <= 0:
     seller_id = create_key(SELLER_NAME, group_id)
 
@@ -369,15 +368,12 @@ def _parse_snapshot_groups(groups_raw: str) -> list[int]:
     return ids
 
 
-def _parse_snapshot_key_id(api_keys_raw: str, names: tuple[str, ...] | str) -> int:
-    if isinstance(names, str):
-        names = (names,)
-    for want in names:
-        for line in api_keys_raw.splitlines():
-            parts = line.split("|")
-            if len(parts) >= 2 and parts[1] == want and parts[0].isdigit():
-                return int(parts[0])
-    # Any active key for the billing user is enough (runtime is ownership-based).
+def _parse_snapshot_key_id(api_keys_raw: str, preferred_name: str = SELLER_KEY_NAME) -> int:
+    """Prefer ops label `openrouter`, else any active key for the billing user."""
+    for line in api_keys_raw.splitlines():
+        parts = line.split("|")
+        if len(parts) >= 2 and parts[1] == preferred_name and parts[0].isdigit():
+            return int(parts[0])
     for line in api_keys_raw.splitlines():
         parts = line.split("|")
         if len(parts) >= 1 and parts[0].isdigit():
@@ -401,7 +397,7 @@ def cmd_update_config(args) -> int:
     supply_group_ids = _parse_snapshot_groups(groups_raw)
     if not supply_group_ids:
         fail("user 32 has no allowed groups; catalog would be empty")
-    seller_id = _parse_snapshot_key_id(keys_raw, LEGACY_SELLER_KEY_NAMES)
+    seller_id = _parse_snapshot_key_id(keys_raw)
     if seller_id <= 0:
         fail("billing user has no API keys; run bootstrap first")
 

--- a/ops/pricing/openrouter-provider-onboarding.md
+++ b/ops/pricing/openrouter-provider-onboarding.md
@@ -35,7 +35,7 @@ Prod bootstrap (creates seller key named `openrouter` if missing + config; print
 
 ```bash
 python3 ops/pricing/manage-openrouter-provider-config.py snapshot
-python3 ops/pricing/manage-openrouter-provider-config.py update-config  # upsert billing user + exclude/stream; strips legacy group_ids / key id lists
+python3 ops/pricing/manage-openrouter-provider-config.py update-config  # upsert billing user + exclude/stream; strips stale group_ids / key id lists if present
 ```
 
 Required fields in settings:

--- a/ops/pricing/probe-openrouter-provider-chain.py
+++ b/ops/pricing/probe-openrouter-provider-chain.py
@@ -26,7 +26,7 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BASE_URL = "https://api.tokenkey.dev"
 BILLING_USER_ID = 32
-SELLER_KEY_NAMES = ("openrouter", "openrouter-inference", "openrouter-monitor")
+SELLER_KEY_NAME = "openrouter"
 
 VALID_INPUT_MODALITIES = {"text", "image", "file", "audio", "video"}
 VALID_OUTPUT_MODALITIES = {"text", "image", "embeddings", "audio", "video", "rerank", "speech", "transcription"}
@@ -279,18 +279,18 @@ def run_probe(base_url: str, api_key: str, full_catalog: bool) -> Report:
 
 
 def fetch_keys_via_ssm() -> str:
-    """Return one seller API key for billing user 32 (legacy dual names accepted)."""
+    """Return one seller API key for billing user 32 (prefer name openrouter)."""
     spec = importlib.util.spec_from_file_location("ssm", REPO_ROOT / "ops/stage0/ssm_execution.py")
     ssm = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(ssm)
     inst = ssm.resolve_prod_instance()
-    names_repr = repr(list(SELLER_KEY_NAMES))
+    preferred = SELLER_KEY_NAME
     py = f"""
 import subprocess, json
 PSQL = ["sudo", "docker", "exec", "-i", "tokenkey-postgres",
         "psql", "-U", "tokenkey", "-d", "tokenkey", "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1", "-c"]
 USER_ID = {BILLING_USER_ID}
-NAMES = {names_repr}
+PREFERRED = {preferred!r}
 
 def key_for(name):
     sql = (
@@ -306,13 +306,7 @@ def any_key():
     )
     return subprocess.check_output(PSQL + [sql], text=True).strip()
 
-key = ""
-for name in NAMES:
-    key = key_for(name)
-    if key:
-        break
-if not key:
-    key = any_key()
+key = key_for(PREFERRED) or any_key()
 print(json.dumps({{"key": key}}))
 """
     shell = f"python3 - <<'PY'\n{py}\nPY"

--- a/ops/pricing/test_manage_openrouter_provider_config.py
+++ b/ops/pricing/test_manage_openrouter_provider_config.py
@@ -44,5 +44,19 @@ class MergeMissingListFieldsTest(unittest.TestCase):
         self.assertEqual(merged["stream_only_model_ids"], ["custom-stream"])
 
 
+class ParseSnapshotKeyIDTest(unittest.TestCase):
+    def test_prefers_openrouter_name(self) -> None:
+        raw = "11|other\n22|openrouter\n33|another"
+        self.assertEqual(mgr._parse_snapshot_key_id(raw), 22)
+
+    def test_falls_back_to_any_key(self) -> None:
+        # Boundary: ops label missing → any billing-user key is enough.
+        raw = "11|legacy-name\n33|another"
+        self.assertEqual(mgr._parse_snapshot_key_id(raw), 11)
+
+    def test_empty(self) -> None:
+        self.assertEqual(mgr._parse_snapshot_key_id(""), 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6847,7 +6847,8 @@
       "must_contain": [
         "OpenRouterProviderModels",
         "BuildOpenRouterProviderCatalog",
-        "GetOpenRouterProviderConfig"
+        "GetOpenRouterProviderConfig",
+        "AllowsSellerAPIKey"
       ],
       "rationale": "OpenRouter seller catalog surface: GET /openrouter/v1/models must stay wired to tk_openrouter_provider_config + BuildOpenRouterProviderCatalog. Upstream merges can drop this companion while the route still compiles via a stub handler."
     },
@@ -6870,7 +6871,8 @@
         "OpenRouterProviderVideoFetch",
         "OpenRouterProviderImageRoute",
         "TranslateOpenRouterImageRequestToOpenAI",
-        "BuildOpenRouterVideoSubmitResponse"
+        "BuildOpenRouterVideoSubmitResponse",
+        "AllowsSellerAPIKey"
       ],
       "rationale": "OpenRouter seller image/video inference adapters: OR JSON ↔ internal handlers with model-id dispatch (antigravity chat for gemini-*-image, grok/openai-compat otherwise) and OR response shapes (b64_json images, 202 video submit + poll)."
     },
@@ -6922,9 +6924,19 @@
       "path": "backend/internal/service/openrouter_provider_tk_model.go",
       "must_contain": [
         "NormalizeOpenRouterProviderChatBody",
-        "InternalModelID"
+        "InternalModelID",
+        "AllowsSellerAPIKey"
       ],
-      "rationale": "OpenRouter inference path must rewrite tokenkey/* public model ids back to internal catalog ids before gateway scheduling."
+      "rationale": "OpenRouter inference path must rewrite tokenkey/* public model ids back to internal catalog ids before gateway scheduling, and only for billing_user seller keys."
+    },
+    {
+      "path": "backend/internal/service/openrouter_provider_tk_config.go",
+      "must_contain": [
+        "AllowsSellerAPIKey",
+        "BillingUserID",
+        "SettingKeyTKOpenRouterProviderConfig"
+      ],
+      "rationale": "OpenRouter seller auth SSOT: any API key owned by billing_user_id gets the full seller surface. Legacy group_ids / allowed_api_key_ids / monitor_api_key_ids must not return."
     },
     {
       "path": "backend/internal/service/openrouter_provider_tk_catalog.go",
@@ -6934,9 +6946,11 @@
         "openRouterProviderBuildModelDocument",
         "openRouterProviderModelHasListedPrice",
         "cfg.CatalogExcluded",
-        "openRouterProviderCatalogCandidates"
+        "openRouterProviderCatalogCandidates",
+        "ResolveOpenRouterProviderSupplyGroupIDs",
+        "BillingUserID"
       ],
-      "rationale": "Catalog builder is the seller onboarding contract owner; schema 2.4 emission + pricing/features drift here breaks OpenRouter provider application compliance."
+      "rationale": "Catalog builder is the seller onboarding contract owner; schema 2.4 emission + pricing/features drift here breaks OpenRouter provider application compliance. Supply groups must resolve from billing_user_id → user_allowed_groups (no group_ids fallback)."
     },
     {
       "path": "backend/internal/service/openrouter_provider_tk_schema.go",


### PR DESCRIPTION
## 摘要
- Runtime：删除 `group_ids` / `allowed_api_key_ids` / `monitor_api_key_ids` 与鉴权别名；供应组与鉴权只认 `billing_user_id`
- Ops/probe：去掉 `LEGACY_NAMES`，优先 `openrouter`，否则任意 billing user key
- Sentinel：为 seller 鉴权 SSOT 补 `AllowsSellerAPIKey` / `ResolveOpenRouterProviderSupplyGroupIDs` 锚点

## 风险
常规。行为收紧：无 `billing_user_id` 时 catalog/鉴权直接失败。prod example 已有 billing_user_id。

## 验证
- `go test -tags=unit` OpenRouterProvider 相关
- `python3 -m unittest ops/pricing/test_manage_openrouter_provider_config.py`
- `python3 scripts/sentinels/check-gateway-tk.py`
- `python3 scripts/sentinels/check-registry-update-gate.py --base origin/main --head HEAD`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`

## 提交
- 716ab227b refactor(openrouter): 去掉 legacy group_ids/key id 与鉴权别名 (no-web-impact)
- 580cdbd34 fix(openrouter): address R-001 — 锚住 billing_user seller 鉴权 SSOT (no-web-impact)
- 最新提交：580cdbd34