### PR TITLE
feat(ops): rollout 后审计 prod 账号分组绑定

### DIFF
--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -35,6 +35,7 @@ description: Drive TokenKey Stage0 release, prod deploy, edge rollout, smoke, ro
 | 发版后控制面探活（prod + deployable edge） | 机械 | `bash ops/observability/probe-release-control-plane.sh`（prod `/health` + `/api/v1/settings/public`，deployable Edge `/health`，JSON lines + summary） |
 | **发版后两阶段实测（live tag→本次 tag 的全部 PR）** | 机械 | `deploy-stage0.yml` 同一 `deploy` job：蓝绿脚本在 Caddy reload 成功的真实切流点输出 `cutover_at`；`Check PR hooks immediately` 查该时刻起的 PR observables，workflow 只补足到 `cutover_at + 300s`，再由 `Check traffic and 5xx after 5 minutes` 查累计流量/5xx；两阶段复用 `plan.json` 与已批的 prod Environment |
 | **发版后 Anthropic OAuth 配置检查（snapshot → check）** | 机械 | `python3 ops/anthropic/manage-anthropic-config.py snapshot` + `check --snapshot`（canonical：`tokenkey-anthropic-oauth-config`） |
+| **发版后健康账号分组合理性检查（只读 advisory）** | 机械 | `bash ops/observability/check-account-group-bindings.sh --target prod`；从健康、可调度账号的显式 `model_mapping` 与 peer 分组证据派生，不硬编码模型→分组表；`review` / 探针失败均不阻塞 rollout |
 | rollout 摘要（git log / diff stat / sentinel / deletion） | 机械 | `bash scripts/release-rollout-summary.sh --mode release` |
 | prod approval 时机、smoke 模型回退 | 判断 | prompt（爆炸半径、用户入口顺序） |
 | post-release verdict + Summary | 机械 | `release_post_check.py evaluate --phase immediate|delayed` + `summary` + `gate`（Summary 显式显示缺失/无效证据与 baseline failure；gate 只接受 phase 匹配且 verdict=`green`，agent 禁止另评） |
@@ -73,6 +74,7 @@ description: Drive TokenKey Stage0 release, prod deploy, edge rollout, smoke, ro
    Workflow 步骤名与 Summary 标题必须对齐：`Check PR hooks immediately`、
    `Check traffic and 5xx after 5 minutes`、`### Traffic / 5xx (+5 min)`（含
    completed requests / top paths）。
+6. Prod smoke 后 advisory：`check-account-group-bindings.sh` 只读检查每个健康、可调度且有显式 `model_mapping` 的账号；无 active group 或与同模型 peer 分组完全不相交时输出 `review`，无 peer 的新模型只记 inconclusive。workflow 必须保持 `continue-on-error`。
 
 Hard rules：`simple_release` 默认 false；bump/tag 提交不得带 skip-ci 字面标记（见 `CLAUDE.md` §9）。
 
@@ -123,6 +125,7 @@ Hard rules：`simple_release` 默认 false；bump/tag 提交不得带 skip-ci �
 | 发版后 Anthropic `snapshot` SSM 失败 | 记 yellow；prod/Edge 镜像仍有效。补 OIDC/实例在线后重跑 snapshot+check，或 `snapshot --skip-prod` 仅 edge。 |
 | 发版后 Account model_mapping `check-accounts` 报 violation | **不要** rollback 镜像；审 `$JOBDIR/post-release-account-model-mapping-check.json` 的账号/group diff。期望与 forbidden policy 均来自 Go SSOT；确认要覆盖 live 配置时走 `/tokenkey-modelops-planner`：`sync-runtime` 先对单个显式 target 做 dry-run，批准后用 CLI 固定短语写入；账号持久层另走 `apply-accounts --confirm yes-apply-account-model-mapping`。 |
 | 发版后 Account model_mapping `check-accounts` SSM 失败 | 记 yellow；prod/Edge 镜像仍有效。补 OIDC/实例在线后重跑 `python3 ops/pricing/manage-account-model-mapping-runtime.py check-accounts --json`；仅排障 edge 时加 `--include-edges` 或 `--skip-prod`。 |
+| 发版后账号分组检查报 `review` | **不要** rollback。查看 `findings[].code`：`no_active_group` 先审 `candidate_groups`；`model_group_peer_mismatch` 比对同模型 peer 证据。该检查只建议、不写线上，也不把无 peer 的新模型当违规。 |
 
 ## 扩展阅读
 

--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -515,6 +515,20 @@ jobs:
             --expected-instance-id "$INSTANCE_ID" \
             --timeout-seconds 180
 
+      - name: Post-deploy account group binding check (read-only)
+        # ADVISORY ONLY: compare each healthy, schedulable account's explicit
+        # model_mapping with peer accounts' established active-group bindings.
+        # A review verdict or probe failure must never block the rollout.
+        continue-on-error: true  # preflight-allow: advisory post-release drift report
+        env:
+          INSTANCE_ID: ${{ steps.instance.outputs.id }}
+        run: |
+          set -euo pipefail
+          bash ops/observability/check-account-group-bindings.sh \
+            --target prod \
+            --expected-instance-id "$INSTANCE_ID" \
+            --timeout-seconds 180
+
       # Same deploy job: reuse the already-approved prod Environment + OIDC.
       # A second job with environment: prod would re-open Required reviewers
       # and start the +5min clock after that gate, not after cutover.

--- a/ops/observability/account_group_binding_check.py
+++ b/ops/observability/account_group_binding_check.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Evaluate healthy account group bindings from live model_mapping peer evidence.
+
+The checker deliberately does not own a model-to-group catalog. For each explicit
+client model, it derives the established groups from other healthy, schedulable
+accounts in the same snapshot. This keeps new models and operator-created groups
+out of a second hand-maintained policy table.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, TextIO
+
+
+SCHEMA_VERSION = 1
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _model_ids(account: dict[str, Any]) -> list[str]:
+    raw = account.get("model_ids")
+    if not isinstance(raw, list):
+        return []
+    return sorted({str(value).strip() for value in raw if str(value).strip()})
+
+
+def _bindings(account: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = account.get("groups")
+    if not isinstance(raw, list):
+        return []
+    result: list[dict[str, Any]] = []
+    seen: set[int] = set()
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        group_id = _positive_int(item.get("id"))
+        if group_id is None or group_id in seen:
+            continue
+        seen.add(group_id)
+        result.append(
+            {
+                "id": group_id,
+                "name": str(item.get("name") or ""),
+                "status": str(item.get("status") or ""),
+            }
+        )
+    return sorted(result, key=lambda item: item["id"])
+
+
+def evaluate_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
+    accounts_raw = snapshot.get("accounts")
+    groups_raw = snapshot.get("groups")
+    if not isinstance(accounts_raw, list) or not isinstance(groups_raw, list):
+        raise ValueError("snapshot must contain accounts and groups arrays")
+
+    group_names: dict[int, str] = {}
+    for item in groups_raw:
+        if not isinstance(item, dict):
+            continue
+        group_id = _positive_int(item.get("id"))
+        if group_id is not None and str(item.get("status") or "") == "active":
+            group_names[group_id] = str(item.get("name") or "")
+
+    accounts: list[dict[str, Any]] = []
+    skipped_ids: list[int] = []
+    for raw in accounts_raw:
+        if not isinstance(raw, dict):
+            continue
+        account_id = _positive_int(raw.get("id"))
+        if account_id is None:
+            continue
+        models = _model_ids(raw)
+        bindings = _bindings(raw)
+        active_group_ids = sorted(
+            {item["id"] for item in bindings if item["id"] in group_names}
+        )
+        account = {
+            "id": account_id,
+            "name": str(raw.get("name") or ""),
+            "platform": str(raw.get("platform") or ""),
+            "model_ids": models,
+            "active_group_ids": active_group_ids,
+            "inactive_groups": [
+                {"id": item["id"], "name": item["name"], "status": item["status"]}
+                for item in bindings
+                if item["id"] not in group_names
+            ],
+        }
+        if models:
+            accounts.append(account)
+        else:
+            skipped_ids.append(account_id)
+
+    model_group_accounts: dict[str, dict[int, set[int]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
+    for account in accounts:
+        for model_id in account["model_ids"]:
+            for group_id in account["active_group_ids"]:
+                model_group_accounts[model_id][group_id].add(account["id"])
+
+    findings: list[dict[str, Any]] = []
+    evaluated_ids: list[int] = []
+    inconclusive_model_count = 0
+
+    for account in sorted(accounts, key=lambda item: item["id"]):
+        evaluated_ids.append(account["id"])
+        active_group_ids = set(account["active_group_ids"])
+        candidate_models: dict[int, set[str]] = defaultdict(set)
+        candidate_peers: dict[int, set[int]] = defaultdict(set)
+        inconclusive_models: list[str] = []
+
+        for model_id in account["model_ids"]:
+            has_peer_group = False
+            for group_id, account_ids in sorted(model_group_accounts[model_id].items()):
+                peer_ids = sorted(account_ids - {account["id"]})
+                if not peer_ids:
+                    continue
+                has_peer_group = True
+                candidate_models[group_id].add(model_id)
+                candidate_peers[group_id].update(peer_ids)
+            if not has_peer_group:
+                inconclusive_models.append(model_id)
+
+        inconclusive_model_count += len(inconclusive_models)
+        candidates = [
+            {
+                "group_id": group_id,
+                "group_name": group_names.get(group_id, ""),
+                "matching_models": sorted(candidate_models[group_id]),
+                "peer_account_count": len(candidate_peers[group_id]),
+            }
+            for group_id in candidate_models
+        ]
+        candidates.sort(
+            key=lambda item: (
+                -len(item["matching_models"]),
+                -item["peer_account_count"],
+                item["group_id"],
+            )
+        )
+
+        base = {
+            "account_id": account["id"],
+            "account_name": account["name"],
+            "platform": account["platform"],
+            "active_groups": [
+                {"id": group_id, "name": group_names[group_id]}
+                for group_id in account["active_group_ids"]
+            ],
+            "model_ids": account["model_ids"],
+            "candidate_groups": candidates,
+        }
+
+        if not active_group_ids:
+            findings.append(
+                {
+                    **base,
+                    "code": "no_active_group",
+                    "inactive_groups": account["inactive_groups"],
+                }
+            )
+            continue
+
+        candidate_group_ids = set(candidate_models)
+        if candidate_group_ids and active_group_ids.isdisjoint(candidate_group_ids):
+            findings.append(
+                {**base, "code": "model_group_peer_mismatch"}
+            )
+
+    ungrouped_count = sum(
+        1 for finding in findings if finding["code"] == "no_active_group"
+    )
+    mismatch_count = sum(
+        1
+        for finding in findings
+        if finding["code"] == "model_group_peer_mismatch"
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "verdict": "review" if findings else "aligned",
+        "basis": "healthy_schedulable_explicit_model_mapping_peer_groups",
+        "summary": {
+            "healthy_schedulable_account_count": len(accounts_raw),
+            "explicit_mapping_account_count": len(accounts),
+            "skipped_no_explicit_mapping_count": len(skipped_ids),
+            "finding_account_count": len(findings),
+            "ungrouped_account_count": ungrouped_count,
+            "peer_mismatch_account_count": mismatch_count,
+            "inconclusive_model_count": inconclusive_model_count,
+        },
+        "coverage": {
+            "evaluated_account_ids": evaluated_ids,
+            "skipped_no_explicit_mapping_account_ids": sorted(skipped_ids),
+        },
+        "findings": findings,
+    }
+
+
+def _load_snapshot(path: str) -> dict[str, Any]:
+    if path == "-":
+        return json.load(sys.stdin)
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None, out: TextIO = sys.stdout) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--snapshot", required=True, help="snapshot JSON path or -")
+    args = parser.parse_args(argv)
+    try:
+        report = evaluate_snapshot(_load_snapshot(args.snapshot))
+    except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+        report = {"schema_version": SCHEMA_VERSION, "verdict": "setup_error", "error": str(exc)}
+        json.dump(report, out, ensure_ascii=False, separators=(",", ":"))
+        out.write("\n")
+        return 2
+    json.dump(report, out, ensure_ascii=False, separators=(",", ":"))
+    out.write("\n")
+    return 1 if report["verdict"] == "review" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/observability/check-account-group-bindings.sh
+++ b/ops/observability/check-account-group-bindings.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Run the prod account group-binding probe and preserve checker-style exit codes:
+# 0 aligned, 1 review, 2 setup/transport failure. The rollout caller is advisory.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TARGET="prod"
+EXPECTED_INSTANCE_ID=""
+TIMEOUT_SECONDS="180"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --target) TARGET="${2:-}"; shift 2 ;;
+    --expected-instance-id) EXPECTED_INSTANCE_ID="${2:-}"; shift 2 ;;
+    --timeout-seconds) TIMEOUT_SECONDS="${2:-}"; shift 2 ;;
+    -h|--help)
+      echo "usage: $0 [--target prod] [--expected-instance-id i-*] [--timeout-seconds 180]"
+      exit 0
+      ;;
+    *) echo "[check-account-group-bindings] unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPORT_FILE="$(mktemp /tmp/tk-account-group-bindings.XXXXXX)"
+trap 'rm -f "$REPORT_FILE"' EXIT
+RUN_PROBE="${ACCOUNT_GROUP_BINDING_RUN_PROBE:-$ROOT/ops/observability/run-probe.sh}"
+ARGS=(
+  --target "$TARGET"
+  --script "$ROOT/ops/observability/probe-account-group-bindings.sh"
+  --timeout-seconds "$TIMEOUT_SECONDS"
+)
+if [ -n "$EXPECTED_INSTANCE_ID" ]; then
+  ARGS+=(--expected-instance-id "$EXPECTED_INSTANCE_ID")
+fi
+
+set +e
+bash "$RUN_PROBE" "${ARGS[@]}" | tee "$REPORT_FILE"
+PROBE_RC=${PIPESTATUS[0]}
+set -e
+
+VERDICT="$(python3 - "$REPORT_FILE" <<'PY'
+import json
+import sys
+
+verdict = ""
+with open(sys.argv[1], encoding="utf-8") as handle:
+    for raw in handle:
+        try:
+            row = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(row, dict) and row.get("verdict"):
+            verdict = str(row["verdict"])
+print(verdict)
+PY
+)"
+
+case "$VERDICT" in
+  aligned)
+    [ "$PROBE_RC" -eq 0 ] || exit 2
+    exit 0
+    ;;
+  review) exit 1 ;;
+  setup_error) exit 2 ;;
+  *)
+    echo "[check-account-group-bindings] no valid verdict (probe rc=$PROBE_RC)" >&2
+    exit 2
+    ;;
+esac

--- a/ops/observability/probe-account-group-bindings.sh
+++ b/ops/observability/probe-account-group-bindings.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Read-only prod account model_mapping -> group-binding peer check.
+set -euo pipefail
+
+SNAPSHOT_SQL=$(cat <<'SQL'
+SELECT jsonb_build_object(
+  'accounts', COALESCE((
+    SELECT jsonb_agg(jsonb_build_object(
+      'id', a.id,
+      'name', a.name,
+      'platform', a.platform,
+      'model_ids', COALESCE((
+        SELECT jsonb_agg(model_id ORDER BY model_id)
+        FROM jsonb_object_keys(
+          CASE
+            WHEN jsonb_typeof(a.credentials->'model_mapping') = 'object'
+              THEN a.credentials->'model_mapping'
+            ELSE '{}'::jsonb
+          END
+        ) AS model_id
+      ), '[]'::jsonb),
+      'groups', COALESCE((
+        SELECT jsonb_agg(jsonb_build_object(
+          'id', g.id, 'name', g.name, 'status', g.status
+        ) ORDER BY g.id)
+        FROM account_groups ag
+        JOIN groups g ON g.id = ag.group_id AND g.deleted_at IS NULL
+        WHERE ag.account_id = a.id
+      ), '[]'::jsonb)
+    ) ORDER BY a.id)
+    FROM accounts a
+    WHERE a.deleted_at IS NULL
+      AND a.status = 'active'
+      AND a.schedulable = true
+      AND (a.temp_unschedulable_until IS NULL OR a.temp_unschedulable_until <= NOW())
+      AND (a.expires_at IS NULL OR a.expires_at > NOW() OR a.auto_pause_on_expired = false)
+      AND (a.overload_until IS NULL OR a.overload_until <= NOW())
+      AND (a.rate_limit_reset_at IS NULL OR a.rate_limit_reset_at <= NOW())
+  ), '[]'::jsonb),
+  'groups', COALESCE((
+    SELECT jsonb_agg(jsonb_build_object(
+      'id', g.id, 'name', g.name, 'status', g.status
+    ) ORDER BY g.id)
+    FROM groups g
+    WHERE g.deleted_at IS NULL AND g.status = 'active'
+  ), '[]'::jsonb)
+)::text;
+SQL
+)
+
+if ! SNAPSHOT="$(docker exec -i \
+    -e 'PGOPTIONS=-c default_transaction_read_only=on -c lock_timeout=100ms -c statement_timeout=10s' \
+    tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t -v ON_ERROR_STOP=1 \
+    -c "$SNAPSHOT_SQL")"; then
+  echo '{"verdict":"setup_error","error":"snapshot_query_failed"}'
+  exit 2
+fi
+
+printf '%s\n' "$SNAPSHOT" | python3 /tmp/account_group_binding_check.py --snapshot -

--- a/ops/observability/probe-contracts.json
+++ b/ops/observability/probe-contracts.json
@@ -87,6 +87,16 @@
       "setup_error"
     ]
   },
+  "probe-account-group-bindings.sh": {
+    "companions": [
+      "ops/observability/account_group_binding_check.py"
+    ],
+    "verdicts": [
+      "aligned",
+      "review",
+      "setup_error"
+    ]
+  },
   "probe_kiro_claude_models.sh": {
     "companions": [
       "ops/stage0/probe_account_model.sh",

--- a/ops/observability/test_account_group_binding_check.py
+++ b/ops/observability/test_account_group_binding_check.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+MODULE_PATH = HERE / "account_group_binding_check.py"
+SPEC = importlib.util.spec_from_file_location("account_group_binding_check", MODULE_PATH)
+assert SPEC and SPEC.loader
+MOD = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MOD
+SPEC.loader.exec_module(MOD)
+
+
+class AccountGroupBindingCheckTest(unittest.TestCase):
+    def group(self, group_id: int, name: str, status: str = "active") -> dict:
+        return {"id": group_id, "name": name, "status": status}
+
+    def account(
+        self,
+        account_id: int,
+        models: list[str],
+        groups: list[dict],
+        *,
+        platform: str = "newapi",
+    ) -> dict:
+        return {
+            "id": account_id,
+            "name": f"account-{account_id}",
+            "platform": platform,
+            "model_ids": models,
+            "groups": groups,
+        }
+
+    def evaluate(self, accounts: list[dict], groups: list[dict] | None = None) -> dict:
+        return MOD.evaluate_snapshot(
+            {"accounts": accounts, "groups": groups or [self.group(1, "claude"), self.group(2, "other")]}
+        )
+
+    def test_shared_model_and_group_is_aligned(self) -> None:
+        report = self.evaluate(
+            [
+                self.account(1, ["claude-opus"], [self.group(1, "claude")]),
+                self.account(2, ["claude-opus"], [self.group(1, "claude")]),
+            ]
+        )
+
+        self.assertEqual(report["verdict"], "aligned")
+        self.assertEqual(report["findings"], [])
+        self.assertEqual(report["summary"]["explicit_mapping_account_count"], 2)
+
+    def test_ungrouped_account_reports_ranked_peer_candidates(self) -> None:
+        report = self.evaluate(
+            [
+                self.account(10, ["claude-opus", "claude-sonnet"], []),
+                self.account(11, ["claude-opus", "claude-sonnet"], [self.group(1, "claude")]),
+                self.account(12, ["claude-opus"], [self.group(2, "other")]),
+            ]
+        )
+
+        self.assertEqual(report["verdict"], "review")
+        finding = next(item for item in report["findings"] if item["account_id"] == 10)
+        self.assertEqual(finding["code"], "no_active_group")
+        self.assertEqual(finding["candidate_groups"][0]["group_id"], 1)
+        self.assertEqual(
+            finding["candidate_groups"][0]["matching_models"],
+            ["claude-opus", "claude-sonnet"],
+        )
+
+    def test_disjoint_binding_reports_ranked_peer_evidence(self) -> None:
+        report = self.evaluate(
+            [
+                self.account(20, ["claude-opus"], [self.group(2, "other")]),
+                self.account(21, ["claude-opus"], [self.group(1, "claude")]),
+            ]
+        )
+
+        finding = next(item for item in report["findings"] if item["account_id"] == 20)
+        self.assertEqual(finding["code"], "model_group_peer_mismatch")
+        self.assertEqual(finding["candidate_groups"][0]["group_id"], 1)
+
+    def test_one_peer_group_overlap_allows_intentional_model_subset(self) -> None:
+        report = self.evaluate(
+            [
+                self.account(25, ["claude-opus", "gpt-model"], [self.group(1, "claude")]),
+                self.account(26, ["claude-opus"], [self.group(1, "claude")]),
+                self.account(27, ["gpt-model"], [self.group(2, "other")]),
+                self.account(28, ["gpt-model"], [self.group(2, "other")]),
+            ]
+        )
+
+        self.assertEqual(report["verdict"], "aligned")
+        self.assertEqual(report["findings"], [])
+
+    def test_account_never_self_certifies_its_group(self) -> None:
+        report = self.evaluate(
+            [self.account(30, ["brand-new-model"], [self.group(2, "other")])]
+        )
+
+        self.assertEqual(report["verdict"], "aligned")
+        self.assertEqual(report["summary"]["inconclusive_model_count"], 1)
+        self.assertEqual(report["findings"], [])
+
+    def test_empty_mapping_is_accounted_for_but_not_compared(self) -> None:
+        report = self.evaluate(
+            [
+                self.account(40, [], []),
+                self.account(41, ["mapped"], [self.group(1, "claude")]),
+            ]
+        )
+
+        self.assertEqual(report["coverage"]["evaluated_account_ids"], [41])
+        self.assertEqual(report["coverage"]["skipped_no_explicit_mapping_account_ids"], [40])
+        self.assertEqual(report["summary"]["skipped_no_explicit_mapping_count"], 1)
+
+    def test_inactive_binding_counts_as_no_active_group(self) -> None:
+        inactive = self.group(9, "retired", "inactive")
+        report = self.evaluate(
+            [self.account(50, ["mapped"], [inactive])],
+            groups=[self.group(1, "claude"), inactive],
+        )
+
+        self.assertEqual(report["verdict"], "review")
+        self.assertEqual(report["findings"][0]["code"], "no_active_group")
+        self.assertEqual(report["findings"][0]["inactive_groups"][0]["id"], 9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/observability/test_check_account_group_bindings.py
+++ b/ops/observability/test_check_account_group_bindings.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parent / "check-account-group-bindings.sh"
+
+
+class CheckAccountGroupBindingsWrapperTest(unittest.TestCase):
+    def run_case(self, verdict: str | None, remote_rc: int) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            fake = Path(directory) / "run-probe.sh"
+            payload = "" if verdict is None else json.dumps({"verdict": verdict})
+            fake.write_text(
+                "#!/usr/bin/env bash\n"
+                + (f"printf '%s\\n' '{payload}'\n" if payload else "")
+                + f"exit {remote_rc}\n",
+                encoding="utf-8",
+            )
+            fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
+            env = os.environ.copy()
+            env["ACCOUNT_GROUP_BINDING_RUN_PROBE"] = str(fake)
+            return subprocess.run(
+                ["bash", str(SCRIPT)], capture_output=True, text=True, check=False, env=env
+            )
+
+    def test_aligned_is_success(self) -> None:
+        proc = self.run_case("aligned", 0)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    def test_review_is_checker_failure_for_advisory_caller(self) -> None:
+        proc = self.run_case("review", 3)
+        self.assertEqual(proc.returncode, 1, proc.stderr)
+
+    def test_setup_or_transport_failure_is_distinct(self) -> None:
+        self.assertEqual(self.run_case("setup_error", 3).returncode, 2)
+        self.assertEqual(self.run_case(None, 2).returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/stage0/test_deploy_stage0_workflow.py
+++ b/ops/stage0/test_deploy_stage0_workflow.py
@@ -118,12 +118,16 @@ class DeployStage0WorkflowTest(unittest.TestCase):
         supplier_projection = deploy.index(
             "name: Post-deploy supplier projection check (read-only)"
         )
+        account_group_binding = deploy.index(
+            "name: Post-deploy account group binding check (read-only)"
+        )
         post_release_immediate = deploy.index("name: Check PR hooks immediately")
         post_release_delayed = deploy.index("name: Check traffic and 5xx after 5 minutes")
         post_release_gate = deploy.index("name: Enforce post-release verdicts")
         self.assertLess(smoke, post_release)
         self.assertLess(smoke, supplier_projection)
-        self.assertLess(supplier_projection, post_release)
+        self.assertLess(supplier_projection, account_group_binding)
+        self.assertLess(account_group_binding, post_release)
         self.assertLess(post_release, post_release_immediate)
         self.assertLess(post_release_immediate, post_release_delayed)
         self.assertLess(post_release_delayed, post_release_gate)
@@ -133,6 +137,10 @@ class DeployStage0WorkflowTest(unittest.TestCase):
         self.assertIn("continue-on-error: true", supplier_block)
         self.assertIn("check-supplier-projection.sh", supplier_block)
         self.assertIn('--expected-instance-id "$INSTANCE_ID"', supplier_block)
+        account_group_block = deploy[account_group_binding:post_release]
+        self.assertIn("continue-on-error: true", account_group_block)
+        self.assertIn("check-account-group-bindings.sh", account_group_block)
+        self.assertIn('--expected-instance-id "$INSTANCE_ID"', account_group_block)
         block = deploy[baseline:image_mutation]
         self.assertIn("resolve-prod-running-tag-via-ssm.sh", block)
         self.assertIn('INSTANCE_ID: ${{ steps.instance.outputs.id }}', block)

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1008,6 +1008,24 @@ else
     echo "  ok: supplier projection post-release check tests"
 fi
 
+# ---- sub2api: account group-binding post-release check ---------------------
+# The advisory rollout check derives group evidence from live healthy peers;
+# keep its no-self-certification, no-mapping accounting and wrapper exit codes tested.
+echo ""
+echo "=== sub2api: account group-binding post-release check ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required for account group-binding check tests)"
+    errors=$((errors + 1))
+elif ! python3 -m unittest \
+    ops.observability.test_account_group_binding_check \
+    ops.observability.test_check_account_group_bindings >/dev/null 2>&1; then
+    echo "  FAIL: account group-binding post-release check tests"
+    echo "        - run: python3 -m unittest ops.observability.test_account_group_binding_check ops.observability.test_check_account_group_bindings"
+    errors=$((errors + 1))
+else
+    echo "  ok: account group-binding post-release check tests"
+fi
+
 # ---- sub2api: generated model-surface bundle drift -------------------------
 # Rollout consumes the generated bundle without compiling Go. Keep the checked-in
 # artifact byte-identical to the Go owner so it cannot become a second hand-edited

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -8228,6 +8228,61 @@
       "rationale": "Behavior regressions pin runtime-state exclusion, credential redaction, structural drift, and the media-only capability lifecycle for the post-release checker."
     },
     {
+      "path": "ops/observability/account_group_binding_check.py",
+      "must_contain": [
+        "def evaluate_snapshot(snapshot: dict[str, Any])",
+        "account_ids - {account[\"id\"]}",
+        "healthy_schedulable_explicit_model_mapping_peer_groups",
+        "model_group_peer_mismatch",
+        "\"verdict\": \"review\" if findings else \"aligned\""
+      ],
+      "rationale": "Pure advisory evaluator for account group bindings. It derives candidate groups from other healthy accounts carrying the same explicit model_mapping key, prevents an account from self-certifying its own binding, and keeps new no-peer models inconclusive instead of inventing a second model-to-group policy table."
+    },
+    {
+      "path": "ops/observability/probe-account-group-bindings.sh",
+      "must_contain": [
+        "default_transaction_read_only=on",
+        "a.status = 'active'",
+        "a.schedulable = true",
+        "a.temp_unschedulable_until IS NULL OR a.temp_unschedulable_until <= NOW()",
+        "a.rate_limit_reset_at IS NULL OR a.rate_limit_reset_at <= NOW()",
+        "python3 /tmp/account_group_binding_check.py --snapshot -"
+      ],
+      "rationale": "Remote prod snapshot owner for the group-binding advisory. The SQL mirrors scheduler health gates, returns only account identity, model_mapping keys and group metadata, and runs under a read-only PostgreSQL transaction."
+    },
+    {
+      "path": "ops/observability/check-account-group-bindings.sh",
+      "must_contain": [
+        "0 aligned, 1 review, 2 setup/transport failure",
+        "--script \"$ROOT/ops/observability/probe-account-group-bindings.sh\"",
+        "review) exit 1",
+        "setup_error) exit 2"
+      ],
+      "rationale": "Local rollout entrypoint preserves stable advisory checker semantics while run-probe transports the read-only SQL and pure evaluator to the exact deployed prod instance."
+    },
+    {
+      "path": "ops/observability/test_account_group_binding_check.py",
+      "must_contain": [
+        "test_shared_model_and_group_is_aligned",
+        "test_ungrouped_account_reports_ranked_peer_candidates",
+        "test_disjoint_binding_reports_ranked_peer_evidence",
+        "test_one_peer_group_overlap_allows_intentional_model_subset",
+        "test_account_never_self_certifies_its_group",
+        "test_empty_mapping_is_accounted_for_but_not_compared",
+        "test_inactive_binding_counts_as_no_active_group"
+      ],
+      "rationale": "Behavior tests pin aligned, ungrouped, mismatched, no-peer, no-mapping and inactive-group outcomes without duplicating a production model or group catalog."
+    },
+    {
+      "path": "ops/observability/test_check_account_group_bindings.py",
+      "must_contain": [
+        "test_aligned_is_success",
+        "test_review_is_checker_failure_for_advisory_caller",
+        "test_setup_or_transport_failure_is_distinct"
+      ],
+      "rationale": "Wrapper tests keep review distinct from transport/setup failure so the workflow can surface both while remaining explicitly non-blocking."
+    },
+    {
       "path": ".github/workflows/deploy-stage0.yml",
       "must_contain": [
         "name: Post-deploy supplier projection check (read-only)",
@@ -8235,6 +8290,16 @@
         "--expected-instance-id \"$INSTANCE_ID\""
       ],
       "rationale": "The supplier projection audit runs automatically after the prod smoke/display gates as an advisory post-release check against the exact deployed instance."
+    },
+    {
+      "path": ".github/workflows/deploy-stage0.yml",
+      "must_contain": [
+        "name: Post-deploy account group binding check (read-only)",
+        "continue-on-error: true  # preflight-allow: advisory post-release drift report",
+        "bash ops/observability/check-account-group-bindings.sh",
+        "--expected-instance-id \"$INSTANCE_ID\""
+      ],
+      "rationale": "Every prod deploy runs the healthy-account model_mapping peer audit after smoke. The step is bound to the exact deployed instance and remains advisory for review findings and probe failures."
     },
     {
       "path": "backend/internal/service/supplier_source_account_store.go",


### PR DESCRIPTION
## 摘要

- 在 prod rollout 完成 smoke 后，自动执行健康、可调度账号的 group 绑定检查。
- 从账号显式 `model_mapping` 与其他健康账号的同模型绑定推导 peer baseline，不维护第二份模型到分组映射。
- 对无 active group 或与 peer 候选组完全不相交的账号输出 `review`；无 peer 的新模型记为 `inconclusive`。
- workflow 保持 `continue-on-error: true`，检查仅提供建议，不阻塞 rollout，也不写线上。

## 风险

- 常规风险：新增 post-release advisory 步骤，不改变网关调度、账号配置或数据库状态。
- 快照 SQL 通过 `default_transaction_read_only=on` 强制只读，并绑定本次部署解析出的 prod instance ID。
- peer baseline 无法判断全新模型，因此选择显式暴露覆盖缺口，不将其误报为违规。
- no-web-impact：仅涉及 ops 检查、workflow 接线和契约测试，无 Web 行为变化。

## 验证

- `PATH=/opt/homebrew/opt/go/libexec/bin:$PATH ./scripts/preflight.sh`：PASS。
- `python3 -m unittest ops.observability.test_account_group_binding_check ops.observability.test_check_account_group_bindings ops.stage0.test_deploy_stage0_workflow`：29 项通过。
- prod 只读实测：34 个健康可调度账号，0 个缺分组，0 个 peer mismatch，`verdict=aligned`。
- `git diff --check origin/main...HEAD`：PASS。

## 提交

- `703502ed0 feat(ops): audit account group bindings after prod rollout`

最新提交：`703502ed0`