### PR TITLE
chore(fingerprint): 对齐 CC/Codex/Kiro 客户端 pin（#1989 #1990 #1991）

### DIFF
--- a/backend/internal/baseline/anthropic-http-mimicry-baselines.json
+++ b/backend/internal/baseline/anthropic-http-mimicry-baselines.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "cc_version": "2.1.260",
+  "cc_version": "2.1.261",
   "description": "Canonical OAuth HTTP mimicry betas for Claude Code CLI. Live wire values are driven at runtime by settings.claude_code_http_mimicry_manifest (sync-runtime / plan-http-mimicry-sync). Compile-time defaults in backend/internal/pkg/claude/constants.go catch up on the release train.",
   "sonnet_opus": [
     "claude-code-20250219",

--- a/backend/internal/pkg/claude/constants.go
+++ b/backend/internal/pkg/claude/constants.go
@@ -81,7 +81,7 @@ const DefaultCacheControlTTL = "5m"
 // CLICurrentVersion 是 sub2api 当前对外伪装的 Claude Code CLI 版本号（三段 semver）。
 // 用于 billing attribution block 中的 cc_version=X.Y.Z.{fp} 前缀以及 fingerprint 计算。
 // 必须与 DefaultHeaders["User-Agent"] 中的版本号严格一致；不一致会被 Anthropic 判第三方。
-const CLICurrentVersion = "2.1.260"
+const CLICurrentVersion = "2.1.261"
 
 // JoinBetaHeader joins beta tokens into the wire anthropic-beta header value.
 func JoinBetaHeader(betas []string) string {
@@ -139,7 +139,7 @@ func FullClaudeCodeHaikuMimicryBetas() []string {
 // 包依赖方向为 service → claude，claude 无法反向 import service，故这里以同步字面量
 // 承载，由守卫测试强制对齐。
 var DefaultHeaders = map[string]string{
-	"User-Agent":                                "claude-cli/2.1.260 (external, cli)",
+	"User-Agent":                                "claude-cli/2.1.261 (external, cli)",
 	"X-Stainless-Lang":                          "js",
 	"X-Stainless-Package-Version":               "0.112.1",
 	"X-Stainless-OS":                            "MacOS",

--- a/backend/internal/pkg/kiro/constants.go
+++ b/backend/internal/pkg/kiro/constants.go
@@ -9,7 +9,7 @@ const DefaultKiroAccountPriority = 10
 // DefaultKiroCLIVersion is the sole Kiro client release owner. The HTTP identity
 // below is captured from the installed kiro-cli binary; do not infer any segment
 // from release metadata alone.
-const DefaultKiroCLIVersion = "2.21.0"
+const DefaultKiroCLIVersion = "2.21.1"
 
 const (
 	kiroCLISDKVersion    = "1.3.10"

--- a/backend/internal/pkg/kiro/constants_test.go
+++ b/backend/internal/pkg/kiro/constants_test.go
@@ -5,7 +5,7 @@ package kiro
 import "testing"
 
 func TestKiroCLIIdentityMatchesObservedCapture(t *testing.T) {
-	const wantUA = "aws-sdk-rust/1.3.10 ua/2.1 api/codewhispererruntime/0.1.10231 os/macos lang/rust/1.92.0 md/appVersion-2.21.0 app/AmazonQ-For-CLI"
+	const wantUA = "aws-sdk-rust/1.3.10 ua/2.1 api/codewhispererruntime/0.1.10231 os/macos lang/rust/1.92.0 md/appVersion-2.21.1 app/AmazonQ-For-CLI"
 	const wantAmzUA = "aws-sdk-rust/1.3.10 ua/2.1 api/codewhispererruntime/0.1.10231 os/macos lang/rust/1.92.0 m/F app/AmazonQ-For-CLI"
 	if KiroCLIUserAgent != wantUA {
 		t.Fatalf("unexpected Kiro CLI User-Agent:\n got: %s\nwant: %s", KiroCLIUserAgent, wantUA)

--- a/backend/internal/service/identity_service.go
+++ b/backend/internal/service/identity_service.go
@@ -88,7 +88,7 @@ func isAcceptableFingerprintUserAgent(ua string) bool {
 // / `StainlessPackageVersion:` 字面量做指纹基线巡检，computed 值会让它失明。
 // 字面量与 canonical 的一致性改由 identity_canonical_consistency_test.go 机械锁死。
 var defaultFingerprint = Fingerprint{
-	UserAgent:               "claude-cli/2.1.260 (external, cli)",
+	UserAgent:               "claude-cli/2.1.261 (external, cli)",
 	StainlessLang:           "js",
 	StainlessPackageVersion: "0.112.1",
 	StainlessOS:             "MacOS",

--- a/backend/internal/service/identity_service_tk_canonical_http.go
+++ b/backend/internal/service/identity_service_tk_canonical_http.go
@@ -56,7 +56,7 @@ const (
 	// neither env nor runtime resolver provides a value. Keep in sync with
 	// the most recent cc CLI release this build was validated against; the
 	// admin UI / runtime resolver is the normal update path going forward.
-	DefaultClaudeCodeUserAgentVersion = "2.1.260"
+	DefaultClaudeCodeUserAgentVersion = "2.1.261"
 
 	// canonicalUAPrefix / canonicalUASuffix wrap the version-only field.
 	// Matches interactive Claude Code REPL ingress (`claude-cli/<version> (external, cli)`).

--- a/backend/internal/service/setting_gateway_runtime.go
+++ b/backend/internal/service/setting_gateway_runtime.go
@@ -146,7 +146,7 @@ const antigravityUserAgentVersionDBTimeout = 5 * time.Second
 // DefaultOpenAICodexVersion is the single source for the forged Codex client
 // version: UA, gateway version header, and usage probe header must all derive
 // from it.
-const DefaultOpenAICodexVersion = "0.153.2"
+const DefaultOpenAICodexVersion = "0.153.4"
 
 // DefaultOpenAICodexUserAgent is the compile-time fallback. Runtime sync may
 // replace its version, but the real CLI OS and terminal fingerprint stays fixed.

--- a/deploy/aws/stage0/anthropic-http-mimicry-baselines.json
+++ b/deploy/aws/stage0/anthropic-http-mimicry-baselines.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "cc_version": "2.1.260",
+  "cc_version": "2.1.261",
   "description": "Canonical OAuth HTTP mimicry betas for Claude Code CLI. Live wire values are driven at runtime by settings.claude_code_http_mimicry_manifest (sync-runtime / plan-http-mimicry-sync). Compile-time defaults in backend/internal/pkg/claude/constants.go catch up on the release train.",
   "sonnet_opus": [
     "claude-code-20250219",

--- a/deploy/aws/stage0/tk_canonical_cc_oauth.json
+++ b/deploy/aws/stage0/tk_canonical_cc_oauth.json
@@ -71,7 +71,7 @@
   ],
   "observed": {
     "model": "claude-haiku-4-5-20251001",
-    "user_agent": "claude-cli/2.1.260 (external, cli)",
+    "user_agent": "claude-cli/2.1.261 (external, cli)",
     "stainless_os": "MacOS",
     "stainless_arch": "arm64",
     "stainless_runtime": "node",

--- a/deploy/aws/stage0/tk_canonical_kiro_cli.json
+++ b/deploy/aws/stage0/tk_canonical_kiro_cli.json
@@ -59,62 +59,62 @@
   ],
   "observed": {
     "source": "real-cli-mitm",
-    "kiro_cli_version": "2.21.0",
+    "kiro_cli_version": "2.21.1",
     "sample_count": 3,
     "samples": [
       {
         "server_name": "codewhisperer.us-east-1.amazonaws.com",
         "extension_order": [
-          5,
-          51,
-          43,
           23,
-          35,
-          13,
+          45,
           11,
-          0,
           10,
-          45
+          51,
+          13,
+          5,
+          43,
+          0,
+          35
         ],
-        "ja3_raw": "771,4866-4865-4867-49196-49195-52393-49200-49199-52392-255,5-51-43-23-35-13-11-0-10-45,29-23-24,0",
-        "ja3_hash": "7d8a254f3d9a593bfcd6d226153bcab0"
+        "ja3_raw": "771,4866-4865-4867-49196-49195-52393-49200-49199-52392-255,23-45-11-10-51-13-5-43-0-35,29-23-24,0",
+        "ja3_hash": "538742d5692e1360e1c0cf02718f6dc4"
       },
       {
         "server_name": "codewhisperer.us-east-1.amazonaws.com",
         "extension_order": [
-          35,
+          5,
+          13,
           43,
           10,
-          51,
-          5,
           0,
-          13,
-          11,
           45,
-          23
-        ],
-        "ja3_raw": "771,4866-4865-4867-49196-49195-52393-49200-49199-52392-255,35-43-10-51-5-0-13-11-45-23,29-23-24,0",
-        "ja3_hash": "584097d752f21fb66f7332019e59f82c"
-      },
-      {
-        "server_name": "codewhisperer.us-east-1.amazonaws.com",
-        "extension_order": [
-          0,
-          13,
-          35,
-          43,
-          10,
-          45,
-          5,
-          51,
           23,
+          35,
+          51,
           11
         ],
-        "ja3_raw": "771,4866-4865-4867-49196-49195-52393-49200-49199-52392-255,0-13-35-43-10-45-5-51-23-11,29-23-24,0",
-        "ja3_hash": "0725b660b1fe26f5df6db59e7464e09f"
+        "ja3_raw": "771,4866-4865-4867-49196-49195-52393-49200-49199-52392-255,5-13-43-10-0-45-23-35-51-11,29-23-24,0",
+        "ja3_hash": "5e99cf39f535a7bc21215ccc12025685"
+      },
+      {
+        "server_name": "codewhisperer.us-east-1.amazonaws.com",
+        "extension_order": [
+          51,
+          23,
+          35,
+          11,
+          45,
+          13,
+          10,
+          5,
+          43,
+          0
+        ],
+        "ja3_raw": "771,4866-4865-4867-49196-49195-52393-49200-49199-52392-255,51-23-35-11-45-13-10-5-43-0,29-23-24,0",
+        "ja3_hash": "94a0df4dbb2dd83fd1644c86b8d63e7f"
       }
     ],
-    "user_agent": "aws-sdk-rust/1.3.10 ua/2.1 api/codewhispererruntime/0.1.10231 os/macos lang/rust/1.92.0 md/appVersion-2.21.0 app/AmazonQ-For-CLI",
+    "user_agent": "aws-sdk-rust/1.3.10 ua/2.1 api/codewhispererruntime/0.1.10231 os/macos lang/rust/1.92.0 md/appVersion-2.21.1 app/AmazonQ-For-CLI",
     "x_amz_user_agent": "aws-sdk-rust/1.3.10 ua/2.1 api/codewhispererruntime/0.1.10231 os/macos lang/rust/1.92.0 m/F app/AmazonQ-For-CLI",
     "protocol": {
       "operations": [

--- a/docs/ops/cc-fingerprint-changelog.md
+++ b/docs/ops/cc-fingerprint-changelog.md
@@ -23,6 +23,7 @@ re-document it per patch — note "A/B unchanged" in the row instead.
 
 | cc version | date (UTC) | type | note |
 |---|---|---|---|
+| 2.1.261 | 2026-09-05 | pure UA | 2.1.260→2.1.261, TLS/beta 未变 |
 | 2.1.260 | 2026-09-04 | pure UA | 2.1.241→2.1.260, TLS/beta 未变 |
 | 2.1.152 | 2026-05-27 (PR #423) | **decision** | Canonical OAuth UA + beta architecture established (first bimodal Haiku observation; runtime HTTP mimicry). Living scope: [`cc-oauth-mimicry-fingerprint-scope.md`](../spec-delta/cc-oauth-mimicry-fingerprint-scope.md). |
 | 2.1.153 | 2026-05-28 | **decision** | Haiku beta **set** changed: added `thinking-token-count` + `structured-outputs`, dropped `claude-code` + `extended-cache-ttl`; `last-wins` variant pick. |

--- a/ops/stage0/smoke_lib.sh
+++ b/ops/stage0/smoke_lib.sh
@@ -49,7 +49,7 @@ if [[ -z "${_TK_SMOKE_LIB_LOADED:-}" ]]; then
   }
 
   smoke_default_claude_user_agent() {
-    printf '%s' "${TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/2.1.260 (external, cli)}"
+    printf '%s' "${TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/2.1.261 (external, cli)}"
   }
 
   # smoke_human_base_url GATEWAY_BASE

--- a/scripts/sentinels/cc-geo-stego-static.json
+++ b/scripts/sentinels/cc-geo-stego-static.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "rationale": "Static anchors for Claude Code geo-stego + prompt-surface normalizers. binary_must_contain uses stable wire/prompt literals (not minified symbol names like KSe/eca that rename every cc patch).",
-  "cc_version": "2.1.260",
+  "cc_version": "2.1.261",
   "binary_default_path": "~/.local/share/claude/versions/{cc_version}",
   "binary_must_contain": [
     "setTimeZone",

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -55,7 +55,7 @@
         "KiroCLIUserAgent",
         "KiroCLIAmzUserAgent",
         "DefaultKiroAccountPriority",
-        "2.21.0",
+        "2.21.1",
         "app/AmazonQ-For-CLI"
       ],
       "rationale": "Single TK-owned Kiro CLI release and HTTP identity. The exact aws-sdk-rust User-Agent pair comes from real CLI wire capture rather than release inference; losing these constants or reintroducing a second builder makes Kiro egress drift from the only supported client identity. DefaultKiroAccountPriority remains the creation-time default for native Kiro accounts."


### PR DESCRIPTION
## 摘要

- 关闭 client-release-watch 漂移：Claude Code `2.1.260→2.1.261`、Codex `0.153.2→0.153.4`、Kiro CLI `2.21.0→2.21.1`
- CC / Codex 按本机 CLI 静态对齐；Kiro 经真实 `kiro-cli` MITM capture 刷新 `tk_canonical_kiro_cli.json` observed（TLS 语义未变，仅 shuffle 样本与 UA 版本）
- 同步 sentinel / baseline / changelog；无 Web / 管理页行为变更

Closes #1989
Closes #1990
Closes #1991

## 风险

- **常规**：出站 UA / version header 随上游 patch bump；Kiro TLS profile 仅刷新 observed 样本，cipher/curve/shuffle 语义不变
- 不改 schema、鉴权边界或公共 API 契约
- `no-web-impact`；`sentinel-registry-reviewed`；`upstream-touch-trivial`

## 验证

- `bash ops/anthropic/capture-cc-fingerprint.sh check`：cc_version match `2.1.261`
- `bash ops/openai/capture-codex-fingerprint.sh check` + `check-consistency`：owner/aliases match `0.153.4`
- `bash ops/kiro/capture-kiro-fingerprint.sh capture --samples 3` → `check`/`diff`：aligned；`emit-profile` 已写入
- `go test -tags=unit ./internal/pkg/kiro/ ./internal/pkg/claude/ ./internal/service/`：PASS
- `python3 -m unittest ops.openai.test_capture_codex_fingerprint`：PASS
- `python3 ops/anthropic/test_capture_cc_fingerprint.py StaticVersionTests`：PASS
- `python3 scripts/sentinels/check-cc-version-sync.py --quiet`：PASS
- `python3 scripts/sentinels/check-kiro.py --quiet`：PASS
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`：PASS
- `bash ops/fingerprint/client-release-watch.sh scan --plan`：CC / Codex / Kiro 均为 `aligned`

## 提交

- `8ab066fd1` chore(fingerprint): align CC/Codex/Kiro pins to upstream CLIs
- 最新提交：`8ab066fd1`

Made with [Cursor](https://cursor.com)