### PR TITLE
chore(fingerprint): align Antigravity CLI pin to 1.1.27

### DIFF
--- a/backend/internal/pkg/antigravity/oauth.go
+++ b/backend/internal/pkg/antigravity/oauth.go
@@ -37,7 +37,7 @@ const (
 	// Ground truth = 本机 `agy`（Antigravity CLI，`brew install --cask antigravity-cli`）版本；
 	// UA 形如 `antigravity/cli/<ver> darwin/arm64`。运行时可经 admin 设置
 	// antigravity_user_agent_version 热推覆盖。
-	DefaultUserAgentVersion = "1.1.26"
+	DefaultUserAgentVersion = "1.1.27"
 
 	// 固定的 redirect_uri（用户需手动复制 code）
 	RedirectURI = "http://localhost:8085/callback"

--- a/backend/internal/pkg/antigravity/oauth_test.go
+++ b/backend/internal/pkg/antigravity/oauth_test.go
@@ -703,7 +703,7 @@ func TestConstants_值正确(t *testing.T) {
 	if RedirectURI != "http://localhost:8085/callback" {
 		t.Errorf("RedirectURI 不匹配: got %s", RedirectURI)
 	}
-	if GetUserAgent() != "antigravity/cli/1.1.26 darwin/arm64" {
+	if GetUserAgent() != "antigravity/cli/1.1.27 darwin/arm64" {
 		t.Errorf("UserAgent 不匹配: got %s", GetUserAgent())
 	}
 	if SessionTTL != 30*time.Minute {

--- a/docs/ops/antigravity-fingerprint-changelog.md
+++ b/docs/ops/antigravity-fingerprint-changelog.md
@@ -17,6 +17,7 @@ Drift-fix recipe (see the `tokenkey-antigravity-fingerprint-alignment` skill):
 
 | date (UTC) | UA version | type | change | note |
 |---|---|---|---|---|
+| 2026-09-06 | **1.1.27** | pure UA | `DefaultUserAgentVersion` 1.1.26 → 1.1.27 | Local `agy --version` ground truth; HTTP UA format unchanged. Closes #2014. |
 | 2026-09-04 | **1.1.26** | pure UA | `DefaultUserAgentVersion` 1.1.19 → 1.1.26 | Local `agy --version` ground truth; HTTP UA format unchanged. |
 | 2026-06-10 | 1.23.2 | baseline | — | capture toolchain added; `DefaultUserAgentVersion=1.23.2`, body `userAgent="antigravity"`, ideType=`ANTIGRAVITY`, `X-Goog-Api-Client=gl-node/22.21.1`. No real-IDE capture yet (IDE not installed locally). |
 | 2026-06-11 | 1.23.2 | toolchain-verify | — | First real-client capture via the **Antigravity CLI** (`agy` 1.0.7, Go) through mitmproxy→gost, not the IDE. Confirms body `userAgent="antigravity"` ✓ and ideType=`ANTIGRAVITY` ✓. CLI is a distinct client from the IDE the baseline mirrors: UA `antigravity/cli/1.0.7 darwin/arm64`, no `gl-node` header (Go, not Node), endpoint `daily-cloudcode-pa.googleapis.com`. No baseline change — IDE remains the mimic target; see skill § "用 Antigravity CLI（`agy`）采集" for the Go-CLI login-keychain trust path. |


### PR DESCRIPTION
## 摘要
- 将 Antigravity CLI `DefaultUserAgentVersion` 从 `1.1.26` 对齐到本机 `agy --version` 的 `1.1.27`
- 同步更新 `oauth_test.go` 断言与 fingerprint changelog
- 修复 #2014（client-release-watch release-drift）

## 风险
- 低：仅 UA 版本常量 bump，HTTP UA 格式与其它指纹字段不变
- 发版前可用 admin `antigravity_user_agent_version` 热推；本 PR 更新编译默认值
- Web impact: none
- sentinel-registry-reviewed：`oauth.go` 仅替换版本字面量；既有 `scripts/sentinels/antigravity.json` 已锚定 UA 格式 `antigravity/cli/%s darwin/arm64`，无需新增 anchor

## 验证
- `agy --version` → `1.1.27`
- `bash ops/antigravity/capture-antigravity-fingerprint.sh check` → ua_version match
- `python3 -m unittest discover -s ops/antigravity -p 'test_*.py' -t ops/antigravity` → OK
- `go test -tags=unit ./internal/pkg/antigravity/` → ok
- `./scripts/preflight.sh` → pass

## 提交
- `da9c94107` chore(fingerprint): align Antigravity CLI pin to 1.1.27
- 最新提交：`da9c94107`