### PR TITLE
fix(gemini): AG edge stub 支持原生 generateContent

### DIFF
--- a/backend/internal/engine/protocolrouter/account.go
+++ b/backend/internal/engine/protocolrouter/account.go
@@ -19,12 +19,15 @@ type GeminiEndpointProfile string
 const (
 	GeminiEndpointNone                 GeminiEndpointProfile = ""
 	GeminiEndpointAntigravityCloudCode GeminiEndpointProfile = "antigravity_cloudcode"
+	GeminiEndpointAntigravityEdgeRelay GeminiEndpointProfile = "antigravity_edge_relay"
 	GeminiEndpointVertexServiceAccount GeminiEndpointProfile = "vertex_service_account"
 )
 
 func (p GeminiEndpointProfile) Valid() bool {
 	switch p {
-	case GeminiEndpointAntigravityCloudCode, GeminiEndpointVertexServiceAccount:
+	case GeminiEndpointAntigravityCloudCode,
+		GeminiEndpointAntigravityEdgeRelay,
+		GeminiEndpointVertexServiceAccount:
 		return true
 	default:
 		return false

--- a/backend/internal/engine/protocolrouter/router_test.go
+++ b/backend/internal/engine/protocolrouter/router_test.go
@@ -122,6 +122,7 @@ func TestPlanGeminiIdentityRequiresTypedProfileAndExactEndpoint(t *testing.T) {
 func TestPlanGeminiProfilesUseExactEndpoint(t *testing.T) {
 	for _, profile := range []GeminiEndpointProfile{
 		GeminiEndpointAntigravityCloudCode,
+		GeminiEndpointAntigravityEdgeRelay,
 		GeminiEndpointVertexServiceAccount,
 	} {
 		t.Run(string(profile), func(t *testing.T) {

--- a/backend/internal/handler/openai_gemini_protocol_execution_test.go
+++ b/backend/internal/handler/openai_gemini_protocol_execution_test.go
@@ -18,6 +18,7 @@ func TestExecuteOpenAIGeminiRouteUsesOnlyPlannedProfile(t *testing.T) {
 	}{
 		{name: "antigravity", profile: protocolrouter.GeminiEndpointAntigravityCloudCode, wantAntigravity: 1, wantRequestID: "ag"},
 		{name: "vertex", profile: protocolrouter.GeminiEndpointVertexServiceAccount, wantVertex: 1, wantRequestID: "vertex"},
+		{name: "antigravity edge relay", profile: protocolrouter.GeminiEndpointAntigravityEdgeRelay, wantVertex: 1, wantRequestID: "vertex"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/backend/internal/service/account_supported_protocols.go
+++ b/backend/internal/service/account_supported_protocols.go
@@ -246,7 +246,13 @@ func protocolAccountSnapshot(account *Account, requestedModel string, requireCom
 			thinkingEnabled,
 		)
 	}
-	exactEndpoints, err := protocolExactEndpoints(account, resolvedModel, geminiProfile, stream)
+	// Edge-relay hops keep the public client model in the URL; mapped provider
+	// ids stay on ResolvedModel for billing/upstream attribution.
+	exactModel := resolvedModel
+	if geminiProfile == protocolrouter.GeminiEndpointAntigravityEdgeRelay {
+		exactModel = requestedModel
+	}
+	exactEndpoints, err := protocolExactEndpoints(account, exactModel, geminiProfile, stream)
 	if err != nil {
 		return protocolrouter.AccountSnapshot{}, err
 	}
@@ -409,6 +415,9 @@ func protocolGeminiEndpointProfile(account *Account) protocolrouter.GeminiEndpoi
 	if account.Platform == PlatformAntigravity && account.Type == AccountTypeOAuth {
 		return protocolrouter.GeminiEndpointAntigravityCloudCode
 	}
+	if tkIsAntigravityEdgeRelayStub(account) {
+		return protocolrouter.GeminiEndpointAntigravityEdgeRelay
+	}
 	if account.IsNewAPIVertexServiceAccount() {
 		return protocolrouter.GeminiEndpointVertexServiceAccount
 	}
@@ -424,6 +433,16 @@ func protocolGeminiExactEndpoint(
 	switch profile {
 	case protocolrouter.GeminiEndpointAntigravityCloudCode:
 		return strings.TrimRight(resolveAntigravityForwardBaseURL(account), "/") + "/v1internal:streamGenerateContent", nil
+	case protocolrouter.GeminiEndpointAntigravityEdgeRelay:
+		baseURL := strings.TrimRight(account.GetGeminiBaseURL(""), "/")
+		if baseURL == "" {
+			return "", errors.New("antigravity edge relay missing base_url")
+		}
+		action := "generateContent"
+		if stream {
+			action = "streamGenerateContent"
+		}
+		return fmt.Sprintf("%s/v1beta/models/%s:%s", baseURL, resolvedModel, action), nil
 	case protocolrouter.GeminiEndpointVertexServiceAccount:
 		action := "generateContent"
 		if stream {

--- a/backend/internal/service/account_supported_protocols_test.go
+++ b/backend/internal/service/account_supported_protocols_test.go
@@ -672,6 +672,24 @@ func TestProtocolAccountSnapshotDerivesGeminiEndpointProfile(t *testing.T) {
 			wantProfile:  protocolrouter.GeminiEndpointVertexServiceAccount,
 			wantEndpoint: "https://us-central1-aiplatform.googleapis.com/v1/projects/project-v/locations/us-central1/publishers/google/models/gemini-2.5-pro:generateContent",
 		},
+		{
+			name: "antigravity edge relay uses public hop model",
+			account: &Account{
+				ID:       85,
+				Platform: PlatformAntigravity,
+				Type:     AccountTypeAPIKey,
+				Credentials: map[string]any{
+					"api_key":  "secret",
+					"base_url": "https://api-us3.tokenkey.dev",
+					"model_mapping": map[string]any{
+						"client-model": "gemini-3.8-flash-medium",
+					},
+				},
+				Extra: map[string]any{SupportedProtocolsExtraKey: []any{"gemini_generate_content"}},
+			},
+			wantProfile:  protocolrouter.GeminiEndpointAntigravityEdgeRelay,
+			wantEndpoint: "https://api-us3.tokenkey.dev/antigravity/v1beta/models/client-model:generateContent",
+		},
 	}
 
 	for _, tt := range tests {
@@ -693,7 +711,14 @@ func TestProtocolAccountSnapshotDerivesGeminiEndpointProfile(t *testing.T) {
 			if snapshot.GeminiProfile() != tt.wantProfile {
 				t.Fatalf("GeminiProfile = %q, want %q", snapshot.GeminiProfile(), tt.wantProfile)
 			}
-			endpoint, err := protocolGeminiExactEndpoint(tt.account, snapshot.ResolvedModel(), snapshot.GeminiProfile(), request.Profile().Stream)
+			exactModel := snapshot.ResolvedModel()
+			if tt.wantProfile == protocolrouter.GeminiEndpointAntigravityEdgeRelay {
+				if exactModel != "gemini-3.8-flash-medium" {
+					t.Fatalf("ResolvedModel = %q, want mapped provider model", exactModel)
+				}
+				exactModel = request.RequestedModel()
+			}
+			endpoint, err := protocolGeminiExactEndpoint(tt.account, exactModel, snapshot.GeminiProfile(), request.Profile().Stream)
 			if err != nil {
 				t.Fatalf("protocolGeminiExactEndpoint: %v", err)
 			}

--- a/backend/internal/service/gemini_chat_completions_compat_service.go
+++ b/backend/internal/service/gemini_chat_completions_compat_service.go
@@ -343,6 +343,7 @@ func (s *GeminiMessagesCompatService) buildGeminiChatCompletionsUpstreamRequestF
 			if err != nil {
 				return nil, "", err
 			}
+			fullURL = protocolExecutionURL(ctx, fullURL)
 
 			restGeminiReq := normalizeGeminiRequestForAIStudio(geminiReq)
 			upstreamReq, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewReader(restGeminiReq))

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -658,6 +658,7 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 			if req.Stream {
 				fullURL += "?alt=sse"
 			}
+			fullURL = protocolExecutionURL(ctx, fullURL)
 
 			restGeminiReq := normalizeGeminiRequestForAIStudio(geminiReq)
 			upstreamReq, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewReader(restGeminiReq))
@@ -1175,6 +1176,7 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 			if useUpstreamStream {
 				fullURL += "?alt=sse"
 			}
+			fullURL = protocolExecutionURL(ctx, fullURL)
 
 			upstreamReq, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewReader(body))
 			if err != nil {

--- a/backend/internal/service/protocol_capability_probe.go
+++ b/backend/internal/service/protocol_capability_probe.go
@@ -531,8 +531,17 @@ func ProtocolProbeCandidates(account *Account) []protocolrouter.Protocol {
 	if account.IsKiroMirrorStub() {
 		return []protocolrouter.Protocol{protocolrouter.ProtocolMessages}
 	}
-	if protocolGeminiEndpointProfile(account).Valid() {
+	geminiProfile := protocolGeminiEndpointProfile(account)
+	switch geminiProfile {
+	case protocolrouter.GeminiEndpointAntigravityCloudCode,
+		protocolrouter.GeminiEndpointVertexServiceAccount:
 		return []protocolrouter.Protocol{protocolrouter.ProtocolGeminiGenerateContent}
+	case protocolrouter.GeminiEndpointAntigravityEdgeRelay:
+		// Edge stubs also expose OpenAI-shape text hops; continue collecting below.
+	default:
+		if geminiProfile.Valid() {
+			return []protocolrouter.Protocol{protocolrouter.ProtocolGeminiGenerateContent}
+		}
 	}
 	switch {
 	case account.Type == AccountTypeAPIKey, account.Type == AccountTypeUpstream:
@@ -546,6 +555,9 @@ func ProtocolProbeCandidates(account *Account) []protocolrouter.Protocol {
 	candidates := make([]protocolrouter.Protocol, 0, len(protocolrouter.AllProtocols()))
 	for _, protocol := range protocolrouter.AllProtocols() {
 		if protocol == protocolrouter.ProtocolGeminiGenerateContent {
+			if geminiProfile == protocolrouter.GeminiEndpointAntigravityEdgeRelay {
+				candidates = append(candidates, protocol)
+			}
 			continue
 		}
 		if protocol == protocolrouter.ProtocolMessages && tkIsOpenAIEdgeMirrorStub(account) {

--- a/backend/internal/service/protocol_capability_probe_gemini.go
+++ b/backend/internal/service/protocol_capability_probe_gemini.go
@@ -214,6 +214,12 @@ func (s *AccountTestService) observeGeminiHTTPProbe(
 	}
 	defer func() { _ = resp.Body.Close() }()
 	body, readErr := io.ReadAll(resp.Body)
+	if readErr == nil {
+		if capacityVerdict, knownCapacity := protocolProbeRelayCapacityVerdict(account, resp.StatusCode, body); knownCapacity {
+			observation.verdict = capacityVerdict
+			return *observation, true
+		}
+	}
 	observation.verdict = classifyGeminiProtocolProbe(resp.StatusCode, body, readErr)
 	return *observation, true
 }

--- a/backend/internal/service/protocol_capability_probe_gemini.go
+++ b/backend/internal/service/protocol_capability_probe_gemini.go
@@ -166,23 +166,54 @@ func (s *AccountTestService) probeGeminiGenerateContentSupport(
 			observation.verdict = ProtocolProbeInconclusive
 			return observation, true
 		}
-		proxyURL := ""
-		if account.ProxyID != nil && account.Proxy != nil {
-			proxyURL = account.Proxy.URL()
-		}
-		resp, err := s.httpUpstream.DoWithTLS(req, proxyURL, account.ID, account.Concurrency, s.resolveAccountTestTLSProfile(account))
-		if err != nil {
-			observation.verdict = classifyGeminiProtocolProbe(0, nil, err)
-			return observation, true
-		}
-		if resp == nil {
+		return s.observeGeminiHTTPProbe(account, req, &observation)
+
+	case protocolrouter.GeminiEndpointAntigravityEdgeRelay:
+		if s == nil || s.httpUpstream == nil {
 			observation.verdict = ProtocolProbeInconclusive
 			return observation, true
 		}
-		defer func() { _ = resp.Body.Close() }()
-		body, readErr := io.ReadAll(resp.Body)
-		observation.verdict = classifyGeminiProtocolProbe(resp.StatusCode, body, readErr)
-		return observation, true
+		mappedModel, requestModel := resolveGeminiForwardModels(account, model)
+		payload := createGeminiTestPayload(mappedModel, defaultGeminiTextTestPrompt)
+		req, err := s.buildGeminiAPIKeyRequest(ctx, account, requestModel, payload)
+		if err != nil {
+			observation.verdict = ProtocolProbeInconclusive
+			return observation, true
+		}
+		return s.observeGeminiHTTPProbe(account, req, &observation)
 	}
 	return observation, false
+}
+
+func (s *AccountTestService) observeGeminiHTTPProbe(
+	account *Account,
+	req *http.Request,
+	observation *protocolProbeObservation,
+) (protocolProbeObservation, bool) {
+	if observation == nil {
+		observation = &protocolProbeObservation{protocol: protocolrouter.ProtocolGeminiGenerateContent}
+	}
+	proxyURL := ""
+	if account != nil && account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+	concurrency := 0
+	accountID := int64(0)
+	if account != nil {
+		concurrency = account.Concurrency
+		accountID = account.ID
+	}
+	resp, err := s.httpUpstream.DoWithTLS(req, proxyURL, accountID, concurrency, s.resolveAccountTestTLSProfile(account))
+	if err != nil {
+		observation.verdict = classifyGeminiProtocolProbe(0, nil, err)
+		return *observation, true
+	}
+	if resp == nil {
+		observation.verdict = ProtocolProbeInconclusive
+		return *observation, true
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, readErr := io.ReadAll(resp.Body)
+	observation.verdict = classifyGeminiProtocolProbe(resp.StatusCode, body, readErr)
+	return *observation, true
 }

--- a/backend/internal/service/protocol_capability_probe_test.go
+++ b/backend/internal/service/protocol_capability_probe_test.go
@@ -269,6 +269,7 @@ func TestProbeAccountProtocolCapabilitiesTreatsEdgeRelayEmptyPoolAsEndpointEvide
 		protocolrouter.ProtocolMessages,
 		protocolrouter.ProtocolChatCompletions,
 		protocolrouter.ProtocolResponses,
+		protocolrouter.ProtocolGeminiGenerateContent,
 	}
 	if !reflect.DeepEqual(got.SupportedProtocols(), want) {
 		t.Fatalf("supported protocols = %v, want %v", got.SupportedProtocols(), want)

--- a/backend/internal/service/protocol_capability_probe_test.go
+++ b/backend/internal/service/protocol_capability_probe_test.go
@@ -733,7 +733,7 @@ func TestProtocolProbeCandidatesCoverGovernedCustomAccountsOnly(t *testing.T) {
 			want: []protocolrouter.Protocol{protocolrouter.ProtocolMessages},
 		},
 		{
-			name: "antigravity edge relay probes its configurable text endpoints",
+			name: "antigravity edge relay probes text hops and native gemini",
 			account: &Account{Platform: PlatformAntigravity, Type: AccountTypeAPIKey, Credentials: map[string]any{
 				"api_key": "secret", "base_url": "https://api-us3.tokenkey.dev",
 			}},
@@ -741,6 +741,7 @@ func TestProtocolProbeCandidatesCoverGovernedCustomAccountsOnly(t *testing.T) {
 				protocolrouter.ProtocolMessages,
 				protocolrouter.ProtocolChatCompletions,
 				protocolrouter.ProtocolResponses,
+				protocolrouter.ProtocolGeminiGenerateContent,
 			},
 		},
 		{

--- a/backend/internal/service/protocol_capability_probe_test.go
+++ b/backend/internal/service/protocol_capability_probe_test.go
@@ -279,6 +279,47 @@ func TestProbeAccountProtocolCapabilitiesTreatsEdgeRelayEmptyPoolAsEndpointEvide
 	}
 }
 
+func TestProbeGeminiEdgeRelayUsesPublicModelAndClassifiesWireResponse(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+		want   ProtocolProbeVerdict
+	}{
+		{"success", http.StatusOK, "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"OK\"}]}}]}\n\n", ProtocolProbePositive},
+		{"unsupported endpoint", http.StatusNotFound, `{"error":{"details":[{"reason":"METHOD_NOT_SUPPORTED"}]}}`, ProtocolProbeEndpointNegative},
+		{"auth failure", http.StatusUnauthorized, `{"error":{"message":"unauthorized"}}`, ProtocolProbeInconclusive},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			account := &Account{
+				ID: 61, Platform: PlatformAntigravity, Type: AccountTypeAPIKey,
+				Credentials: map[string]any{
+					"api_key": "edge-key", "base_url": "https://api-us3.tokenkey.dev",
+					"model_mapping": map[string]any{"gemini-2.5-flash": "gemini-2.5-flash-medium"},
+				},
+			}
+			upstream := &protocolTargetHTTPUpstream{responses: []*http.Response{{
+				StatusCode: tc.status, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(tc.body)),
+			}}}
+			svc := &AccountTestService{httpUpstream: upstream, cfg: &config.Config{}}
+			observation, applicable := svc.probeGeminiGenerateContentSupport(context.Background(), account)
+			if !applicable || observation.verdict != tc.want {
+				t.Fatalf("probe = %#v, applicable %t, want %q", observation, applicable, tc.want)
+			}
+			if len(upstream.requests) != 1 {
+				t.Fatalf("requests = %d, want 1", len(upstream.requests))
+			}
+			req := upstream.requests[0]
+			if got, want := req.URL.String(), "https://api-us3.tokenkey.dev/antigravity/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse"; got != want {
+				t.Fatalf("probe URL = %q, want public model URL %q", got, want)
+			}
+			if req.Header.Get("x-goog-api-key") != "edge-key" || req.Header.Get("Authorization") != "" {
+				t.Fatal("probe must use only edge API-key authentication")
+			}
+		})
+	}
+}
+
 func (u *protocolProbeSetUpstream) Do(
 	req *http.Request,
 	proxyURL string,

--- a/backend/internal/service/protocol_endpoint_identity.go
+++ b/backend/internal/service/protocol_endpoint_identity.go
@@ -175,33 +175,20 @@ func BuildProtocolEndpointIdentity(account *Account) (ProtocolEndpointIdentity, 
 			return ProtocolEndpointIdentity{}, true, fmt.Errorf("unsupported official endpoint profile %q", officialProfile)
 		}
 	} else if geminiProfile := protocolGeminiEndpointProfile(account); geminiProfile.Valid() {
+		// Edge stubs also expose OpenAI-shape text hops; keep those endpoints in
+		// identity alongside native Gemini so CapabilityKey / probe / Plan stay aligned.
+		if geminiProfile == protocolrouter.GeminiEndpointAntigravityEdgeRelay {
+			if err := fillCustomTextProtocolEndpoints(account, &identity, baseURL, protocolBaseURLs); err != nil {
+				return ProtocolEndpointIdentity{}, true, err
+			}
+		}
 		endpoint, err := canonicalGeminiIdentityEndpoint(account, geminiProfile)
 		if err != nil {
 			return ProtocolEndpointIdentity{}, true, err
 		}
 		identity.ProtocolEndpoints[protocolrouter.ProtocolGeminiGenerateContent] = endpoint
-	} else {
-		for _, protocol := range []protocolrouter.Protocol{
-			protocolrouter.ProtocolMessages,
-			protocolrouter.ProtocolChatCompletions,
-			protocolrouter.ProtocolResponses,
-		} {
-			configured := strings.TrimSpace(protocolBaseURLs[protocol])
-			if configured == "" {
-				configured = strings.TrimSpace(baseURL)
-			}
-			if configured == "" {
-				continue
-			}
-			endpointURL, err := normalizeProtocolEndpointURL(configured, protocol)
-			if err != nil {
-				return ProtocolEndpointIdentity{}, true, fmt.Errorf("normalize %s endpoint identity: %w", protocol, err)
-			}
-			identity.ProtocolEndpoints[protocol] = ProtocolEndpoint{
-				URL:        endpointURL,
-				APIVersion: protocolAPIVersion(account, protocol),
-			}
-		}
+	} else if err := fillCustomTextProtocolEndpoints(account, &identity, baseURL, protocolBaseURLs); err != nil {
+		return ProtocolEndpointIdentity{}, true, err
 	}
 	if len(identity.ProtocolEndpoints) == 0 {
 		return ProtocolEndpointIdentity{}, true, errors.New("governed account has no explicit protocol endpoint identity")
@@ -210,6 +197,42 @@ func BuildProtocolEndpointIdentity(account *Account) (ProtocolEndpointIdentity, 
 		return ProtocolEndpointIdentity{}, true, err
 	}
 	return identity, true, nil
+}
+
+func fillCustomTextProtocolEndpoints(
+	account *Account,
+	identity *ProtocolEndpointIdentity,
+	baseURL string,
+	protocolBaseURLs map[protocolrouter.Protocol]string,
+) error {
+	if identity == nil {
+		return errors.New("protocol endpoint identity is required")
+	}
+	if identity.ProtocolEndpoints == nil {
+		identity.ProtocolEndpoints = make(map[protocolrouter.Protocol]ProtocolEndpoint)
+	}
+	for _, protocol := range []protocolrouter.Protocol{
+		protocolrouter.ProtocolMessages,
+		protocolrouter.ProtocolChatCompletions,
+		protocolrouter.ProtocolResponses,
+	} {
+		configured := strings.TrimSpace(protocolBaseURLs[protocol])
+		if configured == "" {
+			configured = strings.TrimSpace(baseURL)
+		}
+		if configured == "" {
+			continue
+		}
+		endpointURL, err := normalizeProtocolEndpointURL(configured, protocol)
+		if err != nil {
+			return fmt.Errorf("normalize %s endpoint identity: %w", protocol, err)
+		}
+		identity.ProtocolEndpoints[protocol] = ProtocolEndpoint{
+			URL:        endpointURL,
+			APIVersion: protocolAPIVersion(account, protocol),
+		}
+	}
+	return nil
 }
 
 func protocolEndpointProfile(account *Account) string {
@@ -391,12 +414,14 @@ func canonicalGeminiIdentityEndpoint(account *Account, profile protocolrouter.Ge
 		base.Path = path.Clean(strings.TrimSuffix(base.Path, "/") + "/v1internal:streamGenerateContent")
 		return ProtocolEndpoint{URL: base.String()}, nil
 	case protocolrouter.GeminiEndpointAntigravityEdgeRelay:
-		base, err := normalizeEndpointIdentityURL(account.GetGeminiBaseURL(""))
-		if err != nil {
+		baseURL := strings.TrimRight(account.GetGeminiBaseURL(""), "/")
+		if _, err := normalizeEndpointIdentityURL(baseURL); err != nil {
 			return ProtocolEndpoint{}, err
 		}
-		base.Path = path.Clean(strings.TrimSuffix(base.Path, "/") + "/v1beta/models/{model}:{action}")
-		return ProtocolEndpoint{URL: base.String(), APIVersion: "v1beta"}, nil
+		return ProtocolEndpoint{
+			URL:        baseURL + "/v1beta/models/{model}:{action}",
+			APIVersion: "v1beta",
+		}, nil
 	case protocolrouter.GeminiEndpointVertexServiceAccount:
 		projectID := strings.TrimSpace(account.VertexProjectID())
 		if projectID == "" {

--- a/backend/internal/service/protocol_endpoint_identity.go
+++ b/backend/internal/service/protocol_endpoint_identity.go
@@ -390,6 +390,13 @@ func canonicalGeminiIdentityEndpoint(account *Account, profile protocolrouter.Ge
 		}
 		base.Path = path.Clean(strings.TrimSuffix(base.Path, "/") + "/v1internal:streamGenerateContent")
 		return ProtocolEndpoint{URL: base.String()}, nil
+	case protocolrouter.GeminiEndpointAntigravityEdgeRelay:
+		base, err := normalizeEndpointIdentityURL(account.GetGeminiBaseURL(""))
+		if err != nil {
+			return ProtocolEndpoint{}, err
+		}
+		base.Path = path.Clean(strings.TrimSuffix(base.Path, "/") + "/v1beta/models/{model}:{action}")
+		return ProtocolEndpoint{URL: base.String(), APIVersion: "v1beta"}, nil
 	case protocolrouter.GeminiEndpointVertexServiceAccount:
 		projectID := strings.TrimSpace(account.VertexProjectID())
 		if projectID == "" {

--- a/backend/internal/service/protocol_endpoint_identity_test.go
+++ b/backend/internal/service/protocol_endpoint_identity_test.go
@@ -270,6 +270,39 @@ func TestBuildProtocolEndpointCapabilityLinkInputSeedsOnlyOfficialProfile(t *tes
 	}
 }
 
+func TestBuildProtocolEndpointIdentityAntigravityEdgeRelayKeepsTextAndGeminiHops(t *testing.T) {
+	account := &Account{
+		Platform: PlatformAntigravity,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":  "secret",
+			"base_url": "https://api-us3.tokenkey.dev",
+		},
+	}
+	identity, governed, err := BuildProtocolEndpointIdentity(account)
+	if err != nil || !governed {
+		t.Fatalf("BuildProtocolEndpointIdentity = governed %t, err %v", governed, err)
+	}
+	if identity.EndpointProfile != string(protocolrouter.GeminiEndpointAntigravityEdgeRelay) {
+		t.Fatalf("EndpointProfile = %q", identity.EndpointProfile)
+	}
+	wantURLs := map[protocolrouter.Protocol]string{
+		protocolrouter.ProtocolMessages:              "https://api-us3.tokenkey.dev/v1/messages",
+		protocolrouter.ProtocolChatCompletions:       "https://api-us3.tokenkey.dev/v1/chat/completions",
+		protocolrouter.ProtocolResponses:             "https://api-us3.tokenkey.dev/v1/responses",
+		protocolrouter.ProtocolGeminiGenerateContent: "https://api-us3.tokenkey.dev/antigravity/v1beta/models/{model}:{action}",
+	}
+	if len(identity.ProtocolEndpoints) != len(wantURLs) {
+		t.Fatalf("ProtocolEndpoints = %#v", identity.ProtocolEndpoints)
+	}
+	for protocol, want := range wantURLs {
+		got, ok := identity.ProtocolEndpoints[protocol]
+		if !ok || got.URL != want {
+			t.Fatalf("%s endpoint = %#v, want %q", protocol, got, want)
+		}
+	}
+}
+
 func cloneMap(input map[string]any) map[string]any {
 	result := make(map[string]any, len(input))
 	for key, value := range input {

--- a/backend/internal/service/protocol_execution.go
+++ b/backend/internal/service/protocol_execution.go
@@ -40,7 +40,10 @@ func ExecuteGeminiProtocolProfile[T any](
 	switch profile {
 	case protocolrouter.GeminiEndpointAntigravityCloudCode:
 		execute = antigravity
-	case protocolrouter.GeminiEndpointVertexServiceAccount:
+	case protocolrouter.GeminiEndpointVertexServiceAccount,
+		protocolrouter.GeminiEndpointAntigravityEdgeRelay:
+		// Vertex SA and AG edge stubs both speak native Gemini generateContent
+		// over HTTP (edge hop: {base}/antigravity/v1beta/...).
 		execute = vertex
 	default:
 		return zero, ErrProtocolRouteUnavailable

--- a/backend/internal/service/protocol_execution_target_test.go
+++ b/backend/internal/service/protocol_execution_target_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -285,6 +286,78 @@ func TestProtocolGeminiVertexPlanBindsExactWireEndpointAndBearer(t *testing.T) {
 				t.Fatalf("x-goog-api-key = %q, want service-account bearer only", got)
 			}
 		})
+	}
+}
+
+func TestProtocolGeminiEdgeRelayPlanBindsExactWireEndpointAndAPIKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, inbound := range protocolrouter.AllProtocols() {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/stream=%t", inbound, stream), func(t *testing.T) {
+				body := []byte(fmt.Sprintf(`{"model":"gemini-2.5-flash","stream":%t,"max_tokens":8,"messages":[{"role":"user","content":"hello"}],"input":"hello","contents":[{"role":"user","parts":[{"text":"hello"}]}]}`, stream))
+				responseBody := `{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1}}`
+				contentType, action := "application/json", "generateContent"
+				if stream {
+					responseBody = "data: " + responseBody + "\n\n"
+					contentType, action = "text/event-stream", "streamGenerateContent"
+				}
+				c, _ := gin.CreateTestContext(httptest.NewRecorder())
+				c.Request = httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+				upstream := &protocolTargetHTTPUpstream{responses: []*http.Response{{
+					StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{contentType}},
+					Body: io.NopCloser(strings.NewReader(responseBody)),
+				}}}
+				svc := &GeminiMessagesCompatService{httpUpstream: upstream, cfg: &config.Config{}}
+				account := &Account{
+					ID: 912, Platform: PlatformAntigravity, Type: AccountTypeAPIKey, Status: StatusActive, Concurrency: 1,
+					Credentials: map[string]any{
+						"api_key": "edge-key", "base_url": "https://api-us3.tokenkey.dev",
+						"model_mapping": map[string]any{"gemini-2.5-flash": "gemini-2.5-flash-medium"},
+					},
+				}
+				attachTestProtocolCapability(account, protocolrouter.ProtocolGeminiGenerateContent)
+				var plan protocolrouter.Plan
+				value, err := protocolTargetTestExecution(t, inbound, body, account, func(ctx context.Context, account *Account, selected protocolrouter.Plan, request protocolrouter.CanonicalRequest) (any, error) {
+					plan = selected
+					account.Credentials["base_url"] = "https://api-us4.tokenkey.dev"
+					switch inbound {
+					case protocolrouter.ProtocolMessages:
+						return svc.Forward(ctx, c, account, request.Body())
+					case protocolrouter.ProtocolChatCompletions:
+						return svc.ForwardAsChatCompletions(ctx, c, account, request.Body())
+					case protocolrouter.ProtocolResponses:
+						return svc.ForwardAsResponses(ctx, c, account, request.Body())
+					default:
+						return svc.ForwardNative(ctx, c, account, request.RequestedModel(), action, stream, request.Body())
+					}
+				})
+				if err != nil {
+					t.Fatalf("ExecuteSelectedProtocol: %v", err)
+				}
+				result, ok := value.(*ForwardResult)
+				if !ok {
+					t.Fatalf("result type = %T", value)
+				}
+				facts, ok := result.ProtocolRouteFacts()
+				if !ok || facts.Endpoint() != plan.Endpoint() {
+					t.Fatalf("route facts = %#v, want endpoint %q", facts, plan.Endpoint())
+				}
+				if len(upstream.requests) != 1 {
+					t.Fatalf("requests = %d, want 1", len(upstream.requests))
+				}
+				req := upstream.requests[0]
+				if got := req.URL.Scheme + "://" + req.URL.Host + req.URL.EscapedPath(); got != plan.Endpoint() {
+					t.Fatalf("wire endpoint = %q, want immutable plan endpoint %q", got, plan.Endpoint())
+				}
+				wantAlt := ""
+				if stream {
+					wantAlt = "sse"
+				}
+				if req.URL.Query().Get("alt") != wantAlt || req.Header.Get("x-goog-api-key") != "edge-key" || req.Header.Get("Authorization") != "" {
+					t.Fatal("wire must preserve stream query and use only edge API-key authentication")
+				}
+			})
+		}
 	}
 }
 

--- a/backend/internal/service/protocol_execution_test.go
+++ b/backend/internal/service/protocol_execution_test.go
@@ -64,6 +64,7 @@ func TestExecuteGeminiProtocolProfileUsesOnlyPlannedProfile(t *testing.T) {
 	}{
 		{name: "antigravity", profile: protocolrouter.GeminiEndpointAntigravityCloudCode, wantAntigravity: 1, wantValue: "ag"},
 		{name: "vertex", profile: protocolrouter.GeminiEndpointVertexServiceAccount, wantVertex: 1, wantValue: "vertex"},
+		{name: "antigravity edge relay", profile: protocolrouter.GeminiEndpointAntigravityEdgeRelay, wantVertex: 1, wantValue: "vertex"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -158,6 +159,79 @@ func TestProtocolExecutionRouterInvokesGeminiIdentityExecutor(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 	if calls != 1 || result.Value != "sent" {
+		t.Fatalf("calls/result = %d/%v", calls, result.Value)
+	}
+}
+
+func TestProtocolExecutionRouterPlansAntigravityEdgeRelayGeminiIdentity(t *testing.T) {
+	router := NewProtocolRouter()
+	request, err := protocolrouter.NewCanonicalRequest(protocolrouter.CanonicalRequestInput{
+		InboundProtocol: protocolrouter.ProtocolGeminiGenerateContent,
+		RequestedModel:  "gemini-3.7-flash",
+		Profile:         protocolrouter.RequestProfile{ContentKinds: protocolrouter.ContentText},
+		Body:            []byte(`{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}`),
+	})
+	if err != nil {
+		t.Fatalf("NewCanonicalRequest: %v", err)
+	}
+	account := &Account{
+		ID:       85,
+		Platform: PlatformAntigravity,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":  "secret",
+			"base_url": "https://api-us3.tokenkey.dev",
+			"model_mapping": map[string]any{
+				"gemini-3.7-flash": "gemini-3.7-flash-medium",
+			},
+		},
+		Extra: map[string]any{},
+	}
+	attachTestProtocolCapability(account, protocolrouter.ProtocolGeminiGenerateContent)
+	snapshot, err := protocolAccountSnapshotForRequest(account, request)
+	if err != nil {
+		t.Fatalf("protocolAccountSnapshotForRequest: %v", err)
+	}
+	if snapshot.GeminiProfile() != protocolrouter.GeminiEndpointAntigravityEdgeRelay {
+		t.Fatalf("GeminiProfile = %q", snapshot.GeminiProfile())
+	}
+	plan, err := router.Plan(request, snapshot)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	wantEndpoint := "https://api-us3.tokenkey.dev/antigravity/v1beta/models/gemini-3.7-flash:generateContent"
+	if plan.Endpoint() != wantEndpoint {
+		t.Fatalf("Endpoint = %q, want %q", plan.Endpoint(), wantEndpoint)
+	}
+	calls := 0
+	ctx := WithProtocolExecutors(context.Background(), ProtocolExecutors{
+		GeminiIdentity: func(_ context.Context, _ *Account, gotPlan protocolrouter.Plan, _ protocolrouter.CanonicalRequest) (any, error) {
+			calls++
+			value, err := ExecuteGeminiProtocolProfile(
+				gotPlan.GeminiProfile(),
+				func() (any, error) {
+					t.Fatal("cloudcode arm must not run for edge relay")
+					return nil, nil
+				},
+				func() (any, error) {
+					return "native", nil
+				},
+			)
+			if err != nil {
+				return nil, err
+			}
+			return value, nil
+		},
+	})
+	ctx = withProtocolExecutionAccount(ctx, account)
+	ctx = protocolrouter.WithExecutionAccountState(ctx, protocolrouter.ExecutionAccountState{
+		AccountID: snapshot.AccountID(), CapabilityKey: snapshot.CapabilityKey(), CredentialPresent: true,
+	})
+	result, err := router.Execute(ctx, plan, request)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if calls != 1 || result.Value != "native" {
 		t.Fatalf("calls/result = %d/%v", calls, result.Value)
 	}
 }

--- a/backend/internal/service/protocol_probe_model_tk.go
+++ b/backend/internal/service/protocol_probe_model_tk.go
@@ -23,10 +23,17 @@ func protocolProbeModelCandidates(account *Account) []string {
 	mapping := account.GetModelMapping()
 	candidates := make([]string, 0, len(mapping))
 	seen := make(map[string]struct{}, len(mapping)+2)
-	for _, upstream := range mapping {
+	for requested, upstream := range mapping {
 		upstream = strings.TrimSpace(upstream)
 		if upstream == "" || strings.Contains(upstream, "*") || protocolProbeModelIsNonText(upstream) {
 			continue
+		}
+		// Edge hops accept public mapping keys and resolve provider IDs themselves.
+		if tkIsAntigravityEdgeRelayStub(account) {
+			upstream = strings.TrimSpace(requested)
+			if upstream == "" || strings.Contains(upstream, "*") || protocolProbeModelIsNonText(upstream) {
+				continue
+			}
 		}
 		if _, ok := seen[upstream]; ok {
 			continue

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -1202,6 +1202,8 @@
       "must_contain": [
         "func protocolProbeModelCandidates(account *Account) []string",
         "func selectProtocolProbeModel(account *Account) string",
+        "tkIsAntigravityEdgeRelayStub(account)",
+        "upstream = strings.TrimSpace(requested)",
         "const protocolProbeMaxModels = 6",
         "func protocolProbeShouldTryNextModel(",
         "func protocolRoutingAccountHasNoTextModels(account *Account) bool",
@@ -1330,16 +1332,25 @@
       "rationale": "Provider-specific Gemini probes reuse production Antigravity and Vertex auth/transport owners, and EdgeRelay probes the public Gemini hop via buildGeminiAPIKeyRequest. Empty-pool capacity on edge stubs must count as positive endpoint evidence (same as text hops). A positive 2xx must carry a recognized Gemini response envelope; only structured unsupported-method 404/405 removes a prior capability."
     },
     {
+      "path": "backend/internal/service/protocol_capability_probe_test.go",
+      "must_contain": [
+        "func TestProbeGeminiEdgeRelayUsesPublicModelAndClassifiesWireResponse(t *testing.T)",
+        "func TestProbeAccountProtocolCapabilitiesTreatsEdgeRelayEmptyPoolAsEndpointEvidence(t *testing.T)"
+      ],
+      "rationale": "Edge Gemini probes must send the public model with edge API-key auth, classify success/unsupported/auth responses, and retain positive endpoint evidence when the edge pool is empty."
+    },
+    {
       "path": "backend/internal/service/protocol_execution_target_test.go",
       "must_contain": [
         "func TestProtocolGeminiAntigravityPlanBindsExactWireEndpointAndBearer(t *testing.T)",
         "func TestProtocolGeminiVertexPlanBindsExactWireEndpointAndBearer(t *testing.T)",
+        "func TestProtocolGeminiEdgeRelayPlanBindsExactWireEndpointAndAPIKey(t *testing.T)",
         "want immutable plan endpoint",
         "want Antigravity bearer",
         "want Vertex bearer",
         "account.Credentials[\"location\"] = \"europe-west1\""
       ],
-      "rationale": "Behavioral wire contracts prove both Gemini profiles keep the immutable planner host/path even if mutable account inputs change after selection, preserve required stream query semantics, bind only the correct bearer credential, and exercise streaming plus non-streaming response paths."
+      "rationale": "Behavioral wire contracts prove all three Gemini profiles keep the immutable planner host/path even if mutable account inputs change after selection, preserve required stream query semantics, bind the correct bearer or edge API-key credential, and exercise streaming plus non-streaming response paths."
     },
     {
       "path": "backend/internal/handler/openai_gemini_protocol_execution.go",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -1273,6 +1273,7 @@
         "responsesToGeminiAdapter",
         "geminiIdentityAdapter",
         "func ExecuteGeminiProtocolProfile[T any](",
+        "protocolrouter.GeminiEndpointAntigravityEdgeRelay",
         "func protocolExecutionURL(ctx context.Context, fallback string) string",
         "func OpenAIForwardResultFromForward(result *ForwardResult) *OpenAIForwardResult",
         "RouteFacts",
@@ -1287,21 +1288,26 @@
       "must_contain": [
         "func protocolGeminiEndpointProfile(account *Account) protocolrouter.GeminiEndpointProfile",
         "protocolrouter.GeminiEndpointAntigravityCloudCode",
+        "tkIsAntigravityEdgeRelayStub(account)",
+        "protocolrouter.GeminiEndpointAntigravityEdgeRelay",
         "account.IsNewAPIVertexServiceAccount()",
         "protocolrouter.GeminiEndpointVertexServiceAccount",
         "resolveAntigravityForwardBaseURL(account)",
-        "buildVertexGeminiURL(account.VertexProjectID(), account.VertexLocation(resolvedModel), resolvedModel, action, false)"
+        "buildVertexGeminiURL(account.VertexProjectID(), account.VertexLocation(resolvedModel), resolvedModel, action, false)",
+        "account.GetGeminiBaseURL(\"\")"
       ],
-      "rationale": "One account-shape owner derives the non-persisted Gemini endpoint profile and exact plan endpoint. Antigravity follows the live production/daily base resolver; NewAPI Vertex requires the exact channel-41 service-account predicate and the canonical Vertex model/location URL builder. Losing these anchors can reintroduce account-class leakage or planner/transport host drift."
+      "rationale": "One account-shape owner derives the non-persisted Gemini endpoint profile and exact plan endpoint. Antigravity OAuth stays on CloudCode; Antigravity edge apikey stubs use EdgeRelay + GetGeminiBaseURL hop URLs; NewAPI Vertex requires the exact channel-41 service-account predicate and the canonical Vertex model/location URL builder. Losing these anchors can reintroduce account-class leakage or planner/transport host drift."
     },
     {
       "path": "backend/internal/service/protocol_capability_probe.go",
       "must_contain": [
         "case protocolrouter.ProtocolGeminiGenerateContent:",
         "return s.probeGeminiGenerateContentSupport(ctx, account)",
-        "return []protocolrouter.Protocol{protocolrouter.ProtocolGeminiGenerateContent}"
+        "return []protocolrouter.Protocol{protocolrouter.ProtocolGeminiGenerateContent}",
+        "case protocolrouter.GeminiEndpointAntigravityEdgeRelay:",
+        "geminiProfile == protocolrouter.GeminiEndpointAntigravityEdgeRelay"
       ],
-      "rationale": "The aggregate per-account probe job dispatches the fourth protocol only for provider-specific Gemini candidates. Removing the dispatch leaves supported_protocols permanently empty for repaired Antigravity/Vertex accounts even though the generic three-protocol probe suite remains green."
+      "rationale": "The aggregate per-account probe job dispatches Gemini for provider-specific CloudCode/Vertex candidates, and for Antigravity edge stubs also keeps OpenAI-shape text hops alongside native generateContent. Removing EdgeRelay dual-path collection or the Gemini dispatch leaves supported_protocols permanently empty or regresses #2029 text hops."
     },
     {
       "path": "backend/internal/service/protocol_capability_probe_gemini.go",
@@ -1316,9 +1322,12 @@
         "UNSUPPORTED_METHOD",
         "func (s *AccountTestService) probeGeminiGenerateContentSupport(",
         "s.antigravityGatewayService.TestConnection(ctx, account, model)",
-        "s.buildGeminiServiceAccountRequest(ctx, account, model, payload)"
+        "s.buildGeminiServiceAccountRequest(ctx, account, model, payload)",
+        "case protocolrouter.GeminiEndpointAntigravityEdgeRelay:",
+        "s.buildGeminiAPIKeyRequest(ctx, account, requestModel, payload)",
+        "protocolProbeRelayCapacityVerdict(account, resp.StatusCode, body)"
       ],
-      "rationale": "Provider-specific Gemini probes reuse production Antigravity and Vertex auth/transport owners. A positive 2xx must carry a recognized Gemini response envelope rather than arbitrary JSON or an error object. Only a structured unsupported-method reason carried by HTTP 404/405 removes a prior capability; auth, other 4xx, raw 404/405, rate-limit, server, network, and malformed 2xx failures stay non-destructive."
+      "rationale": "Provider-specific Gemini probes reuse production Antigravity and Vertex auth/transport owners, and EdgeRelay probes the public Gemini hop via buildGeminiAPIKeyRequest. Empty-pool capacity on edge stubs must count as positive endpoint evidence (same as text hops). A positive 2xx must carry a recognized Gemini response envelope; only structured unsupported-method 404/405 removes a prior capability."
     },
     {
       "path": "backend/internal/service/protocol_execution_target_test.go",
@@ -1509,9 +1518,12 @@
         "ProtocolEndpointIdentity",
         "CanonicalJSON",
         "protocolEndpointCapabilityKeySchemaVersion",
-        "sha256.Sum256"
+        "sha256.Sum256",
+        "fillCustomTextProtocolEndpoints",
+        "GeminiEndpointAntigravityEdgeRelay",
+        "/v1beta/models/{model}:{action}"
       ],
-      "rationale": "Protocol capability ownership is endpoint-scoped. One credential-free canonical identity builder must own platform + channel type + endpoint/profile + API-version normalization and stable key generation; duplicating or deleting it can split identical NewAPI endpoints into conflicting capability rows or merge distinct endpoints."
+      "rationale": "Protocol capability ownership is endpoint-scoped. One credential-free canonical identity builder must own platform + channel type + endpoint/profile + API-version normalization and stable key generation. Antigravity edge stubs must keep text hops alongside native Gemini in identity so PEC keys stay aligned with dual-path probes; duplicating or deleting this can split identical NewAPI endpoints into conflicting capability rows or wipe AG edge OpenAI-shape hops."
     },
     {
       "path": "backend/internal/repository/protocol_endpoint_capability_repo.go",


### PR DESCRIPTION
## 摘要
- Antigravity API-key edge stub 原先缺少 Gemini endpoint profile，原生 generateContent 请求无法入池。新增 `antigravity_edge_relay` 身份，经 `{base}/antigravity/v1beta/...` 转发，并保留 Messages、Chat Completions、Responses 文本端点。
- Edge 协议探测使用公开模型名，空池响应保留为端点存在的正向证据；Gemini API-key 转发绑定 Plan 已验证的端点，保留流式查询参数。
- 更新 newapi sentinel，保护 profile、探测模型选择和传输层回归测试。

## 风险
- 常规风险：补齐现有 edge 原生协议路由；无 Web 界面变化（no-web-impact）。
- Endpoint identity 改变，发布准备阶段须完成能力重关联与 probe；上线后核验 AG stub 的 `EndpointProfile=antigravity_edge_relay` 和 Gemini 实际请求。

## 验证
- 完整 preflight（含 Go lint、协议路由 SSOT、newapi sentinel）通过。
- `go test -tags=unit ./internal/engine/protocolrouter ./internal/service ./internal/handler -count=1` 通过。
- 新增回归测试先复现、修复后通过：公开模型与 provider 模型不同的 probe URL；成功、端点不支持、鉴权失败分类；四种入口的流式/非流式请求绑定 Plan 端点与 API-key。
- 未执行线上付费调用或部署；新提交 CI 由 GitHub checks 跟踪。

## 提交
```
8388d4a70 fix(gemini): address R-001..R-002 edge probe and planned endpoint drift
9dbe123ba chore: retrigger CI after sentinel/probe fix
5f5845ec0 fix(gemini): treat AG edge empty-pool as Gemini probe evidence
1e55df78d fix(gemini): keep AG edge text hops in endpoint identity
3ef1582fc fix(gemini): give AG edge stubs a generateContent protocol identity
```
- 最新提交：`8388d4a70`
