### PR TITLE
feat(newapi): 支持阿里/千帆 Token Plan 账号路由

### DIFF
--- a/backend/internal/integration/newapi/ali_token_plan.go
+++ b/backend/internal/integration/newapi/ali_token_plan.go
@@ -1,0 +1,42 @@
+package newapi
+
+import (
+	"strings"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+)
+
+const (
+	// AliTokenPlanBaseURL is the bare Aliyun MaaS Token Plan host. The Ali
+	// adaptor appends /compatible-mode/v1/* and /apps/anthropic/v1/messages.
+	AliTokenPlanBaseURL = "https://token-plan.cn-beijing.maas.aliyuncs.com"
+	// AliTokenPlanDefaultTestModel is a chat model listed by GET
+	// {AliTokenPlanBaseURL}/compatible-mode/v1/models.
+	AliTokenPlanDefaultTestModel = "qwen3.6-flash"
+)
+
+// NormalizeAliTokenPlanBaseURL collapses accepted Token Plan base spellings
+// (bare host, /compatible-mode/v1, /apps/anthropic) to the canonical host root.
+func NormalizeAliTokenPlanBaseURL(base string) string {
+	base = strings.TrimRight(strings.TrimSpace(base), "/")
+	if base == "" {
+		return base
+	}
+	lower := strings.ToLower(base)
+	switch {
+	case lower == AliTokenPlanBaseURL,
+		strings.HasPrefix(lower, AliTokenPlanBaseURL+"/"):
+		return AliTokenPlanBaseURL
+	default:
+		return base
+	}
+}
+
+// IsAliTokenPlanBaseURL reports whether channelType/base resolve to the Aliyun
+// MaaS Token Plan host rather than DashScope pay-as-you-go.
+func IsAliTokenPlanBaseURL(channelType int, base string) bool {
+	if channelType != newapiconstant.ChannelTypeAli {
+		return false
+	}
+	return NormalizeAliTokenPlanBaseURL(base) == AliTokenPlanBaseURL
+}

--- a/backend/internal/integration/newapi/ali_token_plan_test.go
+++ b/backend/internal/integration/newapi/ali_token_plan_test.go
@@ -1,0 +1,29 @@
+package newapi
+
+import (
+	"testing"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+)
+
+func TestIsAliTokenPlanBaseURL(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		channelType int
+		base        string
+		want        bool
+	}{
+		{newapiconstant.ChannelTypeAli, AliTokenPlanBaseURL, true},
+		{newapiconstant.ChannelTypeAli, AliTokenPlanBaseURL + "/", true},
+		{newapiconstant.ChannelTypeAli, AliTokenPlanBaseURL + "/compatible-mode/v1", true},
+		{newapiconstant.ChannelTypeAli, AliTokenPlanBaseURL + "/apps/anthropic", true},
+		{newapiconstant.ChannelTypeAli, "https://dashscope.aliyuncs.com", false},
+		{newapiconstant.ChannelTypeBaiduV2, AliTokenPlanBaseURL, false},
+	}
+	for _, tc := range cases {
+		got := IsAliTokenPlanBaseURL(tc.channelType, tc.base)
+		if got != tc.want {
+			t.Fatalf("IsAliTokenPlanBaseURL(%d, %q) = %v, want %v", tc.channelType, tc.base, got, tc.want)
+		}
+	}
+}

--- a/backend/internal/integration/newapi/ali_token_plan_test.go
+++ b/backend/internal/integration/newapi/ali_token_plan_test.go
@@ -27,3 +27,16 @@ func TestIsAliTokenPlanBaseURL(t *testing.T) {
 		}
 	}
 }
+
+func TestNormalizeAliTokenPlanBaseURL(t *testing.T) {
+	t.Parallel()
+	if got := NormalizeAliTokenPlanBaseURL(AliTokenPlanBaseURL + "/compatible-mode/v1/"); got != AliTokenPlanBaseURL {
+		t.Fatalf("normalize compatible-mode = %q", got)
+	}
+	if got := NormalizeAliTokenPlanBaseURL(AliTokenPlanBaseURL + "/apps/anthropic"); got != AliTokenPlanBaseURL {
+		t.Fatalf("normalize anthropic = %q", got)
+	}
+	if got := NormalizeAliTokenPlanBaseURL("https://dashscope.aliyuncs.com"); got != "https://dashscope.aliyuncs.com" {
+		t.Fatalf("passthrough = %q", got)
+	}
+}

--- a/backend/internal/integration/newapi/fetch_upstream_models.go
+++ b/backend/internal/integration/newapi/fetch_upstream_models.go
@@ -16,7 +16,7 @@ import (
 // UpstreamModelFetchAllowed matches new-api web MODEL_FETCHABLE_CHANNEL_TYPES (channel.constants.js).
 func UpstreamModelFetchAllowed(channelType int) bool {
 	switch channelType {
-	case 1, 4, 14, 34, 17, 26, 27, 24, 47, 25, 20, 23, 31, 40, 42, 48, 43, 45, 54:
+	case 1, 4, 14, 34, 17, 26, 27, 24, 47, 25, 20, 23, 31, 40, 42, 48, 43, 45, 46, 54:
 		return true
 	default:
 		return false
@@ -72,7 +72,14 @@ func FetchUpstreamModelList(ctx context.Context, baseURL string, channelType int
 
 	switch channelType {
 	case newapiconstant.ChannelTypeAli:
+		base = NormalizeAliTokenPlanBaseURL(base)
 		return fetchOpenAICompatModels(ctx, base+"/compatible-mode/v1/models", key)
+	case newapiconstant.ChannelTypeBaiduV2:
+		modelsURL, err := qianfanModelsURL(channelType, base)
+		if err != nil {
+			return nil, err
+		}
+		return fetchOpenAICompatModels(ctx, modelsURL, key)
 	case newapiconstant.ChannelTypeVolcEngine, newapiconstant.ChannelTypeDoubaoVideo:
 		modelsURL, err := volcEngineModelsURL(channelType, base)
 		if err != nil {
@@ -126,6 +133,15 @@ func volcEngineModelsURL(channelType int, base string) (string, error) {
 		return openAIBase + "/models", nil
 	}
 	return strings.TrimRight(base, "/") + "/api/v3/models", nil
+}
+
+// qianfanModelsURL resolves the admin "fetch models" URL for BaiduV2.
+// Token Plan Person lists at {plan}/models; PAYG has no TokenKey-owned contract.
+func qianfanModelsURL(channelType int, base string) (string, error) {
+	if IsQianfanTokenPlanBaseURL(channelType, base) {
+		return strings.TrimRight(QianfanTokenPlanBaseURL, "/") + "/models", nil
+	}
+	return "", fmt.Errorf("upstream model fetch is not supported for BaiduV2 base_url %q", base)
 }
 
 // openAICompatModelEntry mirrors the OpenAI /v1/models response shape with the

--- a/backend/internal/integration/newapi/fetch_upstream_models_test.go
+++ b/backend/internal/integration/newapi/fetch_upstream_models_test.go
@@ -105,6 +105,23 @@ func TestVolcEngineModelsURL_ResolvesAgentPlanSpecialBase(t *testing.T) {
 	}
 }
 
+func TestQianfanModelsURL_TokenPlanAndPAYG(t *testing.T) {
+	t.Parallel()
+	got, err := qianfanModelsURL(newapiconstant.ChannelTypeBaiduV2, QianfanTokenPlanBaseURL)
+	if err != nil {
+		t.Fatalf("token plan: %v", err)
+	}
+	if want := QianfanTokenPlanBaseURL + "/models"; got != want {
+		t.Fatalf("token plan URL = %q, want %q", got, want)
+	}
+	if _, err := qianfanModelsURL(newapiconstant.ChannelTypeBaiduV2, QianfanBaseURL); err == nil {
+		t.Fatal("PAYG BaiduV2 must fail closed")
+	}
+	if !UpstreamModelFetchAllowed(newapiconstant.ChannelTypeBaiduV2) {
+		t.Fatal("BaiduV2 must allow upstream model fetch so Token Plan admin can list models")
+	}
+}
+
 func TestMoonshotAlternateRegionalBase(t *testing.T) {
 	t.Parallel()
 	if g := MoonshotAlternateRegionalBase("https://api.moonshot.cn"); g != "https://api.moonshot.ai" {

--- a/backend/internal/integration/newapi/qianfan_token_plan.go
+++ b/backend/internal/integration/newapi/qianfan_token_plan.go
@@ -1,0 +1,46 @@
+package newapi
+
+import (
+	"strings"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+)
+
+const (
+	// QianfanTokenPlanBaseURL is the OpenAI-compatible Token Plan Person API root.
+	// Native TokenKey forwarding appends /chat/completions to it.
+	QianfanTokenPlanBaseURL = "https://qianfan.baidubce.com/v2/tokenplan/personal"
+	// QianfanTokenPlanAnthropicBaseURL is the Anthropic-compatible Token Plan Person root.
+	// Native forwarding appends /v1/messages to it.
+	QianfanTokenPlanAnthropicBaseURL = "https://qianfan.baidubce.com/anthropic/tokenplan/personal"
+	// QianfanTokenPlanDefaultTestModel is a chat model listed by GET .../models
+	// on the Token Plan Person OpenAI-compatible root.
+	QianfanTokenPlanDefaultTestModel = "deepseek-v4-flash"
+)
+
+// NormalizeQianfanTokenPlanBaseURL collapses accepted Token Plan Person base
+// spellings to the canonical OpenAI-compatible root. Returns the trimmed input
+// unchanged when it is not a Token Plan Person host/path.
+func NormalizeQianfanTokenPlanBaseURL(base string) string {
+	base = strings.TrimRight(strings.TrimSpace(base), "/")
+	if base == "" {
+		return base
+	}
+	lower := strings.ToLower(base)
+	switch {
+	case lower == QianfanTokenPlanBaseURL,
+		strings.HasPrefix(lower, QianfanTokenPlanBaseURL+"/"):
+		return QianfanTokenPlanBaseURL
+	default:
+		return base
+	}
+}
+
+// IsQianfanTokenPlanBaseURL reports whether channelType/base resolve to the
+// Baidu Qianfan Token Plan Person OpenAI-compatible root (not pay-as-you-go /v2).
+func IsQianfanTokenPlanBaseURL(channelType int, base string) bool {
+	if channelType != newapiconstant.ChannelTypeBaiduV2 {
+		return false
+	}
+	return NormalizeQianfanTokenPlanBaseURL(base) == QianfanTokenPlanBaseURL
+}

--- a/backend/internal/integration/newapi/qianfan_token_plan_test.go
+++ b/backend/internal/integration/newapi/qianfan_token_plan_test.go
@@ -1,0 +1,39 @@
+package newapi
+
+import (
+	"testing"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+)
+
+func TestIsQianfanTokenPlanBaseURL(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		channelType int
+		base        string
+		want        bool
+	}{
+		{newapiconstant.ChannelTypeBaiduV2, QianfanTokenPlanBaseURL, true},
+		{newapiconstant.ChannelTypeBaiduV2, QianfanTokenPlanBaseURL + "/", true},
+		{newapiconstant.ChannelTypeBaiduV2, QianfanTokenPlanBaseURL + "/chat/completions", true},
+		{newapiconstant.ChannelTypeBaiduV2, QianfanBaseURL, false},
+		{newapiconstant.ChannelTypeBaiduV2, QianfanBaseURL + "/v2", false},
+		{newapiconstant.ChannelTypeAli, QianfanTokenPlanBaseURL, false},
+	}
+	for _, tc := range cases {
+		got := IsQianfanTokenPlanBaseURL(tc.channelType, tc.base)
+		if got != tc.want {
+			t.Fatalf("IsQianfanTokenPlanBaseURL(%d, %q) = %v, want %v", tc.channelType, tc.base, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeQianfanTokenPlanBaseURL(t *testing.T) {
+	t.Parallel()
+	if got := NormalizeQianfanTokenPlanBaseURL(QianfanTokenPlanBaseURL + "/chat/completions/"); got != QianfanTokenPlanBaseURL {
+		t.Fatalf("normalize = %q", got)
+	}
+	if got := NormalizeQianfanTokenPlanBaseURL(QianfanBaseURL); got != QianfanBaseURL {
+		t.Fatalf("passthrough = %q", got)
+	}
+}

--- a/backend/internal/service/account_model_mapping_preset_tk.go
+++ b/backend/internal/service/account_model_mapping_preset_tk.go
@@ -88,6 +88,20 @@ func isNewAPIVolcEngineAgentPlanAccount(account *Account) bool {
 		newapiintegration.IsVolcEngineAgentPlanBaseURL(account.ChannelType, account.GetBaseURL())
 }
 
+func isNewAPIQianfanTokenPlanAccount(account *Account) bool {
+	return account != nil &&
+		account.Platform == PlatformNewAPI &&
+		account.ChannelType == newapiconstant.ChannelTypeBaiduV2 &&
+		newapiintegration.IsQianfanTokenPlanBaseURL(account.ChannelType, account.GetBaseURL())
+}
+
+func isNewAPIAliTokenPlanAccount(account *Account) bool {
+	return account != nil &&
+		account.Platform == PlatformNewAPI &&
+		account.ChannelType == newapiconstant.ChannelTypeAli &&
+		newapiintegration.IsAliTokenPlanBaseURL(account.ChannelType, account.GetBaseURL())
+}
+
 func isNewAPIQianfanAccount(account *Account) bool {
 	return account != nil &&
 		account.Platform == PlatformNewAPI &&

--- a/backend/internal/service/account_supported_protocols.go
+++ b/backend/internal/service/account_supported_protocols.go
@@ -439,6 +439,18 @@ func protocolExactEndpoint(account *Account, protocol protocolrouter.Protocol, r
 	if account == nil || account.Platform != PlatformNewAPI || account.ChannelType <= 0 {
 		return "", nil
 	}
+	// Qianfan Token Plan Person: plan roots differ from BaiduV2 PAYG (/v2/...).
+	// Handle before the Chat/Responses-only format switch so Messages is not dropped.
+	if isNewAPIQianfanTokenPlanAccount(account) {
+		switch protocol {
+		case protocolrouter.ProtocolChatCompletions:
+			return strings.TrimRight(newapiintegration.QianfanTokenPlanBaseURL, "/") + "/chat/completions", nil
+		case protocolrouter.ProtocolMessages:
+			return strings.TrimRight(newapiintegration.QianfanTokenPlanAnthropicBaseURL, "/") + "/v1/messages", nil
+		default:
+			return "", nil
+		}
+	}
 	var format newapitypes.RelayFormat
 	switch protocol {
 	case protocolrouter.ProtocolChatCompletions:
@@ -452,13 +464,6 @@ func protocolExactEndpoint(account *Account, protocol protocolrouter.Protocol, r
 		base := strings.TrimRight(newapiintegration.VolcEngineAgentPlanBaseURL, "/")
 		if protocol == protocolrouter.ProtocolResponses {
 			return base + "/responses", nil
-		}
-		return base + "/chat/completions", nil
-	}
-	if isNewAPIQianfanTokenPlanAccount(account) {
-		base := strings.TrimRight(newapiintegration.QianfanTokenPlanBaseURL, "/")
-		if protocol == protocolrouter.ProtocolResponses {
-			return "", nil
 		}
 		return base + "/chat/completions", nil
 	}

--- a/backend/internal/service/account_supported_protocols.go
+++ b/backend/internal/service/account_supported_protocols.go
@@ -455,6 +455,13 @@ func protocolExactEndpoint(account *Account, protocol protocolrouter.Protocol, r
 		}
 		return base + "/chat/completions", nil
 	}
+	if isNewAPIQianfanTokenPlanAccount(account) {
+		base := strings.TrimRight(newapiintegration.QianfanTokenPlanBaseURL, "/")
+		if protocol == protocolrouter.ProtocolResponses {
+			return "", nil
+		}
+		return base + "/chat/completions", nil
+	}
 	in := newAPIBridgeChannelInputForModel(account, 0, "", resolvedModel).WithoutModelMapping()
 	endpoint, err := bridge.ResolveTextEndpoint(in, format, resolvedModel)
 	if err != nil {

--- a/backend/internal/service/account_supported_protocols_test.go
+++ b/backend/internal/service/account_supported_protocols_test.go
@@ -367,6 +367,45 @@ func TestProtocolAccountSnapshotUsesCanonicalAgentPlanEndpoints(t *testing.T) {
 	}
 }
 
+func TestProtocolAccountSnapshotUsesCanonicalQianfanTokenPlanEndpoints(t *testing.T) {
+	account := &Account{
+		ID:          130,
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeBaiduV2,
+		Credentials: map[string]any{
+			"api_key":       "secret",
+			"base_url":      newapiintegration.QianfanTokenPlanBaseURL,
+			"model_mapping": map[string]any{"deepseek-v4-flash": "deepseek-v4-flash"},
+		},
+		Extra: map[string]any{
+			SupportedProtocolsExtraKey: []any{"chat_completions", "messages"},
+		},
+	}
+
+	chatEndpoint, err := protocolExactEndpoint(account, protocolrouter.ProtocolChatCompletions, "deepseek-v4-flash")
+	if err != nil {
+		t.Fatalf("protocolExactEndpoint chat: %v", err)
+	}
+	if got, want := chatEndpoint, newapiintegration.QianfanTokenPlanBaseURL+"/chat/completions"; got != want {
+		t.Fatalf("chat endpoint = %q, want %q", got, want)
+	}
+	messagesEndpoint, err := protocolExactEndpoint(account, protocolrouter.ProtocolMessages, "deepseek-v4-flash")
+	if err != nil {
+		t.Fatalf("protocolExactEndpoint messages: %v", err)
+	}
+	if got, want := messagesEndpoint, newapiintegration.QianfanTokenPlanAnthropicBaseURL+"/v1/messages"; got != want {
+		t.Fatalf("messages endpoint = %q, want %q", got, want)
+	}
+	responsesEndpoint, err := protocolExactEndpoint(account, protocolrouter.ProtocolResponses, "deepseek-v4-flash")
+	if err != nil {
+		t.Fatalf("protocolExactEndpoint responses: %v", err)
+	}
+	if responsesEndpoint != "" {
+		t.Fatalf("responses endpoint = %q, want empty (Token Plan has no responses surface)", responsesEndpoint)
+	}
+}
+
 func TestProtocolExactEndpointsOmitsUnsupportedNewAPIProtocol(t *testing.T) {
 	account := qianfanChatTestAccount(90)
 	attachTestProtocolCapability(account, protocolrouter.ProtocolChatCompletions)

--- a/backend/internal/service/account_test_service_tk_newapi.go
+++ b/backend/internal/service/account_test_service_tk_newapi.go
@@ -44,6 +44,18 @@ func (s *AccountTestService) testNewAPIAccountConnectionTK(c *gin.Context, accou
 			apiKey,
 		)
 	}
+	if isNewAPIQianfanTokenPlanAccount(account) {
+		// Pass the full chat path: buildOpenAIChatCompletionsURL would otherwise
+		// append /v1/chat/completions onto .../tokenplan/personal.
+		return s.testOpenAIChatCompletionsConnection(
+			c,
+			account,
+			testModelID,
+			testPrompt,
+			newapiintegration.QianfanTokenPlanBaseURL+"/chat/completions",
+			apiKey,
+		)
+	}
 
 	stream := true
 	maxTokens := uint(1024)

--- a/backend/internal/service/account_test_service_tk_newapi_volcagentplan.go
+++ b/backend/internal/service/account_test_service_tk_newapi_volcagentplan.go
@@ -9,6 +9,12 @@ func defaultNewAPIAccountTestModel(account *Account) string {
 	if isNewAPIVolcEngineAgentPlanAccount(account) {
 		return newapiintegration.VolcEngineAgentPlanDefaultTestModel
 	}
+	if isNewAPIQianfanTokenPlanAccount(account) {
+		return newapiintegration.QianfanTokenPlanDefaultTestModel
+	}
+	if isNewAPIAliTokenPlanAccount(account) {
+		return newapiintegration.AliTokenPlanDefaultTestModel
+	}
 	return openai.DefaultTestModel
 }
 

--- a/backend/internal/service/newapi_bridge_usage.go
+++ b/backend/internal/service/newapi_bridge_usage.go
@@ -77,6 +77,9 @@ func newAPIBridgeChannelInputForModel(account *Account, userID int64, groupLabel
 	}
 	baseURL := strings.TrimSpace(account.GetBaseURL())
 	baseURL = newapiintegration.NormalizeArkChannelBaseURL(account.ChannelType, baseURL)
+	if account.ChannelType == newapiconstant.ChannelTypeAli {
+		baseURL = newapiintegration.NormalizeAliTokenPlanBaseURL(baseURL)
+	}
 	if shouldNormalizeNewAPIOpenAIChannelBaseURL(account) {
 		baseURL = normalizeNewAPIOpenAIChannelBaseURL(baseURL)
 	}

--- a/backend/internal/service/openai_gateway_bridge_dispatch.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch.go
@@ -27,6 +27,12 @@ func (s *OpenAIGatewayService) ShouldDispatchToNewAPIBridge(account *Account, en
 		(endpoint == BridgeEndpointChatCompletions || endpoint == BridgeEndpointResponses) {
 		return false
 	}
+	// Qianfan Token Plan Person uses /v2/tokenplan/personal/* — the BaiduV2
+	// adaptor would append /v2/chat/completions and miss the plan root.
+	if isNewAPIQianfanTokenPlanAccount(account) &&
+		(endpoint == BridgeEndpointChatCompletions || endpoint == BridgeEndpointResponses) {
+		return false
+	}
 	var st *SettingService
 	if s != nil {
 		st = s.settingService

--- a/backend/internal/service/openai_gateway_bridge_dispatch_test.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_test.go
@@ -82,6 +82,28 @@ func TestOpenAIShouldDispatchToNewAPIBridge(t *testing.T) {
 			want:     false,
 		},
 		{
+			name: "qianfan Token Plan chat uses native OpenAI path",
+			account: &Account{
+				Type:        AccountTypeAPIKey,
+				ChannelType: newapiconstant.ChannelTypeBaiduV2,
+				Platform:    domain.PlatformNewAPI,
+				Credentials: map[string]any{"base_url": newapiintegration.QianfanTokenPlanBaseURL},
+			},
+			endpoint: BridgeEndpointChatCompletions,
+			want:     false,
+		},
+		{
+			name: "qianfan payg still uses newapi bridge",
+			account: &Account{
+				Type:        AccountTypeAPIKey,
+				ChannelType: newapiconstant.ChannelTypeBaiduV2,
+				Platform:    domain.PlatformNewAPI,
+				Credentials: map[string]any{"base_url": newapiintegration.QianfanBaseURL},
+			},
+			endpoint: BridgeEndpointChatCompletions,
+			want:     true,
+		},
+		{
 			name: "positive channel type unknown endpoint",
 			account: &Account{
 				ChannelType: 2,

--- a/backend/internal/service/openai_gateway_cc_pipeline.go
+++ b/backend/internal/service/openai_gateway_cc_pipeline.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
@@ -138,6 +139,9 @@ func (s *OpenAIGatewayService) failoverOpenAIUpstreamHTTPError(
 
 // openAIChatCompletionsTargetURL 解析账号的（非 Grok）Chat Completions 上游端点。
 func (s *OpenAIGatewayService) openAIChatCompletionsTargetURL(account *Account) (string, error) {
+	if isNewAPIQianfanTokenPlanAccount(account) {
+		return newapiintegration.QianfanTokenPlanBaseURL + "/chat/completions", nil
+	}
 	baseURL := nativeOpenAIBaseURLForAccount(account)
 	if baseURL == "" {
 		// A foreign credential (newapi channel, relay, ...) must never be POSTed

--- a/backend/internal/service/openai_gateway_messages_anthropic_native_tk.go
+++ b/backend/internal/service/openai_gateway_messages_anthropic_native_tk.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
@@ -137,6 +138,9 @@ func nativeAnthropicAPIKeyForAccount(account *Account) string {
 func (s *OpenAIGatewayService) nativeAnthropicTargetURL(ctx context.Context, account *Account) (string, error) {
 	if endpoint := protocolExecutionEndpoint(ctx, ""); endpoint != "" {
 		return endpoint, nil
+	}
+	if isNewAPIQianfanTokenPlanAccount(account) {
+		return strings.TrimRight(newapiintegration.QianfanTokenPlanAnthropicBaseURL, "/") + "/v1/messages", nil
 	}
 	baseURL := strings.TrimSpace(account.GetAnthropicProtocolBaseURL())
 	if baseURL == "" {

--- a/backend/internal/service/openai_gateway_messages_tk.go
+++ b/backend/internal/service/openai_gateway_messages_tk.go
@@ -26,6 +26,11 @@ func (s *OpenAIGatewayService) newAPIBridgeOwnsAnthropicMessages(account *Accoun
 	if account == nil || account.Platform != PlatformNewAPI {
 		return false
 	}
+	// Qianfan Token Plan Person exposes a dedicated Anthropic root; do not send
+	// Claude traffic through the BaiduV2 adaptor (which only has /v2/chat).
+	if isNewAPIQianfanTokenPlanAccount(account) {
+		return false
+	}
 	return s.ShouldDispatchToNewAPIBridge(account, BridgeEndpointChatCompletions)
 }
 
@@ -42,6 +47,10 @@ func (s *OpenAIGatewayService) tkTryRouteForwardAsAnthropic(
 	// never claim them for an OpenAI-shaped fallback.
 	if s.newAPIBridgeOwnsAnthropicMessages(account) {
 		result, err := s.ForwardAsAnthropicDispatched(ctx, c, account, body, "", defaultMappedModel)
+		return result, true, err
+	}
+	if isNewAPIQianfanTokenPlanAccount(account) {
+		result, err := s.forwardAnthropicViaNativeAnthropicEndpoint(ctx, c, account, body, defaultMappedModel)
 		return result, true, err
 	}
 	if account.IsAnthropicProtocol() || account.IsAdaptiveAPIProtocol() {

--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -39,6 +39,9 @@ func nativeOpenAIBaseURLForAccount(account *Account) string {
 	if isNewAPIVolcEngineAgentPlanAccount(account) {
 		return newapiintegration.NormalizeArkChannelBaseURL(account.ChannelType, account.GetBaseURL())
 	}
+	if isNewAPIQianfanTokenPlanAccount(account) {
+		return newapiintegration.NormalizeQianfanTokenPlanBaseURL(account.GetBaseURL())
+	}
 	return account.GetOpenAIBaseURL()
 }
 
@@ -49,7 +52,7 @@ func nativeOpenAIApiKeyForAccount(account *Account) string {
 	if isCloudwiseRelayAccount(account) {
 		return strings.TrimSpace(account.GetCredential("api_key"))
 	}
-	if isNewAPIVolcEngineAgentPlanAccount(account) {
+	if isNewAPIVolcEngineAgentPlanAccount(account) || isNewAPIQianfanTokenPlanAccount(account) {
 		return strings.TrimSpace(account.GetCredential("api_key"))
 	}
 	return account.GetOpenAIProtocolAPIKey()

--- a/backend/internal/service/openai_official_upstream_tk.go
+++ b/backend/internal/service/openai_official_upstream_tk.go
@@ -46,6 +46,12 @@ func AccountShouldLocalEstimateCountTokens(account *Account) bool {
 	if account.IsCNProvider() {
 		return true
 	}
+	// Qianfan Token Plan Person has no OpenAI Responses input_tokens surface;
+	// nativeOpenAIBaseURLForAccount is non-empty for chat, so without this
+	// branch count_tokens would invent .../tokenplan/personal/v1/responses/input_tokens.
+	if isNewAPIQianfanTokenPlanAccount(account) {
+		return true
+	}
 	return strings.TrimSpace(nativeOpenAIBaseURLForAccount(account)) == ""
 }
 

--- a/backend/internal/service/openai_official_upstream_tk_test.go
+++ b/backend/internal/service/openai_official_upstream_tk_test.go
@@ -102,6 +102,12 @@ func TestAccountShouldLocalEstimateCountTokens_DerivedForeignAccounts(t *testing
 		ChannelType: newapiconstant.ChannelTypeVolcEngine,
 		Credentials: map[string]any{"api_key": "ark-test", "base_url": newapiintegration.VolcEngineAgentPlanBaseURL},
 	}), "Agent Plan keeps its dedicated Ark input_tokens URL")
+	require.True(t, AccountShouldLocalEstimateCountTokens(&Account{
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: newapiconstant.ChannelTypeBaiduV2,
+		Credentials: map[string]any{"api_key": "qf-test", "base_url": newapiintegration.QianfanTokenPlanBaseURL},
+	}), "Qianfan Token Plan must local-estimate; native chat base must not invent responses/input_tokens")
 	require.False(t, AccountShouldLocalEstimateCountTokens(&Account{
 		Platform: PlatformOpenAI, Type: AccountTypeAPIKey,
 		Credentials: map[string]any{"api_key": "sk-test", "base_url": "https://api.cloudwise.ai/api"},

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -785,6 +785,41 @@
       "rationale": "Agent Plan base-url detection for VolcEngine ch45 accounts using /api/plan/v3 instead of pay-as-you-go /api/v3. Without it admin probes and preset selection fall back to wrong upstream paths (404 InvalidEndpointOrModel)."
     },
     {
+      "path": "backend/internal/integration/newapi/ali_token_plan.go",
+      "must_contain": [
+        "AliTokenPlanBaseURL",
+        "NormalizeAliTokenPlanBaseURL",
+        "IsAliTokenPlanBaseURL"
+      ],
+      "rationale": "Aliyun MaaS Token Plan host detection for ch17 accounts. Without NormalizeAliTokenPlanBaseURL, pasted /compatible-mode/v1 or /apps/anthropic bases double-suffix under the Ali adaptor and every probe/chat 404s."
+    },
+    {
+      "path": "backend/internal/integration/newapi/ali_token_plan_test.go",
+      "must_contain": [
+        "TestIsAliTokenPlanBaseURL",
+        "TestNormalizeAliTokenPlanBaseURL"
+      ],
+      "rationale": "Regression for Ali Token Plan host normalization and channel-type guard; prevents silent misrouting when credentials suffix the compatible-mode or Anthropic path."
+    },
+    {
+      "path": "backend/internal/integration/newapi/qianfan_token_plan.go",
+      "must_contain": [
+        "QianfanTokenPlanBaseURL",
+        "QianfanTokenPlanAnthropicBaseURL",
+        "NormalizeQianfanTokenPlanBaseURL",
+        "IsQianfanTokenPlanBaseURL"
+      ],
+      "rationale": "Baidu Qianfan Token Plan Person base-url detection for ch46. Without it the BaiduV2 adaptor appends /v2/chat/completions onto the plan root (or routes the plan key to PAYG) and every chat/admin test 404s."
+    },
+    {
+      "path": "backend/internal/integration/newapi/qianfan_token_plan_test.go",
+      "must_contain": [
+        "TestIsQianfanTokenPlanBaseURL",
+        "TestNormalizeQianfanTokenPlanBaseURL"
+      ],
+      "rationale": "Regression for Qianfan Token Plan Person path normalization versus PAYG /v2; prevents silent collapse of plan accounts into the BaiduV2 PAYG URL builder."
+    },
+    {
       "path": "backend/internal/integration/newapi/qianfan.go",
       "must_contain": [
         "QianfanBaseURL",
@@ -1012,6 +1047,7 @@
         "func AccountUsesOfficialOpenAIUpstream",
         "baseURL != \"\" && isOfficialOpenAIModelsBaseURL(baseURL)",
         "func AccountShouldLocalEstimateCountTokens",
+        "isNewAPIQianfanTokenPlanAccount(account)",
         "func IsOfficialOpenAIAPIKeyHelpText",
         "func IsForeignCredentialOfficialOpenAIReject",
         "func OfficialOpenAIFallbackAllowed",
@@ -1019,7 +1055,7 @@
         "isOfficialOpenAIModelsBaseURL",
         "platform.openai.com/account/api-keys"
       ],
-      "rationale": "The legacy official-host safety predicate must require an explicit api.openai.com base_url for configurable OpenAI API-key accounts, matching the protocol-routing SSOT; an empty URL is unresolved, not an official profile. NewAPI channels, CN providers, CloudWise/tokensea, and any future platform also default to foreign. OfficialOpenAIFallbackAllowed / ErrForeignCredentialOfficialOpenAIFallback are the write side of this boundary: native forwarders fail closed instead of defaulting an unresolved base_url to api.openai.com, which can POST a DashScope/Ark key to OpenAI and return the 'Incorrect API key provided' routing-defect shape (Qwen/Qwen-2/Qwen-4, 2026-08-24)."
+      "rationale": "The legacy official-host safety predicate must require an explicit api.openai.com base_url for configurable OpenAI API-key accounts, matching the protocol-routing SSOT; an empty URL is unresolved, not an official profile. NewAPI channels, CN providers, CloudWise/tokensea, and any future platform also default to foreign. Qianfan Token Plan must local-estimate count_tokens because nativeOpenAIBaseURLForAccount is non-empty for chat yet the plan has no responses/input_tokens surface. OfficialOpenAIFallbackAllowed / ErrForeignCredentialOfficialOpenAIFallback are the write side of this boundary: native forwarders fail closed instead of defaulting an unresolved base_url to api.openai.com, which can POST a DashScope/Ark key to OpenAI and return the 'Incorrect API key provided' routing-defect shape (Qwen/Qwen-2/Qwen-4, 2026-08-24)."
     },
     {
       "path": "backend/internal/service/openai_gateway_request_body.go",
@@ -1028,9 +1064,10 @@
         "account.Type == AccountTypeAPIKey || account.Type == AccountTypeUpstream",
         "return strings.TrimSpace(account.GetCredential(\"base_url\"))",
         "func nativeOpenAIApiKeyForAccount(account *Account) string",
+        "isNewAPIQianfanTokenPlanAccount(account)",
         "return account.GetOpenAIProtocolAPIKey()"
       ],
-      "rationale": "Native text transports must preserve an omitted configurable OpenAI API-key/upstream base_url as unresolved. Falling through to GetOpenAIBaseURL would synthesize api.openai.com before the fail-closed boundary can distinguish an explicit custom endpoint from an implicit official-host fallback, contradicting docs/approved/protocol-routing-ssot.md section 6. The sibling credential accessor preserves CloudWise and Agent Plan special bindings while using the canonical OpenAI-protocol key accessor for ordinary OpenAI/NewAPI/CN accounts."
+      "rationale": "Native text transports must preserve an omitted configurable OpenAI API-key/upstream base_url as unresolved. Falling through to GetOpenAIBaseURL would synthesize api.openai.com before the fail-closed boundary can distinguish an explicit custom endpoint from an implicit official-host fallback, contradicting docs/approved/protocol-routing-ssot.md section 6. The sibling credential accessor preserves CloudWise, Agent Plan, and Qianfan Token Plan special bindings while using the canonical OpenAI-protocol key accessor for ordinary OpenAI/NewAPI/CN accounts."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_upstream_error_prelude.go",
@@ -1097,21 +1134,27 @@
       "must_contain": [
         "func protocolExactEndpoint(account *Account, protocol protocolrouter.Protocol, resolvedModel string) (string, error)",
         "isNewAPIVolcEngineAgentPlanAccount(account)",
+        "isNewAPIQianfanTokenPlanAccount(account)",
         "newapiintegration.VolcEngineAgentPlanBaseURL",
+        "newapiintegration.QianfanTokenPlanBaseURL",
+        "newapiintegration.QianfanTokenPlanAnthropicBaseURL",
         "endpoint, err := bridge.ResolveTextEndpoint(in, format, resolvedModel)"
       ],
-      "rationale": "Single NewAPI text-endpoint resolver shared by protocol planning and capability probes. Provider paths such as DashScope ch17 and VolcEngine Agent Plan differ from generic /v1 endpoints; losing this owner recreates split path tables and lets probes persist false capability facts for otherwise healthy accounts."
+      "rationale": "Single NewAPI text-endpoint resolver shared by protocol planning and capability probes. Provider paths such as DashScope ch17, VolcEngine Agent Plan, and Qianfan Token Plan Person differ from generic /v1 endpoints; losing this owner recreates split path tables and lets probes persist false capability facts for otherwise healthy accounts."
     },
     {
       "path": "backend/internal/service/account_supported_protocols_test.go",
       "must_contain": [
         "TestProtocolAccountSnapshotUsesCanonicalAgentPlanEndpoints",
+        "TestProtocolAccountSnapshotUsesCanonicalQianfanTokenPlanEndpoints",
         "VolcEngineAgentPlanBaseURL+\"/chat/completions\"",
         "VolcEngineAgentPlanBaseURL+\"/responses\"",
+        "QianfanTokenPlanBaseURL+\"/chat/completions\"",
+        "QianfanTokenPlanAnthropicBaseURL+\"/v1/messages\"",
         "TestProtocolRouterRejectsResolvedModelOutsideOfficialRoutePolicy",
         "ErrModelNotAllowed"
       ],
-      "rationale": "Regression proof that Agent Plan account 88 resolves both governed text protocols under the canonical /api/plan/v3 base instead of probing or executing the generic VolcEngine paths that returned 404 during rollout preparation."
+      "rationale": "Regression proof that Agent Plan and Qianfan Token Plan resolve governed text protocols under their canonical plan bases instead of probing or executing the generic VolcEngine/BaiduV2 paths that returned 404 during rollout preparation."
     },
     {
       "path": "backend/internal/service/protocol_capability_probe.go",


### PR DESCRIPTION
## 摘要
- 对标 `volcengine-agent-plan`，新增阿里 MaaS Token Plan（ch17）与千帆 Token Plan Person（ch46）的 base_url 识别与路由特判。
- 千帆 tokenplan 绕开 BaiduV2 adaptor 的 `/v2/chat/completions` 错拼，走 native chat / Anthropic 转发；Messages / count_tokens / fetch-models 同步按 plan root 处理。
- 阿里仍走现有 Ali adaptor（`compatible-mode` + `apps/anthropic`），并对 Token Plan host 做 base 归一化。
- 线上账号：`ali-token-plan` (#129)、`qianfan-token-plan` (#130)；#129 已写入实测模型 + `deepseek-v4-flash→0731` / `deepseek-v4-pro-0813→pro` 别名；#130 为实测 identity 白名单。

## 风险
- 常规风险：仅命中特定 tokenplan base_url 的 newapi 账号；PAYG 千帆/DashScope 路径不变。
- 发版前千帆 admin/网关仍会 404（线上尚未含本分支）；发版后需复测 #130。

## 验证
- `go test -tags=unit ./internal/integration/newapi/ ./internal/service/ -run 'AliTokenPlan|QianfanTokenPlan|QianfanModelsURL|ShouldDispatchToNewAPIBridge|AccountShouldLocalEstimateCountTokens|ProtocolAccountSnapshotUsesCanonical'` 通过
- `./scripts/preflight.sh` PASS（base=origin/main）
- `scripts/sentinels/check-registry-update-gate.py` PASS（已更新 `scripts/sentinels/newapi.json`）
- 上游直连实测：阿里/千帆 OpenAI + Anthropic 均 200
- Admin：#129 通过；#130 待本 PR 发版后复测

## 提交
- `8b4234911` feat(newapi): 支持阿里/千帆 Token Plan 账号路由 (no-web-impact)
- `27c9031f7` fix(newapi): 补齐 Token Plan 端点/计费探测与 sentinel 锚点 (no-web-impact)
- 最新提交：`27c9031f7`