### PR TITLE
chore(openrouter): exclude wan/audio models from seller catalog

### DIFF
--- a/ops/pricing/examples/openrouter-provider-config.example.json
+++ b/ops/pricing/examples/openrouter-provider-config.example.json
@@ -33,10 +33,7 @@
     "glm-4.5-air",
     "qwen3.8-2.4t-a95b"
   ],
-  "datacenter_country_codes": [
-    "US",
-    "SG"
-  ],
+  "datacenter_country_codes": ["US", "SG"],
   "privacy_policy_url": "https://tokenkey.dev/privacy",
   "terms_of_service_url": "https://tokenkey.dev/terms",
   "status_page_url": "https://status.tokenkey.dev",

--- a/ops/pricing/examples/openrouter-provider-config.example.json
+++ b/ops/pricing/examples/openrouter-provider-config.example.json
@@ -25,7 +25,8 @@
     "doubao-seedance-2-0-fast-260128",
     "doubao-seedance-2-5-260628",
     "wan2.7-image",
-    "wan2.7-image-pro"
+    "wan2.7-image-pro",
+    "qwen-audio-3.0-realtime-plus"
   ],
   "stream_only_model_ids": [
     "glm-4.5",

--- a/ops/pricing/examples/openrouter-provider-config.example.json
+++ b/ops/pricing/examples/openrouter-provider-config.example.json
@@ -23,14 +23,19 @@
     "gpt-5.2",
     "doubao-seedance-2-0-260128",
     "doubao-seedance-2-0-fast-260128",
-    "doubao-seedance-2-5-260628"
+    "doubao-seedance-2-5-260628",
+    "wan2.7-image",
+    "wan2.7-image-pro"
   ],
   "stream_only_model_ids": [
     "glm-4.5",
     "glm-4.5-air",
     "qwen3.8-2.4t-a95b"
   ],
-  "datacenter_country_codes": ["US", "SG"],
+  "datacenter_country_codes": [
+    "US",
+    "SG"
+  ],
   "privacy_policy_url": "https://tokenkey.dev/privacy",
   "terms_of_service_url": "https://tokenkey.dev/terms",
   "status_page_url": "https://status.tokenkey.dev",

--- a/ops/pricing/test_manage_openrouter_provider_config.py
+++ b/ops/pricing/test_manage_openrouter_provider_config.py
@@ -79,6 +79,7 @@ class UnionListFieldsFromExampleTest(unittest.TestCase):
             "doubao-seedance-2-0-260128",
             "wan2.7-image",
             "wan2.7-image-pro",
+            "qwen-audio-3.0-realtime-plus",
         ):
             self.assertIn(mid, example["catalog_excluded_model_ids"])
 

--- a/ops/pricing/test_manage_openrouter_provider_config.py
+++ b/ops/pricing/test_manage_openrouter_provider_config.py
@@ -77,6 +77,8 @@ class UnionListFieldsFromExampleTest(unittest.TestCase):
         for mid in (
             "gemini-3.1-flash-image",
             "doubao-seedance-2-0-260128",
+            "wan2.7-image",
+            "wan2.7-image-pro",
         ):
             self.assertIn(mid, example["catalog_excluded_model_ids"])
 


### PR DESCRIPTION
## 摘要
- `catalog_excluded_model_ids` 增加 `wan2.7-image` / `wan2.7-image-pro` / `qwen-audio-3.0-realtime-plus`
- 保持 OR seller text-only；prod 已 `update-config` union
- 还原无关的 `datacenter_country_codes` 格式噪声；已 rebase 到当前 `origin/main`

## 风险
低。仅 catalog 投影。

## 验证
- `python3 -m unittest ops.pricing.test_manage_openrouter_provider_config`
- 本地 preflight（`PREFLIGHT_BASE=origin/main`）PASS
- prod：wan/audio 均不在 catalog

## 提交
- 2724a899d chore(openrouter): restore datacenter_country_codes one-liner (no-web-impact)
- 9c59653a0 chore(openrouter): exclude qwen-audio realtime from seller catalog (no-web-impact)
- 27379c635 chore(openrouter): exclude wan2.7 image models from seller catalog (no-web-impact)
- 最新提交：2724a899d

Made with [Cursor](https://cursor.com)