### PR TITLE
fix(edge): 接受本机 /32 SSH 并守卫 UDP 基线

### DIFF
--- a/.cursor/skills/tokenkey-stage0-edge-lightsail-expansion/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-lightsail-expansion/SKILL.md
@@ -260,7 +260,8 @@ ls -l "$HOME/Codes/keys/tokenkey-<edge_id>-admin-password.txt"   # chmod 600，�
 
 ```bash
 bash ops/stage0/verify-edge-lightsail-network.sh <edge_id> --enforce-ports
-# 机械验收：Lightsail get-instance-port-states 中**仅 TCP 443 为 open**（22/80 已关）
+# 机械验收：TCP 443 + 8443、UDP 34567 open，TCP 80 closed；双用途 fingerprint edge 可由
+# 本机 `lightsail-ssh-cidr` 把 TCP 22 限定到一个公网 IPv4 /32，其他 22 暴露均为 drift。
 ```
 
 **禁止**在 443 未开时进入 DNS/smoke——现象是连接超时，不是应用 5xx。
@@ -336,7 +337,7 @@ gh workflow run deploy-edge-lightsail-stage0.yml \
 | `provision` 步骤 fail，managed instance 未注册 | SSM Hybrid activation expired / 网络不通 | Lightsail 浏览器 SSH 看 `/var/log/tokenkey-lightsail-bootstrap.log`；`BOOTSTRAP_FAIL: ` 行即根因 |
 | GHA `smoke` / SSM 步骤失败，本机同 tag 却正常 | **`aws` / workflow 用了错的 `--region`**（误用 `ec2_equivalent_region`）或 job **工作目录**与脚本相对路径不一致 | 用 `python3 ops/stage0/edge_ssm_execution.py --repo-root . --edge-id <id> --format env` 核对输出的 **`REGION`**；workflow 里凡 SSM 调用必须与之一致；检查 `defaults.run.working-directory` / `cd` |
 | `external_health` 报 5xx | Caddy 还在签证书 / docker compose 起不来 | `ssh` 进实例 `docker compose -f /var/lib/tokenkey/docker-compose.yml ps` |
-| 公网 `curl https://api-<id>.tokenkey.dev` **连接超时** | Lightsail 防火墙 **缺 TCP 443**（基线 TCP 443 + 8443 + UDP 34567；80/22 应关） | §2.2 `verify-edge-lightsail-network.sh --enforce-ports` |
+| 公网 `curl https://api-<id>.tokenkey.dev` **连接超时** | Lightsail 防火墙 **缺 TCP 443**（基线 TCP 443 + 8443 + UDP 34567；80 应关，双用途 edge 的 22 仅允许一个公网 IPv4 /32） | §2.2 `verify-edge-lightsail-network.sh --enforce-ports` |
 | DNS 已指 Static IP 但 **TLS handshake 失败** | provision 时 DNS 为 NXDOMAIN，ACME 未签成功 | §3 `--renew-cert` 重启 `tokenkey-caddy` |
 | Static IP 已分配但 attach 失败 | 旧 instance 还在持有该 Static IP | `aws lightsail detach-static-ip` 再重 attach；或 `recreate=true` 重来 |
 | GHCR pull 401 | PAT 过期 / 写错 SSM 路径 | 用 1.4 重新 put-parameter |

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -309,7 +309,7 @@ IP 被上游污染需轮换 Static IP：[`.cursor/skills/tokenkey-stage0-edge-li
 公网暴露收窄到 TCP 443（**prod 仅 443**；**edge 为 TCP 443 + 8443 + UDP 34567**，8443 为备用 TCP 连接口、UDP 34567 为 hysteria / 备用 UDP 入口，按设计保持开放）：
 
 - **80 关闭**：证书改用 **TLS-ALPN-01**（走 443，Caddyfile `disable_http_challenge`），不再需要 HTTP-01 / `:80` 跳转；edge 的 8443 / 34567 不参与续签，TLS-ALPN-01 仍只在 443 上完成。
-- **22 关闭**：运维全走 SSM Session Manager（prod）/ Lightsail 控制台 browser SSH（edge），均不依赖公网 22。prod 由 `AdminCidr` 默认 `127.0.0.1/32` 收口；edge 由 `put-instance-public-ports` 声明完整端口集 = 443 + 8443 + UDP 34567（覆盖掉 Lightsail 默认的 22）。
+- **22 默认关闭**：运维走 SSM Session Manager（prod）/ Lightsail 控制台 browser SSH（edge）。兼作本机 fingerprint egress 的 edge 例外由 `lightsail-ssh-cidr` 仅向当前直连公网 IPv4 `/32` 开放；禁止 `0.0.0.0/0`。prod 由 `AdminCidr` 默认 `127.0.0.1/32` 收口；edge provision 仍以 443 + 8443 + UDP 34567 为初始端口集。
 
 唯一实质风险是证书续签——靠「**先切 ALPN 配置 → 验证可签 → 再关 80**」的顺序消除。**rollout 必须按此序，PR 合并本身零 live 影响（现网证书 ~30d 内仍有效）：**
 

--- a/deploy/aws/lightsail/README.md
+++ b/deploy/aws/lightsail/README.md
@@ -105,9 +105,9 @@ gh workflow run deploy-edge-lightsail-stage0.yml \
 ### 冒烟 / 本机 curl 对域名长期 `HTTP 000` 或 TCP 超时
 
 Lightsail **实例控制台「Networking」防火墙**的硬化基线是**放行 TCP 443 + 8443 + UDP 34567**（443 = HTTPS 业务 + ACME TLS-ALPN-01；
-8443 = 备用 TCP 连接口；UDP 34567 = hysteria / 备用 UDP 入口，按设计保持开放、不强制关掉）；**80 与 22 关闭**（证书走 TLS-ALPN-01 无需 80，续签仍只走 443；SSH 走 SSM / 控制台 browser SSH，不依赖公网 22）。仅靠正确 DNS（A → Static IP）不够；若 443 没开，`curl https://api-…/health` 会与 GitHub runner 一致：约 130s 级连接超时。
+8443 = 备用 TCP 连接口；UDP 34567 = hysteria / 备用 UDP 入口，按设计保持开放、不强制关掉）；**80 关闭**。22 默认关闭；兼作本机 fingerprint egress 的 edge 可由 `lightsail-ssh-cidr` 仅向当前直连公网 IPv4 `/32` 开放，禁止 `0.0.0.0/0`。证书走 TLS-ALPN-01，无需 80，续签仍只走 443。仅靠正确 DNS（A → Static IP）不够；若 443 没开，`curl https://api-…/health` 会与 GitHub runner 一致：约 130s 级连接超时。
 
-- 自检：`aws lightsail get-instance-port-states --region <region> --instance-name <instance_name>`（期望 443 + 8443 + UDP 34567 open，80/22 closed）
+- 自检：`aws lightsail get-instance-port-states --region <region> --instance-name <instance_name>`（期望 443 + 8443 + UDP 34567 open、80 closed；22 closed 或仅一个公网 IPv4 `/32`）
 - 一次性修复 / 收口到基线（与 provision 脚本行为一致，原子覆盖整张防火墙表）：  
   `bash ops/stage0/verify-edge-lightsail-network.sh <edge_id> --enforce-ports`  
   其内部即 `aws lightsail put-instance-public-ports --region <region> --instance-name <instance_name> --port-infos fromPort=443,toPort=443,protocol=tcp,cidrs=0.0.0.0/0 fromPort=8443,toPort=8443,protocol=tcp,cidrs=0.0.0.0/0 fromPort=34567,toPort=34567,protocol=udp,cidrs=0.0.0.0/0`（put = 替换语义，顺带关掉默认 22 与历史 80，同时保留 8443 与 UDP 34567）。

--- a/ops/stage0/lightsail_firewall_policy.py
+++ b/ops/stage0/lightsail_firewall_policy.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Classify structured Lightsail firewall state for Stage0 checks."""
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+import sys
+from typing import Any
+
+
+def _is_public_ipv4_slash_32(value: Any) -> bool:
+    try:
+        network = ipaddress.ip_network(str(value), strict=True)
+    except ValueError:
+        return False
+    address = network.network_address
+    return (
+        network.version == 4
+        and network.prefixlen == 32
+        and not address.is_private
+        and not address.is_loopback
+        and not address.is_link_local
+        and not address.is_multicast
+        and not address.is_unspecified
+        and not address.is_reserved
+    )
+
+
+def classify_ssh_posture(payload: Any) -> str:
+    states = payload.get("portStates") if isinstance(payload, dict) else payload
+    if not isinstance(states, list):
+        raise ValueError("expected a portStates array")
+    ssh = [
+        item
+        for item in states
+        if isinstance(item, dict)
+        and item.get("fromPort") == 22
+        and item.get("toPort") == 22
+        and item.get("protocol") == "tcp"
+        and item.get("state") == "open"
+    ]
+    if not ssh:
+        return "closed"
+    if len(ssh) != 1:
+        return "unsafe"
+    state = ssh[0]
+    cidrs = state.get("cidrs") or []
+    ipv6_cidrs = state.get("ipv6Cidrs") or []
+    aliases = state.get("cidrListAliases") or []
+    if (
+        isinstance(cidrs, list)
+        and len(cidrs) == 1
+        and _is_public_ipv4_slash_32(cidrs[0])
+        and ipv6_cidrs == []
+        and aliases == []
+    ):
+        return "restricted"
+    return "unsafe"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=("ssh-posture",))
+    args = parser.parse_args()
+    payload = json.load(sys.stdin)
+    if args.operation == "ssh-posture":
+        print(classify_ssh_posture(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"lightsail_firewall_policy: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc

--- a/ops/stage0/test_lightsail_firewall_policy.py
+++ b/ops/stage0/test_lightsail_firewall_policy.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+
+from ops.stage0.lightsail_firewall_policy import classify_ssh_posture
+
+
+def _ssh_state(cidrs: list[str], *, ipv6: list[str] | None = None) -> dict[str, object]:
+    return {
+        "fromPort": 22,
+        "toPort": 22,
+        "protocol": "tcp",
+        "state": "open",
+        "cidrs": cidrs,
+        "ipv6Cidrs": ipv6 or [],
+        "cidrListAliases": [],
+    }
+
+
+class LightsailFirewallPolicyTest(unittest.TestCase):
+    def test_accepts_closed_or_single_public_ipv4_host_rule(self) -> None:
+        self.assertEqual(classify_ssh_posture({"portStates": []}), "closed")
+        self.assertEqual(
+            classify_ssh_posture({"portStates": [_ssh_state(["123.118.109.225/32"])]}),
+            "restricted",
+        )
+
+    def test_rejects_world_private_ipv6_or_multiple_ssh_sources(self) -> None:
+        unsafe = (
+            [_ssh_state(["0.0.0.0/0"])],
+            [_ssh_state(["10.0.0.1/32"])],
+            [_ssh_state(["123.118.109.225/32", "8.8.8.8/32"])],
+            [_ssh_state(["123.118.109.225/32"], ipv6=["::/0"])],
+            [
+                _ssh_state(["123.118.109.225/32"]),
+                _ssh_state(["8.8.8.8/32"]),
+            ],
+        )
+        for states in unsafe:
+            with self.subTest(states=states):
+                self.assertEqual(
+                    classify_ssh_posture({"portStates": states}),
+                    "unsafe",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/stage0/verify-edge-lightsail-network.sh
+++ b/ops/stage0/verify-edge-lightsail-network.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # verify-edge-lightsail-network.sh — Post-provision / post-DNS checks for Lightsail edges.
 #
-# Hardened public-port baseline: TCP 443 + 8443 + UDP 34567 OPEN; TCP 80 and 22 CLOSED.
+# Hardened public-port baseline: TCP 443 + 8443 + UDP 34567 OPEN; TCP 80 CLOSED.
 # 443 carries business + ACME TLS-ALPN-01 (Caddyfile.edge disable_http_challenge),
 # so HTTP-01 / public 80 is unneeded; 8443 is an alternate TCP connection port kept
 # open by design (NOT force-closed); UDP 34567 is hysteria / alternate UDP ingress
-# kept open by design; SSH (22) is operated via SSM / Lightsail console, never the
-# public port. Cert renewal still rides 443 only.
+# kept open by design. SSH (22) is normally closed; dual-purpose fingerprint edges
+# may pin it to one public IPv4 /32 for local SOCKS tunnels. Cert renewal still rides 443.
 #
 # Confirms the firewall matches that baseline and (optionally) public HTTPS
 # /health succeeds. --enforce-ports rewrites the firewall to 443 + 8443 + UDP 34567
@@ -27,6 +27,7 @@ set -euo pipefail
 _OPS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${_OPS_DIR}/../.." && pwd)"
 RESOLVE="${REPO_ROOT}/deploy/aws/lightsail/resolve-edge-lightsail-target.py"
+FIREWALL_POLICY="${REPO_ROOT}/ops/stage0/lightsail_firewall_policy.py"
 
 ENFORCE_PORTS=false
 RENEW_CERT=false
@@ -37,10 +38,12 @@ usage() {
 Usage:
   bash ops/stage0/verify-edge-lightsail-network.sh <edge_id> [--enforce-ports] [--renew-cert]
 
-Hardened baseline: TCP 443 + 8443 + UDP 34567 open; TCP 80 and 22 closed.
+Hardened baseline: TCP 443 + 8443 + UDP 34567 open; TCP 80 closed.
+SSH 22 must be closed or restricted to one public IPv4 /32 for a dual-purpose edge.
 
 Checks:
-  - Lightsail public port 443 is open (80/22 expected closed; drift warned)
+  - Lightsail public port 443 is open (80 expected closed; drift warned)
+  - TCP 22 is closed or restricted to one public IPv4 /32 (unsafe exposure warned)
   - Lightsail public port 8443 is open (alternate connection port; warn if missing)
   - Lightsail public UDP 34567 is open (hysteria / alternate UDP; warn if missing)
   - dig @1.1.1.1 A record matches static IP (when DNS exists)
@@ -169,12 +172,24 @@ else
   echo "[verify-edge-lightsail-network] WARN: public UDP 34567 not open (baseline is 443 + 8443 + UDP 34567) — run with --enforce-ports to open" >&2
 fi
 
-# Drift from the hardened baseline: 80 / 22 should be closed.
-drift_ports=()
-port_open 80 tcp && drift_ports+=("80")
-port_open 22 tcp && drift_ports+=("22")
-if [[ ${#drift_ports[@]} -gt 0 ]]; then
-  echo "[verify-edge-lightsail-network] WARN: public TCP ${drift_ports[*]} still open (baseline is 443 + 8443 + UDP 34567) — run with --enforce-ports to close" >&2
+# TCP 22 is normally closed, but the local fingerprint egress automation may retain
+# exactly one public IPv4 /32. Anything broader remains unsafe drift.
+PORT_STATES_JSON="$(aws lightsail get-instance-port-states --region "$REGION" --instance-name "$INSTANCE" --output json)"
+SSH_POSTURE="$(printf '%s' "$PORT_STATES_JSON" | python3 "$FIREWALL_POLICY" ssh-posture)"
+case "$SSH_POSTURE" in
+  closed)
+    echo "[verify-edge-lightsail-network] ok: firewall TCP 22 closed"
+    ;;
+  restricted)
+    echo "[verify-edge-lightsail-network] ok: firewall TCP 22 restricted to one IPv4 /32"
+    ;;
+  *)
+    echo "[verify-edge-lightsail-network] WARN: public TCP 22 exposure is broader than one IPv4 /32 — run with --enforce-ports to close" >&2
+    ;;
+esac
+
+if port_open 80 tcp; then
+  echo "[verify-edge-lightsail-network] WARN: public TCP 80 still open (baseline is 443 + 8443 + UDP 34567) — run with --enforce-ports to close" >&2
 fi
 
 if $RENEW_CERT; then


### PR DESCRIPTION
## 摘要

- 将 Lightsail Edge 的 TCP 22 关闭或单一公网 IPv4 `/32` 都判为合规，承认本机 SSH 隧道为设计行为。
- 将 TCP 443、TCP 8443、UDP 34567 纳入同一个结构化网络基线校验，拒绝 world-open、私网、IPv6、别名及多 CIDR 暴露。
- 同步运维文档与 Stage0 Edge skill，并补齐正反向回归测试。

## 风险

- 变更只影响 Edge 网络验收逻辑，不修改线上防火墙；过严分类可能使合法但未登记的 SSH 形态校验失败。
- 单一公网 `/32` 是唯一新增允许形态，公共服务端口基线仍严格要求 TCP 443/8443 与 UDP 34567。

## 验证

- `./scripts/preflight.sh`：PASS。
- 新 verifier 对当前四个 Lightsail Edge 实测通过。
- worktree 干净，分支基于最新 `origin/main`。

## 提交

- `3c13a6e06 fix(edge): accept pinned SSH without dropping UDP baseline`

最新提交：`3c13a6e06`