### PR TITLE
fix(admin): PUT model_mapping 保留 base_url + TTS 契约

### DIFF
--- a/.cursor/skills/tokenkey-account-model-probe/SKILL.md
+++ b/.cursor/skills/tokenkey-account-model-probe/SKILL.md
@@ -28,8 +28,11 @@ automatically ships the registered companions for every script in the table;
 inspect its machine-owned contract before a less familiar path with
 `--script <path> --describe-script`. Use `messages` for
 Anthropic/Kiro, `chat` for OpenAI-compatible chat, `responses` for Codex/OpenAI
-Responses, and `embeddings` for embedding SKUs. Read each script's header for optional
-request-shape parameters; do not copy account-specific commands into this skill.
+Responses, `embeddings` for embedding SKUs, `images` for
+`/v1/images/generations`, and `speech` for OpenAI-compat TTS
+(`POST /v1/audio/speech`, e.g. Ali Token Plan `qwen-audio-3.0-tts-plus`).
+Read each script's header for optional request-shape parameters; do not copy
+account-specific commands into this skill.
 
 ## Interpret the result
 

--- a/.testing/user-stories/stories/US-048-model-supplier-source-management.md
+++ b/.testing/user-stories/stories/US-048-model-supplier-source-management.md
@@ -98,7 +98,8 @@
 - `backend/internal/service/supplier_managed_account_guard_test.go`::`TestUS048_ManagedAccountDuplicateStripsSupplierIdentity`
 - `backend/internal/service/supplier_managed_account_guard_test.go`::`TestUS048_UnmanagedAccountCannotForgeSupplierManagedExtra`
 - `backend/internal/service/supplier_managed_account_guard_test.go`::`TestUS048_PreserveSupplierManagedExtraKeys`
-- `backend/internal/service/admin_service_credentials_merge_test.go`::`TestUpdateAccount_RejectsMissingProtocolEndpointBeforePersist`
+- `backend/internal/service/admin_service_credentials_merge_test.go`::`TestUpdateAccount_ModelMappingOnlyPreservesBaseURL`
+- `backend/internal/service/admin_service_credentials_merge_test.go`::`TestUpdateAccount_RejectsMissingProtocolEndpointWhenBaseURLCleared`
 - `backend/internal/service/admin_service_credentials_merge_test.go`::`TestUpdateAccount_RejectsTypeChangeWithoutProtocolEndpointBeforePersist`
 - `backend/internal/service/admin_service_credentials_merge_test.go`::`TestUpdateAccount_RejectsIncompleteCustomProtocolEndpointBeforePersist`
 - `backend/internal/handler/admin/account_handler_mixed_channel_test.go`::`TestAccountHandlerUpdateReturnsBadRequestForMissingProtocolEndpointIdentity`

--- a/backend/internal/handler/admin/account_handler_mixed_channel_test.go
+++ b/backend/internal/handler/admin/account_handler_mixed_channel_test.go
@@ -157,10 +157,12 @@ func TestAccountHandlerUpdateReturnsBadRequestForMissingProtocolEndpointIdentity
 	router := setupAccountMixedChannelRouter(adminSvc)
 
 	rec := httptest.NewRecorder()
+	// Explicit empty base_url is the real failure mode after Admin merge
+	// preserves omitted base_url on model_mapping-only patches.
 	req := httptest.NewRequest(
 		http.MethodPut,
 		"/api/v1/admin/accounts/132",
-		bytes.NewBufferString(`{"credentials":{"model_mapping":{"qwen-audio-3.0-tts-plus":"qwen-audio-3.0-tts-plus"}}}`),
+		bytes.NewBufferString(`{"credentials":{"base_url":"","model_mapping":{"qwen-audio-3.0-tts-plus":"qwen-audio-3.0-tts-plus"}}}`),
 	)
 	req.Header.Set("Content-Type", "application/json")
 	router.ServeHTTP(rec, req)

--- a/backend/internal/service/account_protocol_endpoint_credentials.go
+++ b/backend/internal/service/account_protocol_endpoint_credentials.go
@@ -16,15 +16,19 @@ const apiBaseURLsCredentialKey = "api_base_urls"
 type CredentialMergeMode int
 
 const (
-	// CredentialMergeAdmin mirrors MergePreservingSensitiveCreds: non-sensitive
-	// keys are wholly decided by incoming (omit = delete); sensitive keys are
-	// preserved when omitted.
+	// CredentialMergeAdmin mirrors MergePreservingSensitiveCreds for most
+	// non-sensitive keys (omit = delete) and preserves sensitive keys when
+	// omitted. base_url is also preserved when omitted so model_mapping-only
+	// (and similar) admin patches cannot wipe protocol endpoint identity; send
+	// an explicit empty/null base_url to clear.
 	CredentialMergeAdmin CredentialMergeMode = iota
 	// CredentialMergePreserveAll mirrors CRS mergeMap: existing keys survive
 	// unless incoming overwrites them. Protocol identity keys are still never
 	// inherited implicitly (see MergeAccountCredentials).
 	CredentialMergePreserveAll
 )
+
+const baseURLCredentialKey = "base_url"
 
 // MergeAccountCredentials is the SSOT credential merge for every persistence
 // write that combines an existing map with an incoming patch/payload.
@@ -42,6 +46,14 @@ func MergeAccountCredentials(existing, incoming map[string]any, channelType int,
 		merged = mergeMap(existing, incoming)
 	default:
 		merged = MergePreservingSensitiveCreds(existing, incoming)
+		// Admin UI / ops often PATCH only model_mapping. Wiping base_url there
+		// fails the #2024 BuildProtocolEndpointIdentity gate even though the
+		// operator never intended to rotate the upstream host.
+		if incoming != nil && !credentialMapHasKey(incoming, baseURLCredentialKey) {
+			if existingVal, ok := existing[baseURLCredentialKey]; ok {
+				merged[baseURLCredentialKey] = existingVal
+			}
+		}
 	}
 	if incoming == nil || !credentialMapHasKey(incoming, apiBaseURLsCredentialKey) {
 		delete(merged, apiBaseURLsCredentialKey)

--- a/backend/internal/service/account_protocol_endpoint_credentials_test.go
+++ b/backend/internal/service/account_protocol_endpoint_credentials_test.go
@@ -10,6 +10,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMergeAccountCredentials_AdminPreservesBaseURLWhenOmitted(t *testing.T) {
+	existing := map[string]any{
+		"api_key":  "sk-existing",
+		"base_url": "https://token-plan.cn-beijing.maas.aliyuncs.com",
+	}
+	incoming := map[string]any{
+		"model_mapping": map[string]any{"qwen-audio-3.0-tts-plus": "qwen-audio-3.0-tts-plus"},
+	}
+	merged := MergeAccountCredentials(existing, incoming, newapiconstant.ChannelTypeAli, CredentialMergeAdmin)
+	require.Equal(t, "https://token-plan.cn-beijing.maas.aliyuncs.com", merged["base_url"])
+	require.Equal(t, "sk-existing", merged["api_key"])
+	mapping, ok := merged["model_mapping"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "qwen-audio-3.0-tts-plus", mapping["qwen-audio-3.0-tts-plus"])
+}
+
+func TestMergeAccountCredentials_AdminExplicitEmptyBaseURLClears(t *testing.T) {
+	existing := map[string]any{
+		"api_key":  "sk-existing",
+		"base_url": "https://token-plan.cn-beijing.maas.aliyuncs.com",
+	}
+	incoming := map[string]any{
+		"base_url": "",
+	}
+	merged := MergeAccountCredentials(existing, incoming, newapiconstant.ChannelTypeAli, CredentialMergeAdmin)
+	require.Equal(t, "", merged["base_url"])
+	require.Equal(t, "sk-existing", merged["api_key"])
+}
+
 func TestMergeAccountCredentials_CRSPreserveAllDropsStaleExclusive(t *testing.T) {
 	existing := supplierManagedCredentials(
 		"https://supplier.example/v1", "supplier-secret",

--- a/backend/internal/service/admin_service_credentials_merge_test.go
+++ b/backend/internal/service/admin_service_credentials_merge_test.go
@@ -122,8 +122,43 @@ func TestUpdateAccount_EmptyCredentialsSkipsUpdate(t *testing.T) {
 	require.Equal(t, "renamed", repo.account.Name)
 }
 
-func TestUpdateAccount_RejectsMissingProtocolEndpointBeforePersist(t *testing.T) {
+func TestUpdateAccount_ModelMappingOnlyPreservesBaseURL(t *testing.T) {
 	accountID := int64(132)
+	baseURL := "https://token-plan.cn-beijing.maas.aliyuncs.com"
+	repo := &updateAccountCredsRepoStub{
+		account: &Account{
+			ID:          accountID,
+			Platform:    PlatformNewAPI,
+			Type:        AccountTypeAPIKey,
+			ChannelType: newapiconstant.ChannelTypeAli,
+			Status:      StatusActive,
+			Credentials: map[string]any{
+				"api_key":  "sk-existing",
+				"base_url": baseURL,
+			},
+		},
+	}
+
+	updated, err := (&adminServiceImpl{accountRepo: repo}).UpdateAccount(
+		context.Background(),
+		accountID,
+		&UpdateAccountInput{Credentials: map[string]any{
+			"model_mapping": map[string]any{"qwen-audio-3.0-tts-plus": "qwen-audio-3.0-tts-plus"},
+		}},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	require.Equal(t, 1, repo.updateCalls)
+	require.Equal(t, baseURL, repo.account.Credentials["base_url"])
+	require.Equal(t, "sk-existing", repo.account.Credentials["api_key"])
+	mapping, ok := repo.account.Credentials["model_mapping"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "qwen-audio-3.0-tts-plus", mapping["qwen-audio-3.0-tts-plus"])
+}
+
+func TestUpdateAccount_RejectsMissingProtocolEndpointWhenBaseURLCleared(t *testing.T) {
+	accountID := int64(135)
 	repo := &updateAccountCredsRepoStub{
 		account: &Account{
 			ID:          accountID,
@@ -142,6 +177,7 @@ func TestUpdateAccount_RejectsMissingProtocolEndpointBeforePersist(t *testing.T)
 		context.Background(),
 		accountID,
 		&UpdateAccountInput{Credentials: map[string]any{
+			"base_url":      "",
 			"model_mapping": map[string]any{"qwen-audio-3.0-tts-plus": "qwen-audio-3.0-tts-plus"},
 		}},
 	)
@@ -149,8 +185,7 @@ func TestUpdateAccount_RejectsMissingProtocolEndpointBeforePersist(t *testing.T)
 	require.Nil(t, updated)
 	require.Equal(t, http.StatusBadRequest, infraerrors.Code(err))
 	require.Equal(t, "INVALID_ACCOUNT_PROTOCOL_ENDPOINT_IDENTITY", infraerrors.Reason(err))
-	require.ErrorContains(t, err, "governed account has no explicit protocol endpoint identity")
-	require.Zero(t, repo.updateCalls, "invalid endpoint identity must be rejected before persistence")
+	require.Zero(t, repo.updateCalls, "cleared base_url must be rejected before persistence")
 }
 
 func TestUpdateAccount_RejectsTypeChangeWithoutProtocolEndpointBeforePersist(t *testing.T) {

--- a/docs/agent_integration.md
+++ b/docs/agent_integration.md
@@ -1030,7 +1030,7 @@ group MUST set `platform` to exactly one of:
 | `anthropic` | `POST /v1/messages` (native Anthropic), `POST /v1/messages/count_tokens`, `POST /responses`, `GET /responses` (WS), and the `requireGroupAnthropic`-gated `/responses`, `/chat/completions`, `/embeddings`, `/images/generations` | Native Claude account pool. |
 | `gemini` | `GET /v1beta/models`, `GET /v1beta/models/:model`, `POST /v1beta/models/*modelAction` | Gemini-native surface. |
 | `antigravity` | `GET /antigravity/models`, the `/antigravity/v1` and `/antigravity/v1beta` subtrees | Antigravity-native surface; admin endpoints under `/admin/antigravity/*`. |
-| `newapi` | Same OpenAI-compat surface as `openai` (`/v1/chat/completions`, `/v1/messages`, `/v1/responses` and the WS variant) | First-class fifth platform — see next section. |
+| `newapi` | Same OpenAI-compat surface as `openai` (`/v1/chat/completions`, `/v1/messages`, `/v1/responses`, `/v1/images/generations`, `POST /v1/audio/speech` where the account mapping + pricing overlay serve TTS) | First-class fifth platform — see next section. |
 | `kiro` | `POST /v1/messages` through the Anthropic-shaped client surface | Kiro-native scheduling pool backed by the vendored CodeWhisperer/EventStream protocol layer. |
 | `grok` | Same OpenAI-compat surface as `openai` (`/v1/chat/completions`, `/v1/messages`, `/v1/responses`, embeddings/images/video where enabled) | First-class Grok/xAI platform. Edge capacity is `type=oauth`; prod edge relay stubs may be `type=apikey` with an edge `base_url`. |
 
@@ -1045,7 +1045,9 @@ all account platforms. Each `data` item contains exactly `id` and
 Per `docs/approved/newapi-as-fifth-platform.md`, `group.platform = "newapi"`
 participates in the **OpenAI-compatible** scheduling pool and answers the
 same three OpenAI-shaped entry points (`/v1/chat/completions`,
-`/v1/messages`, `/v1/responses`) as `openai` groups. Agent-visible
+`/v1/messages`, `/v1/responses`) as `openai` groups, plus media paths the
+account mapping serves (`/v1/images/generations`, and for Ali Token Plan
+TTS `POST /v1/audio/speech`). Agent-visible
 contract:
 
 - A `newapi` group MUST contain at least one `Account.Platform = "newapi"`
@@ -1093,6 +1095,33 @@ adapter registry:
 
 The video registry record TTL defaults to 24h. Polls after expiry or
 after a terminal status (`succeeded` / `failed`) return 404.
+
+### TTS (`POST /v1/audio/speech`) — Ali Token Plan
+
+OpenAI-compat speech synthesis is available when the scheduled `newapi`
+account maps a TTS model (today: `qwen-audio-3.0-tts-plus` on Ali Token
+Plan, `channel_type = 17`) and the pricing overlay has `mode: tts`.
+
+```http
+POST /v1/audio/speech
+Authorization: Bearer <api_key>
+Content-Type: application/json
+
+{
+  "model": "qwen-audio-3.0-tts-plus",
+  "input": "你好，TokenKey",
+  "voice": "longanlingxin",
+  "response_format": "mp3"
+}
+```
+
+- Success: `200` with `Content-Type: audio/mpeg` (raw audio bytes).
+- Omit `voice` → gateway default `longanlingxin` (Ali SpeechSynthesizer).
+- Billing: character-based (`output_cost_per_character`); usage shows
+  `inbound_endpoint=/v1/audio/speech`.
+- Not a Studio media tab (Studio is image/video/chat). The model appears
+  in `GET /v1/models` when `display: true` in the served-models owner.
+- Realtime (`qwen-audio-3.0-realtime-plus`) is **not** on this surface.
 
 ## OpenRouter provider seller surface (TokenKey)
 


### PR DESCRIPTION
## 摘要
- Admin `PUT /admin/accounts/:id` 仅提交 `model_mapping` 时保留已有 `base_url`，避免 #2024 协议端点身份校验把运维局部更新打成 400。
- 显式 `base_url: \"\"` 仍会清空并被拒绝（负向测试）。
- `tokenkey-account-model-probe` 补充 `ENDPOINT=speech`；`docs/agent_integration.md` 补充 Ali Token Plan `POST /v1/audio/speech` 示例与 Studio 边界。
- 同步 US-048 Linked Tests；handler 错误映射用例 body 与真实失败模式对齐（R-001）。

## 风险
- 常规：凭证合并语义微调（Admin omit `base_url` 从「删除」改为「保留」）；显式清空行为不变。
- Web impact: none
- sentinel-registry-reviewed：`account_protocol_endpoint_credentials.go` 为既有 TK merge SSOT 语义修订（非新 companion / 非上游注入点）；正向/负向 unit test 已锚住保留与显式清空行为，本次不新增 sentinel 条目。

## 验证
- `go test -tags=unit` 相关 service/handler 用例通过。
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh` PASS。
- prod #132 抽检：TTS/wan servable（见会话记录）。

## 提交
- `d29fb28d3` fix(admin): PUT 仅改 model_mapping 时保留 base_url
- `ed1aab392` fix(admin): address R-001 — 对齐协议端点身份失败用例 body
- 最新提交：`ed1aab392`