### PR TITLE
fix(admin): 供应源发现模型空屏（null slice JSON）

### DIFF
--- a/backend/internal/service/supplier_source_probe.go
+++ b/backend/internal/service/supplier_source_probe.go
@@ -524,14 +524,46 @@ func cloneSupplierSourceProbeResult(in *SupplierSourceProbeResult) *SupplierSour
 		return emptySupplierSourceProbeResult(0)
 	}
 	out := *in
-	out.UpstreamModels = append([]SupplierUpstreamModelEntry(nil), in.UpstreamModels...)
+	// Always allocate empty (non-nil) slices so JSON encodes [] not null.
+	// Admin discover UI reads .length on these fields; null crashes the panel.
+	out.UpstreamModels = cloneSupplierUpstreamModelEntries(in.UpstreamModels)
 	out.NormalizedModels = cloneSupplierSourceModels(in.NormalizedModels)
-	out.NormalizedChanges = append([]SupplierModelNormalizeChange(nil), in.NormalizedChanges...)
+	out.NormalizedChanges = cloneSupplierModelNormalizeChanges(in.NormalizedChanges)
 	out.SuggestedAppends = cloneSupplierSourceModels(in.SuggestedAppends)
-	out.RejectedCandidates = append([]SupplierProbeRejectedCandidate(nil), in.RejectedCandidates...)
-	out.ConfiguredIssues = append([]SupplierProbeConfiguredIssue(nil), in.ConfiguredIssues...)
-	out.ProbeResults = append([]SupplierProbeResult(nil), in.ProbeResults...)
+	out.RejectedCandidates = cloneSupplierProbeRejectedCandidates(in.RejectedCandidates)
+	out.ConfiguredIssues = cloneSupplierProbeConfiguredIssues(in.ConfiguredIssues)
+	out.ProbeResults = cloneSupplierProbeResults(in.ProbeResults)
 	return &out
+}
+
+func cloneSupplierUpstreamModelEntries(in []SupplierUpstreamModelEntry) []SupplierUpstreamModelEntry {
+	out := make([]SupplierUpstreamModelEntry, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneSupplierModelNormalizeChanges(in []SupplierModelNormalizeChange) []SupplierModelNormalizeChange {
+	out := make([]SupplierModelNormalizeChange, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneSupplierProbeRejectedCandidates(in []SupplierProbeRejectedCandidate) []SupplierProbeRejectedCandidate {
+	out := make([]SupplierProbeRejectedCandidate, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneSupplierProbeConfiguredIssues(in []SupplierProbeConfiguredIssue) []SupplierProbeConfiguredIssue {
+	out := make([]SupplierProbeConfiguredIssue, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneSupplierProbeResults(in []SupplierProbeResult) []SupplierProbeResult {
+	out := make([]SupplierProbeResult, len(in))
+	copy(out, in)
+	return out
 }
 
 func cloneSupplierSourceModels(in []SupplierSourceModel) []SupplierSourceModel {

--- a/backend/internal/service/supplier_source_probe_test.go
+++ b/backend/internal/service/supplier_source_probe_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -223,6 +224,39 @@ func TestUS048_GetSupplierProbeJobMissingReturnsFailedSnapshot(t *testing.T) {
 	require.Equal(t, "missing-job", result.JobID)
 	require.Equal(t, "job_not_found", result.FailedStep)
 	require.Equal(t, SupplierProbeJobFailed, result.ProbeStatus)
+}
+
+func TestCloneSupplierSourceProbeResultEmptySlicesJSONNotNull(t *testing.T) {
+	// Regression: append(nil, empty...) produced nil slices; encoding/json emits null,
+	// and SupplierSourcesView crashes on discoverResult.*.length → blank discover panel.
+	cloned := cloneSupplierSourceProbeResult(&SupplierSourceProbeResult{
+		SourceID:           15,
+		ProbeStatus:        SupplierProbeJobRunning,
+		UpstreamModels:     []SupplierUpstreamModelEntry{{ID: "gpt-5.4"}},
+		NormalizedModels:   make([]SupplierSourceModel, 0),
+		NormalizedChanges:  make([]SupplierModelNormalizeChange, 0),
+		SuggestedAppends:   make([]SupplierSourceModel, 0),
+		RejectedCandidates: make([]SupplierProbeRejectedCandidate, 0),
+		ConfiguredIssues:   make([]SupplierProbeConfiguredIssue, 0),
+		ProbeResults:       make([]SupplierProbeResult, 0),
+	})
+	require.NotNil(t, cloned.NormalizedChanges)
+	require.NotNil(t, cloned.SuggestedAppends)
+	require.NotNil(t, cloned.RejectedCandidates)
+	require.NotNil(t, cloned.ConfiguredIssues)
+	require.NotNil(t, cloned.ProbeResults)
+	require.NotNil(t, cloned.NormalizedModels)
+
+	raw, err := json.Marshal(cloned)
+	require.NoError(t, err)
+	var decoded map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	for _, key := range []string{
+		"upstream_models", "normalized_models", "normalized_changes",
+		"suggested_appends", "rejected_candidates", "configured_issues", "probe_results",
+	} {
+		require.Equal(t, byte('['), decoded[key][0], "field %s must encode as JSON array, got %s", key, decoded[key])
+	}
 }
 
 func TestUS048_StartSupplierProbeJobProbesAllCandidatesAsynchronously(t *testing.T) {

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 724,
-  "hash": "a23d13864d3b3b4edb366aed0ff6839a49d2e7220a8c2c97e09078cfefddef08",
+  "hash": "860b2b674e4a2c9d95c2c379b05d73ae539786688259c45628a31c4da4be6029",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/views/admin/SupplierSourcesView.vue
+++ b/frontend/src/views/admin/SupplierSourcesView.vue
@@ -997,7 +997,15 @@ function supplierDiscoverResultFromError(error: unknown): SupplierSourceProbeRes
   const data = (error as { data?: unknown }).data
   if (!data || typeof data !== 'object') return null
   const candidate = data as Partial<SupplierSourceProbeResult>
-  if (!Array.isArray(candidate.normalized_models) || !Array.isArray(candidate.suggested_appends)) return null
+  // Accept null arrays (legacy JSON) but reject non-array object values.
+  if (candidate.normalized_models != null && !Array.isArray(candidate.normalized_models)) return null
+  if (candidate.suggested_appends != null && !Array.isArray(candidate.suggested_appends)) return null
+  return normalizeSupplierProbeResult(candidate)
+}
+
+function normalizeSupplierProbeResult(
+  candidate: Partial<SupplierSourceProbeResult> | SupplierSourceProbeResult,
+): SupplierSourceProbeResult {
   return {
     source_id: typeof candidate.source_id === 'number' ? candidate.source_id : 0,
     job_id: typeof candidate.job_id === 'string' ? candidate.job_id : undefined,
@@ -1009,10 +1017,11 @@ function supplierDiscoverResultFromError(error: unknown): SupplierSourceProbeRes
       : 'failed',
     probe_total: typeof candidate.probe_total === 'number' ? candidate.probe_total : 0,
     probe_done: typeof candidate.probe_done === 'number' ? candidate.probe_done : 0,
+    // Backend historically cloned empty slices to nil → JSON null; never crash on .length.
     upstream_models: Array.isArray(candidate.upstream_models) ? candidate.upstream_models : [],
-    normalized_models: candidate.normalized_models,
+    normalized_models: Array.isArray(candidate.normalized_models) ? candidate.normalized_models : [],
     normalized_changes: Array.isArray(candidate.normalized_changes) ? candidate.normalized_changes : [],
-    suggested_appends: candidate.suggested_appends,
+    suggested_appends: Array.isArray(candidate.suggested_appends) ? candidate.suggested_appends : [],
     rejected_candidates: Array.isArray(candidate.rejected_candidates) ? candidate.rejected_candidates : [],
     configured_issues: Array.isArray(candidate.configured_issues) ? candidate.configured_issues : [],
     probe_results: Array.isArray(candidate.probe_results) ? candidate.probe_results : [],
@@ -1038,7 +1047,7 @@ async function waitDiscoverJob(
   sourceID: number,
   started: SupplierSourceProbeResult,
 ): Promise<SupplierSourceProbeResult> {
-  let current = started
+  let current = normalizeSupplierProbeResult(started)
   discoverResult.value = current
   const jobID = current.job_id
   if (!jobID || current.probe_status !== 'running') {
@@ -1047,7 +1056,9 @@ async function waitDiscoverJob(
   const deadline = Date.now() + 15 * 60 * 1000
   while (Date.now() < deadline) {
     await new Promise(resolve => window.setTimeout(resolve, 1000))
-    current = await adminAPI.supplierSources.getDiscoverJob(sourceID, jobID)
+    current = normalizeSupplierProbeResult(
+      await adminAPI.supplierSources.getDiscoverJob(sourceID, jobID),
+    )
     discoverResult.value = current
     if (current.probe_status === 'completed') {
       return current

--- a/frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts
+++ b/frontend/src/views/admin/__tests__/SupplierSourcesView.spec.ts
@@ -431,11 +431,12 @@ describe('SupplierSourcesView', () => {
       probe_done: 0,
       upstream_models: [{ id: 'deepseek-v4-pro', type: 'chat' }, { id: 'glm-5.1', type: 'chat' }],
       normalized_models: source.models,
-      normalized_changes: [],
-      suggested_appends: [],
-      rejected_candidates: [],
-      configured_issues: [],
-      probe_results: [],
+      // Reproduce pre-fix backend JSON null empty slices (blank-screen crash).
+      normalized_changes: null as unknown as [],
+      suggested_appends: null as unknown as [],
+      rejected_candidates: null as unknown as [],
+      configured_issues: null as unknown as [],
+      probe_results: null as unknown as [],
       needs_confirmation: false,
     })
     getDiscoverJob


### PR DESCRIPTION
## 摘要
- 修复管理端「发现模型」在上游列表有结果、但规整/拒绝等列表为空时整页白屏的问题（tokensea default 可复现）。
- 根因：`cloneSupplierSourceProbeResult` 把空 slice 克隆成 `nil`，JSON 变成 `null`，前端对 `.length` 抛错。
- 后端克隆一律产出非 nil 空数组；前端收包时规范化 null → `[]`；同步嵌入前端 source stamp。

## 风险
- 低风险 bug 修复；仅影响 supplier discover 响应形状与 Admin UI 容错，不改探测业务语义。
- Web impact: SupplierSourcesView discover 面板。
- sentinel-registry-reviewed：本次仅修正空 slice JSON 编码与 UI 容错，无新增 load-bearing 调度/网关锚点需求。

## 验证
- `go test -tags=unit ./internal/service/ -run 'TestCloneSupplierSourceProbeResultEmptySlicesJSONNotNull|TestUS048_StartSupplierProbeJob'`
- `pnpm test:run src/views/admin/__tests__/SupplierSourcesView.spec.ts`（21 passed）
- `pnpm --dir frontend run build` + frontend-source stamp 对齐
- `./scripts/preflight.sh` PASS

## 提交
```
46689f79c fix(admin): refresh embedded frontend-source stamp after discover UI fix
09306b9a2 fix(admin): keep supplier discover slices as JSON arrays
```
- 最新提交：`46689f79c`