### PR TITLE
fix(antigravity): prod→edge 中继 Gemini chat 走正确 hop

### DIFF
--- a/backend/internal/handler/endpoint.go
+++ b/backend/internal/handler/endpoint.go
@@ -345,9 +345,3 @@ func setActualUpstreamEndpoint(c *gin.Context, endpoint string) {
 		c.Set(ctxKeyActualUpstreamEndpoint, strings.TrimSpace(endpoint))
 	}
 }
-
-func shouldUseAntigravityCompat(account *service.Account) bool {
-	return account != nil &&
-		account.Platform == service.PlatformAntigravity &&
-		account.Type == service.AccountTypeOAuth
-}

--- a/backend/internal/handler/endpoint_test.go
+++ b/backend/internal/handler/endpoint_test.go
@@ -159,27 +159,6 @@ func TestDeriveUpstreamEndpoint(t *testing.T) {
 	}
 }
 
-func TestShouldUseAntigravityCompat(t *testing.T) {
-	tests := []struct {
-		name    string
-		account *service.Account
-		want    bool
-	}{
-		{"oauth", &service.Account{Platform: service.PlatformAntigravity, Type: service.AccountTypeOAuth}, true},
-		{"setup token", &service.Account{Platform: service.PlatformAntigravity, Type: service.AccountTypeSetupToken}, false},
-		{"upstream", &service.Account{Platform: service.PlatformAntigravity, Type: service.AccountTypeUpstream}, false},
-		{"api key", &service.Account{Platform: service.PlatformAntigravity, Type: service.AccountTypeAPIKey}, false},
-		{"anthropic oauth", &service.Account{Platform: service.PlatformAnthropic, Type: service.AccountTypeOAuth}, false},
-		{"nil", nil, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, shouldUseAntigravityCompat(tt.account))
-		})
-	}
-}
-
 func TestGetUpstreamEndpointPrefersRuntimeOverride(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)

--- a/backend/internal/handler/gateway_handler_tk_chat_completions_execute.go
+++ b/backend/internal/handler/gateway_handler_tk_chat_completions_execute.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"context"
-	"errors"
 
 	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -62,20 +61,12 @@ func (h *GatewayHandler) executeChatCompletionsSelectedProtocol(
 				if channelMapping.Mapped {
 					forwardBody = h.gatewayService.ReplaceModelInBody(forwardBody, channelMapping.MappedModel)
 				}
-				if service.UsesGeminiNativeOpenAICompat(account.Platform, reqModel) {
-					if h.geminiCompatService == nil {
-						return nil, errors.New("gemini compatibility service is not configured")
-					}
-					return h.geminiCompatService.ForwardAsChatCompletions(executionCtx, c, account, forwardBody)
-				}
-				if shouldUseAntigravityCompat(account) {
-					if h.antigravityGatewayService == nil {
-						return nil, errors.New("antigravity compatibility service is not configured")
-					}
-					setActualUpstreamEndpoint(c, EndpointAntigravityGenerateContent)
-					return h.antigravityGatewayService.ForwardAsChatCompletions(executionCtx, c, account, forwardBody, parsedReq)
-				}
-				return h.gatewayService.ForwardAsChatCompletions(executionCtx, c, account, forwardBody, parsedReq)
+				return h.tkForwardChatCompletionsByOpenAIShape(
+					executionCtx, c, account, reqModel, forwardBody, parsedReq,
+					func() (*service.ForwardResult, error) {
+						return h.gatewayService.ForwardAsChatCompletions(executionCtx, c, account, forwardBody, parsedReq)
+					},
+				)
 			},
 			ChatIdentity: func(executionCtx context.Context, account *service.Account, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
 				forwardBody := request.Body()
@@ -83,18 +74,13 @@ func (h *GatewayHandler) executeChatCompletionsSelectedProtocol(
 					forwardBody = h.gatewayService.ReplaceModelInBody(forwardBody, channelMapping.MappedModel)
 				}
 				setActualUpstreamEndpoint(c, protocolPlanEndpoint(plan.Endpoint()))
-				switch service.ResolveGovernedOpenAIShapeMode(account, reqModel) {
-				case service.GovernedOpenAIShapeGeminiCompat:
-					if h.geminiCompatService == nil {
-						return nil, errors.New("gemini compatibility service is not configured")
-					}
-					return h.geminiCompatService.ForwardAsChatCompletions(executionCtx, c, account, forwardBody)
-				case service.GovernedOpenAIShapeAntigravityClaudeRelay:
-					return h.gatewayService.ForwardAsChatCompletions(executionCtx, c, account, forwardBody, parsedReq)
-				default:
-					openAIResult, forwardErr := h.openAIGatewayService.ForwardAsChatCompletionsDispatched(executionCtx, c, account, forwardBody, "", channelMapping.MappedModel)
-					return service.ForwardResultFromOpenAI(openAIResult), forwardErr
-				}
+				return h.tkForwardChatCompletionsByOpenAIShape(
+					executionCtx, c, account, reqModel, forwardBody, parsedReq,
+					func() (*service.ForwardResult, error) {
+						openAIResult, forwardErr := h.openAIGatewayService.ForwardAsChatCompletionsDispatched(executionCtx, c, account, forwardBody, "", channelMapping.MappedModel)
+						return service.ForwardResultFromOpenAI(openAIResult), forwardErr
+					},
+				)
 			},
 			ChatToResponses: func(executionCtx context.Context, account *service.Account, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
 				forwardBody := request.Body()
@@ -102,18 +88,13 @@ func (h *GatewayHandler) executeChatCompletionsSelectedProtocol(
 					forwardBody = h.gatewayService.ReplaceModelInBody(forwardBody, channelMapping.MappedModel)
 				}
 				setActualUpstreamEndpoint(c, protocolPlanEndpoint(plan.Endpoint()))
-				switch service.ResolveGovernedOpenAIShapeMode(account, reqModel) {
-				case service.GovernedOpenAIShapeGeminiCompat:
-					if h.geminiCompatService == nil {
-						return nil, errors.New("gemini compatibility service is not configured")
-					}
-					return h.geminiCompatService.ForwardAsChatCompletions(executionCtx, c, account, forwardBody)
-				case service.GovernedOpenAIShapeAntigravityClaudeRelay:
-					return h.gatewayService.ForwardAsChatCompletions(executionCtx, c, account, forwardBody, parsedReq)
-				default:
-					openAIResult, forwardErr := h.openAIGatewayService.ForwardAsChatCompletions(executionCtx, c, account, forwardBody, "", channelMapping.MappedModel)
-					return service.ForwardResultFromOpenAI(openAIResult), forwardErr
-				}
+				return h.tkForwardChatCompletionsByOpenAIShape(
+					executionCtx, c, account, reqModel, forwardBody, parsedReq,
+					func() (*service.ForwardResult, error) {
+						openAIResult, forwardErr := h.openAIGatewayService.ForwardAsChatCompletions(executionCtx, c, account, forwardBody, "", channelMapping.MappedModel)
+						return service.ForwardResultFromOpenAI(openAIResult), forwardErr
+					},
+				)
 			},
 			ChatToMessages: func(executionCtx context.Context, account *service.Account, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
 				forwardBody := request.Body()

--- a/backend/internal/handler/gateway_handler_tk_chat_completions_execute.go
+++ b/backend/internal/handler/gateway_handler_tk_chat_completions_execute.go
@@ -83,8 +83,18 @@ func (h *GatewayHandler) executeChatCompletionsSelectedProtocol(
 					forwardBody = h.gatewayService.ReplaceModelInBody(forwardBody, channelMapping.MappedModel)
 				}
 				setActualUpstreamEndpoint(c, protocolPlanEndpoint(plan.Endpoint()))
-				openAIResult, forwardErr := h.openAIGatewayService.ForwardAsChatCompletionsDispatched(executionCtx, c, account, forwardBody, "", channelMapping.MappedModel)
-				return service.ForwardResultFromOpenAI(openAIResult), forwardErr
+				switch service.ResolveGovernedOpenAIShapeMode(account, reqModel) {
+				case service.GovernedOpenAIShapeGeminiCompat:
+					if h.geminiCompatService == nil {
+						return nil, errors.New("gemini compatibility service is not configured")
+					}
+					return h.geminiCompatService.ForwardAsChatCompletions(executionCtx, c, account, forwardBody)
+				case service.GovernedOpenAIShapeAntigravityClaudeRelay:
+					return h.gatewayService.ForwardAsChatCompletions(executionCtx, c, account, forwardBody, parsedReq)
+				default:
+					openAIResult, forwardErr := h.openAIGatewayService.ForwardAsChatCompletionsDispatched(executionCtx, c, account, forwardBody, "", channelMapping.MappedModel)
+					return service.ForwardResultFromOpenAI(openAIResult), forwardErr
+				}
 			},
 			ChatToResponses: func(executionCtx context.Context, account *service.Account, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
 				forwardBody := request.Body()
@@ -92,8 +102,18 @@ func (h *GatewayHandler) executeChatCompletionsSelectedProtocol(
 					forwardBody = h.gatewayService.ReplaceModelInBody(forwardBody, channelMapping.MappedModel)
 				}
 				setActualUpstreamEndpoint(c, protocolPlanEndpoint(plan.Endpoint()))
-				openAIResult, forwardErr := h.openAIGatewayService.ForwardAsChatCompletions(executionCtx, c, account, forwardBody, "", channelMapping.MappedModel)
-				return service.ForwardResultFromOpenAI(openAIResult), forwardErr
+				switch service.ResolveGovernedOpenAIShapeMode(account, reqModel) {
+				case service.GovernedOpenAIShapeGeminiCompat:
+					if h.geminiCompatService == nil {
+						return nil, errors.New("gemini compatibility service is not configured")
+					}
+					return h.geminiCompatService.ForwardAsChatCompletions(executionCtx, c, account, forwardBody)
+				case service.GovernedOpenAIShapeAntigravityClaudeRelay:
+					return h.gatewayService.ForwardAsChatCompletions(executionCtx, c, account, forwardBody, parsedReq)
+				default:
+					openAIResult, forwardErr := h.openAIGatewayService.ForwardAsChatCompletions(executionCtx, c, account, forwardBody, "", channelMapping.MappedModel)
+					return service.ForwardResultFromOpenAI(openAIResult), forwardErr
+				}
 			},
 			ChatToMessages: func(executionCtx context.Context, account *service.Account, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
 				forwardBody := request.Body()

--- a/backend/internal/handler/gateway_handler_tk_openai_shape_forward.go
+++ b/backend/internal/handler/gateway_handler_tk_openai_shape_forward.go
@@ -1,0 +1,71 @@
+package handler
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+// tkForwardChatCompletionsByOpenAIShape dispatches chat/completions through the
+// ResolveGovernedOpenAIShapeMode SSOT. openAIDefault covers the residual arm
+// (NonGoverned → gatewayService; governed identity → openAIGatewayService).
+func (h *GatewayHandler) tkForwardChatCompletionsByOpenAIShape(
+	executionCtx context.Context,
+	c *gin.Context,
+	account *service.Account,
+	reqModel string,
+	forwardBody []byte,
+	parsedReq *service.ParsedRequest,
+	openAIDefault func() (*service.ForwardResult, error),
+) (*service.ForwardResult, error) {
+	switch service.ResolveGovernedOpenAIShapeMode(account, reqModel) {
+	case service.GovernedOpenAIShapeGeminiCompat:
+		if h.geminiCompatService == nil {
+			return nil, errors.New("gemini compatibility service is not configured")
+		}
+		return h.geminiCompatService.ForwardAsChatCompletions(executionCtx, c, account, forwardBody)
+	case service.GovernedOpenAIShapeAntigravityClaudeRelay:
+		return h.gatewayService.ForwardAsChatCompletions(executionCtx, c, account, forwardBody, parsedReq)
+	case service.GovernedOpenAIShapeAntigravityOAuthCloudCode:
+		if h.antigravityGatewayService == nil {
+			return nil, errors.New("antigravity compatibility service is not configured")
+		}
+		setActualUpstreamEndpoint(c, EndpointAntigravityGenerateContent)
+		return h.antigravityGatewayService.ForwardAsChatCompletions(executionCtx, c, account, forwardBody, parsedReq)
+	default:
+		return openAIDefault()
+	}
+}
+
+// tkForwardResponsesByOpenAIShape dispatches /v1/responses through the same
+// ResolveGovernedOpenAIShapeMode SSOT as chat/completions.
+func (h *GatewayHandler) tkForwardResponsesByOpenAIShape(
+	executionCtx context.Context,
+	c *gin.Context,
+	account *service.Account,
+	reqModel string,
+	forwardBody []byte,
+	parsedReq *service.ParsedRequest,
+	openAIDefault func() (*service.ForwardResult, error),
+) (*service.ForwardResult, error) {
+	switch service.ResolveGovernedOpenAIShapeMode(account, reqModel) {
+	case service.GovernedOpenAIShapeGeminiCompat:
+		if h.geminiCompatService == nil {
+			return nil, errors.New("gemini compatibility service is not configured")
+		}
+		return h.geminiCompatService.ForwardAsResponses(executionCtx, c, account, forwardBody)
+	case service.GovernedOpenAIShapeAntigravityClaudeRelay:
+		return h.gatewayService.ForwardAsResponses(executionCtx, c, account, forwardBody, parsedReq)
+	case service.GovernedOpenAIShapeAntigravityOAuthCloudCode:
+		if h.antigravityGatewayService == nil {
+			return nil, errors.New("antigravity compatibility service is not configured")
+		}
+		setActualUpstreamEndpoint(c, EndpointAntigravityGenerateContent)
+		return h.antigravityGatewayService.ForwardAsResponses(executionCtx, c, account, forwardBody, parsedReq)
+	default:
+		return openAIDefault()
+	}
+}

--- a/backend/internal/handler/gateway_handler_tk_responses_execute.go
+++ b/backend/internal/handler/gateway_handler_tk_responses_execute.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"context"
-	"errors"
 
 	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -79,20 +78,12 @@ func (h *GatewayHandler) executeResponsesSelectedProtocol(
 				if channelMapping.Mapped {
 					forwardBody = h.gatewayService.ReplaceModelInBody(forwardBody, channelMapping.MappedModel)
 				}
-				if service.UsesGeminiNativeOpenAICompat(account.Platform, reqModel) {
-					if h.geminiCompatService == nil {
-						return nil, errors.New("gemini compatibility service is not configured")
-					}
-					return h.geminiCompatService.ForwardAsResponses(executionCtx, c, account, forwardBody)
-				}
-				if shouldUseAntigravityCompat(account) {
-					if h.antigravityGatewayService == nil {
-						return nil, errors.New("antigravity compatibility service is not configured")
-					}
-					setActualUpstreamEndpoint(c, EndpointAntigravityGenerateContent)
-					return h.antigravityGatewayService.ForwardAsResponses(executionCtx, c, account, forwardBody, parsedReq)
-				}
-				return h.gatewayService.ForwardAsResponses(executionCtx, c, account, forwardBody, parsedReq)
+				return h.tkForwardResponsesByOpenAIShape(
+					executionCtx, c, account, reqModel, forwardBody, parsedReq,
+					func() (*service.ForwardResult, error) {
+						return h.gatewayService.ForwardAsResponses(executionCtx, c, account, forwardBody, parsedReq)
+					},
+				)
 			},
 			ResponsesIdentity: func(executionCtx context.Context, account *service.Account, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
 				forwardBody := request.Body()
@@ -100,18 +91,13 @@ func (h *GatewayHandler) executeResponsesSelectedProtocol(
 					forwardBody = h.gatewayService.ReplaceModelInBody(forwardBody, channelMapping.MappedModel)
 				}
 				setActualUpstreamEndpoint(c, protocolPlanEndpoint(plan.Endpoint()))
-				switch service.ResolveGovernedOpenAIShapeMode(account, reqModel) {
-				case service.GovernedOpenAIShapeGeminiCompat:
-					if h.geminiCompatService == nil {
-						return nil, errors.New("gemini compatibility service is not configured")
-					}
-					return h.geminiCompatService.ForwardAsResponses(executionCtx, c, account, forwardBody)
-				case service.GovernedOpenAIShapeAntigravityClaudeRelay:
-					return h.gatewayService.ForwardAsResponses(executionCtx, c, account, forwardBody, parsedReq)
-				default:
-					openAIResult, forwardErr := h.openAIGatewayService.ForwardAsResponsesDispatched(executionCtx, c, account, forwardBody)
-					return service.ForwardResultFromOpenAI(openAIResult), forwardErr
-				}
+				return h.tkForwardResponsesByOpenAIShape(
+					executionCtx, c, account, reqModel, forwardBody, parsedReq,
+					func() (*service.ForwardResult, error) {
+						openAIResult, forwardErr := h.openAIGatewayService.ForwardAsResponsesDispatched(executionCtx, c, account, forwardBody)
+						return service.ForwardResultFromOpenAI(openAIResult), forwardErr
+					},
+				)
 			},
 			ResponsesToChat: func(executionCtx context.Context, account *service.Account, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
 				forwardBody := request.Body()
@@ -119,18 +105,13 @@ func (h *GatewayHandler) executeResponsesSelectedProtocol(
 					forwardBody = h.gatewayService.ReplaceModelInBody(forwardBody, channelMapping.MappedModel)
 				}
 				setActualUpstreamEndpoint(c, protocolPlanEndpoint(plan.Endpoint()))
-				switch service.ResolveGovernedOpenAIShapeMode(account, reqModel) {
-				case service.GovernedOpenAIShapeGeminiCompat:
-					if h.geminiCompatService == nil {
-						return nil, errors.New("gemini compatibility service is not configured")
-					}
-					return h.geminiCompatService.ForwardAsResponses(executionCtx, c, account, forwardBody)
-				case service.GovernedOpenAIShapeAntigravityClaudeRelay:
-					return h.gatewayService.ForwardAsResponses(executionCtx, c, account, forwardBody, parsedReq)
-				default:
-					openAIResult, forwardErr := h.openAIGatewayService.Forward(executionCtx, c, account, forwardBody)
-					return service.ForwardResultFromOpenAI(openAIResult), forwardErr
-				}
+				return h.tkForwardResponsesByOpenAIShape(
+					executionCtx, c, account, reqModel, forwardBody, parsedReq,
+					func() (*service.ForwardResult, error) {
+						openAIResult, forwardErr := h.openAIGatewayService.Forward(executionCtx, c, account, forwardBody)
+						return service.ForwardResultFromOpenAI(openAIResult), forwardErr
+					},
+				)
 			},
 			ResponsesToMessages: func(executionCtx context.Context, account *service.Account, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
 				forwardBody := request.Body()

--- a/backend/internal/handler/gateway_handler_tk_responses_execute.go
+++ b/backend/internal/handler/gateway_handler_tk_responses_execute.go
@@ -100,8 +100,18 @@ func (h *GatewayHandler) executeResponsesSelectedProtocol(
 					forwardBody = h.gatewayService.ReplaceModelInBody(forwardBody, channelMapping.MappedModel)
 				}
 				setActualUpstreamEndpoint(c, protocolPlanEndpoint(plan.Endpoint()))
-				openAIResult, forwardErr := h.openAIGatewayService.ForwardAsResponsesDispatched(executionCtx, c, account, forwardBody)
-				return service.ForwardResultFromOpenAI(openAIResult), forwardErr
+				switch service.ResolveGovernedOpenAIShapeMode(account, reqModel) {
+				case service.GovernedOpenAIShapeGeminiCompat:
+					if h.geminiCompatService == nil {
+						return nil, errors.New("gemini compatibility service is not configured")
+					}
+					return h.geminiCompatService.ForwardAsResponses(executionCtx, c, account, forwardBody)
+				case service.GovernedOpenAIShapeAntigravityClaudeRelay:
+					return h.gatewayService.ForwardAsResponses(executionCtx, c, account, forwardBody, parsedReq)
+				default:
+					openAIResult, forwardErr := h.openAIGatewayService.ForwardAsResponsesDispatched(executionCtx, c, account, forwardBody)
+					return service.ForwardResultFromOpenAI(openAIResult), forwardErr
+				}
 			},
 			ResponsesToChat: func(executionCtx context.Context, account *service.Account, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
 				forwardBody := request.Body()
@@ -109,8 +119,18 @@ func (h *GatewayHandler) executeResponsesSelectedProtocol(
 					forwardBody = h.gatewayService.ReplaceModelInBody(forwardBody, channelMapping.MappedModel)
 				}
 				setActualUpstreamEndpoint(c, protocolPlanEndpoint(plan.Endpoint()))
-				openAIResult, forwardErr := h.openAIGatewayService.Forward(executionCtx, c, account, forwardBody)
-				return service.ForwardResultFromOpenAI(openAIResult), forwardErr
+				switch service.ResolveGovernedOpenAIShapeMode(account, reqModel) {
+				case service.GovernedOpenAIShapeGeminiCompat:
+					if h.geminiCompatService == nil {
+						return nil, errors.New("gemini compatibility service is not configured")
+					}
+					return h.geminiCompatService.ForwardAsResponses(executionCtx, c, account, forwardBody)
+				case service.GovernedOpenAIShapeAntigravityClaudeRelay:
+					return h.gatewayService.ForwardAsResponses(executionCtx, c, account, forwardBody, parsedReq)
+				default:
+					openAIResult, forwardErr := h.openAIGatewayService.Forward(executionCtx, c, account, forwardBody)
+					return service.ForwardResultFromOpenAI(openAIResult), forwardErr
+				}
 			},
 			ResponsesToMessages: func(executionCtx context.Context, account *service.Account, plan protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
 				forwardBody := request.Body()

--- a/backend/internal/service/gateway_governed_openai_shape_tk.go
+++ b/backend/internal/service/gateway_governed_openai_shape_tk.go
@@ -1,13 +1,18 @@
 package service
 
-// GovernedOpenAIShapeMode selects which forwarder governed ChatIdentity /
-// ResponsesIdentity should use. Protocol routing marks Antigravity edge-relay
-// stubs as governed, but their Gemini chat traffic must not enter
-// OpenAIGatewayService (GetOpenAIProtocolAPIKey rejects platform=antigravity).
+// GovernedOpenAIShapeMode selects which forwarder OpenAI-shape chat/responses
+// adapters should use. Protocol routing marks Antigravity edge-relay stubs as
+// governed, but their Gemini chat traffic must not enter OpenAIGatewayService
+// (GetOpenAIProtocolAPIKey rejects platform=antigravity).
+//
+// This is the single owner for Gemini-compat / Antigravity apikey relay /
+// Antigravity OAuth Cloud Code branching. NonGoverned and governed identity
+// adapters both call ResolveGovernedOpenAIShapeMode; only the residual
+// OpenAI/default arm differs by path (gatewayService vs openAIGatewayService).
 type GovernedOpenAIShapeMode int
 
 const (
-	// GovernedOpenAIShapeOpenAI keeps the OpenAI gateway path.
+	// GovernedOpenAIShapeOpenAI keeps the residual OpenAI/default path.
 	GovernedOpenAIShapeOpenAI GovernedOpenAIShapeMode = iota
 	// GovernedOpenAIShapeGeminiCompat hops via GeminiMessagesCompatService
 	// (Antigravity apikey → {base}/antigravity/v1beta/...; Gemini native).
@@ -15,10 +20,13 @@ const (
 	// GovernedOpenAIShapeAntigravityClaudeRelay hops Claude chat/responses
 	// through GatewayService → {GetBaseURL()}/v1/messages on the edge stub.
 	GovernedOpenAIShapeAntigravityClaudeRelay
+	// GovernedOpenAIShapeAntigravityOAuthCloudCode hops via
+	// AntigravityGatewayService (Cloud Code generateContent).
+	GovernedOpenAIShapeAntigravityOAuthCloudCode
 )
 
-// ResolveGovernedOpenAIShapeMode mirrors NonGoverned chat/responses branching
-// for governed OpenAI-shape identity adapters.
+// ResolveGovernedOpenAIShapeMode is the SSOT for OpenAI-shape chat/responses
+// special-case branching shared by NonGoverned and governed identity adapters.
 func ResolveGovernedOpenAIShapeMode(account *Account, model string) GovernedOpenAIShapeMode {
 	if account == nil {
 		return GovernedOpenAIShapeOpenAI
@@ -28,6 +36,9 @@ func ResolveGovernedOpenAIShapeMode(account *Account, model string) GovernedOpen
 	}
 	if account.Platform == PlatformAntigravity && account.Type == AccountTypeAPIKey {
 		return GovernedOpenAIShapeAntigravityClaudeRelay
+	}
+	if account.Platform == PlatformAntigravity && account.Type == AccountTypeOAuth {
+		return GovernedOpenAIShapeAntigravityOAuthCloudCode
 	}
 	return GovernedOpenAIShapeOpenAI
 }

--- a/backend/internal/service/gateway_governed_openai_shape_tk.go
+++ b/backend/internal/service/gateway_governed_openai_shape_tk.go
@@ -1,0 +1,33 @@
+package service
+
+// GovernedOpenAIShapeMode selects which forwarder governed ChatIdentity /
+// ResponsesIdentity should use. Protocol routing marks Antigravity edge-relay
+// stubs as governed, but their Gemini chat traffic must not enter
+// OpenAIGatewayService (GetOpenAIProtocolAPIKey rejects platform=antigravity).
+type GovernedOpenAIShapeMode int
+
+const (
+	// GovernedOpenAIShapeOpenAI keeps the OpenAI gateway path.
+	GovernedOpenAIShapeOpenAI GovernedOpenAIShapeMode = iota
+	// GovernedOpenAIShapeGeminiCompat hops via GeminiMessagesCompatService
+	// (Antigravity apikey → {base}/antigravity/v1beta/...; Gemini native).
+	GovernedOpenAIShapeGeminiCompat
+	// GovernedOpenAIShapeAntigravityClaudeRelay hops Claude chat/responses
+	// through GatewayService → {GetBaseURL()}/v1/messages on the edge stub.
+	GovernedOpenAIShapeAntigravityClaudeRelay
+)
+
+// ResolveGovernedOpenAIShapeMode mirrors NonGoverned chat/responses branching
+// for governed OpenAI-shape identity adapters.
+func ResolveGovernedOpenAIShapeMode(account *Account, model string) GovernedOpenAIShapeMode {
+	if account == nil {
+		return GovernedOpenAIShapeOpenAI
+	}
+	if UsesGeminiNativeOpenAICompat(account.Platform, model) {
+		return GovernedOpenAIShapeGeminiCompat
+	}
+	if account.Platform == PlatformAntigravity && account.Type == AccountTypeAPIKey {
+		return GovernedOpenAIShapeAntigravityClaudeRelay
+	}
+	return GovernedOpenAIShapeOpenAI
+}

--- a/backend/internal/service/gateway_governed_openai_shape_tk_test.go
+++ b/backend/internal/service/gateway_governed_openai_shape_tk_test.go
@@ -1,0 +1,74 @@
+//go:build unit
+
+package service
+
+import "testing"
+
+func TestResolveGovernedOpenAIShapeMode(t *testing.T) {
+	t.Parallel()
+
+	agRelay := &Account{
+		Platform: PlatformAntigravity,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://api-us4.tokenkey.dev",
+			"api_key":  "sk-edge-stub",
+		},
+	}
+	agOAuth := &Account{Platform: PlatformAntigravity, Type: AccountTypeOAuth}
+	openaiKey := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+	cases := []struct {
+		name    string
+		account *Account
+		model   string
+		want    GovernedOpenAIShapeMode
+	}{
+		{
+			name:    "antigravity edge relay gemini chat uses gemini compat hop",
+			account: agRelay,
+			model:   "gemini-3.8-flash",
+			want:    GovernedOpenAIShapeGeminiCompat,
+		},
+		{
+			name:    "antigravity edge relay claude chat uses gateway messages relay",
+			account: agRelay,
+			model:   "claude-sonnet-4-6",
+			want:    GovernedOpenAIShapeAntigravityClaudeRelay,
+		},
+		{
+			name:    "antigravity oauth gemini stays gemini compat predicate",
+			account: agOAuth,
+			model:   "gemini-3.8-flash",
+			want:    GovernedOpenAIShapeGeminiCompat,
+		},
+		{
+			name:    "antigravity oauth claude falls through to openai shape default",
+			account: agOAuth,
+			model:   "claude-sonnet-4-6",
+			want:    GovernedOpenAIShapeOpenAI,
+		},
+		{
+			name:    "openai api key stays openai gateway",
+			account: openaiKey,
+			model:   "gpt-5.6",
+			want:    GovernedOpenAIShapeOpenAI,
+		},
+		{
+			name:    "nil account stays openai gateway",
+			account: nil,
+			model:   "gemini-3.8-flash",
+			want:    GovernedOpenAIShapeOpenAI,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ResolveGovernedOpenAIShapeMode(tc.account, tc.model); got != tc.want {
+				t.Fatalf("ResolveGovernedOpenAIShapeMode = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/service/gateway_governed_openai_shape_tk_test.go
+++ b/backend/internal/service/gateway_governed_openai_shape_tk_test.go
@@ -43,10 +43,10 @@ func TestResolveGovernedOpenAIShapeMode(t *testing.T) {
 			want:    GovernedOpenAIShapeGeminiCompat,
 		},
 		{
-			name:    "antigravity oauth claude falls through to openai shape default",
+			name:    "antigravity oauth claude uses cloud code hop",
 			account: agOAuth,
 			model:   "claude-sonnet-4-6",
-			want:    GovernedOpenAIShapeOpenAI,
+			want:    GovernedOpenAIShapeAntigravityOAuthCloudCode,
 		},
 		{
 			name:    "openai api key stays openai gateway",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6352,12 +6352,22 @@
         "func (h *GatewayHandler) tkAttachChatCompletionsProtocolRouting(",
         "service.WithProtocolRouting(",
         "service.ExecuteSelectedProtocol(",
-        "service.UsesGeminiNativeOpenAICompat(account.Platform, reqModel)",
-        "service.ResolveGovernedOpenAIShapeMode(account, reqModel)",
-        "h.geminiCompatService.ForwardAsChatCompletions",
+        "h.tkForwardChatCompletionsByOpenAIShape(",
         "ChatToGemini:"
       ],
-      "rationale": "Gateway /v1/chat/completions governed protocol boundary: WithProtocolRouting attach + ExecuteSelectedProtocol (incl. ChatToGemini / gemini-native branch) must stay co-located in this companion per protocol-routing SSOT. Governed ChatIdentity must ResolveGovernedOpenAIShapeMode so Antigravity edge-relay Gemini hops via geminiCompat instead of OpenAI GetOpenAIProtocolAPIKey. P2: extracted from gateway_handler_chat_completions.go."
+      "rationale": "Gateway /v1/chat/completions governed protocol boundary: WithProtocolRouting attach + ExecuteSelectedProtocol (incl. ChatToGemini / gemini-native branch) must stay co-located in this companion per protocol-routing SSOT. NonGoverned and ChatIdentity both dispatch via tkForwardChatCompletionsByOpenAIShape (ResolveGovernedOpenAIShapeMode SSOT) so Antigravity edge-relay Gemini hops via geminiCompat instead of OpenAI GetOpenAIProtocolAPIKey. P2: extracted from gateway_handler_chat_completions.go."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler_tk_openai_shape_forward.go",
+      "must_contain": [
+        "func (h *GatewayHandler) tkForwardChatCompletionsByOpenAIShape(",
+        "func (h *GatewayHandler) tkForwardResponsesByOpenAIShape(",
+        "service.ResolveGovernedOpenAIShapeMode(account, reqModel)",
+        "service.GovernedOpenAIShapeGeminiCompat",
+        "service.GovernedOpenAIShapeAntigravityClaudeRelay",
+        "service.GovernedOpenAIShapeAntigravityOAuthCloudCode"
+      ],
+      "rationale": "Single call-site owner for OpenAI-shape chat/responses special-case hops. Both NonGoverned and governed identity adapters must route through these helpers so AG Gemini/Claude/OAuth branching cannot drift."
     },
     {
       "path": "backend/internal/handler/gateway_handler_chat_completions.go",
@@ -6408,13 +6418,11 @@
     {
       "path": "backend/internal/handler/gateway_handler_tk_responses_execute.go",
       "must_contain": [
-        "service.UsesGeminiNativeOpenAICompat(account.Platform, reqModel)",
-        "service.ResolveGovernedOpenAIShapeMode(account, reqModel)",
-        "h.geminiCompatService.ForwardAsResponses",
+        "h.tkForwardResponsesByOpenAIShape(",
         "groupUsesGeminiCompat = service.UsesGeminiNativeOpenAICompat(groupPlatform, reqModel)",
         "selectionSessionHash = \"gemini:\" + selectionSessionHash"
       ],
-      "rationale": "Gateway /v1/responses must branch antigravity/gemini text into GeminiMessagesCompatService.ForwardAsResponses instead of the Anthropic converter chain, with the same gemini sticky session hash and platform guards as /v1/chat/completions. Governed ResponsesIdentity must ResolveGovernedOpenAIShapeMode so Antigravity edge-relay Gemini hops via geminiCompat. P3: Responses Gemini/Antigravity branch + sticky hash live in tk_responses_execute companion."
+      "rationale": "Gateway /v1/responses must share OpenAI-shape SSOT via tkForwardResponsesByOpenAIShape, with the same gemini sticky session hash and platform guards as /v1/chat/completions. P3: Responses Gemini/Antigravity branch + sticky hash live in tk_responses_execute companion."
     },
     {
       "path": "backend/internal/service/gateway_governed_openai_shape_tk.go",
@@ -6422,18 +6430,20 @@
         "func ResolveGovernedOpenAIShapeMode(account *Account, model string) GovernedOpenAIShapeMode",
         "GovernedOpenAIShapeGeminiCompat",
         "GovernedOpenAIShapeAntigravityClaudeRelay",
+        "GovernedOpenAIShapeAntigravityOAuthCloudCode",
         "UsesGeminiNativeOpenAICompat(account.Platform, model)"
       ],
-      "rationale": "SSOT for governed ChatIdentity/ResponsesIdentity forwarder selection. Antigravity apikey edge stubs are protocol-governed but must not enter OpenAIGatewayService for Gemini text; dropping this companion reopens api_key not found on prod→edge Gemini chat."
+      "rationale": "SSOT for OpenAI-shape chat/responses special-case forwarder selection (NonGoverned + governed identity). Antigravity apikey edge stubs are protocol-governed but must not enter OpenAIGatewayService for Gemini text; OAuth Claude must stay on Cloud Code. Dropping this companion reopens api_key not found on prod→edge Gemini chat."
     },
     {
       "path": "backend/internal/service/gateway_governed_openai_shape_tk_test.go",
       "must_contain": [
         "TestResolveGovernedOpenAIShapeMode",
         "antigravity edge relay gemini chat uses gemini compat hop",
-        "antigravity edge relay claude chat uses gateway messages relay"
+        "antigravity edge relay claude chat uses gateway messages relay",
+        "antigravity oauth claude uses cloud code hop"
       ],
-      "rationale": "Positive/negative coverage for ResolveGovernedOpenAIShapeMode: AG edge-relay Gemini → geminiCompat, AG edge-relay Claude → gateway messages relay, OpenAI stays OpenAI."
+      "rationale": "Positive/negative coverage for ResolveGovernedOpenAIShapeMode: AG edge-relay Gemini → geminiCompat, AG edge-relay Claude → gateway messages relay, AG OAuth Claude → Cloud Code, OpenAI stays OpenAI."
     },
     {
       "path": "backend/internal/service/openai_gateway_service_tk_fast_policy.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6353,10 +6353,11 @@
         "service.WithProtocolRouting(",
         "service.ExecuteSelectedProtocol(",
         "service.UsesGeminiNativeOpenAICompat(account.Platform, reqModel)",
+        "service.ResolveGovernedOpenAIShapeMode(account, reqModel)",
         "h.geminiCompatService.ForwardAsChatCompletions",
         "ChatToGemini:"
       ],
-      "rationale": "Gateway /v1/chat/completions governed protocol boundary: WithProtocolRouting attach + ExecuteSelectedProtocol (incl. ChatToGemini / gemini-native branch) must stay co-located in this companion per protocol-routing SSOT. P2: extracted from gateway_handler_chat_completions.go."
+      "rationale": "Gateway /v1/chat/completions governed protocol boundary: WithProtocolRouting attach + ExecuteSelectedProtocol (incl. ChatToGemini / gemini-native branch) must stay co-located in this companion per protocol-routing SSOT. Governed ChatIdentity must ResolveGovernedOpenAIShapeMode so Antigravity edge-relay Gemini hops via geminiCompat instead of OpenAI GetOpenAIProtocolAPIKey. P2: extracted from gateway_handler_chat_completions.go."
     },
     {
       "path": "backend/internal/handler/gateway_handler_chat_completions.go",
@@ -6408,11 +6409,31 @@
       "path": "backend/internal/handler/gateway_handler_tk_responses_execute.go",
       "must_contain": [
         "service.UsesGeminiNativeOpenAICompat(account.Platform, reqModel)",
+        "service.ResolveGovernedOpenAIShapeMode(account, reqModel)",
         "h.geminiCompatService.ForwardAsResponses",
         "groupUsesGeminiCompat = service.UsesGeminiNativeOpenAICompat(groupPlatform, reqModel)",
         "selectionSessionHash = \"gemini:\" + selectionSessionHash"
       ],
-      "rationale": "Gateway /v1/responses must branch antigravity/gemini text into GeminiMessagesCompatService.ForwardAsResponses instead of the Anthropic converter chain, with the same gemini sticky session hash and platform guards as /v1/chat/completions. P3: Responses Gemini/Antigravity branch + sticky hash live in tk_responses_execute companion."
+      "rationale": "Gateway /v1/responses must branch antigravity/gemini text into GeminiMessagesCompatService.ForwardAsResponses instead of the Anthropic converter chain, with the same gemini sticky session hash and platform guards as /v1/chat/completions. Governed ResponsesIdentity must ResolveGovernedOpenAIShapeMode so Antigravity edge-relay Gemini hops via geminiCompat. P3: Responses Gemini/Antigravity branch + sticky hash live in tk_responses_execute companion."
+    },
+    {
+      "path": "backend/internal/service/gateway_governed_openai_shape_tk.go",
+      "must_contain": [
+        "func ResolveGovernedOpenAIShapeMode(account *Account, model string) GovernedOpenAIShapeMode",
+        "GovernedOpenAIShapeGeminiCompat",
+        "GovernedOpenAIShapeAntigravityClaudeRelay",
+        "UsesGeminiNativeOpenAICompat(account.Platform, model)"
+      ],
+      "rationale": "SSOT for governed ChatIdentity/ResponsesIdentity forwarder selection. Antigravity apikey edge stubs are protocol-governed but must not enter OpenAIGatewayService for Gemini text; dropping this companion reopens api_key not found on prod→edge Gemini chat."
+    },
+    {
+      "path": "backend/internal/service/gateway_governed_openai_shape_tk_test.go",
+      "must_contain": [
+        "TestResolveGovernedOpenAIShapeMode",
+        "antigravity edge relay gemini chat uses gemini compat hop",
+        "antigravity edge relay claude chat uses gateway messages relay"
+      ],
+      "rationale": "Positive/negative coverage for ResolveGovernedOpenAIShapeMode: AG edge-relay Gemini → geminiCompat, AG edge-relay Claude → gateway messages relay, OpenAI stays OpenAI."
     },
     {
       "path": "backend/internal/service/openai_gateway_service_tk_fast_policy.go",


### PR DESCRIPTION
## 摘要
- 修复 AG prod apikey 中继在协议治理下被 ChatIdentity 误送进 OpenAI 网关，导致 `api_key not found in credentials`，无法经 edge OAuth 访问 `gemini-3.8-flash`。
- `ResolveGovernedOpenAIShapeMode` 成为 OpenAI-shape 分流 SSOT（GeminiCompat / ClaudeRelay / OAuth Cloud Code）；NonGoverned 与 governed identity 共用 `tkForward*ByOpenAIShape`。
- 账号类型保持 `apikey`（不改 `upstream`）。
- 同步更新 `scripts/sentinels/gateway-tk.json`；删除已被 SSOT 取代的 `shouldUseAntigravityCompat` 死代码。

## 风险
- 常规：公共网关 AG 中继 chat/responses 分流变更；影响 prod AG stub（61/62/85）的 Gemini/Claude OpenAI-shape 路径。
- 不改 mapping / catalog / 账号 type。

## 验证
- `go test -tags=unit ./internal/service/ -run TestResolveGovernedOpenAIShapeMode` 通过
- `PREFLIGHT_BASE=origin/main ./scripts/preflight.sh` PASS
- `endpoint.go` 仅删除已被 Resolve 取代的 dead helper，无需新增 anchor；分流语义锚点已在 `gateway-tk.json`
- 发版后用 `probe_account_model.sh ACCOUNT_ID=62 MODEL=gemini-3.8-flash ENDPOINT=chat` 复测（目标 servable + attribution）

## 标记
sentinel-registry-reviewed
no-web-impact

## 提交
- `64f20f5b3` fix(antigravity): governed ChatIdentity 走 edge 中继 Gemini hop
- `08cd00f31` chore(sentinels): 锚定 AG 中继 governed OpenAI-shape 分流
- `94ff96adf` fix(antigravity): 闭合 OpenAI-shape 分流 SSOT
- `d0c161dee` fix(antigravity): 删除已被 Resolve SSOT 取代的 shouldUseAntigravityCompat
- `5f820bced` chore: refresh CI after PR marker acknowledgement
- 最新提交：`5f820bced`