### PR TITLE
chore(edge): Lightsail 防火墙基线开放 UDP 34567

### DIFF
--- a/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
+++ b/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
@@ -145,7 +145,7 @@ needs input:
 | `probe-gateway-ua-tls-compare` DB 窗太宽 | 未设 `WINDOW_MINUTES`，outage 证据被 LIMIT 稀释 | 根据 issue 换算分钟数， `--env WINDOW_MINUTES=N`。 |
 | `fetch-gateway-debug-log` SSM Failed | debug 文件不存在或 env 未开 | 远端 `docker exec tokenkey test -f /app/data/gateway_debug.log`；无文件则勿拉 body。 |
 | S3 presign / curl PUT 失败 | 实例无外网或桶策略 | 读 SSM stderr；检查 `SSM_OUTPUT_S3_BUCKET` 与 IAM；勿改线上只为 bypass。 |
-| 公网 `curl https://api-<edge>.tokenkey.dev` **连接超时** | Lightsail 防火墙缺 **TCP 443**（基线仅 443；SSM 内 curl 仍正常） | `aws lightsail get-instance-port-states`；`bash ops/stage0/verify-edge-lightsail-network.sh <id> --enforce-ports` |
+| 公网 `curl https://api-<edge>.tokenkey.dev` **连接超时** | Lightsail 防火墙缺 **TCP 443**（基线 TCP 443 + 8443 + UDP 34567；SSM 内 curl 仍正常） | `aws lightsail get-instance-port-states`；`bash ops/stage0/verify-edge-lightsail-network.sh <id> --enforce-ports` |
 | DNS 已指 Static IP 但 **TLS handshake 失败** / 证书错误 | provision 早于 DNS → ACME NXDOMAIN；Caddy 未续签 | DNS 生效后 `verify-edge-lightsail-network.sh <id> --renew-cert` |
 | Edge SSM 找不到 instance | 仍按 EC2 CFN stack 查（edge 已全量迁 Lightsail，无 CFN） | `resolve-edge-deploy-route.py --json`；Lightsail 用 tag SSM `mi-*` |
 

--- a/.cursor/skills/tokenkey-stage0-edge-lightsail-expansion/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-lightsail-expansion/SKILL.md
@@ -336,7 +336,7 @@ gh workflow run deploy-edge-lightsail-stage0.yml \
 | `provision` 步骤 fail，managed instance 未注册 | SSM Hybrid activation expired / 网络不通 | Lightsail 浏览器 SSH 看 `/var/log/tokenkey-lightsail-bootstrap.log`；`BOOTSTRAP_FAIL: ` 行即根因 |
 | GHA `smoke` / SSM 步骤失败，本机同 tag 却正常 | **`aws` / workflow 用了错的 `--region`**（误用 `ec2_equivalent_region`）或 job **工作目录**与脚本相对路径不一致 | 用 `python3 ops/stage0/edge_ssm_execution.py --repo-root . --edge-id <id> --format env` 核对输出的 **`REGION`**；workflow 里凡 SSM 调用必须与之一致；检查 `defaults.run.working-directory` / `cd` |
 | `external_health` 报 5xx | Caddy 还在签证书 / docker compose 起不来 | `ssh` 进实例 `docker compose -f /var/lib/tokenkey/docker-compose.yml ps` |
-| 公网 `curl https://api-<id>.tokenkey.dev` **连接超时** | Lightsail 防火墙 **缺 TCP 443**（基线仅 443，80/22 应关） | §2.2 `verify-edge-lightsail-network.sh --enforce-ports` |
+| 公网 `curl https://api-<id>.tokenkey.dev` **连接超时** | Lightsail 防火墙 **缺 TCP 443**（基线 TCP 443 + 8443 + UDP 34567；80/22 应关） | §2.2 `verify-edge-lightsail-network.sh --enforce-ports` |
 | DNS 已指 Static IP 但 **TLS handshake 失败** | provision 时 DNS 为 NXDOMAIN，ACME 未签成功 | §3 `--renew-cert` 重启 `tokenkey-caddy` |
 | Static IP 已分配但 attach 失败 | 旧 instance 还在持有该 Static IP | `aws lightsail detach-static-ip` 再重 attach；或 `recreate=true` 重来 |
 | GHCR pull 401 | PAT 过期 / 写错 SSM 路径 | 用 1.4 重新 put-parameter |

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -298,29 +298,29 @@ ops/stage0/sync-feishu-config.sh
 
 所有 edge 的 provision / DNS / smoke / 升级 / 回滚都走 `deploy-edge-lightsail-stage0.yml` +
 `edge-targets-lightsail.json`。一次性 IAM addon、GHCR PAT 路径（`/tokenkey/lightsail/<edge_id>/ghcr/pat`）、
-端口放行（**仅 443**，见下「公网端口收窄」）、Static IP / DNS 核对、Anthropic OAuth 重建等完整步骤见
+端口放行（edge：**TCP 443 + 8443 + UDP 34567**，见下「公网端口收窄」）、Static IP / DNS 核对、Anthropic OAuth 重建等完整步骤见
 [`deploy/aws/lightsail/README.md`](lightsail/README.md) 与
 [`.cursor/skills/tokenkey-stage0-edge-lightsail-expansion/SKILL.md`](../../.cursor/skills/tokenkey-stage0-edge-lightsail-expansion/SKILL.md)（`operation=full`）。
 
 IP 被上游污染需轮换 Static IP：[`.cursor/skills/tokenkey-stage0-edge-lightsail-ip-rotation/SKILL.md`](../../.cursor/skills/tokenkey-stage0-edge-lightsail-ip-rotation/SKILL.md) + `ops/lightsail/rotate-static-ip.sh`。
 
-## 公网端口收窄（prod 443-only；edge 443 + 8443）
+## 公网端口收窄（prod 443-only；edge 443 + 8443 + UDP 34567）
 
-公网暴露收窄到 TCP 443（**prod 仅 443**；**edge 为 443 + 8443**，8443 为备用连接口、按设计保持开放）：
+公网暴露收窄到 TCP 443（**prod 仅 443**；**edge 为 TCP 443 + 8443 + UDP 34567**，8443 为备用 TCP 连接口、UDP 34567 为 hysteria / 备用 UDP 入口，按设计保持开放）：
 
-- **80 关闭**：证书改用 **TLS-ALPN-01**（走 443，Caddyfile `disable_http_challenge`），不再需要 HTTP-01 / `:80` 跳转；edge 的 8443 不参与续签，TLS-ALPN-01 仍只在 443 上完成。
-- **22 关闭**：运维全走 SSM Session Manager（prod）/ Lightsail 控制台 browser SSH（edge），均不依赖公网 22。prod 由 `AdminCidr` 默认 `127.0.0.1/32` 收口；edge 由 `put-instance-public-ports` 声明完整端口集 = 443 + 8443（覆盖掉 Lightsail 默认的 22）。
+- **80 关闭**：证书改用 **TLS-ALPN-01**（走 443，Caddyfile `disable_http_challenge`），不再需要 HTTP-01 / `:80` 跳转；edge 的 8443 / 34567 不参与续签，TLS-ALPN-01 仍只在 443 上完成。
+- **22 关闭**：运维全走 SSM Session Manager（prod）/ Lightsail 控制台 browser SSH（edge），均不依赖公网 22。prod 由 `AdminCidr` 默认 `127.0.0.1/32` 收口；edge 由 `put-instance-public-ports` 声明完整端口集 = 443 + 8443 + UDP 34567（覆盖掉 Lightsail 默认的 22）。
 
 唯一实质风险是证书续签——靠「**先切 ALPN 配置 → 验证可签 → 再关 80**」的顺序消除。**rollout 必须按此序，PR 合并本身零 live 影响（现网证书 ~30d 内仍有效）：**
 
 1. **(edge) 重部署 IAM addon**：本次新增 `lightsail:PutInstancePublicPorts` 权限，必须先 `aws cloudformation deploy` 重部 `cicd-oidc-lightsail-addon.yaml`（手工 stack，见上「live==repo 漂移检查」），否则 provision / `--enforce-ports` 会 AccessDenied。
 2. **下发 ALPN 配置（80 仍开）**：`bash ops/stage0/sync_caddyfile_via_ssm.sh` 把新 Caddyfile 热同步到 prod + 全 edge，Caddy reload，业务不断。
-3. **canary 一个 edge 验签**：`bash ops/stage0/verify-edge-lightsail-network.sh <edge> --enforce-ports`（关 80/22，仅留 443）→ SSM 删该 edge 的 `caddy/data` 证书目录并重启 `tokenkey-caddy` → 确认在 80 已关 下经 TLS-ALPN-01 重新签发成功（Caddy 日志 `tls-alpn-01`）→ `https` 冒烟。**ALPN 签不出即停在此、不扩散。**
-4. **edge fleet 收口**：`for e in $(deployable edges); do bash ops/stage0/verify-edge-lightsail-network.sh "$e" --enforce-ports; done`，逐个确认仅剩 443 + https 冒烟。
+3. **canary 一个 edge 验签**：`bash ops/stage0/verify-edge-lightsail-network.sh <edge> --enforce-ports`（关 80/22，留 443 + 8443 + UDP 34567）→ SSM 删该 edge 的 `caddy/data` 证书目录并重启 `tokenkey-caddy` → 确认在 80 已关 下经 TLS-ALPN-01 重新签发成功（Caddy 日志 `tls-alpn-01`）→ `https` 冒烟。**ALPN 签不出即停在此、不扩散。**
+4. **edge fleet 收口**：`for e in $(deployable edges); do bash ops/stage0/verify-edge-lightsail-network.sh "$e" --enforce-ports; done`，逐个确认仅剩基线端口 + https 冒烟。
 5. **prod 关 22**：`aws cloudformation deploy ... --parameter-overrides AdminCidr=127.0.0.1/32 ImageTag=<当前运行态 tag>`（pin ImageTag 防 R5 静默退版）。改 SG ingress 是 in-place 更新、不替换实例。验证 `aws ssm start-session` 可进 + `https://api.tokenkey.dev/health` 正常。
 6. **prod 关 80**：确认 prod Caddy 已在 ALPN 配置（步骤 2）且证书可续后，再 `aws cloudformation deploy`（应用去掉 80 ingress 的新模板）→ `ops/stage0/post_deploy_smoke.sh` 全链路冒烟。
 
-回滚：edge 临时重开 80 用 `aws lightsail put-instance-public-ports --port-infos "fromPort=443,toPort=443,protocol=tcp,cidrs=0.0.0.0/0" "fromPort=80,toPort=80,protocol=tcp,cidrs=0.0.0.0/0"`（声明 443+80，用已授权的 put 而非已删的 open-instance-public-ports）；prod 恢复 SG 80 规则后 `aws cloudformation deploy`。
+回滚：edge 临时重开 80 用 `aws lightsail put-instance-public-ports --port-infos "fromPort=443,toPort=443,protocol=tcp,cidrs=0.0.0.0/0" "fromPort=80,toPort=80,protocol=tcp,cidrs=0.0.0.0/0" "fromPort=8443,toPort=8443,protocol=tcp,cidrs=0.0.0.0/0" "fromPort=34567,toPort=34567,protocol=udp,cidrs=0.0.0.0/0"`（声明基线+80，用已授权的 put 而非已删的 open-instance-public-ports）；prod 恢复 SG 80 规则后 `aws cloudformation deploy`。
 
 ## 升级 / 发版（生产 Stage0）
 

--- a/deploy/aws/lightsail/README.md
+++ b/deploy/aws/lightsail/README.md
@@ -104,14 +104,14 @@ gh workflow run deploy-edge-lightsail-stage0.yml \
 
 ### 冒烟 / 本机 curl 对域名长期 `HTTP 000` 或 TCP 超时
 
-Lightsail **实例控制台「Networking」防火墙**的硬化基线是**放行 TCP 443 + 8443**（443 = HTTPS 业务 + ACME TLS-ALPN-01；
-8443 = 备用连接口，按设计保持开放、不强制关掉）；**80 与 22 关闭**（证书走 TLS-ALPN-01 无需 80，续签仍只走 443；SSH 走 SSM / 控制台 browser SSH，不依赖公网 22）。仅靠正确 DNS（A → Static IP）不够；若 443 没开，`curl https://api-…/health` 会与 GitHub runner 一致：约 130s 级连接超时。
+Lightsail **实例控制台「Networking」防火墙**的硬化基线是**放行 TCP 443 + 8443 + UDP 34567**（443 = HTTPS 业务 + ACME TLS-ALPN-01；
+8443 = 备用 TCP 连接口；UDP 34567 = hysteria / 备用 UDP 入口，按设计保持开放、不强制关掉）；**80 与 22 关闭**（证书走 TLS-ALPN-01 无需 80，续签仍只走 443；SSH 走 SSM / 控制台 browser SSH，不依赖公网 22）。仅靠正确 DNS（A → Static IP）不够；若 443 没开，`curl https://api-…/health` 会与 GitHub runner 一致：约 130s 级连接超时。
 
-- 自检：`aws lightsail get-instance-port-states --region <region> --instance-name <instance_name>`（期望 443 + 8443 open，80/22 closed）
+- 自检：`aws lightsail get-instance-port-states --region <region> --instance-name <instance_name>`（期望 443 + 8443 + UDP 34567 open，80/22 closed）
 - 一次性修复 / 收口到基线（与 provision 脚本行为一致，原子覆盖整张防火墙表）：  
   `bash ops/stage0/verify-edge-lightsail-network.sh <edge_id> --enforce-ports`  
-  其内部即 `aws lightsail put-instance-public-ports --region <region> --instance-name <instance_name> --port-infos fromPort=443,toPort=443,protocol=tcp,cidrs=0.0.0.0/0 fromPort=8443,toPort=8443,protocol=tcp,cidrs=0.0.0.0/0`（put = 替换语义，顺带关掉默认 22 与历史 80，同时保留 8443）。
-- IaC：`provision-edge.sh` 会在 attach Static IP 后用 `put-instance-public-ports` 设为 **443 + 8443**；CI OIDC role 需在
+  其内部即 `aws lightsail put-instance-public-ports --region <region> --instance-name <instance_name> --port-infos fromPort=443,toPort=443,protocol=tcp,cidrs=0.0.0.0/0 fromPort=8443,toPort=8443,protocol=tcp,cidrs=0.0.0.0/0 fromPort=34567,toPort=34567,protocol=udp,cidrs=0.0.0.0/0`（put = 替换语义，顺带关掉默认 22 与历史 80，同时保留 8443 与 UDP 34567）。
+- IaC：`provision-edge.sh` 会在 attach Static IP 后用 `put-instance-public-ports` 设为 **443 + 8443 + UDP 34567**；CI OIDC role 需在
   `cicd-oidc-lightsail-addon.yaml` 中包含 `lightsail:PutInstancePublicPorts`（及 `GetInstancePortStates`）。
 
 ### Admin 登录 / 忘记密码

--- a/deploy/aws/lightsail/provision-edge.sh
+++ b/deploy/aws/lightsail/provision-edge.sh
@@ -188,18 +188,20 @@ aws lightsail attach-static-ip \
 # semantics), not open-instance-public-ports (add-only). This atomically:
 #   - opens 443 (business + ACME TLS-ALPN-01),
 #   - opens 8443 (alternate connection port — kept open by design; NOT force-closed),
+#   - opens UDP 34567 (hysteria / alternate UDP ingress — kept open by design),
 #   - drops the Lightsail-default public SSH (22) — operate via SSM / console SSH,
 #   - keeps public 80 closed — certs use TLS-ALPN-01 on 443, so HTTP-01 is unneeded.
-# Cert renewal still rides 443 only (TLS-ALPN-01); 8443 is a spare ingress port.
+# Cert renewal still rides 443 only (TLS-ALPN-01); 8443 is a spare TCP ingress port.
 # Operate existing edges to this same set via ops/stage0/verify-edge-lightsail-network.sh --enforce-ports.
-echo "setting Lightsail public ports to 443 + 8443 (IPv4) on ${INSTANCE_NAME}"
+echo "setting Lightsail public ports to TCP 443 + 8443 + UDP 34567 (IPv4) on ${INSTANCE_NAME}"
 if aws lightsail put-instance-public-ports \
   --region "$LIGHTSAIL_REGION" \
   --instance-name "$INSTANCE_NAME" \
   --port-infos \
     "fromPort=443,toPort=443,protocol=tcp,cidrs=0.0.0.0/0" \
-    "fromPort=8443,toPort=8443,protocol=tcp,cidrs=0.0.0.0/0" >/dev/null; then
-  echo "lightsail firewall: public ports set to TCP 443 + 8443 (22/80 closed)"
+    "fromPort=8443,toPort=8443,protocol=tcp,cidrs=0.0.0.0/0" \
+    "fromPort=34567,toPort=34567,protocol=udp,cidrs=0.0.0.0/0" >/dev/null; then
+  echo "lightsail firewall: public ports set to TCP 443 + 8443 + UDP 34567 (22/80 closed)"
 else
   echo "::notice::put-instance-public-ports failed — check:" >&2
   echo "       aws lightsail get-instance-port-states --region ${LIGHTSAIL_REGION} --instance-name ${INSTANCE_NAME}" >&2

--- a/ops/lightsail/provision-shadow-small.sh
+++ b/ops/lightsail/provision-shadow-small.sh
@@ -241,7 +241,8 @@ fi
 aws lightsail put-instance-public-ports --region "$REGION" --instance-name "$SHADOW_NAME" \
   --port-infos \
     "fromPort=443,toPort=443,protocol=tcp,cidrs=0.0.0.0/0" \
-    "fromPort=8443,toPort=8443,protocol=tcp,cidrs=0.0.0.0/0" >/dev/null
+    "fromPort=8443,toPort=8443,protocol=tcp,cidrs=0.0.0.0/0" \
+    "fromPort=34567,toPort=34567,protocol=udp,cidrs=0.0.0.0/0" >/dev/null
 SHADOW_IP="$(aws lightsail get-static-ip --region "$REGION" --static-ip-name "$SHADOW_IP_NAME" --query 'staticIp.ipAddress' --output text)"
 echo "shadow temp ip=${SHADOW_IP}"
 assert_live_untouched

--- a/ops/stage0/test_verify_edge_lightsail_network.py
+++ b/ops/stage0/test_verify_edge_lightsail_network.py
@@ -7,6 +7,23 @@ import subprocess
 import unittest
 
 _SCRIPT = pathlib.Path(__file__).resolve().parent / "verify-edge-lightsail-network.sh"
+_PROVISION = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / "deploy"
+    / "aws"
+    / "lightsail"
+    / "provision-edge.sh"
+)
+_SHADOW = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "lightsail"
+    / "provision-shadow-small.sh"
+)
+
+# Edge Lightsail hardened baseline port set (must stay in sync across provision + verify).
+_UDP_34567 = "fromPort=34567,toPort=34567,protocol=udp,cidrs=0.0.0.0/0"
+_TCP_443 = "fromPort=443,toPort=443,protocol=tcp,cidrs=0.0.0.0/0"
+_TCP_8443 = "fromPort=8443,toPort=8443,protocol=tcp,cidrs=0.0.0.0/0"
 
 
 class VerifyEdgeLightsailNetworkTest(unittest.TestCase):
@@ -24,6 +41,7 @@ class VerifyEdgeLightsailNetworkTest(unittest.TestCase):
         )
         self.assertEqual(proc.returncode, 0)
         self.assertIn("verify-edge-lightsail-network.sh", proc.stdout)
+        self.assertIn("UDP 34567", proc.stdout)
 
     def test_missing_arg_shows_usage(self) -> None:
         proc = subprocess.run(
@@ -31,6 +49,29 @@ class VerifyEdgeLightsailNetworkTest(unittest.TestCase):
             capture_output=True, text=True, check=False,
         )
         self.assertEqual(proc.returncode, 1)
+
+    def test_baseline_includes_udp_34567(self) -> None:
+        """Positive: enforce/provision declare UDP 34567 in the public port set."""
+        for path in (_SCRIPT, _PROVISION, _SHADOW):
+            text = path.read_text(encoding="utf-8")
+            self.assertIn(_TCP_443, text, msg=f"{path.name} missing TCP 443")
+            self.assertIn(_TCP_8443, text, msg=f"{path.name} missing TCP 8443")
+            self.assertIn(_UDP_34567, text, msg=f"{path.name} missing UDP 34567")
+
+    def test_baseline_does_not_open_public_22_or_80(self) -> None:
+        """Negative: put-instance-public-ports must not declare public TCP 22/80."""
+        for path in (_SCRIPT, _PROVISION, _SHADOW):
+            text = path.read_text(encoding="utf-8")
+            # Only look at put-instance-public-ports blocks (avoid comment noise).
+            blocks = []
+            lines = text.splitlines()
+            for i, line in enumerate(lines):
+                if "put-instance-public-ports" in line:
+                    blocks.append("\n".join(lines[i : i + 12]))
+            self.assertTrue(blocks, msg=f"{path.name}: no put-instance-public-ports")
+            for block in blocks:
+                self.assertNotIn("fromPort=22,", block, msg=f"{path.name}: opens 22")
+                self.assertNotIn("fromPort=80,", block, msg=f"{path.name}: opens 80")
 
 
 if __name__ == "__main__":

--- a/ops/stage0/verify-edge-lightsail-network.sh
+++ b/ops/stage0/verify-edge-lightsail-network.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 # verify-edge-lightsail-network.sh — Post-provision / post-DNS checks for Lightsail edges.
 #
-# Hardened public-port baseline: TCP 443 + 8443 OPEN, TCP 80 and 22 CLOSED.
+# Hardened public-port baseline: TCP 443 + 8443 + UDP 34567 OPEN; TCP 80 and 22 CLOSED.
 # 443 carries business + ACME TLS-ALPN-01 (Caddyfile.edge disable_http_challenge),
-# so HTTP-01 / public 80 is unneeded; 8443 is an alternate connection port kept
-# open by design (NOT force-closed); SSH (22) is operated via SSM / Lightsail
-# console, never the public port. Cert renewal still rides 443 only.
+# so HTTP-01 / public 80 is unneeded; 8443 is an alternate TCP connection port kept
+# open by design (NOT force-closed); UDP 34567 is hysteria / alternate UDP ingress
+# kept open by design; SSH (22) is operated via SSM / Lightsail console, never the
+# public port. Cert renewal still rides 443 only.
 #
 # Confirms the firewall matches that baseline and (optionally) public HTTPS
-# /health succeeds. --enforce-ports rewrites the firewall to 443 + 8443 (closes
-# 22/80, keeps 8443); --renew-cert restarts Caddy when DNS was late (ACME NXDOMAIN).
+# /health succeeds. --enforce-ports rewrites the firewall to 443 + 8443 + UDP 34567
+# (closes 22/80, keeps 8443 and 34567); --renew-cert restarts Caddy when DNS was
+# late (ACME NXDOMAIN).
 #
 # Usage:
 #   bash ops/stage0/verify-edge-lightsail-network.sh <edge_id> [--enforce-ports] [--renew-cert]
@@ -35,16 +37,17 @@ usage() {
 Usage:
   bash ops/stage0/verify-edge-lightsail-network.sh <edge_id> [--enforce-ports] [--renew-cert]
 
-Hardened baseline: TCP 443 + 8443 open; TCP 80 and 22 closed.
+Hardened baseline: TCP 443 + 8443 + UDP 34567 open; TCP 80 and 22 closed.
 
 Checks:
   - Lightsail public port 443 is open (80/22 expected closed; drift warned)
   - Lightsail public port 8443 is open (alternate connection port; warn if missing)
+  - Lightsail public UDP 34567 is open (hysteria / alternate UDP; warn if missing)
   - dig @1.1.1.1 A record matches static IP (when DNS exists)
   - curl https://api-<edge_id>.tokenkey.dev/health (best effort)
 
 Options:
-  --enforce-ports  put-instance-public-ports to 443 + 8443 (closes public 22 and 80)
+  --enforce-ports  put-instance-public-ports to 443 + 8443 + UDP 34567 (closes public 22 and 80)
   --renew-cert     restart tokenkey-caddy via SSM (after DNS cutover / ACME retry)
 EOF
 }
@@ -120,29 +123,32 @@ fi
 
 port_open() {
   local port="$1"
+  local proto="${2:-tcp}"
   aws lightsail get-instance-port-states --region "$REGION" --instance-name "$INSTANCE" \
-    --query "portStates[?fromPort==\`${port}\` && toPort==\`${port}\` && state=='open'] | length(@)" \
+    --query "portStates[?fromPort==\`${port}\` && toPort==\`${port}\` && protocol=='${proto}' && state=='open'] | length(@)" \
     --output text 2>/dev/null | grep -qv '^0$'
 }
 
 echo "[verify-edge-lightsail-network] edge_id=${EDGE_ID} region=${REGION} instance=${INSTANCE}"
 echo "[verify-edge-lightsail-network] domain=${DOMAIN} static_ip=${STATIC_IP}"
 
-# Hardened baseline = 443 + 8443 open, 80/22 closed. --enforce-ports rewrites the
-# whole firewall to exactly that (put = replace semantics, so it also drops the
-# Lightsail-default public SSH 22 and any historical 80, while KEEPING 8443).
+# Hardened baseline = TCP 443 + 8443 + UDP 34567 open, 80/22 closed. --enforce-ports
+# rewrites the whole firewall to exactly that (put = replace semantics, so it also
+# drops the Lightsail-default public SSH 22 and any historical 80, while KEEPING
+# 8443 and UDP 34567).
 if $ENFORCE_PORTS; then
-  echo "[verify-edge-lightsail-network] enforcing public ports = 443 + 8443 (closes 22 and 80, keeps 8443)..."
+  echo "[verify-edge-lightsail-network] enforcing public ports = TCP 443 + 8443 + UDP 34567 (closes 22 and 80)..."
   aws lightsail put-instance-public-ports \
     --region "$REGION" \
     --instance-name "$INSTANCE" \
     --port-infos \
       "fromPort=443,toPort=443,protocol=tcp,cidrs=0.0.0.0/0" \
-      "fromPort=8443,toPort=8443,protocol=tcp,cidrs=0.0.0.0/0" >/dev/null \
+      "fromPort=8443,toPort=8443,protocol=tcp,cidrs=0.0.0.0/0" \
+      "fromPort=34567,toPort=34567,protocol=udp,cidrs=0.0.0.0/0" >/dev/null \
     || { echo "[verify-edge-lightsail-network] FAIL: put-instance-public-ports failed" >&2; exit 3; }
 fi
 
-if ! port_open 443; then
+if ! port_open 443 tcp; then
   echo "[verify-edge-lightsail-network] FAIL: TCP 443 not open (rerun with --enforce-ports)" >&2
   exit 3
 fi
@@ -150,18 +156,25 @@ echo "[verify-edge-lightsail-network] ok: firewall TCP 443 open"
 
 # 8443 is part of the hardened baseline (alternate connection port). Open is
 # expected; warn (not fail) if missing so an operator can rerun --enforce-ports.
-if port_open 8443; then
+if port_open 8443 tcp; then
   echo "[verify-edge-lightsail-network] ok: firewall TCP 8443 open"
 else
-  echo "[verify-edge-lightsail-network] WARN: public TCP 8443 not open (baseline is 443 + 8443) — run with --enforce-ports to open" >&2
+  echo "[verify-edge-lightsail-network] WARN: public TCP 8443 not open (baseline is 443 + 8443 + UDP 34567) — run with --enforce-ports to open" >&2
+fi
+
+# UDP 34567 is part of the hardened baseline (hysteria / alternate UDP ingress).
+if port_open 34567 udp; then
+  echo "[verify-edge-lightsail-network] ok: firewall UDP 34567 open"
+else
+  echo "[verify-edge-lightsail-network] WARN: public UDP 34567 not open (baseline is 443 + 8443 + UDP 34567) — run with --enforce-ports to open" >&2
 fi
 
 # Drift from the hardened baseline: 80 / 22 should be closed.
 drift_ports=()
-port_open 80 && drift_ports+=("80")
-port_open 22 && drift_ports+=("22")
+port_open 80 tcp && drift_ports+=("80")
+port_open 22 tcp && drift_ports+=("22")
 if [[ ${#drift_ports[@]} -gt 0 ]]; then
-  echo "[verify-edge-lightsail-network] WARN: public TCP ${drift_ports[*]} still open (baseline is 443 + 8443) — run with --enforce-ports to close" >&2
+  echo "[verify-edge-lightsail-network] WARN: public TCP ${drift_ports[*]} still open (baseline is 443 + 8443 + UDP 34567) — run with --enforce-ports to close" >&2
 fi
 
 if $RENEW_CERT; then


### PR DESCRIPTION
## 摘要
- 将 Lightsail edge 公网防火墙基线从 TCP 443 + 8443 扩展为 **TCP 443 + 8443 + UDP 34567**（hysteria / 备用 UDP 入口）。
- 同步 `provision-edge.sh`、`verify-edge-lightsail-network.sh --enforce-ports`、`provision-shadow-small.sh` 与相关文档/skill。
- 本 PR **不改** live 防火墙；现网对齐需另行对 deployable edge 跑 `--enforce-ports`。

## 风险
- 常规风险：运维契约变更（防火墙基线），无公共 API / Web / schema 变更。
- `--enforce-ports` 为整表替换：会关掉现网白名单 SSH（`22@…`），只保留基线端口。
- Web impact: none

## 验证
- `python3 -m unittest ops.stage0.test_verify_edge_lightsail_network -v`（含正/负向：含 UDP 34567、不开放 22/80）
- `./scripts/preflight.sh` PASS

## 提交
- `507edb20e` chore(edge): open UDP 34567 in Lightsail firewall baseline
- 最新提交：`507edb20e`


Made with [Cursor](https://cursor.com)