### PR TITLE
fix(home): 修复海外首页移动端首次调用区域裁切

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 724,
-  "hash": "a1a3cc545ae7ed0691774393425ec3ba85469cf2ed01c3dd27574fdbc010d0b8",
+  "hash": "9575e54adf9ecb28e168af55005b8f4182d88e5d69c6be073d4b6b434add17d4",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/e2e/dual-market-homepage.e2e.ts
+++ b/frontend/e2e/dual-market-homepage.e2e.ts
@@ -153,6 +153,16 @@ async function expectNoViewportOverflow(page: Page) {
   expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth)
 }
 
+async function expectInsideViewport(page: Page, locator: Locator) {
+  const [box, viewportWidth] = await Promise.all([
+    locator.boundingBox(),
+    page.evaluate(() => document.documentElement.clientWidth),
+  ])
+  expect(box).not.toBeNull()
+  expect(box!.x).toBeGreaterThanOrEqual(0)
+  expect(box!.x + box!.width).toBeLessThanOrEqual(viewportWidth)
+}
+
 function rectanglesOverlap(
   first: { x: number; y: number; width: number; height: number },
   second: { x: number; y: number; width: number; height: number },
@@ -354,6 +364,13 @@ test.describe('dual-market homepage', () => {
     const nextSectionSignal = await page.locator('[data-testid="china-models-eyebrow"]').boundingBox()
     expect(nextSectionSignal).not.toBeNull()
     expect(nextSectionSignal!.y + nextSectionSignal!.height).toBeLessThanOrEqual(844)
+
+    const verifyTitle = page.locator('#verify-key-title')
+    const terminal = page.locator('[data-testid="china-export-terminal"]')
+    const copyButton = terminal.locator('.terminal-copy-button')
+    await expectInsideViewport(page, verifyTitle)
+    await expectInsideViewport(page, terminal)
+    await expectInsideViewport(page, copyButton)
     await expectNoViewportOverflow(page)
   })
 

--- a/frontend/src/components/home/HomeTkLanding.tk.vue
+++ b/frontend/src/components/home/HomeTkLanding.tk.vue
@@ -620,7 +620,7 @@
 
       <section class="border-y border-gray-200/50 bg-white/60 px-5 py-16 backdrop-blur-sm dark:border-dark-800/50 dark:bg-dark-800/60 sm:px-8 lg:px-12 lg:py-20" aria-labelledby="verify-key-title">
         <div class="mx-auto grid max-w-7xl gap-10 lg:grid-cols-[minmax(0,0.72fr)_minmax(0,1.28fr)] lg:gap-16">
-          <div>
+          <div class="min-w-0">
             <p class="text-sm font-semibold uppercase text-primary-600 dark:text-primary-400">{{ t('home.chinaExport.verifyEyebrow') }}</p>
             <h2 id="verify-key-title" class="mt-3 text-3xl font-semibold tracking-normal text-gray-950 dark:text-white sm:text-4xl">
               {{ t('home.chinaExport.verifyTitle') }}
@@ -634,7 +634,7 @@
             </a>
           </div>
 
-          <div class="terminal-container w-full max-w-[540px] lg:justify-self-end" data-testid="china-export-terminal">
+          <div class="terminal-container min-w-0 w-full max-w-[540px] lg:justify-self-end" data-testid="china-export-terminal">
             <div class="terminal-window">
               <div class="terminal-header">
                 <div class="terminal-buttons">


### PR DESCRIPTION
## 摘要

- 允许海外首页“首次调用”区域的两个 grid 子项在窄屏收缩，保留桌面端 540px terminal 最大宽度。
- 增加关键标题、terminal 与复制按钮必须完整位于移动端视口内的 Playwright 回归断言，避免 `overflow-hidden` 掩盖裁切。
- 同步内嵌前端来源指纹。

## 风险

- 仅影响海外首页首次调用区的响应式尺寸，不修改国内首页、业务接口、鉴权或跳转。
- terminal 的视觉样式参数未改；命令正文继续在容器内横向滚动。

## 验证

- `./scripts/preflight.sh`
- `pnpm exec vitest run src/views/__tests__/HomeView.compact.spec.ts`
- `pnpm typecheck`
- `pnpm exec eslint e2e/dual-market-homepage.e2e.ts src/components/home/HomeTkLanding.tk.vue --ext .vue,.ts`
- `pnpm build`
- Playwright 真实 Chromium，390x844：标题与 terminal 宽度均为 350px，复制按钮右边界 353.83px，完整位于 390px 视口内。

## 提交

- `593ba1ef4 fix(home): keep global quickstart inside mobile viewport`
- 最新提交：`593ba1ef4`