### PR TITLE
docs(openrouter): 多模态 seller 口径 + catalog 驱动探针

### DIFF
--- a/docs/agent_integration.md
+++ b/docs/agent_integration.md
@@ -1096,7 +1096,11 @@ after a terminal status (`succeeded` / `failed`) return 404.
 
 ## OpenRouter provider seller surface (TokenKey)
 
-TokenKey may expose a seller catalog for OpenRouter onboarding:
+TokenKey may expose a seller catalog for OpenRouter onboarding.
+Product goal is **multimodal** (chat + image + video when supply allows).
+`catalog_excluded_model_ids` only hides currently unservable / unstable /
+protocol-missing models — it is not a permanent text-only policy.
+Live `GET /openrouter/v1/models` is the offer surface.
 
 - `GET /openrouter/v1/models` — any API key owned by `billing_user_id`;
   returns OpenRouter provider **schema 2.4** documents with `tokenkey/<model>`
@@ -1105,10 +1109,12 @@ TokenKey may expose a seller catalog for OpenRouter onboarding:
   (`billing_user_id`, exclude/stream lists). Supply groups are the billing
   user's `user_allowed_groups`. Customer gateway paths outside this seller
   surface are unchanged.
-- Allowlisted OR/monitor keys also receive the same catalog from
-  `GET /v1/models`.
-- Inference keys accept catalog ids on `POST /v1/chat/completions`; TokenKey
+- The same catalog is also returned on `GET /v1/models` for any API key
+  owned by that billing user (no separate monitor/inference key split).
+- Seller keys accept catalog ids on `POST /v1/chat/completions`; TokenKey
   rewrites `tokenkey/<model>` back to internal scheduling ids before routing.
+  Image/video use `/openrouter/v1/images` and `/openrouter/v1/videos` when
+  those modalities appear in the catalog.
 - **Scheme C loop guard**: public groups (`is_exclusive=false`) must not
   bind aggregator upstream accounts (`channel_type` 20/49/53 or
   `openrouter.ai` base URLs). ct20 OpenRouter upstream stays on

--- a/ops/pricing/openrouter-provider-onboarding.md
+++ b/ops/pricing/openrouter-provider-onboarding.md
@@ -2,15 +2,26 @@
 
 Ops checklist for [OpenRouter provider application](https://openrouter.ai/providers/apply/form) and [provider integration docs](https://openrouter.ai/docs/guides/community/for-providers).
 
+## Product posture
+
+**Goal: multimodal seller** (text chat + image + video when supply is ready).  
+`catalog_excluded_model_ids` is **not** a permanent “text-only” switch — it only hides models that are currently unservable (no healthy pool), unstable, or lacking a seller protocol (e.g. realtime audio has no OR audio surface yet).
+
+**Source of truth for what we offer right now:** `GET /openrouter/v1/models` (and the billing-user alias `GET /v1/models`). Probes and the application form must follow that catalog: if a modality row is absent, treat media inference checks as N/A, not as a hard failure.
+
 ## API endpoints (paste into application form)
 
-| Surface | URL |
-| --- | --- |
-| Models catalog | `https://api.tokenkey.dev/openrouter/v1/models` |
-| Alias models catalog | `https://api.tokenkey.dev/v1/models` (same payload for billing-user seller keys) |
-| Chat inference | `https://api.tokenkey.dev/v1/chat/completions` |
-| Image inference | `https://api.tokenkey.dev/openrouter/v1/images` |
-| Video inference | `https://api.tokenkey.dev/openrouter/v1/videos` (submit + poll `/openrouter/v1/videos/{id}`) |
+Always list catalog + chat. List image/video endpoints as **available protocol surfaces**; which models appear there is determined by the live catalog (rows with output modality `image` / `video`).
+
+| Surface | URL | Notes for the form |
+| --- | --- | --- |
+| Models catalog | `https://api.tokenkey.dev/openrouter/v1/models` | Required; schema 2.4 |
+| Alias models catalog | `https://api.tokenkey.dev/v1/models` | Same payload for billing-user seller keys |
+| Chat inference | `https://api.tokenkey.dev/v1/chat/completions` | Required; public ids `tokenkey/<model>` |
+| Image inference | `https://api.tokenkey.dev/openrouter/v1/images` | Protocol ready; models only if catalog lists `output` image |
+| Video inference | `https://api.tokenkey.dev/openrouter/v1/videos` (+ poll `/openrouter/v1/videos/{id}`) | Protocol ready; models only if catalog lists `output` video |
+
+Do **not** claim audio seller endpoints until an OR audio route exists. Audio-capable internal models stay in `catalog_excluded_model_ids` until then.
 
 Catalog + inference auth: any API key owned by `billing_user_id` (ops bootstrap label: `openrouter`). No separate monitor/inference key split. Ops hygiene: `hygiene-keys` ensures one `openrouter` key and disables legacy `openrouter-inference` / `openrouter-monitor` names.
 
@@ -27,7 +38,7 @@ That example tracks **policy fields** (`billing_user_id`, exclude/stream lists, 
 
 Change OR supply surface by editing user 32’s allowed groups only.
 
-Image / video models that the current seller groups cannot serve are listed in `catalog_excluded_model_ids` (text-only seller catalog for now).
+When a model becomes stably servable under those groups, **remove it from** `catalog_excluded_model_ids` (re-include). Keep excludes only for dead/unstable chat, missing supply, or modalities without a seller protocol.
 
 ```bash
 python3 ops/pricing/manage-openrouter-provider-config.py snapshot
@@ -58,7 +69,13 @@ Required fields in settings:
 
 ## Validation
 
+Probes follow the **live catalog**: media inference is exercised only when
+catalog rows exist for that modality; otherwise picks are N/A (not failures).
+Serial smoke must pass for every currently listed catalog row before claiming
+seller readiness for that surface.
+
 ```bash
+python3 -m unittest ops.pricing.test_probe_openrouter_provider_chain
 python3 ops/pricing/probe-openrouter-provider-chain.py --via-ssm --full-catalog
 python3 ops/pricing/probe-openrouter-provider-inference-serial.py --via-ssm
 TK_OR_PROVIDER_KEY=sk-or-seller python3 ops/pricing/export-openrouter-provider-models.py

--- a/ops/pricing/probe-openrouter-provider-chain.py
+++ b/ops/pricing/probe-openrouter-provider-chain.py
@@ -167,8 +167,33 @@ def validate_catalog(payload: dict, report: Report, sample_limit: int = 0) -> li
     return data
 
 
+def catalog_output_modality_counts(catalog: list[dict]) -> dict[str, int]:
+    """Count models by presence of non-text output modalities (and text-only)."""
+    counts = {"text_only": 0, "image": 0, "video": 0, "audio": 0, "other": 0}
+    for m in catalog:
+        if not isinstance(m, dict):
+            continue
+        outs = modality_types(m.get("output_modalities"))
+        if outs == {"text"} or outs == set():
+            counts["text_only"] += 1
+        elif "video" in outs:
+            counts["video"] += 1
+        elif "image" in outs:
+            counts["image"] += 1
+        elif "audio" in outs or "speech" in outs or "transcription" in outs:
+            counts["audio"] += 1
+        else:
+            counts["other"] += 1
+    return counts
+
+
 def pick_models(catalog: list[dict]) -> dict[str, str | None]:
-    out: dict[str, str | None] = {"chat": None, "image": None, "imagen": None, "video": None}
+    """Pick one sample per modality family present in the live catalog.
+
+    Absence is not a failure — probes must follow the catalog (multimodal when
+    listed; N/A when excluded / not offered).
+    """
+    out: dict[str, str | None] = {"chat": None, "image": None, "imagen": None, "video": None, "audio": None}
     for m in catalog:
         mid = m.get("id", "")
         outs = modality_types(m.get("output_modalities"))
@@ -182,12 +207,28 @@ def pick_models(catalog: list[dict]) -> dict[str, str | None]:
             out["imagen"] = mid
         if out["video"] is None and "video" in outs:
             out["video"] = mid
+        if out["audio"] is None and (("audio" in outs) or ("speech" in outs) or ("transcription" in outs)):
+            out["audio"] = mid
     if out["chat"] is None:
         for m in catalog:
             if modality_types(m.get("output_modalities")) == {"text"}:
                 out["chat"] = m.get("id")
                 break
+    # Prefer any image row if gemini/imagen-specific picks missed a generic image model.
+    if out["image"] is None and out["imagen"] is None:
+        for m in catalog:
+            if "image" in modality_types(m.get("output_modalities")):
+                out["image"] = m.get("id")
+                break
     return out
+
+
+def add_catalog_pick(report: Report, name: str, value: str | None) -> None:
+    """Pass when present; N/A (still ok) when catalog has no row for that family."""
+    if value:
+        report.add(name, True, value)
+    else:
+        report.add(name, True, "N/A: none in catalog")
 
 
 def run_probe(base_url: str, api_key: str, full_catalog: bool) -> Report:
@@ -216,24 +257,20 @@ def run_probe(base_url: str, api_key: str, full_catalog: bool) -> Report:
         overlap = len(or_ids & alias_ids)
         report.add("catalog.alias_overlap", overlap >= min(len(or_ids), 1), f"overlap={overlap} or={len(or_ids)} alias={len(alias_ids)}")
 
+    modality_counts = catalog_output_modality_counts(catalog)
+    report.add(
+        "catalog.modality_summary",
+        True,
+        json.dumps(modality_counts, sort_keys=True),
+    )
+
     picks = pick_models(catalog)
     report.add("pick.chat_model", picks["chat"] is not None, picks["chat"] or "")
-    # Media rows may be intentionally catalog_excluded (text-only seller surface).
-    report.add(
-        "pick.gemini_image",
-        True,
-        picks["image"] or "skipped: none in catalog",
-    )
-    report.add(
-        "pick.imagen_image",
-        True,
-        picks["imagen"] or "skipped: none in catalog",
-    )
-    report.add(
-        "pick.video_model",
-        True,
-        picks["video"] or "skipped: none in catalog",
-    )
+    # Follow the live catalog: infer media only when rows exist; otherwise N/A.
+    add_catalog_pick(report, "pick.gemini_image", picks["image"])
+    add_catalog_pick(report, "pick.imagen_image", picks["imagen"])
+    add_catalog_pick(report, "pick.video_model", picks["video"])
+    add_catalog_pick(report, "pick.audio_model", picks["audio"])
 
     # Chat inference with public id
     if picks["chat"]:

--- a/ops/pricing/probe-openrouter-provider-inference-serial.py
+++ b/ops/pricing/probe-openrouter-provider-inference-serial.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Serial inference smoke for every model in the OpenRouter provider catalog.
 
-Routes each catalog row to chat / image / video based on output_modalities.
-Honors openrouter.stream_required metadata (GLM stream-only models).
+Routes each catalog row to chat / image / video based on output_modalities
+(follow the live catalog — multimodal when listed, skip families absent from
+catalog). Honors openrouter.stream_required metadata (GLM stream-only models).
 
     python3 ops/pricing/probe-openrouter-provider-inference-serial.py --via-ssm
     python3 ops/pricing/probe-openrouter-provider-inference-serial.py --via-ssm --sleep 1.5

--- a/ops/pricing/test_probe_openrouter_provider_chain.py
+++ b/ops/pricing/test_probe_openrouter_provider_chain.py
@@ -1,0 +1,81 @@
+"""Unit tests for OpenRouter chain probe catalog-driven picks (no live network)."""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+
+_SCRIPT = pathlib.Path(__file__).resolve().parent / "probe-openrouter-provider-chain.py"
+
+
+def _load():
+    import sys
+
+    name = "or_chain_probe_under_test"
+    spec = importlib.util.spec_from_file_location(name, _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class CatalogDrivenPicksTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.mod = _load()
+
+    def test_text_only_catalog_media_picks_are_none(self) -> None:
+        catalog = [
+            {
+                "id": "tokenkey/deepseek-v4-flash",
+                "input_modalities": [{"type": "text"}],
+                "output_modalities": [{"type": "text"}],
+            }
+        ]
+        picks = self.mod.pick_models(catalog)
+        self.assertEqual(picks["chat"], "tokenkey/deepseek-v4-flash")
+        self.assertIsNone(picks["image"])
+        self.assertIsNone(picks["imagen"])
+        self.assertIsNone(picks["video"])
+        self.assertIsNone(picks["audio"])
+        counts = self.mod.catalog_output_modality_counts(catalog)
+        self.assertEqual(counts["text_only"], 1)
+        self.assertEqual(counts["image"], 0)
+
+    def test_image_and_video_rows_are_picked(self) -> None:
+        catalog = [
+            {
+                "id": "tokenkey/chat",
+                "input_modalities": [{"type": "text"}],
+                "output_modalities": [{"type": "text"}],
+            },
+            {
+                "id": "tokenkey/gemini-3.1-flash-image",
+                "input_modalities": [{"type": "text"}],
+                "output_modalities": [{"type": "image"}],
+            },
+            {
+                "id": "tokenkey/seedance-video",
+                "input_modalities": [{"type": "text"}],
+                "output_modalities": [{"type": "video"}],
+            },
+        ]
+        picks = self.mod.pick_models(catalog)
+        self.assertEqual(picks["image"], "tokenkey/gemini-3.1-flash-image")
+        self.assertEqual(picks["video"], "tokenkey/seedance-video")
+        counts = self.mod.catalog_output_modality_counts(catalog)
+        self.assertEqual(counts["image"], 1)
+        self.assertEqual(counts["video"], 1)
+
+    def test_add_catalog_pick_marks_na_without_failing(self) -> None:
+        report = self.mod.Report()
+        self.mod.add_catalog_pick(report, "pick.video_model", None)
+        self.mod.add_catalog_pick(report, "pick.gemini_image", "tokenkey/x")
+        self.assertTrue(report.passed)
+        self.assertEqual(report.checks[0].detail, "N/A: none in catalog")
+        self.assertEqual(report.checks[1].detail, "tokenkey/x")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要
- 文档明确 OR seller **目标为多模态**；`catalog_excluded` 仅表示临时不可供应，不是永久 text-only
- 链探针按 live catalog：无图/视频/音频行时 `pick.*` 记 N/A（不假红）；补 modality summary 与单测
- 申请表/onboarding 端点与 catalog SSOT 对齐；去掉过时 monitor key 措辞
- 已 rebase 到当前 `origin/main`（修 main-ancestry-guard）

## 风险
低。文档 + ops 探针/单测；无网关行为变更（`no-web-impact`）。

## 验证
- `python3 -m unittest ops.pricing.test_probe_openrouter_provider_chain`（3 OK）
- `probe-openrouter-provider-chain.py --via-ssm` PASS（媒体 N/A）
- `probe-openrouter-provider-inference-serial.py --via-ssm` **76/76 OK**
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh` PASS

## 提交
- 2d0f54254 docs(openrouter): multimodal seller posture + catalog-driven probes (no-web-impact)
- 最新提交：2d0f54254