### PR TITLE
feat(ops): probe_account_model 支持 ENDPOINT=speech

### DIFF
--- a/ops/stage0/probe_account_model.sh
+++ b/ops/stage0/probe_account_model.sh
@@ -125,8 +125,8 @@ if [[ ! "$PROBE_LOCK_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] || [[ "$PROBE_LOCK_TIMEOUT_
   fail_json "PROBE_LOCK_TIMEOUT_SECONDS must be a positive integer"
 fi
 case "$ENDPOINT" in
-  messages|count_tokens|chat|responses|embeddings|images) ;;
-  *) fail_json "ENDPOINT must be messages, count_tokens, chat, responses, embeddings, or images" ;;
+  messages|count_tokens|chat|responses|embeddings|images|speech) ;;
+  *) fail_json "ENDPOINT must be messages, count_tokens, chat, responses, embeddings, images, or speech" ;;
 esac
 
 PROBE_ID="tkprobe-${ACCOUNT_ID}-$(date -u +%Y%m%dT%H%M%SZ)-$$"
@@ -309,6 +309,14 @@ elif endpoint == "images":
         "n": 1,
         "size": "1024x1024",
     }
+elif endpoint == "speech":
+    # OpenAI-compat TTS; Ali Token Plan SpeechSynthesizer path.
+    payload = {
+        "model": model,
+        "input": prompt or "你好",
+        "voice": "longanlingxin",
+        "response_format": "mp3",
+    }
 elif endpoint == "messages":
     payload = {
         "model": model,
@@ -353,6 +361,7 @@ case "$ENDPOINT" in
   embeddings) PATH_SUFFIX="/v1/embeddings"; AUTH_HEADER_NAME="Authorization";;
   responses) PATH_SUFFIX="/v1/responses"; AUTH_HEADER_NAME="Authorization";;
   images) PATH_SUFFIX="/v1/images/generations"; AUTH_HEADER_NAME="Authorization";;
+  speech) PATH_SUFFIX="/v1/audio/speech"; AUTH_HEADER_NAME="Authorization";;
 esac
 
 # Direct probe groups default allow_image_generation=false; image endpoints need it on.

--- a/ops/stage0/test_probe_account_model.py
+++ b/ops/stage0/test_probe_account_model.py
@@ -97,10 +97,16 @@ class ProbeAccountModelTest(unittest.TestCase):
     def test_probe_script_wires_verdict_module_and_embeddings_endpoint(self) -> None:
         script = _SCRIPT.read_text()
 
-        self.assertIn("messages|count_tokens|chat|responses|embeddings", script)
+        self.assertIn(
+            "messages|count_tokens|chat|responses|embeddings|images|speech",
+            script,
+        )
         self.assertIn('elif endpoint == "embeddings":', script)
         self.assertIn('"input": prompt', script)
         self.assertIn('embeddings) PATH_SUFFIX="/v1/embeddings"', script)
+        self.assertIn('elif endpoint == "speech":', script)
+        self.assertIn('"voice": "longanlingxin"', script)
+        self.assertIn('speech) PATH_SUFFIX="/v1/audio/speech"', script)
         self.assertIn("PROBE_SCRIPT_DIR", script)
         self.assertIn("from probe_account_model_verdict import classify_probe_verdict", script)
         self.assertIn("probe_account_model_verdict.py", script)


### PR DESCRIPTION
## 摘要
- 为 `ops/stage0/probe_account_model.sh` 增加 `ENDPOINT=speech`，打 `POST /v1/audio/speech`（OpenAI-compat TTS）。
- 默认 payload：`input`/`voice=longanlingxin`/`response_format=mp3`，用于 Ali Token Plan TTS 网关归因探针。
- 补 `test_probe_account_model.py` speech 接线回归断言（与 embeddings 同级）。

## 风险
- 低：仅 ops 探针脚本与其回归测试；无公共 API / schema / 鉴权变更。
- Web impact: none

## 验证
- `python3 -m unittest ops.stage0.test_probe_account_model` 全绿。
- 本地 `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh` PASS。
- prod 已用 speech 路径实测：`ACCOUNT_ID=129` `MODEL=qwen-audio-3.0-tts-plus` → `verdict=servable`，usage 归因 `#129`，`total_cost` 非 0。

## 提交
- `168ae5264` feat(ops): probe_account_model 支持 ENDPOINT=speech
- `23cf9f7ce` fix(ops): 为 ENDPOINT=speech 补探针接线回归断言
- 最新提交：`23cf9f7ce`