### PR TITLE
fix(admin): 编辑账号前保全协议端点身份

### DIFF
--- a/.testing/user-stories/stories/US-048-model-supplier-source-management.md
+++ b/.testing/user-stories/stories/US-048-model-supplier-source-management.md
@@ -98,6 +98,10 @@
 - `backend/internal/service/supplier_managed_account_guard_test.go`::`TestUS048_ManagedAccountDuplicateStripsSupplierIdentity`
 - `backend/internal/service/supplier_managed_account_guard_test.go`::`TestUS048_UnmanagedAccountCannotForgeSupplierManagedExtra`
 - `backend/internal/service/supplier_managed_account_guard_test.go`::`TestUS048_PreserveSupplierManagedExtraKeys`
+- `backend/internal/service/admin_service_credentials_merge_test.go`::`TestUpdateAccount_RejectsMissingProtocolEndpointBeforePersist`
+- `backend/internal/service/admin_service_credentials_merge_test.go`::`TestUpdateAccount_RejectsTypeChangeWithoutProtocolEndpointBeforePersist`
+- `backend/internal/service/admin_service_credentials_merge_test.go`::`TestUpdateAccount_RejectsIncompleteCustomProtocolEndpointBeforePersist`
+- `backend/internal/handler/admin/account_handler_mixed_channel_test.go`::`TestAccountHandlerUpdateReturnsBadRequestForMissingProtocolEndpointIdentity`
 - `backend/internal/service/crs_sync_supplier_managed_test.go`::`TestUS048_CRSSyncAllowsSupplierManagedAccountOverwrite`
 - `backend/internal/service/crs_sync_supplier_managed_test.go`::`TestUS048_CRSSyncRejectsReservedSupplierExtraOnNewAccount`
 - `backend/internal/service/supplier_source_probe_test.go`::`TestUS048_SupplierModelMatchKeyNormalizesCaseAndSpaces`
@@ -153,6 +157,9 @@
 - `frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts`::`selects the supplier source requested by source_id after loading the list`
 - `frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts`::`shows the supplier-managed badge and treats managed rows like ordinary accounts`
 - `frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts`::`opens the account modal for supplier-managed rows`
+- `frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts`::`loads canonical credentials before editing a compact account row`
+- `frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts`::`keeps the latest account selected when detail requests resolve out of order`
+- `frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts`::`keeps the edit modal closed when account detail loading fails`
 - `frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts`::`allows duplicate of supplier-managed accounts like ordinary accounts`
 - `frontend/src/components/account/__tests__/EditAccountModal.spec.ts`::`shows the supplier-managed hint and submits a normal account update`
 - `frontend/src/components/account/__tests__/SupplierManagedBadge.spec.ts`::`uses marker presence, maps known sources, falls back safely, and refreshes after remount`
@@ -160,6 +167,7 @@
 - `frontend/e2e/us048-supplier-source-management.e2e.ts`::`US048 project-before-validate writes accounts without probing`
 - `frontend/e2e/us048-supplier-source-management.e2e.ts`::`US048 FMGo shows the fixed protocol boundary without account changes`
 - `frontend/e2e/us048-supplier-source-management.e2e.ts`::`US048 accounts UI marks supplier-managed accounts and allows ordinary edits`
+- `frontend/e2e/us048-supplier-source-management.e2e.ts`::`Admin account edit reloads Token Plan detail and preserves endpoint identity`
 
 - Run command:
 

--- a/backend/internal/handler/admin/account_handler_mixed_channel_test.go
+++ b/backend/internal/handler/admin/account_handler_mixed_channel_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
@@ -145,6 +146,30 @@ func TestAccountHandlerUpdateMixedChannelConflictSimplifiedResponse(t *testing.T
 	_, hasRequireConfirmation := resp["require_confirmation"]
 	require.False(t, hasDetails)
 	require.False(t, hasRequireConfirmation)
+}
+
+func TestAccountHandlerUpdateReturnsBadRequestForMissingProtocolEndpointIdentity(t *testing.T) {
+	adminSvc := newStubAdminService()
+	adminSvc.updateAccountErr = infraerrors.BadRequest(
+		"INVALID_ACCOUNT_PROTOCOL_ENDPOINT_IDENTITY",
+		"account credentials must include a valid protocol endpoint",
+	)
+	router := setupAccountMixedChannelRouter(adminSvc)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/api/v1/admin/accounts/132",
+		bytes.NewBufferString(`{"credentials":{"model_mapping":{"qwen-audio-3.0-tts-plus":"qwen-audio-3.0-tts-plus"}}}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, float64(http.StatusBadRequest), resp["code"])
+	require.Equal(t, "INVALID_ACCOUNT_PROTOCOL_ENDPOINT_IDENTITY", resp["reason"])
 }
 
 func TestAccountHandlerUpdateMapsUpstreamBillingRateSyncSettings(t *testing.T) {

--- a/backend/internal/service/account_supported_protocols_test.go
+++ b/backend/internal/service/account_supported_protocols_test.go
@@ -811,10 +811,11 @@ func TestAdminUpdatePreservesCanonicalSupportedProtocolsAndIgnoresClientValue(t 
 	repo := &upstreamBillingProbeAdminRepo{upstreamBillingProbeAccountRepo: &upstreamBillingProbeAccountRepo{
 		accounts: map[int64]*Account{
 			accountID: {
-				ID:       accountID,
-				Platform: PlatformOpenAI,
-				Type:     AccountTypeAPIKey,
-				Status:   StatusActive,
+				ID:          accountID,
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Status:      StatusActive,
+				Credentials: map[string]any{"base_url": "https://relay.example.test/v1"},
 				Extra: map[string]any{
 					SupportedProtocolsExtraKey: []string{"messages"},
 					"old_config":               true,

--- a/backend/internal/service/admin_account_tk_update.go
+++ b/backend/internal/service/admin_account_tk_update.go
@@ -302,7 +302,7 @@ func (s *adminServiceImpl) tkApplyUpdateAccountTKFields(ctx context.Context, acc
 			return err
 		}
 	}
-	if len(input.Credentials) > 0 || input.ChannelType != nil {
+	if len(input.Credentials) > 0 || input.ChannelType != nil || input.Type != "" || input.Extra != nil {
 		if _, _, err := BuildProtocolEndpointIdentity(account); err != nil {
 			return infraerrors.BadRequest(
 				"INVALID_ACCOUNT_PROTOCOL_ENDPOINT_IDENTITY",

--- a/backend/internal/service/admin_account_tk_update.go
+++ b/backend/internal/service/admin_account_tk_update.go
@@ -302,6 +302,14 @@ func (s *adminServiceImpl) tkApplyUpdateAccountTKFields(ctx context.Context, acc
 			return err
 		}
 	}
+	if len(input.Credentials) > 0 || input.ChannelType != nil {
+		if _, _, err := BuildProtocolEndpointIdentity(account); err != nil {
+			return infraerrors.BadRequest(
+				"INVALID_ACCOUNT_PROTOCOL_ENDPOINT_IDENTITY",
+				"account credentials must include a valid protocol endpoint",
+			).WithCause(err)
+		}
+	}
 	SeedOfficialSupportedProtocols(account)
 
 	billingSettingsAppliedAtomically := false

--- a/backend/internal/service/admin_account_upstream_billing_probe_test.go
+++ b/backend/internal/service/admin_account_upstream_billing_probe_test.go
@@ -165,10 +165,11 @@ func TestUpdateAccountPreservesManagedUpstreamBillingProbeStateForUnrelatedEdit(
 	accountID := int64(110)
 	repo := &upstreamBillingProbeAccountRepo{accounts: map[int64]*Account{
 		accountID: {
-			ID:       accountID,
-			Platform: PlatformOpenAI,
-			Type:     AccountTypeAPIKey,
-			Status:   StatusActive,
+			ID:          accountID,
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeAPIKey,
+			Status:      StatusActive,
+			Credentials: map[string]any{"base_url": "https://upstream.example"},
 			Extra: map[string]any{
 				UpstreamBillingProbeEnabledExtraKey:    true,
 				UpstreamBillingRateSyncEnabledExtraKey: true,
@@ -197,11 +198,12 @@ func TestUpdateAccountPreservesGrokBillingSnapshotForUnrelatedEdit(t *testing.T)
 	}
 	repo := &upstreamBillingProbeAccountRepo{accounts: map[int64]*Account{
 		accountID: {
-			ID:       accountID,
-			Platform: PlatformGrok,
-			Type:     AccountTypeOAuth,
-			Status:   StatusActive,
-			Extra:    map[string]any{grokBillingExtraKey: billing},
+			ID:          accountID,
+			Platform:    PlatformGrok,
+			Type:        AccountTypeOAuth,
+			Status:      StatusActive,
+			Credentials: map[string]any{"base_url": "https://grok.example/v1"},
+			Extra:       map[string]any{grokBillingExtraKey: billing},
 		},
 	}}
 
@@ -383,11 +385,12 @@ func TestUpdateAccountAcceptsProbeEnabledAndRejectsInjectedSnapshot(t *testing.T
 	accountID := int64(111)
 	repo := &upstreamBillingProbeAccountRepo{accounts: map[int64]*Account{
 		accountID: {
-			ID:       accountID,
-			Platform: PlatformOpenAI,
-			Type:     AccountTypeAPIKey,
-			Status:   StatusActive,
-			Extra:    map[string]any{},
+			ID:          accountID,
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeAPIKey,
+			Status:      StatusActive,
+			Credentials: map[string]any{"base_url": "https://upstream.example"},
+			Extra:       map[string]any{},
 		},
 	}}
 
@@ -541,10 +544,11 @@ func TestUpdateAccountExplicitProbeDisableUsesDedicatedExtraUpdate(t *testing.T)
 	accountID := int64(113)
 	repo := &upstreamBillingProbeAccountRepo{accounts: map[int64]*Account{
 		accountID: {
-			ID:       accountID,
-			Platform: PlatformOpenAI,
-			Type:     AccountTypeAPIKey,
-			Status:   StatusActive,
+			ID:          accountID,
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeAPIKey,
+			Status:      StatusActive,
+			Credentials: map[string]any{"base_url": "https://upstream.example"},
 			Extra: map[string]any{
 				UpstreamBillingProbeEnabledExtraKey: true,
 				UpstreamBillingProbeExtraKey:        map[string]any{"status": "ok"},
@@ -566,11 +570,12 @@ func TestUpdateAccountExplicitUnchangedProbeEnabledStillUsesDedicatedExtraUpdate
 	accountID := int64(114)
 	repo := &upstreamBillingProbeAccountRepo{accounts: map[int64]*Account{
 		accountID: {
-			ID:       accountID,
-			Platform: PlatformOpenAI,
-			Type:     AccountTypeAPIKey,
-			Status:   StatusActive,
-			Extra:    map[string]any{UpstreamBillingProbeEnabledExtraKey: true},
+			ID:          accountID,
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeAPIKey,
+			Status:      StatusActive,
+			Credentials: map[string]any{"base_url": "https://upstream.example"},
+			Extra:       map[string]any{UpstreamBillingProbeEnabledExtraKey: true},
 		},
 	}}
 

--- a/backend/internal/service/admin_account_upstream_billing_probe_test.go
+++ b/backend/internal/service/admin_account_upstream_billing_probe_test.go
@@ -257,8 +257,11 @@ func TestUpdateAccountInvalidatesProbeSnapshotWhenUpstreamIdentityChanges(t *tes
 		wantEnabled bool
 	}{
 		{
-			name:        "api key",
-			input:       &UpdateAccountInput{Credentials: map[string]any{"api_key": "sk-new"}},
+			name: "api key",
+			input: &UpdateAccountInput{Credentials: map[string]any{
+				"api_key":  "sk-new",
+				"base_url": "https://old.example",
+			}},
 			wantEnabled: true,
 		},
 		{
@@ -269,6 +272,7 @@ func TestUpdateAccountInvalidatesProbeSnapshotWhenUpstreamIdentityChanges(t *tes
 		{
 			name: "header override",
 			input: &UpdateAccountInput{Credentials: map[string]any{
+				"base_url":                   "https://old.example",
 				credKeyHeaderOverrideEnabled: true,
 				credKeyHeaderOverrides:       map[string]any{"x-route": "new"},
 			}},

--- a/backend/internal/service/admin_service_credentials_merge_test.go
+++ b/backend/internal/service/admin_service_credentials_merge_test.go
@@ -11,6 +11,7 @@ import (
 
 	newapiconstant "github.com/QuantumNous/new-api/constant"
 	newapifusion "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -119,6 +120,37 @@ func TestUpdateAccount_EmptyCredentialsSkipsUpdate(t *testing.T) {
 
 	require.Equal(t, "rt-existing", repo.account.Credentials["refresh_token"], "空 credentials 不应触碰已有 token")
 	require.Equal(t, "renamed", repo.account.Name)
+}
+
+func TestUpdateAccount_RejectsMissingProtocolEndpointBeforePersist(t *testing.T) {
+	accountID := int64(132)
+	repo := &updateAccountCredsRepoStub{
+		account: &Account{
+			ID:          accountID,
+			Platform:    PlatformNewAPI,
+			Type:        AccountTypeAPIKey,
+			ChannelType: newapiconstant.ChannelTypeAli,
+			Status:      StatusActive,
+			Credentials: map[string]any{
+				"api_key":  "sk-existing",
+				"base_url": "https://token-plan.cn-beijing.maas.aliyuncs.com",
+			},
+		},
+	}
+
+	updated, err := (&adminServiceImpl{accountRepo: repo}).UpdateAccount(
+		context.Background(),
+		accountID,
+		&UpdateAccountInput{Credentials: map[string]any{
+			"model_mapping": map[string]any{"qwen-audio-3.0-tts-plus": "qwen-audio-3.0-tts-plus"},
+		}},
+	)
+
+	require.Nil(t, updated)
+	require.Equal(t, http.StatusBadRequest, infraerrors.Code(err))
+	require.Equal(t, "INVALID_ACCOUNT_PROTOCOL_ENDPOINT_IDENTITY", infraerrors.Reason(err))
+	require.ErrorContains(t, err, "governed account has no explicit protocol endpoint identity")
+	require.Zero(t, repo.updateCalls, "invalid endpoint identity must be rejected before persistence")
 }
 
 func TestUpdateAccount_ResolvesNewAPIMoonshotRegionBeforePersist(t *testing.T) {

--- a/backend/internal/service/admin_service_credentials_merge_test.go
+++ b/backend/internal/service/admin_service_credentials_merge_test.go
@@ -153,6 +153,54 @@ func TestUpdateAccount_RejectsMissingProtocolEndpointBeforePersist(t *testing.T)
 	require.Zero(t, repo.updateCalls, "invalid endpoint identity must be rejected before persistence")
 }
 
+func TestUpdateAccount_RejectsTypeChangeWithoutProtocolEndpointBeforePersist(t *testing.T) {
+	accountID := int64(133)
+	repo := &updateAccountCredsRepoStub{
+		account: &Account{
+			ID:          accountID,
+			Platform:    PlatformAnthropic,
+			Type:        AccountTypeOAuth,
+			Status:      StatusActive,
+			Credentials: map[string]any{"access_token": "at-existing"},
+		},
+	}
+
+	updated, err := (&adminServiceImpl{accountRepo: repo}).UpdateAccount(
+		context.Background(),
+		accountID,
+		&UpdateAccountInput{Type: AccountTypeAPIKey},
+	)
+
+	require.Nil(t, updated)
+	require.Equal(t, http.StatusBadRequest, infraerrors.Code(err))
+	require.Equal(t, "INVALID_ACCOUNT_PROTOCOL_ENDPOINT_IDENTITY", infraerrors.Reason(err))
+	require.Zero(t, repo.updateCalls, "invalid type transition must be rejected before persistence")
+}
+
+func TestUpdateAccount_RejectsIncompleteCustomProtocolEndpointBeforePersist(t *testing.T) {
+	accountID := int64(134)
+	repo := &updateAccountCredsRepoStub{
+		account: &Account{
+			ID:          accountID,
+			Platform:    PlatformAnthropic,
+			Type:        AccountTypeOAuth,
+			Status:      StatusActive,
+			Credentials: map[string]any{"access_token": "at-existing"},
+		},
+	}
+
+	updated, err := (&adminServiceImpl{accountRepo: repo}).UpdateAccount(
+		context.Background(),
+		accountID,
+		&UpdateAccountInput{Extra: map[string]any{"custom_base_url_enabled": true}},
+	)
+
+	require.Nil(t, updated)
+	require.Equal(t, http.StatusBadRequest, infraerrors.Code(err))
+	require.Equal(t, "INVALID_ACCOUNT_PROTOCOL_ENDPOINT_IDENTITY", infraerrors.Reason(err))
+	require.Zero(t, repo.updateCalls, "incomplete custom endpoint must be rejected before persistence")
+}
+
 func TestUpdateAccount_ResolvesNewAPIMoonshotRegionBeforePersist(t *testing.T) {
 	fail := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "wrong region", http.StatusUnauthorized)

--- a/backend/internal/service/admin_service_overages_test.go
+++ b/backend/internal/service/admin_service_overages_test.go
@@ -126,10 +126,11 @@ func TestUpdateAccount_EmptyExtraPayloadCanClearQuotaLimits(t *testing.T) {
 	accountID := int64(103)
 	repo := &updateAccountOveragesRepoStub{
 		account: &Account{
-			ID:       accountID,
-			Platform: PlatformAnthropic,
-			Type:     AccountTypeAPIKey,
-			Status:   StatusActive,
+			ID:          accountID,
+			Platform:    PlatformAnthropic,
+			Type:        AccountTypeAPIKey,
+			Status:      StatusActive,
+			Credentials: map[string]any{"base_url": "https://upstream.example"},
 			Extra: map[string]any{
 				"quota_limit":        100.0,
 				"quota_daily_limit":  10.0,
@@ -162,10 +163,11 @@ func TestUpdateAccount_FixedWeeklyResetClearsLegacyRollingUsage(t *testing.T) {
 	accountID := int64(104)
 	repo := &updateAccountOveragesRepoStub{
 		account: &Account{
-			ID:       accountID,
-			Platform: PlatformAnthropic,
-			Type:     AccountTypeAPIKey,
-			Status:   StatusActive,
+			ID:          accountID,
+			Platform:    PlatformAnthropic,
+			Type:        AccountTypeAPIKey,
+			Status:      StatusActive,
+			Credentials: map[string]any{"base_url": "https://upstream.example"},
 			Extra: map[string]any{
 				"quota_weekly_limit": 40.0,
 				"quota_weekly_used":  12.5,

--- a/backend/internal/service/supplier_managed_account_guard_test.go
+++ b/backend/internal/service/supplier_managed_account_guard_test.go
@@ -58,7 +58,10 @@ func TestUS048_ManagedAccountBehavesLikeOrdinaryAccountForUpdates(t *testing.T) 
 	updated, err := svc.UpdateAccount(context.Background(), repo.account.ID, &UpdateAccountInput{
 		Name: "renamed-managed", Status: StatusDisabled, Concurrency: &concurrency,
 		Priority: &priority, GroupIDs: &groupIDs, Notes: &notes,
-		Credentials:           map[string]any{"api_key": "rotated"},
+		Credentials: map[string]any{
+			"api_key":  "rotated",
+			"base_url": "https://supplier.example/v1",
+		},
 		SkipMixedChannelCheck: true,
 	})
 	require.NoError(t, err)

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 724,
-  "hash": "151bde525c0bc2109b3c1105395d627e16a96b9299c84a57250ed415ae758284",
+  "hash": "01269fdec9d3d80b9a64728f0cbd36e242b446373573c5697fc222562c2e1df7",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 724,
-  "hash": "36ebacf7c7aa344b95af0be8ac14d5000bb0f4e7a9591a9dd0d8005fc8b2d638",
+  "hash": "151bde525c0bc2109b3c1105395d627e16a96b9299c84a57250ed415ae758284",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/e2e/us048-supplier-source-management.e2e.ts
+++ b/frontend/e2e/us048-supplier-source-management.e2e.ts
@@ -399,6 +399,34 @@ test('US048 FMGo shows the fixed protocol boundary without account changes', asy
 test('US048 accounts UI marks supplier-managed accounts and allows ordinary edits', async ({ page }) => {
   await installBase(page, async (route, path) => {
     const request = route.request()
+    if (path === '/api/v1/admin/accounts/101' && request.method() === 'GET') {
+      await fulfillSuccess(route, {
+        id: 101,
+        name: '佳杰/VSTECS · 档位 3',
+        platform: 'newapi',
+        type: 'apikey',
+        channel_type: 1,
+        status: 'active',
+        schedulable: true,
+        priority: 130,
+        concurrency: 1,
+        group_ids: [],
+        supported_protocols: ['chat_completions'],
+        credentials: {
+          base_url: 'https://token.vstecscloud.com/v1',
+          model_mapping: { 'deepseek-v4-pro': 'deepseek-v4-pro' },
+          model_pricing_status: { 'deepseek-v4-pro': 'priced' },
+        },
+        credentials_status: { has_api_key: true },
+        extra: {
+          supplier_source_id: 7,
+          supplier_discount_band: 3,
+        },
+        created_at: '2026-08-28T00:00:00Z',
+        updated_at: '2026-08-28T00:00:00Z',
+      })
+      return true
+    }
     if (path === '/api/v1/admin/accounts' && request.method() === 'GET') {
       await fulfillSuccess(route, {
         items: [{
@@ -491,6 +519,109 @@ test('US048 accounts UI marks supplier-managed accounts and allows ordinary edit
   await expect(page.locator('[data-test="source-select-7"]')).toHaveClass(/border-primary-500/)
   await expect(page.locator('[data-test="supplier-name"]')).toHaveValue('佳杰')
   await expect(page.locator('[data-test="supplier-lane"]')).toHaveValue('VSTECS')
+})
+
+test('Admin account edit reloads Token Plan detail and preserves endpoint identity', async ({ page }) => {
+  const baseUrl = 'https://token-plan.cn-beijing.maas.aliyuncs.com'
+  const mapping = { 'qwen-audio-3.0-tts-plus': 'qwen-audio-3.0-tts-plus' }
+  let detailRequests = 0
+  let submitted: Record<string, unknown> | null = null
+
+  const fullAccount = {
+    id: 132,
+    name: 'Ali Token Plan 132',
+    notes: '',
+    platform: 'newapi',
+    type: 'apikey',
+    channel_type: 17,
+    status: 'active',
+    schedulable: true,
+    priority: 1,
+    concurrency: 1,
+    rate_multiplier: 1,
+    group_ids: [],
+    supported_protocols: ['chat_completions'],
+    credentials: {
+      base_url: baseUrl,
+      model_mapping: mapping,
+      model_pricing_status: { 'qwen-audio-3.0-tts-plus': 'priced' },
+    },
+    credentials_status: { has_api_key: true },
+    extra: {},
+    expires_at: null,
+    auto_pause_on_expired: false,
+    created_at: '2026-09-05T00:00:00Z',
+    updated_at: '2026-09-06T00:00:00Z',
+  }
+
+  await installBase(page, async (route, path) => {
+    const request = route.request()
+    if (path === '/api/v1/admin/accounts/132' && request.method() === 'GET') {
+      detailRequests += 1
+      await fulfillSuccess(route, fullAccount)
+      return true
+    }
+    if (path === '/api/v1/admin/accounts/132' && request.method() === 'PUT') {
+      submitted = request.postDataJSON() as Record<string, unknown>
+      await fulfillSuccess(route, fullAccount)
+      return true
+    }
+    if (path === '/api/v1/admin/accounts' && request.method() === 'GET') {
+      const { credentials: _credentials, credentials_status: _credentialsStatus, ...compactAccount } = fullAccount
+      await fulfillSuccess(route, {
+        items: [compactAccount], total: 1, page: 1, page_size: 20, pages: 1,
+      })
+      return true
+    }
+    if (path === '/api/v1/admin/accounts/today-stats/batch' && request.method() === 'POST') {
+      await fulfillSuccess(route, { stats: {} })
+      return true
+    }
+    if (path === '/api/v1/admin/accounts/usage/batch' && request.method() === 'POST') {
+      await fulfillSuccess(route, { usage: {} })
+      return true
+    }
+    if (path === '/api/v1/admin/accounts/upstream-billing-probe/settings' && request.method() === 'GET') {
+      await fulfillSuccess(route, { enabled: true, interval_minutes: 30 })
+      return true
+    }
+    if (path === '/api/v1/admin/proxies/all' && request.method() === 'GET') {
+      await fulfillSuccess(route, [])
+      return true
+    }
+    if (path === '/api/v1/admin/groups/all' && request.method() === 'GET') {
+      await fulfillSuccess(route, [])
+      return true
+    }
+    if (path === '/api/v1/admin/edge-accounts' && request.method() === 'GET') {
+      await fulfillSuccess(route, { platform: '__by_stub__', edges: [], ts: 1 })
+      return true
+    }
+    if (path === '/api/v1/admin/supplier-sources' && request.method() === 'GET') {
+      await fulfillSuccess(route, [])
+      return true
+    }
+    return false
+  })
+
+  await page.goto('/admin/accounts')
+  const row = page.locator('tr[data-row-id="132"]')
+  await row.locator('[data-testid="account-edit-btn"]').click()
+
+  const dialog = page.getByRole('dialog')
+  await expect(dialog.getByRole('heading', { name: '编辑账号' })).toBeVisible()
+  expect(detailRequests).toBe(1)
+  await expect.poll(async () =>
+    dialog.locator('input').evaluateAll(inputs => inputs.map(input => (input as HTMLInputElement).value))
+  ).toContain(baseUrl)
+
+  await dialog.locator('[data-tour="account-form-submit"]').click()
+  await expect(dialog).toHaveCount(0)
+
+  expect(submitted).not.toBeNull()
+  expect(submitted?.channel_type).toBe(17)
+  expect((submitted?.credentials as Record<string, unknown>)?.base_url).toBe(baseUrl)
+  expect((submitted?.credentials as Record<string, unknown>)?.model_mapping).toEqual(mapping)
 })
 
 test('US048 operator copies a source into a new editor and filters the list', async ({ page }) => {

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -1882,24 +1882,27 @@ const cols = computed(() =>
   )
 )
 
-const accountDetailLoading = new Set<number>()
+const accountDetailRequests = new Map<number, Promise<Account | null>>()
 const loadAccountDetails = async (account: Pick<Account, 'id'>): Promise<Account | null> => {
-  if (accountDetailLoading.has(account.id)) return null
-  accountDetailLoading.add(account.id)
-  try {
-    return await adminAPI.accounts.getById(account.id)
-  } catch (error) {
-    console.error('Failed to load account details:', error)
-    appStore.showError(extractApiErrorMessage(error, t('common.error')))
-    return null
-  } finally {
-    accountDetailLoading.delete(account.id)
-  }
+  const pending = accountDetailRequests.get(account.id)
+  if (pending) return pending
+
+  const request = adminAPI.accounts.getById(account.id)
+    .catch((error) => {
+      console.error('Failed to load account details:', error)
+      appStore.showError(extractApiErrorMessage(error, t('common.error')))
+      return null
+    })
+    .finally(() => accountDetailRequests.delete(account.id))
+  accountDetailRequests.set(account.id, request)
+  return request
 }
 
+let editRequestGeneration = 0
 const handleEdit = async (a: Account) => {
+  const generation = ++editRequestGeneration
   const account = await loadAccountDetails(a)
-  if (!account) return
+  if (!account || generation !== editRequestGeneration) return
   edAcc.value = account
   showEdit.value = true
 }

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -1882,8 +1882,25 @@ const cols = computed(() =>
   )
 )
 
-const handleEdit = (a: Account) => {
-  edAcc.value = a
+const accountDetailLoading = new Set<number>()
+const loadAccountDetails = async (account: Pick<Account, 'id'>): Promise<Account | null> => {
+  if (accountDetailLoading.has(account.id)) return null
+  accountDetailLoading.add(account.id)
+  try {
+    return await adminAPI.accounts.getById(account.id)
+  } catch (error) {
+    console.error('Failed to load account details:', error)
+    appStore.showError(extractApiErrorMessage(error, t('common.error')))
+    return null
+  } finally {
+    accountDetailLoading.delete(account.id)
+  }
+}
+
+const handleEdit = async (a: Account) => {
+  const account = await loadAccountDetails(a)
+  if (!account) return
+  edAcc.value = account
   showEdit.value = true
 }
 const closeActionMenu = () => {

--- a/frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts
@@ -6,6 +6,7 @@ import AccountsView from '../AccountsView.vue'
 const {
   listAccounts,
   listWithEtag,
+  getById,
   getBatchTodayStats,
   getBatchPassiveUsage,
   getAllProxies,
@@ -22,6 +23,7 @@ const {
 } = vi.hoisted(() => ({
   listAccounts: vi.fn(),
   listWithEtag: vi.fn(),
+  getById: vi.fn(),
   getBatchTodayStats: vi.fn(),
   getBatchPassiveUsage: vi.fn(),
   getAllProxies: vi.fn(),
@@ -42,6 +44,7 @@ vi.mock('@/api/admin', () => ({
     accounts: {
       list: listAccounts,
       listWithEtag,
+      getById,
       getBatchTodayStats,
       getBatchPassiveUsage,
       getUpstreamBillingProbeSettings: vi.fn().mockResolvedValue({ enabled: true, interval_minutes: 30 }),
@@ -112,7 +115,7 @@ const AccountActionMenuStub = {
 
 const EditAccountModalStub = {
   props: ['show', 'account'],
-  template: '<div data-test="edit-modal" :data-show="String(show)" :data-account-id="account?.id ?? 0" />'
+  template: '<div data-test="edit-modal" :data-show="String(show)" :data-account-id="account?.id ?? 0" :data-base-url="account?.credentials?.base_url" />'
 }
 
 const managedAccount = {
@@ -181,6 +184,15 @@ describe('AccountsView supplier-managed accounts', () => {
         pages: 1
       }
     })
+    getById.mockImplementation(async (id: number) => {
+      const account = id === managedAccount.id ? managedAccount : ordinaryAccount
+      return {
+        ...account,
+        credentials: {
+          base_url: id === ordinaryAccount.id ? 'https://token-plan.example.test' : 'https://supplier.example.test'
+        }
+      }
+    })
     getBatchTodayStats.mockResolvedValue({ stats: {} })
     getBatchPassiveUsage.mockResolvedValue({ usage: {} })
     getAllProxies.mockResolvedValue([])
@@ -230,9 +242,24 @@ describe('AccountsView supplier-managed accounts', () => {
     await flushPromises()
 
     const modal = wrapper.get('[data-test="edit-modal"]')
+    expect(getById).toHaveBeenCalledWith(7)
     expect(modal.attributes('data-show')).toBe('true')
     expect(modal.attributes('data-account-id')).toBe('7')
     expect(showError).not.toHaveBeenCalled()
+  })
+
+  it('loads canonical credentials before editing a compact account row', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(ordinaryAccount).not.toHaveProperty('credentials')
+    await wrapper.get('[data-test="account-row-8"]').get('[data-testid="account-edit-btn"]').trigger('click')
+    await flushPromises()
+
+    expect(getById).toHaveBeenCalledWith(8)
+    const modal = wrapper.get('[data-test="edit-modal"]')
+    expect(modal.attributes('data-account-id')).toBe('8')
+    expect(modal.attributes('data-base-url')).toBe('https://token-plan.example.test')
   })
 
   it('allows duplicate of supplier-managed accounts like ordinary accounts', async () => {

--- a/frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts
@@ -262,6 +262,48 @@ describe('AccountsView supplier-managed accounts', () => {
     expect(modal.attributes('data-base-url')).toBe('https://token-plan.example.test')
   })
 
+  it('keeps the latest account selected when detail requests resolve out of order', async () => {
+    let resolveManaged!: (value: unknown) => void
+    let resolveOrdinary!: (value: unknown) => void
+    getById.mockImplementation((id: number) => new Promise<unknown>((resolve) => {
+      if (id === managedAccount.id) resolveManaged = resolve
+      else resolveOrdinary = resolve
+    }))
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.get('[data-test="account-row-7"]').get('[data-testid="account-edit-btn"]').trigger('click')
+    await wrapper.get('[data-test="account-row-8"]').get('[data-testid="account-edit-btn"]').trigger('click')
+
+    resolveOrdinary({
+      ...ordinaryAccount,
+      credentials: { base_url: 'https://token-plan.example.test' }
+    })
+    await flushPromises()
+    expect(wrapper.get('[data-test="edit-modal"]').attributes('data-account-id')).toBe('8')
+
+    resolveManaged({
+      ...managedAccount,
+      credentials: { base_url: 'https://supplier.example.test' }
+    })
+    await flushPromises()
+    expect(wrapper.get('[data-test="edit-modal"]').attributes('data-account-id')).toBe('8')
+  })
+
+  it('keeps the edit modal closed when account detail loading fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    getById.mockRejectedValueOnce(new Error('detail failed'))
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.get('[data-test="account-row-8"]').get('[data-testid="account-edit-btn"]').trigger('click')
+    await flushPromises()
+
+    expect(showError).toHaveBeenCalledWith('detail failed')
+    expect(wrapper.find('[data-test="edit-modal"]').exists()).toBe(false)
+    consoleError.mockRestore()
+  })
+
   it('allows duplicate of supplier-managed accounts like ordinary accounts', async () => {
     const wrapper = mountView()
     await flushPromises()


### PR DESCRIPTION
## 摘要

- 修复 Admin 账号列表使用 `lite=1` 紧凑数据直接打开编辑框的问题；编辑前调用单账号详情接口，确保 `credentials.base_url`、模型映射等完整字段进入表单。
- 详情请求按账号复用，并以最后一次编辑点击为准；较慢的旧请求不会再覆盖当前选择，详情加载失败时保持弹窗关闭并显示错误。
- 在账号端点身份相关字段更新后、持久化前校验协议端点身份。覆盖 `credentials`、`channel_type`、`type` 与完整替换的 `extra`；无端点的受管账号返回 HTTP 400 / `INVALID_ACCOUNT_PROTOCOL_ENDPOINT_IDENTITY`，不再在仓储事务阶段触发 HTTP 500。
- 增加账号 132 形状的 service、handler、组件与 Playwright 回归，覆盖 Ali `channel_type=17`、Token Plan Base URL 和 `qwen-audio-3.0-tts-plus` 映射保留。
- 生产证据：`2026-09-06T09:57:12.022Z`，`PUT /api/v1/admin/accounts/132`，request ID `cbd6d2c7-4ad0-4d05-9de1-ff028740d726`。

## 风险

- 合法更新保持原行为；缺少或非法协议端点身份的更新由事务内 500 收敛为持久化前 400。
- 既有相关测试中缺少生产必需端点的夹具已补成合法账号形状，不改变各测试原有断言。
- `sentinel-registry-reviewed`：详情加载行为已有 focused 组件测试、Playwright 回归及 US-048 Linked Tests 机械锚点；上游删除实现或测试会使 CI 失败，因此不新增重复 sentinel。

## 验证

- `PATH=/opt/homebrew/bin:$PATH PREFLIGHT_BASE=origin/main bash scripts/preflight.sh`
- `go test -tags=unit ./internal/service -count=1`
- `go test -tags=unit ./internal/handler/admin -count=1`
- `pnpm exec vitest run src/views/admin/__tests__/AccountsView.supplierManaged.spec.ts src/components/account/__tests__/EditAccountModal.spec.ts`（64/64）
- `pnpm typecheck`
- `pnpm lint:check`
- `python3 .testing/user-stories/verify_quality.py`（44 stories，0 issues）
- `E2E_BASE_URL=http://127.0.0.1:4173 pnpm exec playwright test e2e/us048-supplier-source-management.e2e.ts --grep "Admin account edit reloads Token Plan detail and preserves endpoint identity" --project=chromium`（1/1）

## 提交

- `dd0b6e024 fix(admin): 编辑账号前加载完整端点身份`
- `72ff67dc5 fix(admin): address R-001..R-003 account edit gaps`

最新提交：`72ff67dc5`