### PR TITLE
fix(routing): 在 Universal 选组前规范化 Claude 别名

### DIFF
--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -2318,6 +2318,9 @@ func classifyOpsErrorLog(c *gin.Context, errType, message, code string, status i
 		}
 	}
 	phase = tkOpsClassifyFinalClientValidationPhase(phase, effectiveUpstreamError, routingCapacityLimited, errType, message, code, status)
+	if c != nil && c.GetBool(service.OpsRoutingInternalErrorKey) && !effectiveUpstreamError {
+		phase = "routing"
+	}
 	errorOwner = classifyOpsErrorOwner(phase, message)
 	errorSource = classifyOpsErrorSource(phase, message)
 	localClientAuthError := !effectiveUpstreamError && phase == "auth" && isOpsClientAuthError(code, msg)

--- a/backend/internal/handler/ops_error_logger_tk_universal_routing_test.go
+++ b/backend/internal/handler/ops_error_logger_tk_universal_routing_test.go
@@ -1,0 +1,44 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type unavailableUniversalSpan struct{}
+
+func (unavailableUniversalSpan) GetAvailableGroups(context.Context, int64) ([]service.Group, error) {
+	return nil, errors.New("protocol capability unavailable")
+}
+
+func TestOpsUniversalRoutingFailureIsPlatformOwned(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, path := range []string{"/v1/messages", "/v1/messages/count_tokens", "/v1/chat/completions", "/v1beta/models/gemini-3-flash-preview:generateContent"} {
+		t.Run(path, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{"model":"opus","messages":[{"role":"user","content":"hello"}]}`))
+			key := &service.APIKey{ID: 1, UserID: 1, RoutingMode: service.RoutingModeUniversal}
+			resolver := service.NewUniversalRoutingResolver(unavailableUniversalSpan{})
+			require.True(t, middleware.MaybeResolveUniversal(c, key, resolver))
+			require.Equal(t, http.StatusInternalServerError, recorder.Code)
+			parsed := parseOpsErrorResponse(recorder.Body.Bytes())
+			phase, limited, owner, source := classifyOpsErrorLog(c, parsed.ErrorType, parsed.Message, parsed.Code, recorder.Code)
+			require.Equal(t, "routing", phase)
+			require.Equal(t, "platform", owner)
+			require.Equal(t, "gateway", source)
+			require.False(t, limited)
+			require.NotEqual(t, "permission_error", parsed.ErrorType)
+			require.False(t, hasOpsUpstreamErrorContext(c))
+		})
+	}
+}

--- a/backend/internal/server/middleware/universal_routing_tk.go
+++ b/backend/internal/server/middleware/universal_routing_tk.go
@@ -82,6 +82,20 @@ func MaybeResolveUniversal(c *gin.Context, apiKey *service.APIKey, resolver *ser
 				body, err = pkghttputil.NormalizeLenientJSONRequestBody(body, 0)
 			}
 			if err == nil {
+				if shape == service.ShapeAnthropicMessages || shape == service.ShapeAnthropicCountTokens {
+					parsed, parseErr := service.ParseGatewayRequest(service.NewRequestBodyRef(body), service.PlatformAnthropic)
+					if parseErr == nil {
+						if normalized, resolved := service.TkApplyBareModelAlias(forcedPlatform, parsed); resolved != "" {
+							body = normalized
+							// Planning and the handler must consume the same alias rewrite,
+							// including when the client sent a compressed request.
+							c.Request.Body = io.NopCloser(bytes.NewReader(body))
+							c.Request.ContentLength = int64(len(body))
+							c.Request.Header.Del("Content-Encoding")
+							c.Request.Header.Del("Content-Length")
+						}
+					}
+				}
 				if shape != service.ShapeGemini && shape != service.ShapeOpenAIImagesEdit {
 					var document struct {
 						Model string `json:"model"`
@@ -356,11 +370,15 @@ func writeUniversalRoutingError(c *gin.Context, shape service.UniversalShape, mo
 func writeUniversalRoutingInternalError(c *gin.Context, shape service.UniversalShape) {
 	const status = http.StatusInternalServerError
 	const msg = "Failed to resolve a backing platform for this request. Please retry."
+	c.Set(service.OpsRoutingInternalErrorKey, true)
 	switch shape {
 	case service.ShapeGemini:
 		GoogleErrorWriter(c, status, msg)
 	case service.ShapeAnthropicMessages, service.ShapeAnthropicCountTokens:
-		AnthropicErrorWriter(c, status, msg)
+		c.JSON(status, gin.H{
+			"type":  "error",
+			"error": gin.H{"type": "api_error", "code": "universal_routing_internal_error", "message": msg},
+		})
 	default:
 		c.JSON(status, gin.H{
 			"error": gin.H{

--- a/backend/internal/server/middleware/universal_routing_tk_alias_test.go
+++ b/backend/internal/server/middleware/universal_routing_tk_alias_test.go
@@ -1,0 +1,119 @@
+//go:build unit
+
+package middleware
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/engine/protocolrouter"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
+	pkghttputil "github.com/Wei-Shaw/sub2api/internal/pkg/httputil"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestUniversalAliasUsesSameModelForPlanAndHandler(t *testing.T) {
+	for _, path := range []string{"/v1/messages", "/v1/messages/count_tokens"} {
+		for _, compressed := range []bool{false, true} {
+			t.Run(path+map[bool]string{false: "/plain", true: "/gzip"}[compressed], func(t *testing.T) {
+				const body = `{"model":"opus","max_tokens":16,"messages":[{"role":"user","content":"hello"}]}`
+				c, _ := newTestCtx(http.MethodPost, path, body)
+				if compressed {
+					var buf bytes.Buffer
+					w := gzip.NewWriter(&buf)
+					_, err := w.Write([]byte(body))
+					require.NoError(t, err)
+					require.NoError(t, w.Close())
+					c.Request.Body = io.NopCloser(bytes.NewReader(buf.Bytes()))
+					c.Request.ContentLength = int64(buf.Len())
+					c.Request.Header.Set("Content-Encoding", "gzip")
+				}
+				key := &service.APIKey{ID: 1, UserID: 1, RoutingMode: service.RoutingModeUniversal}
+				resolver := service.NewUniversalRoutingResolver(&stubSpanLister{groups: []service.Group{activeGroup(1, service.PlatformAnthropic)}})
+				router := service.NewProtocolRouter()
+				account := &service.Account{ID: 1, Platform: service.PlatformAnthropic, Type: service.AccountTypeAPIKey,
+					Credentials: map[string]any{"base_url": "https://example.com", "api_key": "test-only", "model_mapping": map[string]any{"claude-opus-5": "claude-opus-5"}}}
+				identity, governed, err := service.BuildProtocolEndpointIdentity(account)
+				require.NoError(t, err)
+				require.True(t, governed)
+				account.ProtocolEndpointCapabilityID = &account.ID
+				account.ProtocolEndpointCapability = &service.ProtocolEndpointCapability{ID: account.ID, CapabilityKey: identity.Key(), Identity: identity,
+					SupportedProtocols: []protocolrouter.Protocol{protocolrouter.ProtocolMessages}, Revision: 1,
+					ProbeEvidence: service.ProtocolProbeEvidence{InitialProbeCompleted: true}}
+				evaluated := false
+				resolver.SetCandidateEvaluator(router, func(ctx context.Context, _ service.Group, model string, shape service.UniversalShape) (service.GroupCandidateEligibility, error) {
+					evaluated = true
+					require.Nil(t, key.GroupID)
+					require.Equal(t, "claude-opus-5", model)
+					if shape == service.ShapeAnthropicMessages {
+						request, ok := service.ProtocolRoutingRequest(ctx)
+						require.True(t, ok)
+						require.Equal(t, model, request.RequestedModel())
+						require.Equal(t, model, gjson.GetBytes(request.Body(), "model").String())
+						snapshot, err := service.ProtocolAccountSnapshot(account, model)
+						require.NoError(t, err)
+						plan, err := router.Plan(request, snapshot)
+						require.NoError(t, err)
+						require.Equal(t, model, plan.ResolvedModel())
+					}
+					return service.GroupCandidateEligibility{Supported: true, Available: true}, nil
+				})
+				require.False(t, MaybeResolveUniversal(c, key, resolver))
+				require.True(t, evaluated)
+				require.Equal(t, int64(1), *key.GroupID)
+				handlerBody, err := pkghttputil.ReadRequestBodyWithPrealloc(c.Request)
+				require.NoError(t, err)
+				require.Equal(t, "claude-opus-5", gjson.GetBytes(handlerBody, "model").String())
+				require.Equal(t, "hello", gjson.GetBytes(handlerBody, "messages.0.content").String())
+				require.Equal(t, int64(len(handlerBody)), c.Request.ContentLength)
+			})
+		}
+	}
+}
+
+func TestUniversalInternalErrorKeepsServerOwnership(t *testing.T) {
+	c, recorder := newTestCtx(http.MethodPost, "/v1/messages", `{"model":"opus","messages":[{"role":"user","content":"hello"}]}`)
+	resolver := service.NewUniversalRoutingResolver(&stubSpanLister{err: errors.New("capability unavailable")})
+	key := &service.APIKey{ID: 1, UserID: 1, RoutingMode: service.RoutingModeUniversal}
+	require.True(t, MaybeResolveUniversal(c, key, resolver))
+	require.Equal(t, http.StatusInternalServerError, recorder.Code)
+	require.Equal(t, "api_error", gjson.Get(recorder.Body.String(), "error.type").String())
+	require.Equal(t, "universal_routing_internal_error", gjson.Get(recorder.Body.String(), "error.code").String())
+	require.Nil(t, key.GroupID)
+}
+
+func TestUniversalAliasPreservesUnmatchedAndForcedRequests(t *testing.T) {
+	for _, tc := range []struct{ name, path, model, force string }{
+		{"canonical", "/v1/messages", "claude-opus-5", ""},
+		{"unknown", "/v1/messages", "unknown-family", ""},
+		{"other_protocol", "/v1/chat/completions", "opus", ""},
+		{"forced_platform", "/v1/messages", "opus", service.PlatformAntigravity},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{"model":"` + tc.model + `","messages":[{"role":"user","content":"hello"}]}`
+			c, _ := newTestCtx(http.MethodPost, tc.path, body)
+			platform := service.PlatformAnthropic
+			if tc.force != "" {
+				platform = tc.force
+				c.Request = c.Request.WithContext(context.WithValue(c.Request.Context(), ctxkey.ForcePlatform, tc.force))
+			}
+			resolver := service.NewUniversalRoutingResolver(&stubSpanLister{groups: []service.Group{activeGroup(1, platform)}})
+			resolver.SetCandidateEvaluator(service.NewProtocolRouter(), func(_ context.Context, _ service.Group, model string, _ service.UniversalShape) (service.GroupCandidateEligibility, error) {
+				require.Equal(t, tc.model, model)
+				return service.GroupCandidateEligibility{Supported: true, Available: true}, nil
+			})
+			key := &service.APIKey{ID: 1, UserID: 1, RoutingMode: service.RoutingModeUniversal}
+			require.False(t, MaybeResolveUniversal(c, key, resolver))
+			restored, err := io.ReadAll(c.Request.Body)
+			require.NoError(t, err)
+			require.Equal(t, body, string(restored))
+		})
+	}
+}

--- a/backend/internal/service/gateway_request_tk_bare_model_alias.go
+++ b/backend/internal/service/gateway_request_tk_bare_model_alias.go
@@ -27,8 +27,9 @@ import (
 // "claude-3-5-haiku-20241022" (versioned ⇒ natural miss; the deprecated-model
 // interceptor keeps owning it), unknown families, substrings — is returned
 // byte-identical with zero rewrites. The rewrite
-// happens at the handler throat BEFORE channel mapping / session hash /
-// scheduling / usage recording, so every downstream consumer (including the
+// happens before Universal candidate evaluation, or at the direct-key handler
+// throat BEFORE channel mapping / session hash / scheduling / usage recording,
+// so every downstream consumer (including the
 // originalModel billing key) sees only the resolved full id.
 
 // tkBareAliasFamilyPattern recognizes ids of the shape `claude-<family>(-<num>)+`:
@@ -136,8 +137,8 @@ func tkResolveBareModelAlias(model string, aliases map[string]string) (string, b
 	return resolved, ok
 }
 
-// TkApplyBareModelAlias is the handler-throat entry point (Messages and
-// CountTokens, right after the request model is parsed and before channel
+// TkApplyBareModelAlias is shared by Universal ingress and the direct-key
+// handler (Messages and CountTokens, before candidate evaluation / channel
 // mapping / session hash / scheduling). Gate: anthropic path only — platform
 // empty (no force-platform, no group) or PlatformAnthropic. On a hit it
 // surgically rewrites ONLY the body's model field (sjson), refreshes parsed

--- a/backend/internal/service/ops_upstream_context.go
+++ b/backend/internal/service/ops_upstream_context.go
@@ -18,6 +18,9 @@ const (
 	// body size + model stashed at handler entry without a service→handler cycle.
 	OpsModelKey       = "ops_model"
 	OpsRequestBodyKey = "ops_request_body"
+	// OpsRoutingInternalErrorKey records a pre-selection infrastructure failure,
+	// independently of the inbound protocol's error envelope.
+	OpsRoutingInternalErrorKey = "ops_routing_internal_error"
 
 	OpsUpstreamStatusCodeKey   = "ops_upstream_status_code"
 	OpsUpstreamErrorMessageKey = "ops_upstream_error_message"

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -99,10 +99,30 @@
       "path": "backend/internal/server/middleware/universal_routing_tk.go",
       "must_contain": [
         "resolver.WithRequest",
+        "service.TkApplyBareModelAlias(forcedPlatform, parsed)",
+        "c.Set(service.OpsRoutingInternalErrorKey, true)",
         "writeUniversalRoutingCapacityError",
         "apiKey.GroupID = &backing.ID"
       ],
       "rationale": "Actual request profile reaches evaluation before a single billing group is bound."
+    },
+    {
+      "path": "backend/internal/server/middleware/universal_routing_tk_alias_test.go",
+      "must_contain": [
+        "TestUniversalAliasUsesSameModelForPlanAndHandler",
+        "router.Plan(request, snapshot)",
+        "TestUniversalAliasPreservesUnmatchedAndForcedRequests"
+      ],
+      "rationale": "Universal resolves existing Claude aliases before candidate planning and passes the same normalized body to execution, including compressed requests. Alias misses and forced-platform requests preserve the existing contract."
+    },
+    {
+      "path": "backend/internal/handler/ops_error_logger_tk_universal_routing_test.go",
+      "must_contain": [
+        "TestOpsUniversalRoutingFailureIsPlatformOwned",
+        "middleware.MaybeResolveUniversal(c, key, resolver)",
+        "classifyOpsErrorLog(c, parsed.ErrorType, parsed.Message, parsed.Code, recorder.Code)"
+      ],
+      "rationale": "A pre-selection Universal failure must remain routing/platform-owned across protocol envelopes and must not disappear into client permission failures."
     },
     {
       "path": "backend/internal/handler/protocol_request.go",


### PR DESCRIPTION
## 问题与结果

Universal key 调用 `/v1/messages` 并发送 `model=opus` 时，候选评估发生在既有 Claude 别名规范化之前。健康账号无法匹配短模型名，最终暴露协议能力错误并返回 500。改为在 Universal 候选评估前复用 `TkApplyBareModelAlias`，让选组、Plan 和后续 handler 消费同一份规范化模型与请求体；同时覆盖 `/v1/messages/count_tokens` 和 gzip 请求。

v1.8.204 在 2026-09-07 12:44:52 UTC 切流；截至 14:35:30 UTC，生产日志有 33 次 `opus` 触发的 `protocol endpoint capability is invalid or conflicted`。它们没有选中账号，也没有上游调用。这些内部 500 又被 Anthropic middleware 的固定 `permission_error` 信封错误归为客户端责任。

## 实现与 SSOT

- 别名解析继续由现有 `TkApplyBareModelAlias` 和 catalog 派生表拥有，没有新增模型映射表。
- 只有命中既有 Claude 别名时才同步重写下游请求；压缩请求同步调整编码与长度。规范模型名、未知模型、其他协议及强制平台的既有行为保留。
- 模型映射与协议合法性仍归 `protocolrouter.Plan`，候选可用性与计费绑定边界保留。
- Universal 内部失败写出 Anthropic `api_error`，通过明确的 Ops context 标记统一归为 `routing / platform / gateway`，避免依赖协议错误信封猜责任方。
- 增加真实 Plan、middleware 到错误分类器的回归测试及 sentinel。

## 验证

- 新测试在修复前复现：选组仍收到 `opus`，内部 500 返回 `permission_error`；修复后通过。
- 聚焦 middleware / handler 回归测试通过。
- 后端完整单测和 golangci-lint 通过。
- 前端 lint、类型检查与关键测试通过。
- 完整 preflight 通过。

风险：normal。no-web-impact：仅恢复既有网关别名兼容并修正服务端错误归属，无 UI 变更。

## 发布边界

#2034 已覆盖账号 93 的 269 次本地凭证读取失败及账号 62 的 `model is required`；#2035 补充其 SSOT 防回退测试。本 PR 补齐 `opus` 的 33 次选组失败。

同窗口 `gemini-3-flash-preview` 的 176 次协议能力失败、真实上游错误与空池不属于本 PR 的修复承诺。尚未部署，生产 `opus` 成功请求与计量落账仍需发布后验收。
