### PR TITLE
fix(gateway): 修复 Antigravity Chat 转发覆盖协议 Plan

### DIFF
--- a/backend/internal/handler/gateway_handler_tk_openai_shape_forward.go
+++ b/backend/internal/handler/gateway_handler_tk_openai_shape_forward.go
@@ -9,9 +9,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// tkForwardChatCompletionsByOpenAIShape dispatches chat/completions through the
-// ResolveGovernedOpenAIShapeMode SSOT. openAIDefault covers the residual arm
-// (NonGoverned → gatewayService; governed identity → openAIGatewayService).
+// A bound Plan already selected the converter. Platform/model compatibility
+// dispatch is only a fallback for requests outside protocol routing.
 func (h *GatewayHandler) tkForwardChatCompletionsByOpenAIShape(
 	executionCtx context.Context,
 	c *gin.Context,
@@ -21,6 +20,9 @@ func (h *GatewayHandler) tkForwardChatCompletionsByOpenAIShape(
 	parsedReq *service.ParsedRequest,
 	openAIDefault func() (*service.ForwardResult, error),
 ) (*service.ForwardResult, error) {
+	if _, planned := service.ProtocolExecutionPlan(executionCtx); planned {
+		return openAIDefault()
+	}
 	switch service.ResolveGovernedOpenAIShapeMode(account, reqModel) {
 	case service.GovernedOpenAIShapeGeminiCompat:
 		if h.geminiCompatService == nil {
@@ -40,8 +42,7 @@ func (h *GatewayHandler) tkForwardChatCompletionsByOpenAIShape(
 	}
 }
 
-// tkForwardResponsesByOpenAIShape dispatches /v1/responses through the same
-// ResolveGovernedOpenAIShapeMode SSOT as chat/completions.
+// Responses shares the same Plan-first boundary as Chat Completions.
 func (h *GatewayHandler) tkForwardResponsesByOpenAIShape(
 	executionCtx context.Context,
 	c *gin.Context,
@@ -51,6 +52,9 @@ func (h *GatewayHandler) tkForwardResponsesByOpenAIShape(
 	parsedReq *service.ParsedRequest,
 	openAIDefault func() (*service.ForwardResult, error),
 ) (*service.ForwardResult, error) {
+	if _, planned := service.ProtocolExecutionPlan(executionCtx); planned {
+		return openAIDefault()
+	}
 	switch service.ResolveGovernedOpenAIShapeMode(account, reqModel) {
 	case service.GovernedOpenAIShapeGeminiCompat:
 		if h.geminiCompatService == nil {

--- a/backend/internal/handler/gateway_handler_tk_planned_openai_shape_test.go
+++ b/backend/internal/handler/gateway_handler_tk_planned_openai_shape_test.go
@@ -1,0 +1,160 @@
+package handler
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+type plannedOpenAIShapeAccountRepo struct {
+	service.AccountRepository
+	account *service.Account
+}
+
+func (r *plannedOpenAIShapeAccountRepo) GetByID(context.Context, int64) (*service.Account, error) {
+	return r.account, nil
+}
+
+type plannedOpenAIShapeUpstream struct {
+	service.HTTPUpstream
+	request *http.Request
+	body    []byte
+}
+
+func (u *plannedOpenAIShapeUpstream) Do(request *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
+	u.request = request
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		return nil, err
+	}
+	u.body = body
+	code := http.StatusOK
+	response := `{"id":"chatcmpl-edge","object":"chat.completion","model":"gemini-3.8-flash","choices":[{"index":0,"message":{"role":"assistant","content":"OK"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}`
+	contentType := "application/json"
+	switch {
+	case strings.Contains(request.URL.Path, ":generateContent"):
+		response = `{"candidates":[{"content":{"role":"model","parts":[{"text":"OK"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":2,"totalTokenCount":5}}`
+	case strings.HasSuffix(request.URL.Path, "/responses"):
+		response = `{"id":"resp-edge","object":"response","status":"completed","model":"gemini-3.8-flash","output":[{"type":"message","id":"msg-edge","role":"assistant","status":"completed","content":[{"type":"output_text","text":"OK"}]}],"usage":{"input_tokens":3,"output_tokens":2,"total_tokens":5}}`
+		if gjson.GetBytes(body, "stream").Bool() {
+			contentType = "text/event-stream"
+			response = "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":" + response + "}\n\n"
+		}
+	case gjson.GetBytes(body, "stream").Bool():
+		contentType = "text/event-stream"
+		response = "data: " + `{"id":"chatcmpl-edge","object":"chat.completion.chunk","model":"gemini-3.8-flash","choices":[{"index":0,"delta":{"role":"assistant","content":"OK"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}` + "\n\ndata: [DONE]\n\n"
+	}
+	if !strings.Contains(request.URL.Path, ":generateContent") && gjson.GetBytes(body, "model").String() == "" {
+		code = http.StatusBadRequest
+		response = `{"error":{"message":"model is required","type":"invalid_request_error"}}`
+	}
+	return &http.Response{StatusCode: code, Header: http.Header{"Content-Type": {contentType}}, Body: io.NopCloser(strings.NewReader(response))}, nil
+}
+
+func TestGatewayPlannedAntigravityOpenAIShapeKeepsPlannedWire(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const model = "gemini-3.8-flash"
+	const upstreamModel = "gemini-3.8-flash-medium"
+	for _, tc := range []struct {
+		name    string
+		inbound protocolrouter.Protocol
+		target  protocolrouter.Protocol
+		stream  bool
+	}{
+		{"chat_identity", protocolrouter.ProtocolChatCompletions, protocolrouter.ProtocolChatCompletions, false},
+		{"chat_identity_stream", protocolrouter.ProtocolChatCompletions, protocolrouter.ProtocolChatCompletions, true},
+		{"chat_to_responses", protocolrouter.ProtocolChatCompletions, protocolrouter.ProtocolResponses, false},
+		{"responses_identity", protocolrouter.ProtocolResponses, protocolrouter.ProtocolResponses, false},
+		{"responses_to_chat", protocolrouter.ProtocolResponses, protocolrouter.ProtocolChatCompletions, false},
+		{"responses_to_chat_stream", protocolrouter.ProtocolResponses, protocolrouter.ProtocolChatCompletions, true},
+		{"chat_to_gemini", protocolrouter.ProtocolChatCompletions, protocolrouter.ProtocolGeminiGenerateContent, false},
+		{"responses_to_gemini", protocolrouter.ProtocolResponses, protocolrouter.ProtocolGeminiGenerateContent, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			account := &service.Account{
+				ID: 62, Name: "antigravity-us4", Platform: service.PlatformAntigravity,
+				Type: service.AccountTypeAPIKey, Status: service.StatusActive, Schedulable: true,
+				Credentials: map[string]any{
+					"base_url": "https://api-us4.tokenkey.dev", "api_key": "edge-test-key",
+					"model_mapping": map[string]any{model: upstreamModel},
+				},
+			}
+			protocols := []protocolrouter.Protocol{tc.target}
+			if tc.target != protocolrouter.ProtocolGeminiGenerateContent {
+				protocols = append(protocols, protocolrouter.ProtocolGeminiGenerateContent)
+			}
+			attachHandlerTestProtocolCapability(t, account, protocols...)
+			body := []byte(`{"model":"gemini-3.8-flash","messages":[{"role":"user","content":"hello"}],"max_tokens":32}`)
+			path := "/v1/chat/completions"
+			if tc.inbound == protocolrouter.ProtocolResponses {
+				path = "/v1/responses"
+				body = []byte(`{"model":"gemini-3.8-flash","input":"hello","max_output_tokens":32}`)
+			}
+			body, err := sjson.SetBytes(body, "stream", tc.stream)
+			require.NoError(t, err)
+			request, err := newCanonicalProtocolRequest(tc.inbound, protocolrouter.ResponsesPathNone, model, tc.stream, body)
+			require.NoError(t, err)
+			snapshot, err := service.ProtocolAccountSnapshot(account, model)
+			require.NoError(t, err)
+			router := service.NewProtocolRouter()
+			plan, err := router.Plan(request, snapshot)
+			require.NoError(t, err)
+			require.Equal(t, tc.target, plan.TargetProtocol())
+			require.Equal(t, upstreamModel, plan.ResolvedModel())
+
+			repo := &plannedOpenAIShapeAccountRepo{account: account}
+			upstream := &plannedOpenAIShapeUpstream{}
+			cfg := &config.Config{RunMode: config.RunModeSimple}
+			h := &GatewayHandler{
+				protocolRouter:       router,
+				gatewayService:       service.NewGatewayService(repo, nil, nil, nil, nil, nil, nil, nil, cfg, nil, nil, nil, nil, nil, nil, upstream, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil),
+				openAIGatewayService: service.NewOpenAIGatewayService(repo, nil, nil, nil, nil, nil, nil, cfg, nil, nil, nil, nil, nil, upstream, nil, nil, nil, nil, nil, nil, nil, nil),
+				geminiCompatService:  service.NewGeminiMessagesCompatService(repo, nil, nil, nil, nil, nil, upstream, nil, cfg),
+			}
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodPost, path, strings.NewReader(string(body)))
+			ctx := service.WithProtocolRouting(c.Request.Context(), router, request)
+			c.Request = c.Request.WithContext(ctx)
+			selection := &service.AccountSelectionResult{Account: account, ProtocolPlan: &plan}
+			var result *service.ForwardResult
+			if tc.inbound == protocolrouter.ProtocolChatCompletions {
+				result, err = h.executeChatCompletionsSelectedProtocol(c, ctx, selection, account, service.ChannelMappingResult{}, model, nil)
+			} else {
+				result, err = h.executeResponsesSelectedProtocol(c, ctx, selection, account, service.ChannelMappingResult{}, model, nil)
+			}
+			require.NoError(t, err, recorder.Body.String())
+			require.Equal(t, http.StatusOK, recorder.Code)
+			require.NotNil(t, upstream.request)
+			require.Equal(t, plan.Endpoint(), upstream.request.URL.String())
+			if tc.target == protocolrouter.ProtocolGeminiGenerateContent {
+				require.Equal(t, "edge-test-key", upstream.request.Header.Get("x-goog-api-key"))
+				require.True(t, gjson.GetBytes(upstream.body, "contents").IsArray())
+			} else {
+				require.Equal(t, "Bearer edge-test-key", upstream.request.Header.Get("Authorization"))
+				require.Empty(t, upstream.request.Header.Get("x-goog-api-key"))
+				require.Equal(t, plan.ResolvedModel(), gjson.GetBytes(upstream.body, "model").String())
+				require.False(t, gjson.GetBytes(upstream.body, "contents").Exists())
+				if tc.target == protocolrouter.ProtocolChatCompletions {
+					require.True(t, gjson.GetBytes(upstream.body, "messages").IsArray())
+				} else {
+					require.True(t, gjson.GetBytes(upstream.body, "input").Exists())
+				}
+			}
+			require.Contains(t, recorder.Body.String(), "OK")
+			require.Equal(t, 3, result.Usage.InputTokens)
+			require.Equal(t, 2, result.Usage.OutputTokens)
+		})
+	}
+}

--- a/backend/internal/service/account_test_service_tk_newapi_volcagentplan_test.go
+++ b/backend/internal/service/account_test_service_tk_newapi_volcagentplan_test.go
@@ -91,7 +91,7 @@ func TestNativeAgentPlanUsesNewAPIKeyCredential(t *testing.T) {
 	require.Equal(t, "agent-plan-key", token)
 	require.Equal(t, "apikey", kind)
 
-	fallbackKey, targetURL, err := svc.resolveCCFallbackTarget(account)
+	fallbackKey, targetURL, err := svc.resolveCCFallbackTarget(context.Background(), account)
 	require.NoError(t, err)
 	require.Equal(t, "agent-plan-key", fallbackKey)
 	require.Equal(t, newapiintegration.VolcEngineAgentPlanBaseURL+"/chat/completions", targetURL)

--- a/backend/internal/service/gateway_governed_openai_shape_tk.go
+++ b/backend/internal/service/gateway_governed_openai_shape_tk.go
@@ -1,14 +1,7 @@
 package service
 
-// GovernedOpenAIShapeMode selects which forwarder OpenAI-shape chat/responses
-// adapters should use. Protocol routing marks Antigravity edge-relay stubs as
-// governed, but their Gemini chat traffic must not enter OpenAIGatewayService
-// (GetOpenAIProtocolAPIKey rejects platform=antigravity).
-//
-// This is the single owner for Gemini-compat / Antigravity apikey relay /
-// Antigravity OAuth Cloud Code branching. NonGoverned and governed identity
-// adapters both call ResolveGovernedOpenAIShapeMode; only the residual
-// OpenAI/default arm differs by path (gatewayService vs openAIGatewayService).
+// GovernedOpenAIShapeMode preserves platform compatibility dispatch only when
+// no protocol Plan is bound. Governed execution uses the Plan's adapter instead.
 type GovernedOpenAIShapeMode int
 
 const (
@@ -25,8 +18,8 @@ const (
 	GovernedOpenAIShapeAntigravityOAuthCloudCode
 )
 
-// ResolveGovernedOpenAIShapeMode is the SSOT for OpenAI-shape chat/responses
-// special-case branching shared by NonGoverned and governed identity adapters.
+// ResolveGovernedOpenAIShapeMode selects the legacy chat/responses forwarder
+// for requests outside protocol routing.
 func ResolveGovernedOpenAIShapeMode(account *Account, model string) GovernedOpenAIShapeMode {
 	if account == nil {
 		return GovernedOpenAIShapeOpenAI

--- a/backend/internal/service/openai_gateway_cc_pipeline.go
+++ b/backend/internal/service/openai_gateway_cc_pipeline.go
@@ -160,8 +160,12 @@ func (s *OpenAIGatewayService) openAIChatCompletionsTargetURL(account *Account) 
 }
 
 // resolveCCFallbackTarget 解析两条 CC 回退路径共用的账号凭证与上游端点
-// （回退路径仅面向 APIKey 账号，凭证恒为 openai api_key）。
-func (s *OpenAIGatewayService) resolveCCFallbackTarget(account *Account) (apiKey string, targetURL string, err error) {
+// Bound protocol plans own the endpoint and use the shared protocol credential binding.
+func (s *OpenAIGatewayService) resolveCCFallbackTarget(ctx context.Context, account *Account) (apiKey string, targetURL string, err error) {
+	if targetURL = protocolExecutionEndpoint(ctx, ""); targetURL != "" {
+		apiKey, _, err = s.GetAccessToken(ctx, account)
+		return apiKey, targetURL, err
+	}
 	apiKey = strings.TrimSpace(account.GetOpenAIProtocolAPIKey())
 	if apiKey == "" {
 		return "", "", fmt.Errorf("account %d missing api_key", account.ID)

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -169,11 +169,13 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 	)
 
 	// 5. Build and send upstream request via the shared CC pipeline
-	targetURL, err := s.rawChatCompletionsURL(account)
-	if err != nil {
-		return nil, err
+	targetURL := protocolExecutionEndpoint(ctx, "")
+	if targetURL == "" {
+		targetURL, err = s.rawChatCompletionsURL(account)
+		if err != nil {
+			return nil, err
+		}
 	}
-	targetURL = protocolExecutionEndpoint(ctx, targetURL)
 	SetActualOpenAIUpstreamEndpoint(c, grokChatRawEndpoint)
 	customUA := account.GetOpenAIUserAgent()
 	if customUA == "" && account.IsGrokOAuth() {

--- a/backend/internal/service/openai_gateway_messages_chat_fallback.go
+++ b/backend/internal/service/openai_gateway_messages_chat_fallback.go
@@ -102,7 +102,7 @@ func (s *OpenAIGatewayService) forwardAnthropicViaRawChatCompletions(
 	)
 
 	// 3. Build and send upstream request via the shared CC pipeline
-	apiKey, targetURL, err := s.resolveCCFallbackTarget(account)
+	apiKey, targetURL, err := s.resolveCCFallbackTarget(ctx, account)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/service/openai_gateway_responses_chat_fallback.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback.go
@@ -100,7 +100,7 @@ func (s *OpenAIGatewayService) forwardResponsesViaRawChatCompletions(
 	SetOpsUpstreamModel(c, upstreamModel)
 
 	// Build and send upstream request via the shared CC pipeline
-	apiKey, targetURL, err := s.resolveCCFallbackTarget(account)
+	apiKey, targetURL, err := s.resolveCCFallbackTarget(ctx, account)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1148,6 +1148,13 @@ func (s *OpenAIGatewayService) GetAccessToken(ctx context.Context, account *Acco
 		}
 		return accessToken, "oauth", nil
 	case AccountTypeAPIKey:
+		if protocolExecutionBound(ctx) {
+			apiKey := strings.TrimSpace(protocolAuthorizationToken(account))
+			if apiKey == "" {
+				return "", "", errors.New("api_key not found in credentials")
+			}
+			return apiKey, "apikey", nil
+		}
 		if account.Platform == PlatformGrok {
 			apiKey := strings.TrimSpace(account.GetCredential("api_key"))
 			if apiKey == "" {

--- a/backend/internal/service/protocol_execution_test.go
+++ b/backend/internal/service/protocol_execution_test.go
@@ -54,6 +54,45 @@ func protocolExecutionAccountLoaderForTest(account *Account) ProtocolExecutionAc
 	}
 }
 
+func TestProtocolPlannedAPIKeyUsesProtocolAuthorizationOwner(t *testing.T) {
+	account := &Account{
+		ID: 62, Name: "antigravity-us4", Platform: PlatformAntigravity, Type: AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://api-us4.tokenkey.dev", "api_key": "edge-test-key",
+			"model_mapping": map[string]any{"gemini-3.8-flash": "gemini-3.8-flash"},
+		},
+	}
+	attachTestProtocolCapability(account, protocolrouter.ProtocolChatCompletions)
+	request, err := protocolrouter.NewCanonicalRequest(protocolrouter.CanonicalRequestInput{
+		InboundProtocol: protocolrouter.ProtocolChatCompletions, RequestedModel: "gemini-3.8-flash",
+		Body: []byte(`{"model":"gemini-3.8-flash","messages":[{"role":"user","content":"hello"}]}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := protocolAccountSnapshotForRequest(account, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := NewProtocolRouter().Plan(request, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc := &OpenAIGatewayService{}
+	if _, _, err := svc.GetAccessToken(context.Background(), account); err == nil {
+		t.Fatal("unplanned traffic must retain the legacy credential boundary")
+	}
+	ctx := withProtocolExecutionPlan(context.Background(), plan)
+	key, kind, err := svc.GetAccessToken(ctx, account)
+	if err != nil || key != "edge-test-key" || kind != "apikey" {
+		t.Fatalf("planned credential binding: kind=%q err=%v", kind, err)
+	}
+	delete(account.Credentials, "api_key")
+	if key, _, err := svc.GetAccessToken(ctx, account); err == nil || key != "" {
+		t.Fatal("missing planned credential must fail closed")
+	}
+}
+
 func TestExecuteGeminiProtocolProfileUsesOnlyPlannedProfile(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -6490,19 +6490,70 @@
         "h.tkForwardChatCompletionsByOpenAIShape(",
         "ChatToGemini:"
       ],
-      "rationale": "Gateway /v1/chat/completions governed protocol boundary: WithProtocolRouting attach + ExecuteSelectedProtocol (incl. ChatToGemini / gemini-native branch) must stay co-located in this companion per protocol-routing SSOT. NonGoverned and ChatIdentity both dispatch via tkForwardChatCompletionsByOpenAIShape (ResolveGovernedOpenAIShapeMode SSOT) so Antigravity edge-relay Gemini hops via geminiCompat instead of OpenAI GetOpenAIProtocolAPIKey. P2: extracted from gateway_handler_chat_completions.go."
+      "rationale": "Gateway /v1/chat/completions governed protocol boundary: WithProtocolRouting attach + ExecuteSelectedProtocol (incl. ChatToGemini / gemini-native branch) must stay co-located in this companion per protocol-routing SSOT. Bound adapters must execute the Plan-selected protocol without platform/model redispatch. P2: extracted from gateway_handler_chat_completions.go."
     },
     {
       "path": "backend/internal/handler/gateway_handler_tk_openai_shape_forward.go",
       "must_contain": [
         "func (h *GatewayHandler) tkForwardChatCompletionsByOpenAIShape(",
         "func (h *GatewayHandler) tkForwardResponsesByOpenAIShape(",
+        "service.ProtocolExecutionPlan(executionCtx)",
         "service.ResolveGovernedOpenAIShapeMode(account, reqModel)",
         "service.GovernedOpenAIShapeGeminiCompat",
         "service.GovernedOpenAIShapeAntigravityClaudeRelay",
         "service.GovernedOpenAIShapeAntigravityOAuthCloudCode"
       ],
-      "rationale": "Single call-site owner for OpenAI-shape chat/responses special-case hops. Both NonGoverned and governed identity adapters must route through these helpers so AG Gemini/Claude/OAuth branching cannot drift."
+      "rationale": "Chat/Responses forwarding must honor a bound protocolrouter.Plan before legacy platform/model dispatch. Redispatching a Chat identity through Gemini compatibility sends a model-less Gemini body to the Chat endpoint."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler_tk_planned_openai_shape_test.go",
+      "must_contain": [
+        "TestGatewayPlannedAntigravityOpenAIShapeKeepsPlannedWire",
+        "require.Equal(t, plan.Endpoint(), upstream.request.URL.String())",
+        "require.Equal(t, plan.ResolvedModel(), gjson.GetBytes(upstream.body, \"model\").String())",
+        "require.Equal(t, 3, result.Usage.InputTokens)",
+        "chat_identity_stream",
+        "responses_to_chat_stream",
+        "chat_to_responses",
+        "responses_identity",
+        "chat_to_gemini",
+        "responses_to_gemini"
+      ],
+      "rationale": "Wire-level regression for Antigravity edge account selection: real Plan, handler adapters and transport builders must agree on endpoint, protocol body, mapped model, credentials and usage, including streaming."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service.go",
+      "must_contain": [
+        "if protocolExecutionBound(ctx) {",
+        "strings.TrimSpace(protocolAuthorizationToken(account))"
+      ],
+      "rationale": "Plan-bound API-key execution must consume the existing protocol authorization owner used during capability evaluation. Falling back to the legacy OpenAI-only accessor rejects valid Antigravity edge credentials."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_chat_completions_raw.go",
+      "must_contain": [
+        "targetURL := protocolExecutionEndpoint(ctx, \"\")",
+        "targetURL, err = s.rawChatCompletionsURL(account)"
+      ],
+      "rationale": "Raw Chat must consume the Plan endpoint before the legacy URL resolver, which cannot resolve every protocol-governed platform. The planned-wire regression verifies the destination actually sent."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_cc_pipeline.go",
+      "must_contain": [
+        "resolveCCFallbackTarget(ctx context.Context, account *Account)",
+        "if targetURL = protocolExecutionEndpoint(ctx, \"\"); targetURL != \"\" {",
+        "apiKey, _, err = s.GetAccessToken(ctx, account)"
+      ],
+      "rationale": "Messages/Responses-to-Chat converters must share Plan-bound endpoint and credential consumption; legacy resolver rules apply only without a Plan."
+    },
+    {
+      "path": "backend/internal/service/protocol_execution_test.go",
+      "must_contain": [
+        "TestProtocolPlannedAPIKeyUsesProtocolAuthorizationOwner",
+        "unplanned traffic must retain the legacy credential boundary",
+        "missing planned credential must fail closed"
+      ],
+      "rationale": "Bound API-key credential regression covers accepted protocol credentials, unchanged unplanned behavior, and missing-key rejection."
     },
     {
       "path": "backend/internal/handler/gateway_handler_chat_completions.go",
@@ -6568,7 +6619,7 @@
         "GovernedOpenAIShapeAntigravityOAuthCloudCode",
         "UsesGeminiNativeOpenAICompat(account.Platform, model)"
       ],
-      "rationale": "SSOT for OpenAI-shape chat/responses special-case forwarder selection (NonGoverned + governed identity). Antigravity apikey edge stubs are protocol-governed but must not enter OpenAIGatewayService for Gemini text; OAuth Claude must stay on Cloud Code. Dropping this companion reopens api_key not found on prod→edge Gemini chat."
+      "rationale": "Legacy fallback for OpenAI-shape chat/responses outside bound protocol routing. Bound plans own converter selection; this platform/model classifier must not override their wire protocol. OAuth Claude retains its Cloud Code fallback."
     },
     {
       "path": "backend/internal/service/gateway_governed_openai_shape_tk_test.go",


### PR DESCRIPTION
## 摘要

修复 Universal Key 调用 `chat/completions + gemini-3.8-flash` 时，Antigravity 账号 62 已被选中却返回 `400 model is required` 的执行层错误。

`protocolrouter.Plan` 已选定 Chat 原生协议，但后续按平台和模型的兼容分流又把请求转换成 Gemini body，发送地址却仍使用 Plan 的 `/v1/chat/completions`，导致缺少顶层 `model`。Responses 存在相同的二次分流问题。

绑定 Plan 后直接执行其选定的适配器，统一消费 Plan 的 endpoint、模型映射和既有协议凭证 owner；平台兼容分流仅保留给没有 Plan 的旧路径。同步补齐原生 Chat 与 Messages/Responses 转 Chat 的 endpoint、凭证接线，并更新 sentinel 锚点。

## 风险

- 常规风险：恢复已批准的候选资格 SSOT 中 `protocolrouter.Plan` 的协议决策权；未改变选组、调度降权、授权或计费规则。
- 发送前的账号重载、Plan 一致性检查、endpoint 校验继续生效；缺少 API key 时拒绝发送。未绑定 Plan 的旧凭证及 URL 规则保持原样。
- `no-web-impact`：无 WebUI 或公共 API 契约变更。
- 尚未部署。线上业务验收仍需使用 Universal Key 指定账号 62，确认请求成功且成功计量记录归属正确。

## 验证

- 修复前，真实 Plan、handler 适配器和请求构造器配合模拟上游，稳定复现 `400 model is required`；修复后通过。
- 回归覆盖 Chat/Responses 原生、两者互转、转 Gemini，以及 Chat 和 Responses 转 Chat 的流式路径；断言实际发送的 URL、body、鉴权、`gemini-3.8-flash-medium` 映射及返回用量。
- 凭证回归覆盖绑定 Plan 后成功取 key、未绑定 Plan 维持旧行为、缺失 key 时拒绝发送。
- 线上对照：从 prod 使用账号 62 的实际凭证与映射模型，向 us4 发送正确 Chat body，返回 HTTP 200，`prompt_tokens=257`、`completion_tokens=28`。此对照证明上游可服务，不代替修复部署后的 Universal Key 计量验收。
- `go test -tags unit ./internal/handler ./internal/service ./internal/engine/protocolrouter` 通过。
- `make test` 通过：后端全量单测、Go lint、前端 lint/typecheck、207 项关键测试及 ESLint 配置回归。
- `scripts/preflight.sh` 通过；xj-review 复审无阻塞发现。

## 提交

- `50674c51a` fix(gateway): honor protocol plans for Antigravity chat forwarding

最新提交：50674c51a
