### PR TITLE
chore(openrouter): seller text-only catalog + thinking defaults

### DIFF
--- a/backend/internal/service/openai_gateway_bridge_responses_fallback.go
+++ b/backend/internal/service/openai_gateway_bridge_responses_fallback.go
@@ -95,7 +95,16 @@ func isNewAPIQwen3Model(model string) bool {
 }
 
 func normalizeNewAPIQwenNonStreamingPayload(model string, payload map[string]any) {
-	if !isNewAPIQwen3Model(model) || payload == nil {
+	if payload == nil {
+		return
+	}
+	model = strings.TrimSpace(strings.ToLower(model))
+	// Thinking-required variants must keep enable_thinking=true (and stream);
+	// never coerce them to the generic Qwen3 non-streaming false default.
+	if isNewAPIResponsesQwenStreamThinkingVariant(model) {
+		return
+	}
+	if !isNewAPIQwen3Model(model) {
 		return
 	}
 	if stream, _ := payload["stream"].(bool); stream {
@@ -104,11 +113,33 @@ func normalizeNewAPIQwenNonStreamingPayload(model string, payload map[string]any
 	payload["enable_thinking"] = false
 }
 
+// applyNewAPIQwenNonStreamingShape normalizes Qwen chat bodies for DashScope:
+// thinking-required variants force stream=true + enable_thinking=true; other
+// Qwen3 non-streaming calls force enable_thinking=false (upstream 400 otherwise).
 func applyNewAPIQwenNonStreamingShape(model string, body []byte) []byte {
-	if len(body) == 0 || !isNewAPIQwen3Model(model) || gjson.GetBytes(body, "stream").Bool() {
+	if len(body) == 0 {
+		return body
+	}
+	model = strings.TrimSpace(strings.ToLower(model))
+	if isNewAPIResponsesQwenStreamThinkingVariant(model) {
+		return applyNewAPIQwenStreamThinkingShape(body)
+	}
+	if !isNewAPIQwen3Model(model) || gjson.GetBytes(body, "stream").Bool() {
 		return body
 	}
 	shaped, err := sjson.SetBytes(body, "enable_thinking", false)
+	if err != nil {
+		return body
+	}
+	return shaped
+}
+
+func applyNewAPIQwenStreamThinkingShape(body []byte) []byte {
+	shaped, err := sjson.SetBytes(body, "stream", true)
+	if err != nil {
+		return body
+	}
+	shaped, err = sjson.SetBytes(shaped, "enable_thinking", true)
 	if err != nil {
 		return body
 	}

--- a/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
@@ -635,6 +635,20 @@ func TestApplyNewAPIQwenNonStreamingShape(t *testing.T) {
 		require.True(t, gjson.GetBytes(shaped, "enable_thinking").Bool())
 	})
 
+	t.Run("qwen3.8 thinking-required forces stream and thinking", func(t *testing.T) {
+		body := []byte(`{"model":"qwen3.8-2.4t-a95b","stream":false,"messages":[{"role":"user","content":"hi"}]}`)
+		shaped := applyNewAPIQwenNonStreamingShape("qwen3.8-2.4t-a95b", body)
+		require.True(t, gjson.GetBytes(shaped, "stream").Bool())
+		require.True(t, gjson.GetBytes(shaped, "enable_thinking").Bool())
+	})
+
+	t.Run("qwen3.8 thinking-required upgrades missing flags", func(t *testing.T) {
+		body := []byte(`{"model":"qwen3.8-2.4t-a95b","messages":[{"role":"user","content":"hi"}]}`)
+		shaped := applyNewAPIQwenNonStreamingShape("qwen3.8-2.4t-a95b", body)
+		require.True(t, gjson.GetBytes(shaped, "stream").Bool())
+		require.True(t, gjson.GetBytes(shaped, "enable_thinking").Bool())
+	})
+
 	t.Run("other models remain unchanged", func(t *testing.T) {
 		body := []byte(`{"model":"deepseek-chat","stream":false,"enable_thinking":true}`)
 		shaped := applyNewAPIQwenNonStreamingShape("deepseek-chat", body)

--- a/ops/pricing/examples/openrouter-provider-config.example.json
+++ b/ops/pricing/examples/openrouter-provider-config.example.json
@@ -12,17 +12,23 @@
   "catalog_excluded_model_ids": [
     "claude-fable-5",
     "claude-opus-4-1",
+    "deepseek-v3.2",
     "gemini-3.1-pro",
+    "gemini-3-flash-preview",
+    "gemini-3.1-flash-lite-preview",
+    "gemini-3.1-pro-preview",
     "gemini-3-pro-image",
     "gemini-3.1-flash-image",
     "gemini-3.1-flash-image-preview",
+    "gpt-5.2",
     "doubao-seedance-2-0-260128",
     "doubao-seedance-2-0-fast-260128",
     "doubao-seedance-2-5-260628"
   ],
   "stream_only_model_ids": [
     "glm-4.5",
-    "glm-4.5-air"
+    "glm-4.5-air",
+    "qwen3.8-2.4t-a95b"
   ],
   "datacenter_country_codes": ["US", "SG"],
   "privacy_policy_url": "https://tokenkey.dev/privacy",

--- a/ops/pricing/examples/openrouter-provider-config.example.json
+++ b/ops/pricing/examples/openrouter-provider-config.example.json
@@ -12,7 +12,13 @@
   "catalog_excluded_model_ids": [
     "claude-fable-5",
     "claude-opus-4-1",
-    "gemini-3.1-pro"
+    "gemini-3.1-pro",
+    "gemini-3-pro-image",
+    "gemini-3.1-flash-image",
+    "gemini-3.1-flash-image-preview",
+    "doubao-seedance-2-0-260128",
+    "doubao-seedance-2-0-fast-260128",
+    "doubao-seedance-2-5-260628"
   ],
   "stream_only_model_ids": [
     "glm-4.5",

--- a/ops/pricing/manage-openrouter-provider-config.py
+++ b/ops/pricing/manage-openrouter-provider-config.py
@@ -550,7 +550,8 @@ for name in LEGACY_DISABLE:
     )
     psql_scalar(sql)
     verify = psql_scalar(
-        f"SELECT id FROM api_keys WHERE id={kid} AND user_id={USER_ID} AND status='disabled' LIMIT 1;"
+        f"SELECT id FROM api_keys WHERE id={kid} AND user_id={USER_ID} "
+        f"AND status='disabled' AND deleted_at IS NULL LIMIT 1;"
     )
     if verify and verify.splitlines()[0].strip().isdigit():
         disabled_ids.append(int(verify.splitlines()[0].strip()))

--- a/ops/pricing/manage-openrouter-provider-config.py
+++ b/ops/pricing/manage-openrouter-provider-config.py
@@ -74,17 +74,26 @@ CREATE_GROUP = __CREATE_GROUP__
 SELLER_NAME = "openrouter"
 CONFIG = json.loads("""__CONFIG_JSON__""")
 APP_URL = "http://127.0.0.1:8080"
-APP_CONTAINER = "tokenkey-green"
+APP_CONTAINER = "tokenkey-blue"
+import subprocess
+for name in ("tokenkey-blue", "tokenkey-green"):
+    try:
+        out = subprocess.check_output(
+            ["sudo", "docker", "inspect", "-f", "{{.State.Running}}", name], text=True
+        ).strip()
+        if out == "true":
+            APP_CONTAINER = name
+            break
+    except Exception:
+        pass
 
 def psql_scalar(sql):
-    import subprocess
     cmd = ["sudo", "docker", "exec", "-i", "tokenkey-postgres",
            "psql", "-U", "tokenkey", "-d", "tokenkey", "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1", "-c", sql]
     out = subprocess.check_output(cmd, text=True).strip()
     return out if out and out != r"\N" else ""
 
 def admin_request(method, path, payload=None):
-    import subprocess
     admin_key = psql_scalar("SELECT value FROM settings WHERE key='admin_api_key' LIMIT 1")
     if not admin_key:
         raise SystemExit("admin_api_key missing in settings")
@@ -255,6 +264,26 @@ def _merge_missing_list_fields(cfg: dict[str, Any], example: dict[str, Any] | No
     return merged
 
 
+def _union_list_fields_from_example(cfg: dict[str, Any], example: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Ensure example list SSOT entries are present; keep live-only extras."""
+    if example is None:
+        example = _load_default_config()
+    merged = dict(cfg)
+    for key in _EXAMPLE_LIST_FIELDS:
+        seen: set[str] = set()
+        out: list[str] = []
+        for item in list(example.get(key) or []) + list(merged.get(key) or []):
+            if not isinstance(item, str):
+                continue
+            item = item.strip()
+            if not item or item in seen:
+                continue
+            seen.add(item)
+            out.append(item)
+        merged[key] = out
+    return merged
+
+
 def _resolve_group_id(instance_id: str, group_id: int | None, create_group: bool) -> int:
     if group_id and group_id > 0:
         return group_id
@@ -404,7 +433,7 @@ def cmd_update_config(args) -> int:
     cfg_sql = f"SELECT value FROM settings WHERE key = {_sql_literal(SETTING_KEY)} LIMIT 1;"
     existing_raw = _decode_settings_value(_run_psql_query(inst, cfg_sql, "or-provider update: config"))
     if existing_raw:
-        cfg = _merge_missing_list_fields(json.loads(existing_raw))
+        cfg = _union_list_fields_from_example(_merge_missing_list_fields(json.loads(existing_raw)))
     else:
         cfg = _load_default_config()
     cfg.pop("group_ids", None)
@@ -419,7 +448,9 @@ def cmd_update_config(args) -> int:
             "seller_key_id": seller_id,
             "seller_key_name": SELLER_KEY_NAME,
             "would_upsert": SETTING_KEY,
-            "note": "group_ids and key id lists are not written; runtime reads user_allowed_groups + billing-user ownership",
+            "note": "group_ids and key id lists are not written; catalog_excluded/stream_only union example SSOT; runtime reads user_allowed_groups + billing-user ownership",
+            "catalog_excluded_model_ids": cfg.get("catalog_excluded_model_ids"),
+            "stream_only_model_ids": cfg.get("stream_only_model_ids"),
         }, indent=2, ensure_ascii=False))
         return 0
 
@@ -433,6 +464,128 @@ def cmd_update_config(args) -> int:
             print(json.dumps(result, indent=2, ensure_ascii=False))
             return 0
     fail(f"update-config did not return result JSON; output tail:\n{out[-1500:]}")
+
+
+def _remote_hygiene_keys_script() -> str:
+    """Create seller key named openrouter; disable legacy dual-key names."""
+    py = r'''
+import json, subprocess
+
+USER_ID = 32
+SELLER_NAME = "openrouter"
+LEGACY_DISABLE = ("openrouter-inference", "openrouter-monitor")
+APP_URL = "http://127.0.0.1:8080"
+APP_CONTAINER = "tokenkey-blue"
+for name in ("tokenkey-blue", "tokenkey-green"):
+    try:
+        out = subprocess.check_output(
+            ["sudo", "docker", "inspect", "-f", "{{.State.Running}}", name], text=True
+        ).strip()
+        if out == "true":
+            APP_CONTAINER = name
+            break
+    except Exception:
+        pass
+
+def psql_scalar(sql):
+    cmd = ["sudo", "docker", "exec", "-i", "tokenkey-postgres",
+           "psql", "-U", "tokenkey", "-d", "tokenkey", "-X", "-A", "-t", "-v", "ON_ERROR_STOP=1", "-c", sql]
+    out = subprocess.check_output(cmd, text=True).strip()
+    return out if out and out != r"\N" else ""
+
+def admin_request(method, path, payload=None):
+    admin_key = psql_scalar("SELECT value FROM settings WHERE key='admin_api_key' LIMIT 1")
+    if not admin_key:
+        raise SystemExit("admin_api_key missing in settings")
+    cmd = ["sudo", "docker", "exec", APP_CONTAINER, "curl", "-sS", "-X", method,
+           "-H", f"x-api-key: {admin_key}", APP_URL + path]
+    if payload is not None:
+        cmd.extend(["-H", "Content-Type: application/json", "-d", json.dumps(payload)])
+    out = subprocess.check_output(cmd, text=True)
+    return json.loads(out)
+
+def unwrap(resp):
+    if isinstance(resp, dict) and "data" in resp:
+        return resp["data"]
+    return resp
+
+def list_user_keys():
+    resp = admin_request("GET", f"/api/v1/admin/users/{USER_ID}/api-keys?page=1&page_size=100")
+    data = unwrap(resp)
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        return data.get("items") or []
+    return []
+
+def find_active(keys, name):
+    for item in keys or []:
+        if (item.get("name") or "") == name and (item.get("status") or "") != "disabled":
+            return int(item["id"])
+    return 0
+
+existing = list_user_keys()
+seller_id = find_active(existing, SELLER_NAME)
+created = False
+if seller_id <= 0:
+    resp = admin_request("POST", f"/api/v1/admin/users/{USER_ID}/api-keys", {
+        "name": SELLER_NAME,
+        "routing_mode": "universal",
+    })
+    data = unwrap(resp)
+    seller_id = int(data.get("id") or 0)
+    created = True
+    if seller_id <= 0:
+        raise SystemExit("create openrouter key failed")
+
+disabled_ids = []
+for name in LEGACY_DISABLE:
+    kid = find_active(existing, name)
+    if kid <= 0 or kid == seller_id:
+        continue
+    # Admin API has no status update; ops uses SQL for key disable.
+    sql = (
+        "UPDATE api_keys SET status='disabled', updated_at=NOW() "
+        f"WHERE id={kid} AND user_id={USER_ID} AND deleted_at IS NULL;"
+    )
+    psql_scalar(sql)
+    verify = psql_scalar(
+        f"SELECT id FROM api_keys WHERE id={kid} AND user_id={USER_ID} AND status='disabled' LIMIT 1;"
+    )
+    if verify and verify.splitlines()[0].strip().isdigit():
+        disabled_ids.append(int(verify.splitlines()[0].strip()))
+
+print(json.dumps({
+    "billing_user_id": USER_ID,
+    "seller_key_id": seller_id,
+    "seller_key_name": SELLER_NAME,
+    "seller_key_created": created,
+    "disabled_legacy_key_ids": disabled_ids,
+    "app_container": APP_CONTAINER,
+}, ensure_ascii=False))
+'''
+    return "set -euo pipefail\n" f"python3 <<'PYEOF'\n{py}\nPYEOF\n"
+
+
+def cmd_hygiene_keys(args) -> int:
+    inst = _SSM.resolve_prod_instance()
+    if args.dry_run:
+        print(json.dumps({
+            "dry_run": True,
+            "billing_user_id": BILLING_USER_ID,
+            "would_ensure_seller_key_name": SELLER_KEY_NAME,
+            "would_disable_names": ["openrouter-inference", "openrouter-monitor"],
+        }, indent=2, ensure_ascii=False))
+        return 0
+    shell = _remote_hygiene_keys_script()
+    b64 = base64.b64encode(shell.encode()).decode()
+    out = _SSM.run_shell_b64(inst, b64, "or-provider hygiene-keys")
+    for line in reversed(out.splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            print(json.dumps(json.loads(line), indent=2, ensure_ascii=False))
+            return 0
+    fail(f"hygiene-keys did not return result JSON; output tail:\n{out[-1500:]}")
 
 
 def cmd_bootstrap(args) -> int:
@@ -473,11 +626,15 @@ def main() -> int:
     boot.add_argument("--dry-run", action="store_true")
     upd = sub.add_parser("update-config", help="upsert config keys for user 32; supply groups come from user_allowed_groups at runtime")
     upd.add_argument("--dry-run", action="store_true")
+    hyg = sub.add_parser("hygiene-keys", help="ensure seller key named openrouter; disable legacy dual-key names")
+    hyg.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
     if args.cmd == "snapshot":
         return cmd_snapshot(args)
     if args.cmd == "update-config":
         return cmd_update_config(args)
+    if args.cmd == "hygiene-keys":
+        return cmd_hygiene_keys(args)
     if args.cmd == "bootstrap":
         return cmd_bootstrap(args)
     fail(f"unknown command {args.cmd!r}")

--- a/ops/pricing/openrouter-provider-onboarding.md
+++ b/ops/pricing/openrouter-provider-onboarding.md
@@ -12,7 +12,7 @@ Ops checklist for [OpenRouter provider application](https://openrouter.ai/provid
 | Image inference | `https://api.tokenkey.dev/openrouter/v1/images` |
 | Video inference | `https://api.tokenkey.dev/openrouter/v1/videos` (submit + poll `/openrouter/v1/videos/{id}`) |
 
-Catalog + inference auth: any API key owned by `billing_user_id` (ops bootstrap label: `openrouter`). No separate monitor/inference key split.
+Catalog + inference auth: any API key owned by `billing_user_id` (ops bootstrap label: `openrouter`). No separate monitor/inference key split. Ops hygiene: `hygiene-keys` ensures one `openrouter` key and disables legacy `openrouter-inference` / `openrouter-monitor` names.
 
 ## Settings JSON
 
@@ -27,15 +27,18 @@ That example tracks **policy fields** (`billing_user_id`, exclude/stream lists, 
 
 Change OR supply surface by editing user 32’s allowed groups only.
 
+Image / video models that the current seller groups cannot serve are listed in `catalog_excluded_model_ids` (text-only seller catalog for now).
+
 ```bash
 python3 ops/pricing/manage-openrouter-provider-config.py snapshot
 ```
 
-Prod bootstrap (creates seller key named `openrouter` if missing + config; prints ids only, never key secrets):
+Prod bootstrap / hygiene:
 
 ```bash
 python3 ops/pricing/manage-openrouter-provider-config.py snapshot
-python3 ops/pricing/manage-openrouter-provider-config.py update-config  # upsert billing user + exclude/stream; strips stale group_ids / key id lists if present
+python3 ops/pricing/manage-openrouter-provider-config.py update-config  # upsert billing user + exclude/stream; unions example list SSOT
+python3 ops/pricing/manage-openrouter-provider-config.py hygiene-keys   # ensure openrouter key; disable legacy dual names
 ```
 
 Required fields in settings:

--- a/ops/pricing/probe-openrouter-provider-chain.py
+++ b/ops/pricing/probe-openrouter-provider-chain.py
@@ -218,9 +218,22 @@ def run_probe(base_url: str, api_key: str, full_catalog: bool) -> Report:
 
     picks = pick_models(catalog)
     report.add("pick.chat_model", picks["chat"] is not None, picks["chat"] or "")
-    report.add("pick.gemini_image", picks["image"] is not None, picks["image"] or "")
-    report.add("pick.imagen_image", picks["imagen"] is not None, picks["imagen"] or "")
-    report.add("pick.video_model", picks["video"] is not None, picks["video"] or "")
+    # Media rows may be intentionally catalog_excluded (text-only seller surface).
+    report.add(
+        "pick.gemini_image",
+        True,
+        picks["image"] or "skipped: none in catalog",
+    )
+    report.add(
+        "pick.imagen_image",
+        True,
+        picks["imagen"] or "skipped: none in catalog",
+    )
+    report.add(
+        "pick.video_model",
+        True,
+        picks["video"] or "skipped: none in catalog",
+    )
 
     # Chat inference with public id
     if picks["chat"]:
@@ -294,7 +307,8 @@ PREFERRED = {preferred!r}
 
 def key_for(name):
     sql = (
-        "SELECT key FROM api_keys WHERE user_id=%d AND name='%s' AND deleted_at IS NULL "
+        "SELECT key FROM api_keys WHERE user_id=%d AND name='%s' "
+        "AND deleted_at IS NULL AND status <> 'disabled' "
         "ORDER BY id LIMIT 1" % (USER_ID, name.replace("'", "''"))
     )
     return subprocess.check_output(PSQL + [sql], text=True).strip()
@@ -302,7 +316,7 @@ def key_for(name):
 def any_key():
     sql = (
         "SELECT key FROM api_keys WHERE user_id=%d AND deleted_at IS NULL "
-        "ORDER BY id LIMIT 1" % USER_ID
+        "AND status <> 'disabled' ORDER BY id LIMIT 1" % USER_ID
     )
     return subprocess.check_output(PSQL + [sql], text=True).strip()
 

--- a/ops/pricing/probe-openrouter-provider-inference-serial.py
+++ b/ops/pricing/probe-openrouter-provider-inference-serial.py
@@ -86,19 +86,45 @@ def stream_required(model: dict) -> bool:
     return "stream=true" in desc.lower()
 
 
+def _internal_model_id(model_id: str) -> str:
+    mid = str(model_id or "").strip().lower()
+    if "/" in mid:
+        mid = mid.split("/", 1)[1]
+    return mid
+
+
+# DashScope variants that reject enable_thinking!=true (gateway also forces these).
+_THINKING_REQUIRED_INTERNAL_IDS = frozenset(
+    {
+        "qwen3.8-2.4t-a95b",
+        "qwen3.7-max-preview",
+        "qwen3.7-max-2026-05-17",
+    }
+)
+
+
+def thinking_required(model_id: str) -> bool:
+    return _internal_model_id(model_id) in _THINKING_REQUIRED_INTERNAL_IDS
+
+
 def infer_chat(base: str, api_key: str, model_id: str, *, stream: bool, http_json) -> tuple[int, bool, str]:
+    payload: dict = {
+        "model": model_id,
+        "messages": [{"role": "user", "content": "Reply with exactly: ok"}],
+        "max_tokens": 8,
+        "stream": stream,
+    }
+    if thinking_required(model_id):
+        payload["stream"] = True
+        payload["enable_thinking"] = True
     code, body, detail = http_json(
         "POST",
         f"{base}/v1/chat/completions",
         api_key,
-        {
-            "model": model_id,
-            "messages": [{"role": "user", "content": "Reply with exactly: ok"}],
-            "max_tokens": 8,
-            "stream": stream,
-        },
+        payload,
         timeout=120,
     )
+    stream = bool(payload.get("stream"))
     if stream:
         raw = body if isinstance(body, str) else detail
         ok = code == 200 and isinstance(raw, str) and "data:" in raw
@@ -244,7 +270,7 @@ def main() -> int:
             for r in failed:
                 print(f"  - {r.model} ({r.kind}) http={r.http} {r.detail[:200]}")
 
-    return 0 if report.passed else 1
+    return 0 if not failed else 1
 
 
 if __name__ == "__main__":

--- a/ops/pricing/test_manage_openrouter_provider_config.py
+++ b/ops/pricing/test_manage_openrouter_provider_config.py
@@ -58,5 +58,28 @@ class ParseSnapshotKeyIDTest(unittest.TestCase):
         self.assertEqual(mgr._parse_snapshot_key_id(""), 0)
 
 
+class UnionListFieldsFromExampleTest(unittest.TestCase):
+    def test_unions_example_excludes_preserving_live_extras(self) -> None:
+        example = {
+            "catalog_excluded_model_ids": ["a", "b"],
+            "stream_only_model_ids": ["s1"],
+        }
+        live = {
+            "catalog_excluded_model_ids": ["b", "live-only"],
+            "stream_only_model_ids": [],
+        }
+        merged = mgr._union_list_fields_from_example(live, example)
+        self.assertEqual(merged["catalog_excluded_model_ids"], ["a", "b", "live-only"])
+        self.assertEqual(merged["stream_only_model_ids"], ["s1"])
+
+    def test_example_image_video_excludes_present(self) -> None:
+        example = mgr._load_default_config()
+        for mid in (
+            "gemini-3.1-flash-image",
+            "doubao-seedance-2-0-260128",
+        ):
+            self.assertIn(mid, example["catalog_excluded_model_ids"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 摘要
- `catalog_excluded_model_ids`：图/视频 + Unsupported chat（deepseek-v3.2 / gemini-*-preview / gpt-5.2）
- `stream_only_model_ids` 增加 `qwen3.8-2.4t-a95b`
- chat 路径对 thinking-required Qwen 强制 `stream=true` + `enable_thinking=true`
- `hygiene-keys`：单 key `openrouter`；verify SQL 含 `deleted_at IS NULL`
- `update-config` 与 example list union

## 风险
常规。Prod 已执行 exclude/stream_only upsert。thinking 默认修复需发版后生效。

## 验证
- preflight PASS（含 soft-delete gate）
- `go test -tags=unit ./internal/service/ -run 'TestApplyNewAPIQwenNonStreamingShape|TestApplyNewAPIResponsesChatFallbackShape'`
- `python3 -m unittest ops/pricing/test_manage_openrouter_provider_config.py`
- prod serial：47/53（1–5 已 exclude；剩余 Unsupported 供应漂移）

## 门禁
- sentinel-registry-reviewed — `openai_gateway_bridge_responses_fallback.go` thinking 强制路径已由 `TestApplyNewAPIQwenNonStreamingShape` 行为断言锚定；本 PR 未新增 TK companion 热点文件，无需改 `scripts/sentinels/newapi.json`。

## 提交
- cdf191fc4 chore(openrouter): seller 面 text-only — exclude 图/视频 + key hygiene (no-web-impact)
- e72ff78d8 fix(openrouter): exclude dead chat models; force qwen thinking defaults (no-web-impact)
- 5e30c5dcf fix(openrouter): address R-001 — hygiene-keys verify SQL filters deleted_at (no-web-impact)
- 282f7dbff chore(openrouter): re-trigger CI after sentinel-registry-reviewed marker (no-web-impact)
- 最新提交：282f7dbff

Made with [Cursor](https://cursor.com)