### PR TITLE
fix(openai): 落库 Codex session-id 与出站 installation_id

### DIFF
--- a/backend/internal/handler/openai_gateway_handler_tk_forward_usage.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_forward_usage.go
@@ -40,29 +40,31 @@ func (h *OpenAIGatewayHandler) tkSubmitHTTPForwardUsage(res *service.OpenAIForwa
 	requestPayloadHash := service.HashUsageRequestPayload(in.Body)
 	quotaPlatform := service.QuotaPlatform(in.C.Request.Context(), in.APIKey)
 	sessionID := service.ExtractClientSessionID(in.C)
+	codexInstallationID := service.CodexEgressInstallationIDForUsage(in.C, in.Account)
 	tkHoldRequestID := in.Hold.HandOffToSettlement()
 	cyberBlocked := service.GetOpsCyberPolicy(in.C) != nil
 	gatewayLatencyMs := tkSnapshotGatewayTransferLatencyMs(in.C)
 	h.submitOpenAIUsageRecordTask(in.C.Request.Context(), res, func(ctx context.Context) {
 		if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
-			Result:             res,
-			APIKey:             in.APIKey,
-			User:               in.APIKey.User,
-			Account:            in.Account,
-			Subscription:       in.Subscription,
-			InboundEndpoint:    GetInboundEndpoint(in.C),
-			UpstreamEndpoint:   resolveOpenAIUpstreamEndpoint(in.C, in.Account, res),
-			UserAgent:          userAgent,
-			IPAddress:          clientIP,
-			RequestPayloadHash: requestPayloadHash,
-			APIKeyService:      h.apiKeyService,
-			TkHoldRequestID:    tkHoldRequestID,
-			QuotaPlatform:      quotaPlatform,
-			SessionID:          sessionID,
-			GatewayLatencyMs:   gatewayLatencyMs,
-			ChannelUsageFields: clientRequestedUsageFields(in.C, in.ChannelMapping, in.ReqModel, res.UpstreamModel),
-			PricingAt:          in.PricingAt,
-			CyberBlocked:       cyberBlocked,
+			Result:              res,
+			APIKey:              in.APIKey,
+			User:                in.APIKey.User,
+			Account:             in.Account,
+			Subscription:        in.Subscription,
+			InboundEndpoint:     GetInboundEndpoint(in.C),
+			UpstreamEndpoint:    resolveOpenAIUpstreamEndpoint(in.C, in.Account, res),
+			UserAgent:           userAgent,
+			IPAddress:           clientIP,
+			RequestPayloadHash:  requestPayloadHash,
+			APIKeyService:       h.apiKeyService,
+			TkHoldRequestID:     tkHoldRequestID,
+			QuotaPlatform:       quotaPlatform,
+			SessionID:           sessionID,
+			CodexInstallationID: codexInstallationID,
+			GatewayLatencyMs:    gatewayLatencyMs,
+			ChannelUsageFields:  clientRequestedUsageFields(in.C, in.ChannelMapping, in.ReqModel, res.UpstreamModel),
+			PricingAt:           in.PricingAt,
+			CyberBlocked:        cyberBlocked,
 		}); err != nil {
 			logger.L().With(
 				zap.String("component", in.LogComponent),

--- a/backend/internal/handler/openai_gateway_handler_tk_responses_ws.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_responses_ws.go
@@ -187,28 +187,30 @@ func (h *OpenAIGatewayHandler) tkWSAfterTurnSubmitUsage(in tkWSAfterTurnUsageInp
 	tkHoldRequestID := in.TurnHold.HandOffForTurn()
 	quotaPlatform := service.QuotaPlatform(in.C.Request.Context(), in.APIKey)
 	sessionID := service.ExtractClientSessionID(in.C)
+	codexInstallationID := service.CodexEgressInstallationIDForUsage(in.C, in.Account)
 	turnRecordPricingAt := in.TurnPricing.currentOr(in.TurnStart)
 	cyberBlocked := service.GetOpsCyberPolicy(in.C) != nil
 	turnUsageFields := in.TurnMapping.ToUsageFields(in.TurnRequestedModel, in.TurnUpstreamModel)
 	h.submitOpenAIUsageRecordTask(in.Ctx, in.Result, func(taskCtx context.Context) {
 		if err := h.gatewayService.RecordUsage(taskCtx, &service.OpenAIRecordUsageInput{
-			Result:             in.Result,
-			APIKey:             in.APIKey,
-			User:               in.APIKey.User,
-			Account:            in.Account,
-			Subscription:       in.Subscription,
-			InboundEndpoint:    GetInboundEndpoint(in.C),
-			UpstreamEndpoint:   resolveOpenAIUpstreamEndpoint(in.C, in.Account, in.Result),
-			UserAgent:          in.UserAgent,
-			IPAddress:          in.ClientIP,
-			RequestPayloadHash: in.RequestPayloadHash,
-			APIKeyService:      h.apiKeyService,
-			TkHoldRequestID:    tkHoldRequestID,
-			QuotaPlatform:      quotaPlatform,
-			SessionID:          sessionID,
-			ChannelUsageFields: turnUsageFields,
-			PricingAt:          turnRecordPricingAt,
-			CyberBlocked:       cyberBlocked,
+			Result:              in.Result,
+			APIKey:              in.APIKey,
+			User:                in.APIKey.User,
+			Account:             in.Account,
+			Subscription:        in.Subscription,
+			InboundEndpoint:     GetInboundEndpoint(in.C),
+			UpstreamEndpoint:    resolveOpenAIUpstreamEndpoint(in.C, in.Account, in.Result),
+			UserAgent:           in.UserAgent,
+			IPAddress:           in.ClientIP,
+			RequestPayloadHash:  in.RequestPayloadHash,
+			APIKeyService:       h.apiKeyService,
+			TkHoldRequestID:     tkHoldRequestID,
+			QuotaPlatform:       quotaPlatform,
+			SessionID:           sessionID,
+			CodexInstallationID: codexInstallationID,
+			ChannelUsageFields:  turnUsageFields,
+			PricingAt:           turnRecordPricingAt,
+			CyberBlocked:        cyberBlocked,
 		}); err != nil {
 			in.ReqLog.Error("openai.websocket_record_usage_failed",
 				zap.Int64("account_id", in.Account.ID),

--- a/backend/internal/repository/usage_log_repo_insert.go
+++ b/backend/internal/repository/usage_log_repo_insert.go
@@ -84,6 +84,7 @@ var usageLogInsertArgTypes = [...]string{
 	"text",        // billing_mode
 	"numeric",     // account_stats_cost
 	"text",        // session_id
+	"text",        // codex_installation_id
 	"timestamptz", // created_at
 }
 
@@ -279,6 +280,7 @@ func cloneUsageLog(log *service.UsageLog) *service.UsageLog {
 	snapshot.UserAgent = cloneUsageLogValue(log.UserAgent)
 	snapshot.IPAddress = cloneUsageLogValue(log.IPAddress)
 	snapshot.SessionID = cloneUsageLogValue(log.SessionID)
+	snapshot.CodexInstallationID = cloneUsageLogValue(log.CodexInstallationID)
 	snapshot.ImageSize = cloneUsageLogValue(log.ImageSize)
 	snapshot.ImageInputSize = cloneUsageLogValue(log.ImageInputSize)
 	snapshot.ImageOutputSize = cloneUsageLogValue(log.ImageOutputSize)
@@ -422,6 +424,7 @@ func (r *usageLogRepository) createSinglePrepared(
 			billing_mode,
 			account_stats_cost,
 			session_id,
+			codex_installation_id,
 			created_at
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7,
@@ -429,7 +432,7 @@ func (r *usageLogRepository) createSinglePrepared(
 			$10, $11, $12, $13,
 			$14, $15, $16, $17,
 			$18, $19, $20, $21, $22, $23,
-			$24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60
+			$24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61
 		)
 		ON CONFLICT DO NOTHING
 		RETURNING id, created_at
@@ -992,12 +995,13 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 			billing_mode,
 			account_stats_cost,
 			session_id,
+			codex_installation_id,
 			created_at
 		) AS (VALUES `)
 
 	// Each batch row prepends the synthetic input_index before the 58
 	// usage-log column values.
-	args := make([]any, 0, len(keys)*60)
+	args := make([]any, 0, len(keys)*61)
 	argPos := 1
 	for idx, key := range keys {
 		if idx > 0 {
@@ -1085,6 +1089,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 				billing_mode,
 				account_stats_cost,
 				session_id,
+				codex_installation_id,
 				created_at
 			)
 			SELECT
@@ -1147,6 +1152,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 				billing_mode,
 				account_stats_cost,
 				session_id,
+				codex_installation_id,
 				created_at
 			FROM input
 			ON CONFLICT DO NOTHING
@@ -1249,6 +1255,7 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			billing_mode,
 			account_stats_cost,
 			session_id,
+			codex_installation_id,
 			created_at
 		) AS (VALUES `)
 
@@ -1337,6 +1344,7 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			billing_mode,
 			account_stats_cost,
 			session_id,
+			codex_installation_id,
 			created_at
 		)
 		SELECT
@@ -1399,6 +1407,7 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			billing_mode,
 			account_stats_cost,
 			session_id,
+			codex_installation_id,
 			created_at
 			FROM input
 			ON CONFLICT DO NOTHING
@@ -1469,6 +1478,7 @@ func execUsageLogInsertNoResult(ctx context.Context, sqlq sqlExecutor, prepared 
 			billing_mode,
 			account_stats_cost,
 			session_id,
+			codex_installation_id,
 			created_at
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7,
@@ -1476,7 +1486,7 @@ func execUsageLogInsertNoResult(ctx context.Context, sqlq sqlExecutor, prepared 
 			$10, $11, $12, $13,
 			$14, $15, $16, $17,
 			$18, $19, $20, $21, $22, $23,
-			$24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60
+			$24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61
 		)
 		ON CONFLICT DO NOTHING
 		`, prepared.args...)
@@ -1604,6 +1614,7 @@ func prepareUsageLogInsert(log *service.UsageLog) usageLogInsertPrepared {
 			billingMode,
 			freezeUsageLogFloat64(log.AccountStatsCost), // account_stats_cost
 			sessionID, // session_id
+			nullString(log.CodexInstallationID), // codex_installation_id
 			createdAt,
 		},
 	}

--- a/backend/internal/repository/usage_log_repo_insert.go
+++ b/backend/internal/repository/usage_log_repo_insert.go
@@ -1613,7 +1613,7 @@ func prepareUsageLogInsert(log *service.UsageLog) usageLogInsertPrepared {
 			billingTier,
 			billingMode,
 			freezeUsageLogFloat64(log.AccountStatsCost), // account_stats_cost
-			sessionID, // session_id
+			sessionID,                           // session_id
 			nullString(log.CodexInstallationID), // codex_installation_id
 			createdAt,
 		},

--- a/backend/internal/repository/usage_log_repo_query.go
+++ b/backend/internal/repository/usage_log_repo_query.go
@@ -19,7 +19,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
-const usageLogSelectColumns = "id, user_id, api_key_id, account_id, request_id, model, requested_model, upstream_model, upstream_response_model, upstream_model_mismatch, group_id, subscription_id, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cache_creation_5m_tokens, cache_creation_1h_tokens, image_output_tokens, image_output_cost, image_input_tokens, image_input_cost, input_cost, output_cost, cache_creation_cost, cache_read_cost, total_cost, actual_cost, rate_multiplier, account_rate_multiplier, billing_type, request_type, stream, openai_ws_mode, duration_ms, gateway_latency_ms, first_token_ms, user_agent, ip_address, image_count, image_size, image_input_size, image_output_size, image_size_source, image_size_breakdown, video_count, video_resolution, video_duration_seconds, service_tier, reasoning_effort, inbound_endpoint, upstream_endpoint, cache_ttl_overridden, long_context_billing_applied, channel_id, model_mapping_chain, billing_tier, billing_mode, account_stats_cost, session_id, created_at"
+const usageLogSelectColumns = "id, user_id, api_key_id, account_id, request_id, model, requested_model, upstream_model, upstream_response_model, upstream_model_mismatch, group_id, subscription_id, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cache_creation_5m_tokens, cache_creation_1h_tokens, image_output_tokens, image_output_cost, image_input_tokens, image_input_cost, input_cost, output_cost, cache_creation_cost, cache_read_cost, total_cost, actual_cost, rate_multiplier, account_rate_multiplier, billing_type, request_type, stream, openai_ws_mode, duration_ms, gateway_latency_ms, first_token_ms, user_agent, ip_address, image_count, image_size, image_input_size, image_output_size, image_size_source, image_size_breakdown, video_count, video_resolution, video_duration_seconds, service_tier, reasoning_effort, inbound_endpoint, upstream_endpoint, cache_ttl_overridden, long_context_billing_applied, channel_id, model_mapping_chain, billing_tier, billing_mode, account_stats_cost, session_id, codex_installation_id, created_at"
 
 func (r *usageLogRepository) GetByID(ctx context.Context, id int64) (log *service.UsageLog, err error) {
 	query := "SELECT " + usageLogSelectColumns + " FROM usage_logs WHERE id = $1"
@@ -499,6 +499,7 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 		billingMode               sql.NullString
 		accountStatsCost          sql.NullFloat64
 		sessionID                 sql.NullString
+		codexInstallationID       sql.NullString
 		createdAt                 time.Time
 	)
 
@@ -563,6 +564,7 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 		&billingMode,
 		&accountStatsCost,
 		&sessionID,
+		&codexInstallationID,
 		&createdAt,
 	); err != nil {
 		return nil, err
@@ -696,6 +698,9 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 	}
 	if sessionID.Valid {
 		log.SessionID = &sessionID.String
+	}
+	if codexInstallationID.Valid {
+		log.CodexInstallationID = &codexInstallationID.String
 	}
 
 	return log, nil

--- a/backend/internal/repository/usage_log_repo_request_type_test.go
+++ b/backend/internal/repository/usage_log_repo_request_type_test.go
@@ -101,6 +101,7 @@ func TestUsageLogRepositoryCreateSyncRequestTypeAndLegacyFields(t *testing.T) {
 			sqlmock.AnyArg(), // billing_mode
 			sqlmock.AnyArg(), // account_stats_cost
 			sqlmock.AnyArg(), // session_id
+			sqlmock.AnyArg(), // codex_installation_id
 			createdAt,
 		).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at"}).AddRow(int64(99), createdAt))
@@ -194,6 +195,7 @@ func TestUsageLogRepositoryCreate_PersistsServiceTier(t *testing.T) {
 			sqlmock.AnyArg(), // billing_mode
 			sqlmock.AnyArg(), // account_stats_cost
 			sqlmock.AnyArg(), // session_id
+			sqlmock.AnyArg(), // codex_installation_id
 			createdAt,
 		).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at"}).AddRow(int64(100), createdAt))
@@ -1328,6 +1330,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullString{},  // billing_mode
 			sql.NullFloat64{}, // account_stats_cost
 			sql.NullString{},  // session_id
+			sql.NullString{},  // codex_installation_id
 			now,
 		}})
 		require.NoError(t, err)
@@ -1389,6 +1392,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullString{},  // billing_mode
 			sql.NullFloat64{}, // account_stats_cost
 			sql.NullString{},  // session_id
+			sql.NullString{},  // codex_installation_id
 			now,
 		}})
 		require.NoError(t, err)
@@ -1450,6 +1454,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullString{},  // billing_mode
 			sql.NullFloat64{}, // account_stats_cost
 			sql.NullString{},  // session_id
+			sql.NullString{},  // codex_installation_id
 			now,
 		}})
 		require.NoError(t, err)

--- a/backend/internal/repository/usage_log_repo_request_type_test.go
+++ b/backend/internal/repository/usage_log_repo_request_type_test.go
@@ -1251,7 +1251,8 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullString{},
 			sql.NullString{},
 			sql.NullFloat64{},
-			sql.NullString{},
+			sql.NullString{}, // session_id
+			sql.NullString{}, // codex_installation_id
 			now,
 		}})
 		require.NoError(t, err)

--- a/backend/internal/repository/usage_log_session_id_unit_test.go
+++ b/backend/internal/repository/usage_log_session_id_unit_test.go
@@ -32,7 +32,7 @@ func newSessionIDUsageLog(sessionID *string) *service.UsageLog {
 // arg slice / arg-type table so the five INSERT column lists stay in sync. session_id
 // is the penultimate arg (created_at is always last).
 func TestPrepareUsageLogInsert_SessionIDArgWiring(t *testing.T) {
-	require.Len(t, usageLogInsertArgTypes, 60, "arg-type table must include upstream_response_model, upstream_model_mismatch, gateway_latency_ms and session_id")
+	require.Len(t, usageLogInsertArgTypes, 61, "arg-type table must include session_id and codex_installation_id")
 
 	sessionID := "sess-persisted-123"
 	prepared := prepareUsageLogInsert(newSessionIDUsageLog(&sessionID))
@@ -40,29 +40,31 @@ func TestPrepareUsageLogInsert_SessionIDArgWiring(t *testing.T) {
 	require.Len(t, prepared.args, len(usageLogInsertArgTypes),
 		"prepared args must match the arg-type table length")
 
-	// created_at is last; session_id is the arg immediately before it.
-	sessionArg := prepared.args[len(prepared.args)-2]
+	// created_at is last; codex_installation_id is penultimate; session_id precedes it.
+	sessionArg := prepared.args[len(prepared.args)-3]
 	ns, ok := sessionArg.(sql.NullString)
 	require.True(t, ok, "session_id arg should be a sql.NullString, got %T", sessionArg)
 	require.True(t, ns.Valid)
 	require.Equal(t, sessionID, ns.String)
 
-	require.Equal(t, "text", usageLogInsertArgTypes[len(usageLogInsertArgTypes)-2],
+	require.Equal(t, "text", usageLogInsertArgTypes[len(usageLogInsertArgTypes)-3],
 		"session_id arg type must be text")
+	require.Equal(t, "text", usageLogInsertArgTypes[len(usageLogInsertArgTypes)-2],
+		"codex_installation_id arg type must be text")
 }
 
 // TestPrepareUsageLogInsert_SessionIDNullWhenAbsent proves an absent session id is
 // persisted as SQL NULL rather than an empty string.
 func TestPrepareUsageLogInsert_SessionIDNullWhenAbsent(t *testing.T) {
 	prepared := prepareUsageLogInsert(newSessionIDUsageLog(nil))
-	sessionArg := prepared.args[len(prepared.args)-2]
+	sessionArg := prepared.args[len(prepared.args)-3]
 	ns, ok := sessionArg.(sql.NullString)
 	require.True(t, ok, "session_id arg should be a sql.NullString, got %T", sessionArg)
 	require.False(t, ns.Valid, "absent session id must be NULL, not empty string")
 
 	empty := ""
 	preparedEmpty := prepareUsageLogInsert(newSessionIDUsageLog(&empty))
-	nsEmpty := preparedEmpty.args[len(preparedEmpty.args)-2].(sql.NullString)
+	nsEmpty := preparedEmpty.args[len(preparedEmpty.args)-3].(sql.NullString)
 	require.False(t, nsEmpty.Valid, "empty session id must also be NULL")
 }
 
@@ -71,6 +73,8 @@ func TestPrepareUsageLogInsert_SessionIDNullWhenAbsent(t *testing.T) {
 func TestUsageLogInsertQueries_IncludeSessionID(t *testing.T) {
 	require.Contains(t, usageLogSelectColumns, "session_id",
 		"SELECT column list must include session_id")
+	require.Contains(t, usageLogSelectColumns, "codex_installation_id",
+		"SELECT column list must include codex_installation_id")
 	require.Contains(t, usageLogSelectColumns, "upstream_response_model",
 		"SELECT column list must include upstream_response_model")
 	require.Contains(t, usageLogSelectColumns, "upstream_model_mismatch",
@@ -86,6 +90,7 @@ func TestUsageLogInsertQueries_IncludeSessionID(t *testing.T) {
 	batchQuery, batchArgs := buildUsageLogBatchInsertQuery([]string{key},
 		map[string]usageLogInsertPrepared{key: prepared})
 	require.Contains(t, batchQuery, "session_id")
+	require.Contains(t, batchQuery, "codex_installation_id")
 	// Two column references (INSERT column list + SELECT ... FROM input) plus the CTE def.
 	require.GreaterOrEqual(t, strings.Count(batchQuery, "session_id"), 3)
 	require.Len(t, batchArgs, len(prepared.args)+1,
@@ -93,5 +98,6 @@ func TestUsageLogInsertQueries_IncludeSessionID(t *testing.T) {
 
 	bestEffortQuery, bestEffortArgs := buildUsageLogBestEffortInsertQuery([]usageLogInsertPrepared{prepared})
 	require.Contains(t, bestEffortQuery, "session_id")
+	require.Contains(t, bestEffortQuery, "codex_installation_id")
 	require.Len(t, bestEffortArgs, len(prepared.args))
 }

--- a/backend/internal/service/openai_codex_fingerprint.go
+++ b/backend/internal/service/openai_codex_fingerprint.go
@@ -380,6 +380,29 @@ func resolveCodexFingerprintIDsFromRequest(account *Account, clientHeaders http.
 	return resolveCodexFingerprintIDs(account, clientSessionID, mode)
 }
 
+// CodexEgressInstallationIDForUsage returns the outbound installation_id that
+// fingerprint convergence applies (or would apply) for this account+request.
+// Prefer staged IDs from the live attempt when present so usage_logs matches the
+// headers actually sent upstream; otherwise resolve from account+client headers.
+// Empty when fingerprint is off / unavailable — callers persist NULL.
+func CodexEgressInstallationIDForUsage(c *gin.Context, account *Account) string {
+	if ids := stagedCodexFingerprintIDs(c, account); ids != nil {
+		return strings.TrimSpace(ids.installationID)
+	}
+	if account == nil {
+		return ""
+	}
+	var headers http.Header
+	if c != nil && c.Request != nil {
+		headers = c.Request.Header
+	}
+	ids := resolveCodexFingerprintIDsFromRequest(account, headers)
+	if ids == nil {
+		return ""
+	}
+	return strings.TrimSpace(ids.installationID)
+}
+
 // applyCodexFingerprintHeaders 按预计算的收敛 ID 改写出站 HTTP 头中的设备指纹。
 // 在 buildUpstreamRequest 的白名单透传之后、enforceCodexIdentityHeaders 之前调用。
 func applyCodexFingerprintHeaders(h http.Header, ids *codexFingerprintIDs) {

--- a/backend/internal/service/openai_codex_fingerprint_test.go
+++ b/backend/internal/service/openai_codex_fingerprint_test.go
@@ -990,3 +990,37 @@ func TestApplyCodexFingerprintClientMetadataRaw_NonObjectBodyUntouched(t *testin
 		assert.Equal(t, []byte(body), out)
 	}
 }
+
+func TestCodexEgressInstallationIDForUsage_DeviceMode(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	account := newTestOAuthAccount(17, map[string]any{
+		codexFingerprintModeExtraKey: string(codexFingerprintDevice),
+		codexFingerprintSeedExtraKey: testCodexFingerprintSeed,
+	})
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	req.Header.Set("session-id", "client-sess-A")
+	c.Request = req
+
+	got := CodexEgressInstallationIDForUsage(c, account)
+	want := resolveDeviceModeInstallationID(account, testCodexFingerprintSeed, "client-sess-A")
+	require.Equal(t, want, got)
+	require.NotEmpty(t, got)
+
+	// Staged IDs from a live attempt win over header re-resolve.
+	staged := resolveCodexFingerprintIDs(account, "other-sess", codexFingerprintDevice)
+	require.NotNil(t, staged)
+	stageCodexFingerprintIDs(c, staged)
+	require.Equal(t, staged.installationID, CodexEgressInstallationIDForUsage(c, account))
+}
+
+func TestCodexEgressInstallationIDForUsage_OffReturnsEmpty(t *testing.T) {
+	account := newTestOAuthAccount(17, map[string]any{
+		codexFingerprintModeExtraKey: string(codexFingerprintOff),
+	})
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Request.Header.Set("session-id", "ignored")
+	require.Empty(t, CodexEgressInstallationIDForUsage(c, account))
+}

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -26,6 +26,7 @@ const (
 
 var explicitOpenAIHeaderSessionNames = []string{
 	"session_id",
+	"session-id", // Codex CLI / Desktop / VS Code hyphen form
 	"conversation_id",
 	openCodeSessionAffinityHeader,
 	openCodeSessionIDHeader,

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -27,11 +27,12 @@ type OpenAIRecordUsageInput struct {
 	UpstreamEndpoint   string
 	UserAgent          string // 请求的 User-Agent
 	IPAddress          string // 请求的客户端 IP 地址
-	SessionID          string // 客户端显式会话标识（session_id / X-Session-Id 等请求头），仅用于用量行会话关联
-	RequestPayloadHash string
-	APIKeyService      APIKeyQuotaUpdater
-	QuotaPlatform      string // user×platform quota platform resolved by the handler before async billing.
-	TkHoldRequestID    string // pre-flight balance hold key consumed by usage billing settlement.
+	SessionID             string // 客户端显式会话标识（session_id / session-id / X-Session-Id 等），仅用于用量行会话关联
+	CodexInstallationID   string // 出站 installation_id（指纹收敛后）；空表示不适用/未测
+	RequestPayloadHash    string
+	APIKeyService         APIKeyQuotaUpdater
+	QuotaPlatform         string // user×platform quota platform resolved by the handler before async billing.
+	TkHoldRequestID       string // pre-flight balance hold key consumed by usage billing settlement.
 	// PricingAt 是请求级定价时刻（请求开始捕获，与利润门的 D 同源）：高峰因子
 	// 按该时刻计算，保证同一请求从准入到扣费不中途变价。零值回退记录时刻
 	//（既有行为），供未装配的路径（图片/异步/cyber 等）沿用。
@@ -438,6 +439,7 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 
 	// 添加 SessionID（客户端显式会话标识；缺失/无效时保持 nil）
 	usageLog.SessionID = optionalTrimmedStringPtr(input.SessionID)
+	usageLog.CodexInstallationID = optionalTrimmedStringPtr(input.CodexInstallationID)
 
 	if apiKey.GroupID != nil {
 		usageLog.GroupID = apiKey.GroupID

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -18,21 +18,21 @@ import (
 
 // OpenAIRecordUsageInput input for recording usage
 type OpenAIRecordUsageInput struct {
-	Result             *OpenAIForwardResult
-	APIKey             *APIKey
-	User               *User
-	Account            *Account
-	Subscription       *UserSubscription
-	InboundEndpoint    string
-	UpstreamEndpoint   string
-	UserAgent          string // 请求的 User-Agent
-	IPAddress          string // 请求的客户端 IP 地址
-	SessionID             string // 客户端显式会话标识（session_id / session-id / X-Session-Id 等），仅用于用量行会话关联
-	CodexInstallationID   string // 出站 installation_id（指纹收敛后）；空表示不适用/未测
-	RequestPayloadHash    string
-	APIKeyService         APIKeyQuotaUpdater
-	QuotaPlatform         string // user×platform quota platform resolved by the handler before async billing.
-	TkHoldRequestID       string // pre-flight balance hold key consumed by usage billing settlement.
+	Result              *OpenAIForwardResult
+	APIKey              *APIKey
+	User                *User
+	Account             *Account
+	Subscription        *UserSubscription
+	InboundEndpoint     string
+	UpstreamEndpoint    string
+	UserAgent           string // 请求的 User-Agent
+	IPAddress           string // 请求的客户端 IP 地址
+	SessionID           string // 客户端显式会话标识（session_id / session-id / X-Session-Id 等），仅用于用量行会话关联
+	CodexInstallationID string // 出站 installation_id（指纹收敛后）；空表示不适用/未测
+	RequestPayloadHash  string
+	APIKeyService       APIKeyQuotaUpdater
+	QuotaPlatform       string // user×platform quota platform resolved by the handler before async billing.
+	TkHoldRequestID     string // pre-flight balance hold key consumed by usage billing settlement.
 	// PricingAt 是请求级定价时刻（请求开始捕获，与利润门的 D 同源）：高峰因子
 	// 按该时刻计算，保证同一请求从准入到扣费不中途变价。零值回退记录时刻
 	//（既有行为），供未装配的路径（图片/异步/cyber 等）沿用。

--- a/backend/internal/service/session_id.go
+++ b/backend/internal/service/session_id.go
@@ -25,6 +25,10 @@ var clientSessionIDHeaders = append(
 // protocol-agnostic and shared by every gateway handler so all supported protocols
 // record session_id through one seam. Returns "" when no valid identifier is present.
 //
+// Codex clients send `session-id` (hyphen); OpenAI-compatible sticky clients often
+// send `session_id` (underscore). Both are accepted so usage_logs can COUNT DISTINCT
+// sessions for OAuth egress forensics (device/session fingerprint investigations).
+//
 // This value feeds only usage_logs.session_id persistence. It does NOT affect sticky
 // routing, account selection, request_id semantics, or upstream prompt caching, which
 // keep their own (intentionally broader) session-signal resolution.

--- a/backend/internal/service/session_id_test.go
+++ b/backend/internal/service/session_id_test.go
@@ -80,6 +80,7 @@ func TestExtractClientSessionID_SupportedHeaders(t *testing.T) {
 		value  string
 	}{
 		{"session_id", "session_id", "sess-A"},
+		{"session-id hyphen (Codex)", "session-id", "sess-codex-hyphen"},
 		{"conversation_id", "conversation_id", "conv-B"},
 		{"X-Session-Affinity", openCodeSessionAffinityHeader, "aff-C"},
 		{"X-Session-Id", openCodeSessionIDHeader, "sid-D"},
@@ -99,11 +100,22 @@ func TestExtractClientSessionID_HeaderPrecedence(t *testing.T) {
 	// session_id ranks ahead of conversation_id and the X-* variants.
 	c := newSessionHeaderContext(t, map[string]string{
 		"session_id":                "primary",
+		"session-id":                "codex-hyphen",
 		"conversation_id":           "secondary",
 		openCodeSessionIDHeader:     "tertiary",
 		codeBuddyConversationHeader: "quaternary",
 	})
 	require.Equal(t, "primary", ExtractClientSessionID(c))
+}
+
+func TestExtractClientSessionID_CodexHyphenWhenUnderscoreAbsent(t *testing.T) {
+	// Codex CLI/Desktop only send session-id; without this, usage_logs.session_id
+	// stays NULL and outbound session cardinality cannot be audited.
+	c := newSessionHeaderContext(t, map[string]string{
+		"session-id":      "codex-only-session",
+		"conversation_id": "should-not-win",
+	})
+	require.Equal(t, "codex-only-session", ExtractClientSessionID(c))
 }
 
 func TestExtractClientSessionID_Sanitizes(t *testing.T) {

--- a/backend/internal/service/usage_log.go
+++ b/backend/internal/service/usage_log.go
@@ -179,9 +179,13 @@ type UsageLog struct {
 	UserAgent        *string
 	IPAddress        *string
 	// SessionID is the explicit client-provided request correlation identifier
-	// (e.g. the session_id / X-Session-Id headers). Nil when the client sent no
-	// valid session header. It is never derived from prompt_cache_key or content.
+	// (e.g. the session_id / session-id / X-Session-Id headers). Nil when the
+	// client sent no valid session header. It is never derived from
+	// prompt_cache_key or content.
 	SessionID *string
+	// CodexInstallationID is the outbound x-codex-installation-id after
+	// fingerprint convergence. Nil when fingerprint is off / non-Codex / unmeasured.
+	CodexInstallationID *string
 
 	// Cache TTL Override 标记（管理员强制替换了缓存 TTL 计费）
 	CacheTTLOverridden bool

--- a/backend/migrations/tk_095_usage_logs_codex_installation_id.sql
+++ b/backend/migrations/tk_095_usage_logs_codex_installation_id.sql
@@ -1,0 +1,10 @@
+-- Persist outbound Codex installation_id for OAuth egress forensics.
+-- Lets operators COUNT DISTINCT devices after fingerprint convergence without
+-- relying on rotated docker logs. Nullable: non-Codex / fingerprint-off rows stay NULL.
+-- bluegreen-safe-destructive-ok: nullable expand-only column on usage_logs.
+
+ALTER TABLE usage_logs
+    ADD COLUMN IF NOT EXISTS codex_installation_id VARCHAR(64);
+
+COMMENT ON COLUMN usage_logs.codex_installation_id IS
+    'Outbound Codex x-codex-installation-id after fingerprint convergence (device/session/full). NULL when not applicable (fingerprint off, non-Codex, or unmeasured).';

--- a/backend/migrations/tk_095_usage_logs_codex_installation_id.sql
+++ b/backend/migrations/tk_095_usage_logs_codex_installation_id.sql
@@ -8,3 +8,4 @@ ALTER TABLE usage_logs
 
 COMMENT ON COLUMN usage_logs.codex_installation_id IS
     'Outbound Codex x-codex-installation-id after fingerprint convergence (device/session/full). NULL when not applicable (fingerprint off, non-Codex, or unmeasured).';
+-- high-risk-anchor: nullable expand-only usage_logs.codex_installation_id (tk_095)


### PR DESCRIPTION
## 摘要
- Codex 客户端只发 `session-id`（连字符），原先不入 `usage_logs.session_id`；现补认该头。
- 新增可空列 `usage_logs.codex_installation_id`（`tk_095`）记录出站 installation，便于 device 桶扇出排查。
- no-web-impact

## 风险
- 高风险路径命中：`backend/migrations/` schema 变更（可空 expand-only，`ADD COLUMN IF NOT EXISTS`）。
- high-risk-anchor：`tk_095` 仅新增可空列，不改既有列/不删数据；部署后历史行仍为 NULL。
- upstream-touch-trivial：用量落库 / session 提取 / fingerprint 小范围遥测扩展。
- sentinel-registry-reviewed：gateway-tk / usage 接线，无需新增 sentinel 锚点。

## 验证
- `go test -tags=unit`（session_id / CodexEgressInstallationIDForUsage / usage_log insert / scan fixture）通过
- `make lint` 0 issues
- preflight PASS

## 提交
- 9a5ce01d3 fix(repository): align usage_log scan fixture with codex_installation_id
- 82d056d90 chore(migrations): acknowledge tk_095 usage_logs column as high-risk-anchor
- a535b34c0 style: gofmt usage log insert and openai gateway usage
- b2c0b40d7 fix(openai): 落库 Codex session-id 与出站 installation_id 便于吊销排查
- 最新提交：9a5ce01d3