### PR TITLE
refactor: P2 openai forward/passthrough + gateway 闭包 TK companion

### DIFF
--- a/backend/internal/server/routes/gateway.go
+++ b/backend/internal/server/routes/gateway.go
@@ -51,53 +51,10 @@ func RegisterGatewayRoutes(
 	requireGroupAnthropic := middleware.RequireGroupAssignment(settingService, middleware.AnthropicErrorWriter)
 	requireGroupGoogle := middleware.RequireGroupAssignment(settingService, middleware.GoogleErrorWriter)
 
-	isOpenAIGatewayPlatform := func(c *gin.Context) bool {
-		return getGroupPlatform(c) == service.PlatformOpenAI
-	}
-	countTokensHandler := func(c *gin.Context) {
-		switch getGroupPlatform(c) {
-		case service.PlatformOpenAI, service.PlatformKimi, service.PlatformZhipu, service.PlatformDeepseek:
-			h.OpenAIGateway.CountTokens(c)
-		case service.PlatformGrok:
-			h.OpenAIGateway.GrokCountTokens(c)
-		default:
-			if isOpenAICompatPlatform(getGroupPlatform(c)) {
-				h.OpenAIGateway.CountTokens(c)
-				return
-			}
-			h.Gateway.CountTokens(c)
-		}
-	}
-	modelsHandler := func(c *gin.Context) {
-		apiKey, _ := middleware.GetAPIKeyFromContext(c)
-		if c.Query("client_version") != "" && (isOpenAIGatewayPlatform(c) || getGroupPlatform(c) == service.PlatformComposite || (apiKey != nil && apiKey.IsUniversal())) {
-			h.OpenAIGateway.CodexModels(c)
-			return
-		}
-		h.Gateway.Models(c)
-	}
-	// /responses/*subpath 的子路径会被转发到上游同名端点之后，因此在入口就拒掉
-	// 不可转发的子路径，不让它进入调度与转发流程。可转发的判定见
-	// service.IsForwardableOpenAIResponsesRequestPath 及 upstream_path_guard.go。
-	guardResponsesSubpath := func(next gin.HandlerFunc) gin.HandlerFunc {
-		return func(c *gin.Context) {
-			if !service.IsForwardableOpenAIResponsesRequestPath(c) {
-				service.MarkOpsClientBusinessLimited(c, service.OpsClientBusinessLimitedReasonLocalPolicyDenied)
-				c.AbortWithStatusJSON(http.StatusNotFound, gin.H{
-					"error": gin.H{
-						"type":    "not_found_error",
-						"message": "Unsupported responses subpath",
-					},
-				})
-				return
-			}
-			if service.IsOpenAIResponsesInputTokensRequestPath(c) && isOpenAICompatPlatform(getGroupPlatform(c)) {
-				h.OpenAIGateway.ResponsesInputTokens(c)
-				return
-			}
-			next(c)
-		}
-	}
+	countTokensHandler := tkOpenAICompatCountTokensPOST(h)
+	modelsHandler := tkModelsHandler(h)
+	// /responses/*subpath：入口拒掉不可转发子路径（见 service.IsForwardableOpenAIResponsesRequestPath）。
+	guardResponsesSubpath := tkGuardResponsesSubpath(h)
 	responsesHandler := tkOpenAICompatResponsesPOST(h)
 
 	// API网关（Claude API兼容）
@@ -259,7 +216,7 @@ func RegisterGatewayRoutes(
 	registerTKOpenAICompatImagePresignRoutesNoPrefix(rootRoutes, h, bodyLimit, clientRequestID, trajectoryID, qaCapture, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), requireGroupAnthropic)
 	registerTKOpenAICompatVideoRoutesNoPrefix(rootRoutes, h, bodyLimit, clientRequestID, trajectoryID, qaCapture, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), requireGroupAnthropic)
 	rootRoutes.Register(http.MethodPost, "/alpha/search", SyncInference, textBodyLimit, clientRequestID, trajectoryID, qaCapture, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), requireGroupAnthropic, h.OpenAIGateway.AlphaSearch)
-	rootRoutes.Register(http.MethodPost, "/messages/count_tokens", Excluded("count_tokens"), bodyLimit, clientRequestID, trajectoryID, qaCapture, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), requireGroupAnthropic, tkOpenAICompatCountTokensPOST(h))
+	rootRoutes.Register(http.MethodPost, "/messages/count_tokens", Excluded("count_tokens"), bodyLimit, clientRequestID, trajectoryID, qaCapture, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), requireGroupAnthropic, countTokensHandler)
 	codexDirect := r.Group("/backend-api/codex")
 	codexDirect.Use(bodyLimit, clientRequestID, trajectoryID, qaCapture, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), requireGroupAnthropic)
 	codexRoutes := newTerminalRouteRegistrar(codexDirect, terminalOutcomeRecorder)

--- a/backend/internal/server/routes/gateway_tk_openai_compat_handlers.go
+++ b/backend/internal/server/routes/gateway_tk_openai_compat_handlers.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/Wei-Shaw/sub2api/internal/handler"
+	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 
 	"github.com/gin-gonic/gin"
@@ -31,6 +32,8 @@ func tkOpenAICompatMessagesPOST(h *handler.Handlers) gin.HandlerFunc {
 func tkOpenAICompatCountTokensPOST(h *handler.Handlers) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		switch getGroupPlatform(c) {
+		case service.PlatformOpenAI, service.PlatformKimi, service.PlatformZhipu, service.PlatformDeepseek:
+			h.OpenAIGateway.CountTokens(c)
 		case service.PlatformGrok:
 			h.OpenAIGateway.GrokCountTokens(c)
 		default:
@@ -39,6 +42,41 @@ func tkOpenAICompatCountTokensPOST(h *handler.Handlers) gin.HandlerFunc {
 				return
 			}
 			h.Gateway.CountTokens(c)
+		}
+	}
+}
+
+func tkModelsHandler(h *handler.Handlers) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		apiKey, _ := middleware.GetAPIKeyFromContext(c)
+		if c.Query("client_version") != "" && (getGroupPlatform(c) == service.PlatformOpenAI || getGroupPlatform(c) == service.PlatformComposite || (apiKey != nil && apiKey.IsUniversal())) {
+			h.OpenAIGateway.CodexModels(c)
+			return
+		}
+		h.Gateway.Models(c)
+	}
+}
+
+// tkGuardResponsesSubpath rejects non-forwardable /responses/*subpath requests
+// before scheduling. Forwardable paths: service.IsForwardableOpenAIResponsesRequestPath.
+func tkGuardResponsesSubpath(h *handler.Handlers) func(gin.HandlerFunc) gin.HandlerFunc {
+	return func(next gin.HandlerFunc) gin.HandlerFunc {
+		return func(c *gin.Context) {
+			if !service.IsForwardableOpenAIResponsesRequestPath(c) {
+				service.MarkOpsClientBusinessLimited(c, service.OpsClientBusinessLimitedReasonLocalPolicyDenied)
+				c.AbortWithStatusJSON(http.StatusNotFound, gin.H{
+					"error": gin.H{
+						"type":    "not_found_error",
+						"message": "Unsupported responses subpath",
+					},
+				})
+				return
+			}
+			if service.IsOpenAIResponsesInputTokensRequestPath(c) && isOpenAICompatPlatform(getGroupPlatform(c)) {
+				h.OpenAIGateway.ResponsesInputTokens(c)
+				return
+			}
+			next(c)
 		}
 	}
 }

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -129,8 +129,9 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	if handled || err != nil {
 		return result, err
 	}
-	// Refresh request view only when API-key normalize inside the companion
-	// mutated the payload (same as pre-extract inline path).
+	// Companion may mutate body via API-key normalize; refresh only on change.
+	// (Pre-extract main always re-parsed inside the API-key branch; equal bytes
+	// make a fresh view a no-op, so skip the alloc.)
 	if !bytes.Equal(body, outBody) {
 		body = outBody
 		originalBody = outBody
@@ -1229,6 +1230,18 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 	for key, values := range authHeaders {
 		for _, value := range values {
 			req.Header.Add(key, value)
+		}
+	}
+
+	// Set headers specific to OAuth accounts (ChatGPT internal API).
+	// Must run BEFORE the client whitelist copy so account Host/chatgpt-account-id
+	// cannot be ordered after a future whitelist expansion (parity with upstream-
+	// shaped main: auth → ChatGPT → whitelist → session/UA/fingerprint).
+	if account.UsesOpenAICodexProtocol() {
+		// Required: set Host for ChatGPT API (must use req.Host, not Header.Set)
+		req.Host = "chatgpt.com"
+		if err := resolveAndSetOpenAIChatGPTAccountHeaders(ctx, s.accountRepo, req.Header, account); err != nil {
+			return nil, fmt.Errorf("resolve chatgpt account headers: %w", err)
 		}
 	}
 

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -10,50 +10,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
-	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
 )
-
-var errCodexClientRestricted = errors.New("codex_cli_only restriction: only codex official clients are allowed")
-
-func isOfficialOpenAICodexUserAgent(ua string) bool {
-	ua = strings.TrimSpace(ua)
-	if ua == "" {
-		return false
-	}
-	return openai.IsCodexCLIRequest(ua) || openai.IsCodexOfficialClientRequest(ua)
-}
-
-func resolveOpenAICodexUserAgent(ctx context.Context, s *OpenAIGatewayService, account *Account, inboundUserAgent string) string {
-	if s != nil && s.cfg != nil && s.cfg.Gateway.ForceCodexCLI {
-		return codexCLIUserAgent
-	}
-	if account != nil {
-		if customUA := strings.TrimSpace(account.GetOpenAIUserAgent()); customUA != "" {
-			return customUA
-		}
-	}
-	if isOfficialOpenAICodexUserAgent(inboundUserAgent) {
-		return strings.TrimSpace(inboundUserAgent)
-	}
-	if s != nil && s.settingService != nil {
-		if ua := strings.TrimSpace(s.settingService.GetOpenAICodexUserAgent(ctx)); ua != "" {
-			return ua
-		}
-	}
-	return codexCLIUserAgent
-}
-
-func (s *OpenAIGatewayService) applyOpenAICodexUserAgent(ctx context.Context, req *http.Request, account *Account, inboundUserAgent string) {
-	if req == nil || account == nil || !account.IsOpenAIOAuthLike() {
-		return
-	}
-	req.Header.Set("user-agent", resolveOpenAICodexUserAgent(ctx, s, account, inboundUserAgent))
-}
 
 // Forward forwards request to OpenAI API
 func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, account *Account, body []byte) (*OpenAIForwardResult, error) {
@@ -164,46 +125,20 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		return s.forwardGrokResponses(ctx, c, account, body, originalModel, reqStream, startTime)
 	}
 
-	if target, planned := protocolExecutionTarget(ctx); planned {
-		switch target {
-		case protocolrouter.ProtocolMessages:
-			return s.forwardResponsesViaNativeAnthropic(ctx, c, account, body, reqModel)
-		case protocolrouter.ProtocolChatCompletions:
-			return s.forwardResponsesViaRawChatCompletions(ctx, c, account, body)
-		case protocolrouter.ProtocolResponses:
-			// Continue through the native Responses transport below.
-		default:
-			return nil, fmt.Errorf("unsupported selected protocol target %q", target)
-		}
+	result, outBody, handled, err := s.tkTryRouteOpenAIForwardProtocol(ctx, c, account, body, reqModel)
+	if handled || err != nil {
+		return result, err
 	}
-
-	// CN 供应商 anthropic 协议账号：/v1/responses 入站是交叉协议组合
-	// （Responses 客户端 × Anthropic 上游），转成 Anthropic 请求走原生端点。
-	// 不能落到下面的 raw-CC 分支——其 URL 构造会把 anthropic base 当 CC base 用。
-	if account.IsAnthropicProtocol() {
-		return s.forwardResponsesViaNativeAnthropic(ctx, c, account, body, reqModel)
-	}
-	if account.IsOpenAIApiKey() {
-		if normalized, changed, normalizeErr := normalizeOpenAIParallelToolCallsWithoutTools(body); normalizeErr != nil {
-			return nil, normalizeErr
-		} else if changed {
-			body = normalized
-			originalBody = normalized
-		}
-		if normalized, changed, normalizeErr := normalizeOpenAIAPIKeyStoreFalseReasoningReplay(body, isOpenAIResponsesCompactPath(c)); normalizeErr != nil {
-			return nil, normalizeErr
-		} else if changed {
-			body = normalized
-			originalBody = normalized
-		}
+	// Refresh request view only when API-key normalize inside the companion
+	// mutated the payload (same as pre-extract inline path).
+	if !bytes.Equal(body, outBody) {
+		body = outBody
+		originalBody = outBody
 		requestView = newOpenAIRequestView(body)
 		reqModel, reqStream, promptCacheKey = requestView.Model, requestView.Stream, requestView.PromptCacheKey
 		originalModel = reqModel
 	}
 
-	if shouldForwardOpenAIResponsesViaRawChatCompletions(account) {
-		return s.forwardResponsesViaRawChatCompletions(ctx, c, account, body)
-	}
 	if account.IsOpenAI() && (account.IsOpenAIApiKey() || account.IsOpenAIOAuthLike()) {
 		sanitizedBody, changed, sanitizeErr := sanitizeOpenAIResponsesInputItemIDs(body)
 		if sanitizeErr != nil {
@@ -500,52 +435,15 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		if decodeErr != nil {
 			return nil, decodeErr
 		}
-		codexResult := codexTransformResult{}
-		if compatMessagesBridge {
-			codexResult = applyCodexOAuthTransformWithOptions(decoded, codexOAuthTransformOptions{IsCodexCLI: isCodexCLI, IsCompact: isCompactRequest, SkipDefaultInstructions: true, PreserveToolCallIDs: true})
-			ensureCodexOAuthInstructionsField(decoded)
+		var codexModified bool
+		upstreamModel, promptCacheKey, codexModified, err = s.tkApplyCodexOAuthForwardBody(
+			c, account, decoded, isCodexCLI, isCompactRequest, compatMessagesBridge, upstreamModel, promptCacheKey,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if codexModified {
 			markDecodedModified()
-		} else {
-			codexResult = applyCodexOAuthTransform(decoded, isCodexCLI, isCompactRequest)
-		}
-		if codexResult.Error != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"type": "invalid_request_error", "message": codexResult.Error.Error()}})
-			return nil, codexResult.Error
-		}
-		setCodexToolNameReverse(c, codexResult.ToolNameReverse)
-		if codexResult.Modified {
-			markDecodedModified()
-		}
-		// 带真实 device_id 时补齐 client_metadata 安装标识，与真实 Codex 对齐（compact 形态不同，跳过）。
-		if !isCompactRequest && applyCodexClientMetadata(decoded, account) {
-			markDecodedModified()
-		}
-		stageCodexFingerprintIDs(c, nil)
-		// 指纹收敛：一次性解析收敛 ID，请求体和出站头共享同一份 IDs（保证 turn_id 等随机字段一致）。
-		// fingerprintIDs 在此处解析，后续 buildUpstreamRequest 中使用同一份。
-		if !isCompactRequest {
-			var clientHeaders http.Header
-			if c != nil && c.Request != nil {
-				clientHeaders = c.Request.Header
-			}
-			fpIDs := resolveCodexFingerprintIDsFromRequest(account, clientHeaders)
-			if fpIDs != nil {
-				if applyCodexFingerprintClientMetadata(decoded, fpIDs) {
-					markDecodedModified()
-				}
-			}
-			// 将 fpIDs 存入 gin context，供 buildUpstreamRequest 中头改写使用。
-			// 无条件覆写（含 nil）：failover 从收敛账号切到 off 账号时，上一
-			// 账号的 IDs 不得残留（stageCodexFingerprintIDs 注释）。
-			stageCodexFingerprintIDs(c, fpIDs)
-		}
-		if codexResult.NormalizedModel != "" {
-			upstreamModel = codexResult.NormalizedModel
-		}
-		if currentPromptCacheKey, ok := decoded["prompt_cache_key"].(string); ok && currentPromptCacheKey != "" {
-			promptCacheKey = currentPromptCacheKey
-		} else if codexResult.PromptCacheKey != "" {
-			promptCacheKey = codexResult.PromptCacheKey
 		}
 	}
 
@@ -1268,49 +1166,6 @@ func openAIStreamFailoverBlockedByClientOutput(firstTokenMs *int) bool {
 	return firstTokenMs != nil
 }
 
-func shouldForwardOpenAIResponsesViaRawChatCompletions(account *Account) bool {
-	if account == nil || account.Type != AccountTypeAPIKey {
-		return false
-	}
-	if account.IsCNProvider() {
-		// CN 的显式协议配置优先于异步探针 Extra；adaptive 仅 DeepSeek 有原生
-		// Responses，Kimi/GLM 回退 Chat Completions。
-		switch account.GetAPIProtocol() {
-		case APIProtocolChatCompletions:
-			return true
-		case APIProtocolAdaptive:
-			return account.Platform != PlatformDeepseek
-		case APIProtocolResponses, APIProtocolAnthropic:
-			return false
-		default:
-			return false
-		}
-	}
-	// Dual-stack MaaS relays advertise /v1/responses (probe treats 400 as
-	// "endpoint exists") but only implement Chat + Anthropic Messages.
-	if account.IsOpenAICloudwiseRelay() || account.IsOpenAITokenseaRelay() {
-		return true
-	}
-	return !openai_compat.ShouldUseResponsesAPI(account.Extra)
-}
-
-func (s *OpenAIGatewayService) enforceCodexClientRestriction(ctx context.Context, c *gin.Context, account *Account, body []byte) error {
-	restrictionResult := s.detectCodexClientRestriction(c, account, body)
-	apiKeyID := getAPIKeyIDFromContext(c)
-	logCodexCLIOnlyDetection(ctx, c, account, apiKeyID, restrictionResult, body)
-	if restrictionResult.Enabled && !restrictionResult.Matched {
-		MarkOpsClientPolicyDenied(c, OpsClientPolicyDeniedReasonLocalPolicyDenied)
-		c.JSON(http.StatusForbidden, gin.H{
-			"error": gin.H{
-				"type":    "forbidden_error",
-				"message": CodexClientRestrictionMessage(restrictionResult),
-			},
-		})
-		return errCodexClientRestricted
-	}
-	return nil
-}
-
 func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.Context, account *Account, body []byte, token string, isStream bool, promptCacheKey string, isCodexCLI bool) (*http.Request, error) {
 	// A governed request executes the immutable endpoint selected by
 	// protocolrouter. Legacy/non-governed traffic may resolve an explicit
@@ -1377,15 +1232,6 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 		}
 	}
 
-	// Set headers specific to OAuth accounts (ChatGPT internal API)
-	if account.UsesOpenAICodexProtocol() {
-		// Required: set Host for ChatGPT API (must use req.Host, not Header.Set)
-		req.Host = "chatgpt.com"
-		if err := resolveAndSetOpenAIChatGPTAccountHeaders(ctx, s.accountRepo, req.Header, account); err != nil {
-			return nil, fmt.Errorf("resolve chatgpt account headers: %w", err)
-		}
-	}
-
 	// Whitelist passthrough headers
 	for key, values := range c.Request.Header {
 		lowerKey := strings.ToLower(key)
@@ -1395,76 +1241,8 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 			}
 		}
 	}
-	// 客户端回带的 x-codex-turn-state 若已知由其他账号铸造（failover 换号），
-	// 剥离后再出站——异账号 blob 与本账号的（指纹收敛后）出站身份自相矛盾。
-	s.guardOpenAICodexTurnStateEcho(c, account, req.Header)
-	if account.UsesOpenAICodexProtocol() {
-		compatMessagesBridge := isOpenAICompatMessagesBridgeContext(c) || isOpenAICompatMessagesBridgeBody(body)
-		// 清除客户端透传的 session 头，后续用隔离后的值重新设置，防止跨用户会话碰撞。
-		clientConversationID := strings.TrimSpace(req.Header.Get("conversation_id"))
-		req.Header.Del("conversation_id")
-		req.Header.Del("session_id")
-
-		if compatMessagesBridge {
-			req.Header.Del("OpenAI-Beta")
-			req.Header.Del("originator")
-		} else {
-			req.Header.Set("originator", resolveOpenAIUpstreamOriginator(c, isCodexCLI))
-		}
-		apiKeyID := getAPIKeyIDFromContext(c)
-		if isOpenAIResponsesCompactPath(c) {
-			req.Header.Set("accept", "application/json")
-			if req.Header.Get("version") == "" {
-				req.Header.Set("version", CodexCanonicalClientVersion())
-			}
-			compactSession := resolveOpenAICompactSessionID(c)
-			req.Header.Set("session_id", isolateOpenAISessionID(apiKeyID, compactSession))
-		} else {
-			req.Header.Set("accept", "text/event-stream")
-			if req.Header.Get("version") == "" {
-				req.Header.Set("version", codexCLIVersion)
-			}
-		}
-		if promptCacheKey != "" {
-			isolated := isolateOpenAISessionID(apiKeyID, promptCacheKey)
-			req.Header.Set("session_id", isolated)
-			if !compatMessagesBridge || clientConversationID != "" {
-				req.Header.Set("conversation_id", isolated)
-			}
-		}
-	} else if isOpenAIResponsesCompactPath(c) {
-		// compact 上游是 unary JSON 协议：API-key 账号也显式声明 Accept，
-		// 避免 OpenAI 兼容网关按 SSE 返回（#3777 期望行为 4）。
-		req.Header.Set("accept", "application/json")
-	}
-
-	// Apply custom User-Agent if configured
-	if account.IsOpenAIOAuthLike() {
-		inboundUA := ""
-		if c != nil {
-			inboundUA = c.GetHeader("User-Agent")
-		}
-		s.applyOpenAICodexUserAgent(ctx, req, account, inboundUA)
-	} else {
-		customUA := account.GetOpenAIUserAgent()
-		if customUA != "" {
-			req.Header.Set("user-agent", customUA)
-		}
-	}
-
-	// 若开启 ForceCodexCLI，则强制将上游 User-Agent 伪装为规范 Codex 身份。
-	// 用于网关未透传/改写 User-Agent 时，仍能命中 Codex 侧识别逻辑。
-	if s.cfg != nil && s.cfg.Gateway.ForceCodexCLI {
-		req.Header.Set("user-agent", CodexCanonicalUserAgent())
-	}
-
-	// 指纹收敛：使用 Forward() 中预计算的收敛 ID 改写出站头，与请求体使用同一份 IDs。
-	applyStagedCodexFingerprintHeaders(c, account, req.Header)
-
-	// 终态收口：强制统一 OAuth 出站身份（User-Agent / originator / version 同源自洽）。
-	// 客户端自报身份不参与构造，浏览器型 UA 也因此不会再到达上游（原浏览器 UA 兜底已被吸收）。
-	if account.IsOpenAIOAuthLike() {
-		enforceCodexIdentityHeadersWithUA(req.Header, s.codexIdentityOverrideUA(account))
+	if err := s.tkApplyOpenAIForwardUpstreamHeaders(ctx, c, req, account, body, promptCacheKey, isCodexCLI); err != nil {
+		return nil, err
 	}
 
 	// Codex ChatGPT upstream rejects Content-Type with charset parameters

--- a/backend/internal/service/openai_gateway_forward_tk_codex_identity.go
+++ b/backend/internal/service/openai_gateway_forward_tk_codex_identity.go
@@ -1,0 +1,65 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
+	"github.com/gin-gonic/gin"
+)
+
+var errCodexClientRestricted = errors.New("codex_cli_only restriction: only codex official clients are allowed")
+
+func isOfficialOpenAICodexUserAgent(ua string) bool {
+	ua = strings.TrimSpace(ua)
+	if ua == "" {
+		return false
+	}
+	return openai.IsCodexCLIRequest(ua) || openai.IsCodexOfficialClientRequest(ua)
+}
+
+func resolveOpenAICodexUserAgent(ctx context.Context, s *OpenAIGatewayService, account *Account, inboundUserAgent string) string {
+	if s != nil && s.cfg != nil && s.cfg.Gateway.ForceCodexCLI {
+		return codexCLIUserAgent
+	}
+	if account != nil {
+		if customUA := strings.TrimSpace(account.GetOpenAIUserAgent()); customUA != "" {
+			return customUA
+		}
+	}
+	if isOfficialOpenAICodexUserAgent(inboundUserAgent) {
+		return strings.TrimSpace(inboundUserAgent)
+	}
+	if s != nil && s.settingService != nil {
+		if ua := strings.TrimSpace(s.settingService.GetOpenAICodexUserAgent(ctx)); ua != "" {
+			return ua
+		}
+	}
+	return codexCLIUserAgent
+}
+
+func (s *OpenAIGatewayService) applyOpenAICodexUserAgent(ctx context.Context, req *http.Request, account *Account, inboundUserAgent string) {
+	if req == nil || account == nil || !account.IsOpenAIOAuthLike() {
+		return
+	}
+	req.Header.Set("user-agent", resolveOpenAICodexUserAgent(ctx, s, account, inboundUserAgent))
+}
+
+func (s *OpenAIGatewayService) enforceCodexClientRestriction(ctx context.Context, c *gin.Context, account *Account, body []byte) error {
+	restrictionResult := s.detectCodexClientRestriction(c, account, body)
+	apiKeyID := getAPIKeyIDFromContext(c)
+	logCodexCLIOnlyDetection(ctx, c, account, apiKeyID, restrictionResult, body)
+	if restrictionResult.Enabled && !restrictionResult.Matched {
+		MarkOpsClientPolicyDenied(c, OpsClientPolicyDeniedReasonLocalPolicyDenied)
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": gin.H{
+				"type":    "forbidden_error",
+				"message": CodexClientRestrictionMessage(restrictionResult),
+			},
+		})
+		return errCodexClientRestricted
+	}
+	return nil
+}

--- a/backend/internal/service/openai_gateway_forward_tk_codex_oauth_body.go
+++ b/backend/internal/service/openai_gateway_forward_tk_codex_oauth_body.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// tkApplyCodexOAuthForwardBody applies Codex OAuth body transforms and stages
+// fingerprint IDs for the non-passthrough Forward path. Caller must ensureReqBody
+// before invoke and markDecodedModified when modified is true.
+func (s *OpenAIGatewayService) tkApplyCodexOAuthForwardBody(
+	c *gin.Context,
+	account *Account,
+	decoded map[string]any,
+	isCodexCLI, isCompactRequest, compatMessagesBridge bool,
+	upstreamModel, promptCacheKey string,
+) (newUpstreamModel, newPromptCacheKey string, modified bool, err error) {
+	newUpstreamModel = upstreamModel
+	newPromptCacheKey = promptCacheKey
+
+	codexResult := codexTransformResult{}
+	if compatMessagesBridge {
+		codexResult = applyCodexOAuthTransformWithOptions(decoded, codexOAuthTransformOptions{IsCodexCLI: isCodexCLI, IsCompact: isCompactRequest, SkipDefaultInstructions: true, PreserveToolCallIDs: true})
+		ensureCodexOAuthInstructionsField(decoded)
+		modified = true
+	} else {
+		codexResult = applyCodexOAuthTransform(decoded, isCodexCLI, isCompactRequest)
+	}
+	if codexResult.Error != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"type": "invalid_request_error", "message": codexResult.Error.Error()}})
+		return newUpstreamModel, newPromptCacheKey, modified, codexResult.Error
+	}
+	setCodexToolNameReverse(c, codexResult.ToolNameReverse)
+	if codexResult.Modified {
+		modified = true
+	}
+	// 带真实 device_id 时补齐 client_metadata 安装标识，与真实 Codex 对齐（compact 形态不同，跳过）。
+	if !isCompactRequest && applyCodexClientMetadata(decoded, account) {
+		modified = true
+	}
+	stageCodexFingerprintIDs(c, nil)
+	// 指纹收敛：一次性解析收敛 ID，请求体和出站头共享同一份 IDs（保证 turn_id 等随机字段一致）。
+	// fingerprintIDs 在此处解析，后续 buildUpstreamRequest 中使用同一份。
+	if !isCompactRequest {
+		var clientHeaders http.Header
+		if c != nil && c.Request != nil {
+			clientHeaders = c.Request.Header
+		}
+		fpIDs := resolveCodexFingerprintIDsFromRequest(account, clientHeaders)
+		if fpIDs != nil {
+			if applyCodexFingerprintClientMetadata(decoded, fpIDs) {
+				modified = true
+			}
+		}
+		// 将 fpIDs 存入 gin context，供 buildUpstreamRequest 中头改写使用。
+		// 无条件覆写（含 nil）：failover 从收敛账号切到 off 账号时，上一
+		// 账号的 IDs 不得残留（stageCodexFingerprintIDs 注释）。
+		stageCodexFingerprintIDs(c, fpIDs)
+	}
+	if codexResult.NormalizedModel != "" {
+		newUpstreamModel = codexResult.NormalizedModel
+	}
+	if currentPromptCacheKey, ok := decoded["prompt_cache_key"].(string); ok && currentPromptCacheKey != "" {
+		newPromptCacheKey = currentPromptCacheKey
+	} else if codexResult.PromptCacheKey != "" {
+		newPromptCacheKey = codexResult.PromptCacheKey
+	}
+	return newUpstreamModel, newPromptCacheKey, modified, nil
+}

--- a/backend/internal/service/openai_gateway_forward_tk_protocol_dispatch.go
+++ b/backend/internal/service/openai_gateway_forward_tk_protocol_dispatch.go
@@ -1,0 +1,93 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
+	"github.com/gin-gonic/gin"
+)
+
+// tkTryRouteOpenAIForwardProtocol handles TokenKey early protocol routing after
+// the Grok early-return and before the main /v1/responses path.
+//
+// When an API-key body normalization mutates the payload, outBody carries the
+// updated bytes so Forward can refresh requestView / originalBody. Callers must
+// treat outBody as authoritative whenever handled is false.
+func (s *OpenAIGatewayService) tkTryRouteOpenAIForwardProtocol(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	reqModel string,
+) (result *OpenAIForwardResult, outBody []byte, handled bool, err error) {
+	outBody = body
+
+	if target, planned := protocolExecutionTarget(ctx); planned {
+		switch target {
+		case protocolrouter.ProtocolMessages:
+			result, err = s.forwardResponsesViaNativeAnthropic(ctx, c, account, outBody, reqModel)
+			return result, outBody, true, err
+		case protocolrouter.ProtocolChatCompletions:
+			result, err = s.forwardResponsesViaRawChatCompletions(ctx, c, account, outBody)
+			return result, outBody, true, err
+		case protocolrouter.ProtocolResponses:
+			// Continue through the native Responses transport below.
+		default:
+			return nil, outBody, true, fmt.Errorf("unsupported selected protocol target %q", target)
+		}
+	}
+
+	// CN 供应商 anthropic 协议账号：/v1/responses 入站是交叉协议组合
+	// （Responses 客户端 × Anthropic 上游），转成 Anthropic 请求走原生端点。
+	// 不能落到下面的 raw-CC 分支——其 URL 构造会把 anthropic base 当 CC base 用。
+	if account.IsAnthropicProtocol() {
+		result, err = s.forwardResponsesViaNativeAnthropic(ctx, c, account, outBody, reqModel)
+		return result, outBody, true, err
+	}
+	if account.IsOpenAIApiKey() {
+		if normalized, changed, normalizeErr := normalizeOpenAIParallelToolCallsWithoutTools(outBody); normalizeErr != nil {
+			return nil, outBody, true, normalizeErr
+		} else if changed {
+			outBody = normalized
+		}
+		if normalized, changed, normalizeErr := normalizeOpenAIAPIKeyStoreFalseReasoningReplay(outBody, isOpenAIResponsesCompactPath(c)); normalizeErr != nil {
+			return nil, outBody, true, normalizeErr
+		} else if changed {
+			outBody = normalized
+		}
+	}
+
+	if shouldForwardOpenAIResponsesViaRawChatCompletions(account) {
+		result, err = s.forwardResponsesViaRawChatCompletions(ctx, c, account, outBody)
+		return result, outBody, true, err
+	}
+	return nil, outBody, false, nil
+}
+
+func shouldForwardOpenAIResponsesViaRawChatCompletions(account *Account) bool {
+	if account == nil || account.Type != AccountTypeAPIKey {
+		return false
+	}
+	if account.IsCNProvider() {
+		// CN 的显式协议配置优先于异步探针 Extra；adaptive 仅 DeepSeek 有原生
+		// Responses，Kimi/GLM 回退 Chat Completions。
+		switch account.GetAPIProtocol() {
+		case APIProtocolChatCompletions:
+			return true
+		case APIProtocolAdaptive:
+			return account.Platform != PlatformDeepseek
+		case APIProtocolResponses, APIProtocolAnthropic:
+			return false
+		default:
+			return false
+		}
+	}
+	// Dual-stack MaaS relays advertise /v1/responses (probe treats 400 as
+	// "endpoint exists") but only implement Chat + Anthropic Messages.
+	if account.IsOpenAICloudwiseRelay() || account.IsOpenAITokenseaRelay() {
+		return true
+	}
+	return !openai_compat.ShouldUseResponsesAPI(account.Extra)
+}

--- a/backend/internal/service/openai_gateway_forward_tk_protocol_dispatch_test.go
+++ b/backend/internal/service/openai_gateway_forward_tk_protocol_dispatch_test.go
@@ -1,0 +1,198 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type protocolDispatchHTTPUpstream struct {
+	requests []*http.Request
+}
+
+func (u *protocolDispatchHTTPUpstream) Do(req *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
+	if req != nil && req.Body != nil {
+		body, _ := io.ReadAll(req.Body)
+		_ = req.Body.Close()
+		req.Body = io.NopCloser(bytes.NewReader(body))
+	}
+	u.requests = append(u.requests, req)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(strings.NewReader(
+			`{"id":"resp_1","object":"response","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1}}`,
+		)),
+	}, nil
+}
+
+func (u *protocolDispatchHTTPUpstream) DoWithTLS(req *http.Request, proxyURL string, accountID int64, concurrency int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	return u.Do(req, proxyURL, accountID, concurrency)
+}
+
+func TestTkTryRouteOpenAIForwardProtocol_OAuthContinuesNativeResponses(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	svc := &OpenAIGatewayService{}
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	body := []byte(`{"model":"gpt-5","input":"hi"}`)
+
+	result, outBody, handled, err := svc.tkTryRouteOpenAIForwardProtocol(context.Background(), c, account, body, "gpt-5")
+	require.NoError(t, err)
+	require.False(t, handled, "OAuth must fall through to native Responses transport")
+	require.Nil(t, result)
+	require.Equal(t, body, outBody)
+}
+
+func TestTkTryRouteOpenAIForwardProtocol_APIKeyNormalizeMutatesOutBodyThenContinues(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	svc := &OpenAIGatewayService{}
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://api.openai.com",
+		},
+		// Extra empty → ShouldUseResponsesAPI true → shouldForward false.
+		Extra: map[string]any{},
+	}
+	body := []byte(`{"model":"gpt-5","input":"hi","parallel_tool_calls":true}`)
+
+	result, outBody, handled, err := svc.tkTryRouteOpenAIForwardProtocol(context.Background(), c, account, body, "gpt-5")
+	require.NoError(t, err)
+	require.False(t, handled, "after normalize, native Responses must continue when Extra allows Responses")
+	require.Nil(t, result)
+	require.NotEqual(t, string(body), string(outBody), "normalize must strip parallel_tool_calls without tools")
+	require.NotContains(t, string(outBody), "parallel_tool_calls")
+}
+
+func TestTkTryRouteOpenAIForwardProtocol_CloudwiseRawChatAfterNormalize(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstream := &protocolDispatchHTTPUpstream{}
+	svc := &OpenAIGatewayService{
+		cfg: &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{
+			Enabled:           false,
+			AllowInsecureHTTP: true,
+		}}},
+		httpUpstream: upstream,
+	}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":  "sk-cloudwise",
+			"base_url": "https://api.cloudwise.ai/api",
+		},
+	}
+	require.True(t, account.IsOpenAICloudwiseRelay())
+	body := []byte(`{"model":"gpt-5","input":"hi","parallel_tool_calls":true}`)
+
+	result, outBody, handled, err := svc.tkTryRouteOpenAIForwardProtocol(context.Background(), c, account, body, "gpt-5")
+	require.NoError(t, err)
+	require.True(t, handled, "cloudwise dual-stack must route via raw Chat Completions")
+	require.NotNil(t, result)
+	require.NotContains(t, string(outBody), "parallel_tool_calls", "normalize must run BEFORE shouldForward raw-CC")
+	require.NotEmpty(t, upstream.requests, "raw-CC path must hit upstream")
+	require.Contains(t, upstream.requests[0].URL.Path, "chat/completions")
+}
+
+func TestTkTryRouteOpenAIForwardProtocol_AnthropicProtocolBeforeRawChat(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstream := &protocolDispatchHTTPUpstream{}
+	svc := &OpenAIGatewayService{
+		cfg: &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{
+			Enabled:           false,
+			AllowInsecureHTTP: true,
+		}}},
+		httpUpstream: upstream,
+	}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	account := &Account{
+		Platform: PlatformKimi,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":      "sk-kimi",
+			"base_url":     "http://kimi.example",
+			"api_protocol": APIProtocolAnthropic,
+		},
+	}
+	require.True(t, account.IsAnthropicProtocol())
+	require.True(t, account.IsCNProvider())
+
+	body := []byte(`{"model":"kimi-k2","input":"hi"}`)
+	_, _, handled, _ := svc.tkTryRouteOpenAIForwardProtocol(context.Background(), c, account, body, "kimi-k2")
+	// Native Anthropic conversion may error without full fixtures; what matters is
+	// handled=true (Anthropic branch taken) and NOT chat/completions upstream.
+	require.True(t, handled, "Anthropic protocol must short-circuit before raw-CC")
+	for _, req := range upstream.requests {
+		require.NotContains(t, req.URL.Path, "chat/completions", "must not fall through to raw-CC URL construction")
+	}
+}
+
+func TestTkTryRouteOpenAIForwardProtocol_UnsupportedPlannedTargetErrors(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	// ChatCompletions→Gemini is a legal plan target that Forward's companion
+	// switch does not implement (defensive default arm).
+	account := &Account{
+		ID:       902,
+		Platform: PlatformAntigravity,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token":  "ag-token",
+			"project_id":    "ag-project",
+			"model_mapping": map[string]any{"gemini-2.5-flash": "gemini-2.5-flash"},
+		},
+		Extra: map[string]any{SupportedProtocolsExtraKey: []any{string(protocolrouter.ProtocolGeminiGenerateContent)}},
+	}
+	attachTestProtocolCapability(account, protocolrouter.ProtocolGeminiGenerateContent)
+	snapshot, err := ProtocolAccountSnapshot(account, "gemini-2.5-flash")
+	require.NoError(t, err)
+	req, err := protocolrouter.NewCanonicalRequest(protocolrouter.CanonicalRequestInput{
+		InboundProtocol: protocolrouter.ProtocolChatCompletions,
+		RequestedModel:  "gemini-2.5-flash",
+		Profile:         protocolrouter.RequestProfile{ContentKinds: protocolrouter.ContentText},
+		Body:            []byte(`{"model":"gemini-2.5-flash","messages":[{"role":"user","content":"hi"}]}`),
+	})
+	require.NoError(t, err)
+	plan, err := NewProtocolRouter().Plan(req, snapshot)
+	require.NoError(t, err)
+	require.Equal(t, protocolrouter.ProtocolGeminiGenerateContent, plan.TargetProtocol())
+
+	ctx := withProtocolExecutionPlan(context.Background(), plan)
+	svc := &OpenAIGatewayService{}
+
+	result, _, handled, routeErr := svc.tkTryRouteOpenAIForwardProtocol(ctx, c, account, []byte(`{}`), "gemini-2.5-flash")
+	require.True(t, handled)
+	require.Nil(t, result)
+	require.Error(t, routeErr)
+	require.Contains(t, routeErr.Error(), "unsupported selected protocol target")
+}

--- a/backend/internal/service/openai_gateway_forward_tk_upstream_headers.go
+++ b/backend/internal/service/openai_gateway_forward_tk_upstream_headers.go
@@ -1,0 +1,105 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// tkApplyOpenAIForwardUpstreamHeaders applies Codex/OAuth outbound headers after
+// auth headers + whitelist copy and before ApplyHeaderOverrides.
+func (s *OpenAIGatewayService) tkApplyOpenAIForwardUpstreamHeaders(
+	ctx context.Context,
+	c *gin.Context,
+	req *http.Request,
+	account *Account,
+	body []byte,
+	promptCacheKey string,
+	isCodexCLI bool,
+) error {
+	// Set headers specific to OAuth accounts (ChatGPT internal API)
+	if account.UsesOpenAICodexProtocol() {
+		// Required: set Host for ChatGPT API (must use req.Host, not Header.Set)
+		req.Host = "chatgpt.com"
+		if err := resolveAndSetOpenAIChatGPTAccountHeaders(ctx, s.accountRepo, req.Header, account); err != nil {
+			return fmt.Errorf("resolve chatgpt account headers: %w", err)
+		}
+	}
+
+	// 客户端回带的 x-codex-turn-state 若已知由其他账号铸造（failover 换号），
+	// 剥离后再出站——异账号 blob 与本账号的（指纹收敛后）出站身份自相矛盾。
+	s.guardOpenAICodexTurnStateEcho(c, account, req.Header)
+	if account.UsesOpenAICodexProtocol() {
+		compatMessagesBridge := isOpenAICompatMessagesBridgeContext(c) || isOpenAICompatMessagesBridgeBody(body)
+		// 清除客户端透传的 session 头，后续用隔离后的值重新设置，防止跨用户会话碰撞。
+		clientConversationID := strings.TrimSpace(req.Header.Get("conversation_id"))
+		req.Header.Del("conversation_id")
+		req.Header.Del("session_id")
+
+		if compatMessagesBridge {
+			req.Header.Del("OpenAI-Beta")
+			req.Header.Del("originator")
+		} else {
+			req.Header.Set("originator", resolveOpenAIUpstreamOriginator(c, isCodexCLI))
+		}
+		apiKeyID := getAPIKeyIDFromContext(c)
+		if isOpenAIResponsesCompactPath(c) {
+			req.Header.Set("accept", "application/json")
+			if req.Header.Get("version") == "" {
+				req.Header.Set("version", CodexCanonicalClientVersion())
+			}
+			compactSession := resolveOpenAICompactSessionID(c)
+			req.Header.Set("session_id", isolateOpenAISessionID(apiKeyID, compactSession))
+		} else {
+			req.Header.Set("accept", "text/event-stream")
+			if req.Header.Get("version") == "" {
+				req.Header.Set("version", codexCLIVersion)
+			}
+		}
+		if promptCacheKey != "" {
+			isolated := isolateOpenAISessionID(apiKeyID, promptCacheKey)
+			req.Header.Set("session_id", isolated)
+			if !compatMessagesBridge || clientConversationID != "" {
+				req.Header.Set("conversation_id", isolated)
+			}
+		}
+	} else if isOpenAIResponsesCompactPath(c) {
+		// compact 上游是 unary JSON 协议：API-key 账号也显式声明 Accept，
+		// 避免 OpenAI 兼容网关按 SSE 返回（#3777 期望行为 4）。
+		req.Header.Set("accept", "application/json")
+	}
+
+	// Apply custom User-Agent if configured
+	if account.IsOpenAIOAuthLike() {
+		inboundUA := ""
+		if c != nil {
+			inboundUA = c.GetHeader("User-Agent")
+		}
+		s.applyOpenAICodexUserAgent(ctx, req, account, inboundUA)
+	} else {
+		customUA := account.GetOpenAIUserAgent()
+		if customUA != "" {
+			req.Header.Set("user-agent", customUA)
+		}
+	}
+
+	// 若开启 ForceCodexCLI，则强制将上游 User-Agent 伪装为规范 Codex 身份。
+	// 用于网关未透传/改写 User-Agent 时，仍能命中 Codex 侧识别逻辑。
+	if s.cfg != nil && s.cfg.Gateway.ForceCodexCLI {
+		req.Header.Set("user-agent", CodexCanonicalUserAgent())
+	}
+
+	// 指纹收敛：使用 Forward() 中预计算的收敛 ID 改写出站头，与请求体使用同一份 IDs。
+	applyStagedCodexFingerprintHeaders(c, account, req.Header)
+
+	// 终态收口：强制统一 OAuth 出站身份（User-Agent / originator / version 同源自洽）。
+	// 客户端自报身份不参与构造，浏览器型 UA 也因此不会再到达上游（原浏览器 UA 兜底已被吸收）。
+	if account.IsOpenAIOAuthLike() {
+		enforceCodexIdentityHeadersWithUA(req.Header, s.codexIdentityOverrideUA(account))
+	}
+
+	return nil
+}

--- a/backend/internal/service/openai_gateway_forward_tk_upstream_headers.go
+++ b/backend/internal/service/openai_gateway_forward_tk_upstream_headers.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -10,7 +9,9 @@ import (
 )
 
 // tkApplyOpenAIForwardUpstreamHeaders applies Codex/OAuth outbound headers after
-// auth headers + whitelist copy and before ApplyHeaderOverrides.
+// auth + ChatGPT Host/account headers + whitelist copy, and before
+// ApplyHeaderOverrides. ChatGPT Host/chatgpt-account-id stay in
+// buildUpstreamRequest (before whitelist) — do not move them here.
 func (s *OpenAIGatewayService) tkApplyOpenAIForwardUpstreamHeaders(
 	ctx context.Context,
 	c *gin.Context,
@@ -20,15 +21,6 @@ func (s *OpenAIGatewayService) tkApplyOpenAIForwardUpstreamHeaders(
 	promptCacheKey string,
 	isCodexCLI bool,
 ) error {
-	// Set headers specific to OAuth accounts (ChatGPT internal API)
-	if account.UsesOpenAICodexProtocol() {
-		// Required: set Host for ChatGPT API (must use req.Host, not Header.Set)
-		req.Host = "chatgpt.com"
-		if err := resolveAndSetOpenAIChatGPTAccountHeaders(ctx, s.accountRepo, req.Header, account); err != nil {
-			return fmt.Errorf("resolve chatgpt account headers: %w", err)
-		}
-	}
-
 	// 客户端回带的 x-codex-turn-state 若已知由其他账号铸造（failover 换号），
 	// 剥离后再出站——异账号 blob 与本账号的（指纹收敛后）出站身份自相矛盾。
 	s.guardOpenAICodexTurnStateEcho(c, account, req.Header)

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -622,28 +622,6 @@ func stripOpenAILegacyResponsesBeta(headers http.Header) {
 	}
 }
 
-func shouldFailoverOpenAIPassthroughResponse(account *Account, statusCode int, responseBody []byte) bool {
-	semantic := gatewayFailureSemanticUnclassified
-	if hit, _, _ := detectOpenAICyberPolicy(responseBody); hit {
-		semantic = gatewayFailureSemanticSharedFault
-	} else if isOpenAIContextWindowError("", responseBody) {
-		semantic = gatewayFailureSemanticSharedFault
-	} else if isOpenAIHTTPUpstreamAccessStateError(statusCode, "", responseBody) ||
-		isOpenAIRequestBodyTooLargeError(statusCode, "", responseBody) {
-		semantic = gatewayFailureSemanticAccountFault
-	}
-	obs := gatewayFailoverObservation{
-		Profile:    gatewayFailoverProfileOpenAIPassthrough,
-		Semantic:   semantic,
-		StatusCode: statusCode,
-	}
-	if account != nil {
-		obs.AccountType = account.Type
-		obs.AccountConfiguredRetry = account.IsPoolMode() && account.IsPoolModeRetryableStatus(statusCode)
-	}
-	return classifyGatewayFailover(obs).RetryNextAccount
-}
-
 func writeOpenAIPassthroughErrorHeaders(dst, src http.Header) {
 	if dst == nil {
 		return
@@ -1184,32 +1162,6 @@ func sanitizeOpenAICapacityShedErrorCodeForClient(payload []byte) ([]byte, bool)
 	return updated, changed
 }
 
-// openAIStreamFailedClientResponse maps response.failed to the downstream HTTP
-// status/type when no admin passthrough rule matches. Caller-fault rejections
-// must not surface as 502 because clients retry that status indefinitely.
-func openAIStreamFailedClientResponse(payload []byte, message string, default5xxErrType string) (statusCode int, errType string) {
-	statusCode = openAIStreamFailedEventSemanticStatus(payload, message)
-	switch statusCode {
-	case http.StatusBadRequest:
-		errType = "invalid_request_error"
-	case http.StatusUnauthorized:
-		errType = "authentication_error"
-	case http.StatusForbidden:
-		errType = "permission_error"
-	case http.StatusTooManyRequests:
-		errType = "rate_limit_error"
-	case http.StatusServiceUnavailable:
-		errType = "api_error"
-	default:
-		if statusCode >= 500 {
-			errType = default5xxErrType
-		} else {
-			errType = "api_error"
-		}
-	}
-	return statusCode, errType
-}
-
 func openAIStreamFailedEventSemanticStatus(payload []byte, message string) int {
 	if isOpenAIContextWindowError(message, payload) {
 		return http.StatusBadRequest
@@ -1367,91 +1319,6 @@ func applyOpenAIStreamFailedErrorPassthroughRule(
 		"upstream_error",
 		"Upstream request failed",
 	)
-}
-
-func openAIStreamFailedEventShouldFailover(payload []byte, message string) bool {
-	semantic := gatewayFailureSemanticTransientFault
-	if hit, _, _ := detectOpenAICyberPolicy(payload); hit {
-		semantic = gatewayFailureSemanticSharedFault
-	} else if isOpenAIContextWindowError(message, payload) {
-		semantic = gatewayFailureSemanticSharedFault
-	} else if isOpenAIUpstreamAccessStateError(message, payload) {
-		semantic = gatewayFailureSemanticAccountFault
-	} else {
-		semanticStatus := openAIStreamFailureStatus(payload, message)
-		if semanticStatus == http.StatusForbidden {
-			if openAIStream403AccountFailure(payload, message) {
-				semantic = gatewayFailureSemanticAccountFault
-			} else {
-				semantic = gatewayFailureSemanticSharedFault
-			}
-		} else if semanticStatus != http.StatusTooManyRequests &&
-			!isOpenAITransientProcessingError(http.StatusBadRequest, message, payload) {
-			code := strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "response.error.code").String()))
-			if code == "" {
-				code = strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "error.code").String()))
-			}
-			errType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "response.error.type").String()))
-			if errType == "" {
-				errType = strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "error.type").String()))
-			}
-			combined := strings.ToLower(strings.TrimSpace(message + " " + code + " " + errType))
-			for _, marker := range []string{
-				"invalid_request",
-				"content_policy",
-				"policy",
-				"safety",
-				"high-risk cyber",
-				"not allowed",
-				"violat",
-			} {
-				if strings.Contains(combined, marker) {
-					semantic = gatewayFailureSemanticSharedFault
-					break
-				}
-			}
-		}
-	}
-	return classifyGatewayFailover(gatewayFailoverObservation{
-		Profile:    gatewayFailoverProfileOpenAI,
-		Semantic:   semantic,
-		StatusCode: openAIStreamFailureStatus(payload, message),
-	}).RetryNextAccount
-}
-
-func openAIStreamErrorEventShouldFailover(payload []byte, message string) bool {
-	semantic := gatewayFailureSemanticSharedFault
-	if hit, _, _ := detectOpenAICyberPolicy(payload); hit {
-		semantic = gatewayFailureSemanticSharedFault
-	} else if isOpenAIContextWindowError(message, payload) {
-		semantic = gatewayFailureSemanticSharedFault
-	} else if isOpenAIUpstreamAccessStateError(message, payload) {
-		semantic = gatewayFailureSemanticAccountFault
-	} else {
-		switch openAIStreamFailedEventSemanticStatus(payload, message) {
-		case http.StatusForbidden:
-			if openAIStream403AccountFailure(payload, message) {
-				semantic = gatewayFailureSemanticAccountFault
-			}
-		case http.StatusUnauthorized, http.StatusTooManyRequests, 529:
-			semantic = gatewayFailureSemanticAccountFault
-		default:
-			combined := strings.ToLower(strings.TrimSpace(message + " " +
-				gjson.GetBytes(payload, "error.message").String() + " " +
-				gjson.GetBytes(payload, "response.error.message").String()))
-			if isOpenAITransientProcessingError(http.StatusBadRequest, message, payload) ||
-				strings.Contains(combined, "temporary") ||
-				strings.Contains(combined, "try again") ||
-				strings.Contains(combined, "please retry") {
-				semantic = gatewayFailureSemanticTransientFault
-			}
-		}
-	}
-	return classifyGatewayFailover(gatewayFailoverObservation{
-		Profile:    gatewayFailoverProfileOpenAI,
-		Semantic:   semantic,
-		StatusCode: openAIStreamFailedEventSemanticStatus(payload, message),
-	}).RetryNextAccount
 }
 
 func (s *OpenAIGatewayService) handleOpenAIStreamTerminalAccountSideEffects(
@@ -1646,8 +1513,12 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 	suppressCurrentEvent := false
 	responseFailedPending := false
 	upstreamRequestID := strings.TrimSpace(resp.Header.Get("x-request-id"))
-	// pendingLines 在首个可见输出前保留前导事件，确保无输出失败仍可安全 failover。
-	pendingLines := make([]string, 0, 8)
+	// pending SSE 在首个可见输出前保留前导事件，确保无输出失败仍可安全 failover。
+	shortStreamBufferBytes := 0
+	if s.cfg != nil && s.cfg.Gateway.ResponsesShortStreamBufferBytes > 0 {
+		shortStreamBufferBytes = s.cfg.Gateway.ResponsesShortStreamBufferBytes
+	}
+	pendingSSE := newTkPassthroughPendingSSE(shortStreamBufferBytes)
 	// flushPending 表示已写入但未到 SSE 空行边界的脏状态；defer 兜底函数退出前的残留，断连后不再 Flush。
 	flushPending := false
 	pendingSSEEventType := ""
@@ -1659,42 +1530,16 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 		flushPending = false
 	}
 	defer flushPendingOutput()
-	pendingBytes := 0
-	shortStreamBufferBytes := 0
-	if s.cfg != nil && s.cfg.Gateway.ResponsesShortStreamBufferBytes > 0 {
-		shortStreamBufferBytes = s.cfg.Gateway.ResponsesShortStreamBufferBytes
-	}
-	appendPendingLine := func(line string) {
-		pendingLines = append(pendingLines, line)
-		pendingBytes += len(line) + 1
-	}
-	writePendingLines := func() bool {
-		for _, pending := range pendingLines {
-			if _, err := fmt.Fprintln(w, pending); err != nil {
-				clientDisconnected = true
-				logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] Client disconnected during streaming, continue draining upstream for usage: account=%d", account.ID)
-				return false
-			}
-		}
-		pendingLines = pendingLines[:0]
-		pendingBytes = 0
-		return true
-	}
-	shouldReleasePending := func(lineStartsClientOutput bool) bool {
-		if !lineStartsClientOutput {
-			return false
-		}
-		if shortStreamBufferBytes <= 0 || sawDone || sawTerminalEvent || sawFailedEvent {
-			return true
-		}
-		return pendingBytes >= shortStreamBufferBytes
-	}
 	ensureResponseFailedTerminal := func() {
 		if !codexState.sawBareError || codexState.sawResponseFailed || failureDelivered {
 			return
 		}
 		codexState.finalizeBareErrorAtStreamEnd(s, c, account, resp.Header, failedMessage)
-		if clientDisconnected || !writePendingLines() {
+		if clientDisconnected {
+			return
+		}
+		if !pendingSSE.writeAndClear(w, account.ID) {
+			clientDisconnected = true
 			return
 		}
 		if _, err := fmt.Fprint(w, buildOpenAIResponseFailedSSE(responseID, originalModel, codexState.bareErrorPayload, failedMessage)); err != nil {
@@ -1800,7 +1645,6 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 				}
 				failedMessage = failureOut.failedMessage
 				if failureOut.streamEarlyErr != nil {
-					sawFailedEvent = failureOut.sawFailedEvent
 					return resultWithUsage(), failureOut.streamEarlyErr
 				}
 				forceFlushFailedEvent = failureOut.forceFlushFailedEvent
@@ -1863,11 +1707,12 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 
 		if !clientDisconnected && !failureDelivered && !suppressCurrentEvent {
 			if !clientOutputStarted {
-				appendPendingLine(line)
-				if !shouldReleasePending(lineStartsClientOutput) {
+				pendingSSE.append(line)
+				if !pendingSSE.shouldRelease(lineStartsClientOutput, sawDone || sawTerminalEvent || sawFailedEvent) {
 					continue
 				}
-				if !writePendingLines() {
+				if !pendingSSE.writeAndClear(w, account.ID) {
+					clientDisconnected = true
 					continue
 				}
 				clientOutputStarted = true
@@ -1909,7 +1754,7 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 			logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] SSE line too long: account=%d max_size=%d error=%v", account.ID, maxLineSize, err)
 			return resultWithUsage(), err
 		}
-		if !openAIStreamClientOutputStarted(c, clientOutputStarted) && (!semanticOutputSeen || pendingBytes > 0) {
+		if !openAIStreamClientOutputStarted(c, clientOutputStarted) && (!semanticOutputSeen || pendingSSE.bytes > 0) {
 			msg := "OpenAI stream disconnected before completion"
 			if errText := strings.TrimSpace(err.Error()); errText != "" {
 				msg += ": " + errText
@@ -1938,7 +1783,7 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 			zap.Int64("account_id", account.ID),
 			zap.String("upstream_request_id", upstreamRequestID),
 		).Info("OpenAI passthrough 上游流在未收到 [DONE] 时结束，疑似断流")
-		if !openAIStreamClientOutputStarted(c, clientOutputStarted) && (!semanticOutputSeen || pendingBytes > 0) {
+		if !openAIStreamClientOutputStarted(c, clientOutputStarted) && (!semanticOutputSeen || pendingSSE.bytes > 0) {
 			return resultWithUsage(),
 				s.newOpenAIStreamFailoverError(c, account, true, upstreamRequestID, nil, "OpenAI stream ended before a terminal event")
 		}

--- a/backend/internal/service/openai_gateway_passthrough_tk_failover.go
+++ b/backend/internal/service/openai_gateway_passthrough_tk_failover.go
@@ -1,0 +1,141 @@
+package service
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+func shouldFailoverOpenAIPassthroughResponse(account *Account, statusCode int, responseBody []byte) bool {
+	semantic := gatewayFailureSemanticUnclassified
+	if hit, _, _ := detectOpenAICyberPolicy(responseBody); hit {
+		semantic = gatewayFailureSemanticSharedFault
+	} else if isOpenAIContextWindowError("", responseBody) {
+		semantic = gatewayFailureSemanticSharedFault
+	} else if isOpenAIHTTPUpstreamAccessStateError(statusCode, "", responseBody) ||
+		isOpenAIRequestBodyTooLargeError(statusCode, "", responseBody) {
+		semantic = gatewayFailureSemanticAccountFault
+	}
+	obs := gatewayFailoverObservation{
+		Profile:    gatewayFailoverProfileOpenAIPassthrough,
+		Semantic:   semantic,
+		StatusCode: statusCode,
+	}
+	if account != nil {
+		obs.AccountType = account.Type
+		obs.AccountConfiguredRetry = account.IsPoolMode() && account.IsPoolModeRetryableStatus(statusCode)
+	}
+	return classifyGatewayFailover(obs).RetryNextAccount
+}
+
+// openAIStreamFailedClientResponse maps response.failed to the downstream HTTP
+// status/type when no admin passthrough rule matches. Caller-fault rejections
+// must not surface as 502 because clients retry that status indefinitely.
+func openAIStreamFailedClientResponse(payload []byte, message string, default5xxErrType string) (statusCode int, errType string) {
+	statusCode = openAIStreamFailedEventSemanticStatus(payload, message)
+	switch statusCode {
+	case http.StatusBadRequest:
+		errType = "invalid_request_error"
+	case http.StatusUnauthorized:
+		errType = "authentication_error"
+	case http.StatusForbidden:
+		errType = "permission_error"
+	case http.StatusTooManyRequests:
+		errType = "rate_limit_error"
+	case http.StatusServiceUnavailable:
+		errType = "api_error"
+	default:
+		if statusCode >= 500 {
+			errType = default5xxErrType
+		} else {
+			errType = "api_error"
+		}
+	}
+	return statusCode, errType
+}
+
+func openAIStreamFailedEventShouldFailover(payload []byte, message string) bool {
+	semantic := gatewayFailureSemanticTransientFault
+	if hit, _, _ := detectOpenAICyberPolicy(payload); hit {
+		semantic = gatewayFailureSemanticSharedFault
+	} else if isOpenAIContextWindowError(message, payload) {
+		semantic = gatewayFailureSemanticSharedFault
+	} else if isOpenAIUpstreamAccessStateError(message, payload) {
+		semantic = gatewayFailureSemanticAccountFault
+	} else {
+		semanticStatus := openAIStreamFailureStatus(payload, message)
+		if semanticStatus == http.StatusForbidden {
+			if openAIStream403AccountFailure(payload, message) {
+				semantic = gatewayFailureSemanticAccountFault
+			} else {
+				semantic = gatewayFailureSemanticSharedFault
+			}
+		} else if semanticStatus != http.StatusTooManyRequests &&
+			!isOpenAITransientProcessingError(http.StatusBadRequest, message, payload) {
+			code := strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "response.error.code").String()))
+			if code == "" {
+				code = strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "error.code").String()))
+			}
+			errType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "response.error.type").String()))
+			if errType == "" {
+				errType = strings.ToLower(strings.TrimSpace(gjson.GetBytes(payload, "error.type").String()))
+			}
+			combined := strings.ToLower(strings.TrimSpace(message + " " + code + " " + errType))
+			for _, marker := range []string{
+				"invalid_request",
+				"content_policy",
+				"policy",
+				"safety",
+				"high-risk cyber",
+				"not allowed",
+				"violat",
+			} {
+				if strings.Contains(combined, marker) {
+					semantic = gatewayFailureSemanticSharedFault
+					break
+				}
+			}
+		}
+	}
+	return classifyGatewayFailover(gatewayFailoverObservation{
+		Profile:    gatewayFailoverProfileOpenAI,
+		Semantic:   semantic,
+		StatusCode: openAIStreamFailureStatus(payload, message),
+	}).RetryNextAccount
+}
+
+func openAIStreamErrorEventShouldFailover(payload []byte, message string) bool {
+	semantic := gatewayFailureSemanticSharedFault
+	if hit, _, _ := detectOpenAICyberPolicy(payload); hit {
+		semantic = gatewayFailureSemanticSharedFault
+	} else if isOpenAIContextWindowError(message, payload) {
+		semantic = gatewayFailureSemanticSharedFault
+	} else if isOpenAIUpstreamAccessStateError(message, payload) {
+		semantic = gatewayFailureSemanticAccountFault
+	} else {
+		switch openAIStreamFailedEventSemanticStatus(payload, message) {
+		case http.StatusForbidden:
+			if openAIStream403AccountFailure(payload, message) {
+				semantic = gatewayFailureSemanticAccountFault
+			}
+		case http.StatusUnauthorized, http.StatusTooManyRequests, 529:
+			semantic = gatewayFailureSemanticAccountFault
+		default:
+			combined := strings.ToLower(strings.TrimSpace(message + " " +
+				gjson.GetBytes(payload, "error.message").String() + " " +
+				gjson.GetBytes(payload, "response.error.message").String()))
+			if isOpenAITransientProcessingError(http.StatusBadRequest, message, payload) ||
+				strings.Contains(combined, "temporary") ||
+				strings.Contains(combined, "try again") ||
+				strings.Contains(combined, "please retry") {
+				semantic = gatewayFailureSemanticTransientFault
+			}
+		}
+	}
+	return classifyGatewayFailover(gatewayFailoverObservation{
+		Profile:    gatewayFailoverProfileOpenAI,
+		Semantic:   semantic,
+		StatusCode: openAIStreamFailedEventSemanticStatus(payload, message),
+	}).RetryNextAccount
+}

--- a/backend/internal/service/openai_gateway_passthrough_tk_short_stream_buffer.go
+++ b/backend/internal/service/openai_gateway_passthrough_tk_short_stream_buffer.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+)
+
+// tkPassthroughPendingSSE buffers leading SSE lines before the first client-visible
+// output so a short/no-output failure can still failover safely.
+type tkPassthroughPendingSSE struct {
+	lines []string
+	bytes int
+	limit int
+}
+
+func newTkPassthroughPendingSSE(limit int) *tkPassthroughPendingSSE {
+	return &tkPassthroughPendingSSE{
+		lines: make([]string, 0, 8),
+		limit: limit,
+	}
+}
+
+func (p *tkPassthroughPendingSSE) append(line string) {
+	p.lines = append(p.lines, line)
+	p.bytes += len(line) + 1
+}
+
+// shouldRelease mirrors the previous closure: release only when a line starts
+// client output; limit<=0 (or forceRelease) releases immediately; otherwise wait
+// until buffered bytes reach the configured short-stream limit.
+func (p *tkPassthroughPendingSSE) shouldRelease(lineStartsClientOutput bool, forceRelease bool) bool {
+	if !lineStartsClientOutput {
+		return false
+	}
+	if p.limit <= 0 || forceRelease {
+		return true
+	}
+	return p.bytes >= p.limit
+}
+
+// writeAndClear writes buffered lines then clears. On write error it logs the
+// same disconnect message as before and returns false (caller sets
+// clientDisconnected). Does not Flush — Flush stays at the call site and is
+// skipped after disconnect.
+func (p *tkPassthroughPendingSSE) writeAndClear(w io.Writer, accountID int64) bool {
+	for _, pending := range p.lines {
+		if _, err := fmt.Fprintln(w, pending); err != nil {
+			logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] Client disconnected during streaming, continue draining upstream for usage: account=%d", accountID)
+			return false
+		}
+	}
+	p.lines = p.lines[:0]
+	p.bytes = 0
+	return true
+}

--- a/backend/internal/service/openai_gateway_passthrough_tk_short_stream_buffer_test.go
+++ b/backend/internal/service/openai_gateway_passthrough_tk_short_stream_buffer_test.go
@@ -1,0 +1,56 @@
+package service
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTkPassthroughPendingSSE_LimitZeroReleasesOnFirstClientOutput(t *testing.T) {
+	p := newTkPassthroughPendingSSE(0)
+	p.append(`data: {"type":"response.output_item.added"}`)
+	require.True(t, p.shouldRelease(true, false), "limit<=0 must release immediately once client output starts")
+	require.False(t, p.shouldRelease(false, false), "preamble/non-output lines must stay buffered")
+}
+
+func TestTkPassthroughPendingSSE_ForceReleaseIgnoresByteWindow(t *testing.T) {
+	p := newTkPassthroughPendingSSE(4096)
+	p.append("event: response.created")
+	require.False(t, p.shouldRelease(true, false), "under limit without force must hold")
+	require.True(t, p.shouldRelease(true, true), "forceRelease (terminal/failed) must flush held window")
+}
+
+func TestTkPassthroughPendingSSE_ReleasesWhenBufferedBytesReachLimit(t *testing.T) {
+	p := newTkPassthroughPendingSSE(20)
+	line := "data: " + strings.Repeat("x", 10) // len(line)+1 == 17
+	p.append(line)
+	require.False(t, p.shouldRelease(true, false))
+	p.append("data: y") // +8 → 25 >= 20
+	require.Equal(t, 17+8, p.bytes)
+	require.True(t, p.shouldRelease(true, false))
+}
+
+func TestTkPassthroughPendingSSE_WriteAndClearDoesNotFlushAndResets(t *testing.T) {
+	p := newTkPassthroughPendingSSE(64)
+	p.append("data: one")
+	p.append("data: two")
+	var buf bytes.Buffer
+	ok := p.writeAndClear(&buf, 42)
+	require.True(t, ok)
+	require.Equal(t, "data: one\ndata: two\n", buf.String())
+	require.Zero(t, p.bytes)
+	require.Empty(t, p.lines)
+}
+
+func TestTkPassthroughPendingSSE_WriteFailureReturnsFalseWithoutClearingPartialSemantics(t *testing.T) {
+	p := newTkPassthroughPendingSSE(64)
+	p.append("data: boom")
+	ok := p.writeAndClear(&errWriter{}, 7)
+	require.False(t, ok, "client disconnect must surface as false so call site sets clientDisconnected")
+}
+
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, bytes.ErrTooLarge }

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -3138,6 +3138,34 @@ func TestOpenAIBuildUpstreamRequestGrokAPIKeyRelayRequiresBaseURL(t *testing.T) 
 	require.Contains(t, err.Error(), "missing base_url")
 }
 
+// ChatGPT Host + chatgpt-account-id must survive the full header pipeline
+// (auth → ChatGPT → whitelist → tkApply). Order itself is pinned by the
+// gateway-tk sentinel contiguous substring on buildUpstreamRequest.
+func TestOpenAIBuildUpstreamRequestSetsChatGPTHostAndAccountID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5","stream":true}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	// Client noise that must not displace account-owned ChatGPT headers
+	// (chatgpt-account-id is not in openaiAllowedHeaders; Host is req.Host).
+	c.Request.Header.Set("chatgpt-account-id", "client-spoofed")
+	c.Request.Header.Set("Host", "evil.example")
+
+	svc := &OpenAIGatewayService{}
+	account := &Account{
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Credentials: map[string]any{"chatgpt_account_id": "acct-from-credentials"},
+	}
+
+	req, err := svc.buildUpstreamRequest(c.Request.Context(), c, account, body, "token", false, "", false)
+	require.NoError(t, err)
+	require.Equal(t, "chatgpt.com", req.Host)
+	require.Equal(t, "acct-from-credentials", req.Header.Get("chatgpt-account-id"))
+	require.NotEqual(t, "client-spoofed", req.Header.Get("chatgpt-account-id"))
+}
+
 func TestOpenAIBuildUpstreamRequestOAuthOfficialClientOriginatorCompatibility(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/scripts/checks/protocol-routing-ssot.py
+++ b/scripts/checks/protocol-routing-ssot.py
@@ -112,7 +112,7 @@ TARGET_BOUNDARIES = {
         "protocolExecutionTarget",
         "protocolExecutionBound",
     ),
-    "backend/internal/service/openai_gateway_forward.go": ("protocolExecutionTarget",),
+    "backend/internal/service/openai_gateway_forward_tk_protocol_dispatch.go": ("protocolExecutionTarget",),
     "backend/internal/service/openai_gateway_bridge_dispatch.go": ("protocolExecutionBound",),
 }
 

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2279,11 +2279,11 @@
       "rationale": "Handler MUST translate the canonical-OAuth UA-reject service error into an immediate HTTP 403 + `permission_error` body without falling into failover. Without this branch the rejection propagates as a generic upstream error and the failover loop retries the same forbidden ingress against other accounts, defeating the gate."
     },
     {
-      "path": "backend/internal/service/openai_gateway_passthrough.go",
+      "path": "backend/internal/service/openai_gateway_passthrough_tk_short_stream_buffer.go",
       "must_contain": [
-        "shortStreamBufferBytes",
-        "pendingLines",
-        "shouldReleasePending"
+        "type tkPassthroughPendingSSE struct {",
+        "func (p *tkPassthroughPendingSSE) shouldRelease(",
+        "func (p *tkPassthroughPendingSSE) writeAndClear("
       ],
       "rationale": "TK short-stream buffer on the OpenAI Responses passthrough (upstream Wei-Shaw/sub2api#2245). When gateway.responses_short_stream_buffer_bytes>0, handleStreamingResponsePassthrough holds the first body content in a byte window before the first flush, so an upstream that EOFs before a terminal event fails over cleanly instead of shipping a half-finished HTTP 200 SSE that strict Responses clients reject with 'stream closed before response.completed'. An upstream merge that rewrites the passthrough streaming loop could silently drop this guard; the sentinel forces the merge to keep (or deliberately remove) the buffer wiring."
     },
@@ -3586,7 +3586,6 @@
     {
       "path": "backend/internal/service/openai_gateway_forward.go",
       "must_contain": [
-        "func (s *OpenAIGatewayService) enforceCodexClientRestriction(ctx context.Context, c *gin.Context, account *Account, body []byte) error {",
         "if err := s.enforceCodexClientRestriction(ctx, c, account, body); err != nil {"
       ],
       "rationale": "codex_cli_only (only Codex official clients) must be enforced at EVERY OpenAI gateway forward entry point through the single helper enforceCodexClientRestriction — not only on /v1/responses (Forward). Upstream Wei-Shaw/sub2api#3014: enforcement living only inside Forward let plain clients reach a restricted OAuth account via the /v1/chat/completions compat entry (internally converted to Responses), bypassing the policy. Anchor the helper definition + the Forward call site so a future merge/refactor cannot drop the shared enforcement back into a single endpoint and silently re-open the bypass. The rejection returns a plain error (NOT *UpstreamFailoverError) so handlers do not fail over to another account and re-bypass the per-account policy. Regression test: TestForwardAsChatCompletions_CodexCliOnlyBlocksCompatEntry."
@@ -6102,11 +6101,10 @@
       "rationale": "Regression anchors for buffered missing-terminal failover: [DONE]/EOF with no content must UpstreamFailoverError without committing client body; partial delta without terminal must stay 502 and must not failover. The NonRetryable anchors pin the shouldFailover gate: a content_policy/safety/invalid_request response.failed must surface to the client as an error and must NOT failover to a sibling account."
     },
     {
-      "path": "backend/internal/service/openai_gateway_forward.go",
+      "path": "backend/internal/service/openai_gateway_forward_tk_codex_identity.go",
       "must_contain": [
         "func resolveOpenAICodexUserAgent(",
-        "func (s *OpenAIGatewayService) applyOpenAICodexUserAgent(",
-        "enforceCodexIdentityHeadersWithUA(req.Header, s.codexIdentityOverrideUA(account))"
+        "func (s *OpenAIGatewayService) applyOpenAICodexUserAgent("
       ],
       "rationale": "OpenAI OAuth upstream Codex fingerprint normalization (prod GPT-pro1 id=9, 2026-06-25). Non-Codex OAuth ingress must be re-presented upstream as the canonical Codex identity, and the terminal HTTP forward call must enforce a User-Agent/originator/version triple derived from one runtime version owner. Dropping the final enforcement call silently restores arbitrary or stale client identity upstream, which degrades account health while unrelated unit tests can remain green. This anchors structure only; the version literal is intentionally owned by fingerprint-alignment."
     },
@@ -6153,7 +6151,7 @@
       ]
     },
     {
-      "path": "backend/internal/service/openai_gateway_forward.go",
+      "path": "backend/internal/service/openai_gateway_forward_tk_upstream_headers.go",
       "must_contain": [
         "if compatMessagesBridge {",
         "req.Header.Del(\"originator\")"
@@ -6613,7 +6611,7 @@
       "rationale": "Admin handler for POST /admin/users/:id/api-keys. Pins the CreateForUser entry point and idempotency scope for ops relay key provisioning."
     },
     {
-      "path": "backend/internal/service/openai_gateway_passthrough.go",
+      "path": "backend/internal/service/openai_gateway_passthrough_tk_failover.go",
       "must_contain": [
         "func openAIStreamFailedClientResponse(",
         "must not surface as 502"
@@ -8396,7 +8394,7 @@
       "rationale": "OpenAI HTTP adapters may classify content, context, capability and transient payloads, but their final account failover decision must stay wired to the global owner."
     },
     {
-      "path": "backend/internal/service/openai_gateway_passthrough.go",
+      "path": "backend/internal/service/openai_gateway_passthrough_tk_failover.go",
       "must_contain": [
         "Profile:    gatewayFailoverProfileOpenAIPassthrough",
         "AccountConfiguredRetry = account.IsPoolMode()",
@@ -8593,6 +8591,29 @@
         "tkHooks.stopHoldReconciler()"
       ],
       "rationale": "provideCleanup must still Stop the hold reconciler via tkHooks after TK cleanup deps were extracted."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_passthrough.go",
+      "must_contain": [
+        "shortStreamBufferBytes",
+        "newTkPassthroughPendingSSE(",
+        "pendingSSE.shouldRelease("
+      ],
+      "rationale": "TK short-stream buffer on the OpenAI Responses passthrough (upstream Wei-Shaw/sub2api#2245). When gateway.responses_short_stream_buffer_bytes>0, handleStreamingResponsePassthrough holds the first body content in a byte window before the first flush, so an upstream that EOFs before a terminal event fails over cleanly instead of shipping a half-finished HTTP 200 SSE that strict Responses clients reject with 'stream closed before response.completed'. An upstream merge that rewrites the passthrough streaming loop could silently drop this guard; the sentinel forces the merge to keep (or deliberately remove) the buffer wiring. Companion holds buffer type; upstream-shaped file must keep wiring call sites."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_forward_tk_codex_identity.go",
+      "must_contain": [
+        "func (s *OpenAIGatewayService) enforceCodexClientRestriction(ctx context.Context, c *gin.Context, account *Account, body []byte) error {"
+      ],
+      "rationale": "codex_cli_only (only Codex official clients) must be enforced at EVERY OpenAI gateway forward entry point through the single helper enforceCodexClientRestriction — not only on /v1/responses (Forward). Upstream Wei-Shaw/sub2api#3014: enforcement living only inside Forward let plain clients reach a restricted OAuth account via the /v1/chat/completions compat entry (internally converted to Responses), bypassing the policy. Anchor the helper definition + the Forward call site so a future merge/refactor cannot drop the shared enforcement back into a single endpoint and silently re-open the bypass. The rejection returns a plain error (NOT *UpstreamFailoverError) so handlers do not fail over to another account and re-bypass the per-account policy. Regression test: TestForwardAsChatCompletions_CodexCliOnlyBlocksCompatEntry. Helper definition lives in TK companion; Forward keeps the call site."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_forward_tk_upstream_headers.go",
+      "must_contain": [
+        "enforceCodexIdentityHeadersWithUA(req.Header, s.codexIdentityOverrideUA(account))"
+      ],
+      "rationale": "OpenAI OAuth upstream Codex fingerprint normalization (prod GPT-pro1 id=9, 2026-06-25). Non-Codex OAuth ingress must be re-presented upstream as the canonical Codex identity, and the terminal HTTP forward call must enforce a User-Agent/originator/version triple derived from one runtime version owner. Dropping the final enforcement call silently restores arbitrary or stale client identity upstream, which degrades account health while unrelated unit tests can remain green. This anchors structure only; the version literal is intentionally owned by fingerprint-alignment. Identity header enforcement call site moved with upstream-header companion."
     }
   ]
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -8609,11 +8609,22 @@
       "rationale": "codex_cli_only (only Codex official clients) must be enforced at EVERY OpenAI gateway forward entry point through the single helper enforceCodexClientRestriction — not only on /v1/responses (Forward). Upstream Wei-Shaw/sub2api#3014: enforcement living only inside Forward let plain clients reach a restricted OAuth account via the /v1/chat/completions compat entry (internally converted to Responses), bypassing the policy. Anchor the helper definition + the Forward call site so a future merge/refactor cannot drop the shared enforcement back into a single endpoint and silently re-open the bypass. The rejection returns a plain error (NOT *UpstreamFailoverError) so handlers do not fail over to another account and re-bypass the per-account policy. Regression test: TestForwardAsChatCompletions_CodexCliOnlyBlocksCompatEntry. Helper definition lives in TK companion; Forward keeps the call site."
     },
     {
+      "path": "backend/internal/service/openai_gateway_forward.go",
+      "must_contain": [
+        "req.Host = \"chatgpt.com\"\n\t\tif err := resolveAndSetOpenAIChatGPTAccountHeaders(ctx, s.accountRepo, req.Header, account); err != nil {\n\t\t\treturn nil, fmt.Errorf(\"resolve chatgpt account headers: %w\", err)\n\t\t}\n\t}\n\n\t// Whitelist passthrough headers\n\tfor key, values := range c.Request.Header {\n\t\tlowerKey := strings.ToLower(key)\n\t\tif openaiAllowedHeaders[lowerKey] {\n\t\t\tfor _, v := range values {\n\t\t\t\treq.Header.Add(key, v)\n\t\t\t}\n\t\t}\n\t}\n\tif err := s.tkApplyOpenAIForwardUpstreamHeaders(ctx, c, req, account, body, promptCacheKey, isCodexCLI); err != nil {"
+      ],
+      "rationale": "OpenAI OAuth HTTP forward must keep auth → ChatGPT Host/chatgpt-account-id → client whitelist → tkApplyOpenAIForwardUpstreamHeaders (session/UA/fingerprint/enforce). P2 companion extraction briefly parked ChatGPT headers after whitelist; chatgpt-account-id is not in openaiAllowedHeaders today so outbound bytes stayed equivalent, but the drifted order would silently accept a future whitelist expansion or upstream merge. Contiguous substring pins relative order in the upstream-shaped call site."
+    },
+    {
       "path": "backend/internal/service/openai_gateway_forward_tk_upstream_headers.go",
       "must_contain": [
         "enforceCodexIdentityHeadersWithUA(req.Header, s.codexIdentityOverrideUA(account))"
       ],
-      "rationale": "OpenAI OAuth upstream Codex fingerprint normalization (prod GPT-pro1 id=9, 2026-06-25). Non-Codex OAuth ingress must be re-presented upstream as the canonical Codex identity, and the terminal HTTP forward call must enforce a User-Agent/originator/version triple derived from one runtime version owner. Dropping the final enforcement call silently restores arbitrary or stale client identity upstream, which degrades account health while unrelated unit tests can remain green. This anchors structure only; the version literal is intentionally owned by fingerprint-alignment. Identity header enforcement call site moved with upstream-header companion."
+      "must_not_contain": [
+        "resolveAndSetOpenAIChatGPTAccountHeaders",
+        "req.Host = \"chatgpt.com\""
+      ],
+      "rationale": "OpenAI OAuth upstream Codex fingerprint normalization (prod GPT-pro1 id=9, 2026-06-25). Non-Codex OAuth ingress must be re-presented upstream as the canonical Codex identity, and the terminal HTTP forward call must enforce a User-Agent/originator/version triple derived from one runtime version owner. Dropping the final enforcement call silently restores arbitrary or stale client identity upstream, which degrades account health while unrelated unit tests can remain green. This anchors structure only; the version literal is intentionally owned by fingerprint-alignment. Identity header enforcement call site moved with upstream-header companion. ChatGPT Host/account headers must NOT live here — they belong before whitelist in buildUpstreamRequest."
     }
   ]
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -8611,6 +8611,23 @@
     {
       "path": "backend/internal/service/openai_gateway_forward.go",
       "must_contain": [
+        "return s.forwardGrokResponses(ctx, c, account, body, originalModel, reqStream, startTime)\n\t}\n\n\tresult, outBody, handled, err := s.tkTryRouteOpenAIForwardProtocol(ctx, c, account, body, reqModel)"
+      ],
+      "rationale": "OpenAI Forward must keep PlatformGrok early-return BEFORE tkTryRouteOpenAIForwardProtocol. Dropping the order lets Grok traffic enter protocol/normalize/raw-CC companions and regresses the dedicated Grok Responses path while unit tests on companion helpers can stay green."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_forward_tk_protocol_dispatch.go",
+      "must_contain": [
+        "if target, planned := protocolExecutionTarget(ctx); planned {",
+        "if account.IsAnthropicProtocol() {",
+        "if account.IsOpenAIApiKey() {",
+        "if shouldForwardOpenAIResponsesViaRawChatCompletions(account) {"
+      ],
+      "rationale": "P2 protocol-dispatch companion owns the load-bearing early-routing order after Grok: planned protocol target → Anthropic-protocol native → API-key normalize → shouldForward raw-CC. Reordering (especially Anthropic after raw-CC, or normalize after shouldForward) silently breaks CN Anthropic Responses and CloudWise dual-stack accounts. Focused regressions live in openai_gateway_forward_tk_protocol_dispatch_test.go."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_forward.go",
+      "must_contain": [
         "req.Host = \"chatgpt.com\"\n\t\tif err := resolveAndSetOpenAIChatGPTAccountHeaders(ctx, s.accountRepo, req.Header, account); err != nil {\n\t\t\treturn nil, fmt.Errorf(\"resolve chatgpt account headers: %w\", err)\n\t\t}\n\t}\n\n\t// Whitelist passthrough headers\n\tfor key, values := range c.Request.Header {\n\t\tlowerKey := strings.ToLower(key)\n\t\tif openaiAllowedHeaders[lowerKey] {\n\t\t\tfor _, v := range values {\n\t\t\t\treq.Header.Add(key, v)\n\t\t\t}\n\t\t}\n\t}\n\tif err := s.tkApplyOpenAIForwardUpstreamHeaders(ctx, c, req, account, body, promptCacheKey, isCodexCLI); err != nil {"
       ],
       "rationale": "OpenAI OAuth HTTP forward must keep auth → ChatGPT Host/chatgpt-account-id → client whitelist → tkApplyOpenAIForwardUpstreamHeaders (session/UA/fingerprint/enforce). P2 companion extraction briefly parked ChatGPT headers after whitelist; chatgpt-account-id is not in openaiAllowedHeaders today so outbound bytes stayed equivalent, but the drifted order would silently accept a future whitelist expansion or upstream merge. Contiguous substring pins relative order in the upstream-shaped call site."


### PR DESCRIPTION
## 摘要
- `openai_gateway_forward`：Codex identity、协议早分流、OAuth body、上游 headers 抽到 `*_tk_*` companion（此前零 companion）。
- `openai_gateway_passthrough`：failover 分类器与 short-stream pending buffer 迁出上游形文件。
- `routes/gateway.go`：`countTokensHandler` / `modelsHandler` / `guardResponsesSubpath` 收口到 `gateway_tk_openai_compat_handlers.go`。
- 同步 `protocol-routing-ssot.py` 与 `gateway-tk` sentinel 锚点路径。
- review/风险消除：恢复 ChatGPT headers 在 whitelist 之前；补协议早分流 + short-stream companion 聚焦回归与顺序 sentinel。

## 风险
- 常规风险：行为应保持不变；OpenAI Responses/Codex/passthrough 热路径若抽错会立刻表现为 4xx/流失败。
- 已核实消除：Host/account 头顺序、协议早分流顺序、short-stream/failover 等价、gateway 闭包与 main 等价。

## 验证
- `./scripts/preflight.sh` → PASS
- `go test -tags=unit ./internal/service/ -run 'TestTkTryRouteOpenAIForwardProtocol_|TestTkPassthroughPendingSSE_|TestOpenAIBuildUpstreamRequestSetsChatGPTHostAndAccountID|TestOpenAIStreamingPassthrough_ShortStreamBuffer'`

## 提交
- `0a4f963af` refactor: P2 openai forward/passthrough + gateway 闭包 TK companion
- `9260c6628` fix(openai-forward): restore ChatGPT headers before whitelist — R-001..R-003
- `f656b3c8a` test(openai-gateway): pin P2 companion hot-path regressions
- 最新提交：`f656b3c8a`