### PR TITLE
fix(routing): 无效协议能力按候选拒绝，避免 Universal 整体 500

### DIFF
--- a/backend/internal/service/account_supported_protocols.go
+++ b/backend/internal/service/account_supported_protocols.go
@@ -222,14 +222,15 @@ func protocolAccountSnapshot(account *Account, requestedModel string, requireCom
 	}
 	if capability.CapabilityKey == "" || capability.Revision <= 0 ||
 		!protocolCapabilityHasVerifiedRoutingEvidence(capability) {
-		return protocolrouter.AccountSnapshot{}, errors.New("protocol endpoint capability is invalid or conflicted")
+		// Loaded but unusable evidence rejects this candidate, not the whole pool.
+		return protocolrouter.AccountSnapshot{}, fmt.Errorf("%w: protocol endpoint capability is invalid or conflicted", protocolrouter.ErrNoLegalRoute)
 	}
 	identity, governed, err := BuildProtocolEndpointIdentity(account)
 	if err != nil {
 		return protocolrouter.AccountSnapshot{}, err
 	}
 	if !governed || identity.Key() != capability.CapabilityKey {
-		return protocolrouter.AccountSnapshot{}, errors.New("account endpoint identity does not match linked capability")
+		return protocolrouter.AccountSnapshot{}, fmt.Errorf("%w: account endpoint identity does not match linked capability", protocolrouter.ErrNoLegalRoute)
 	}
 	protocols := routingSupportedProtocols(account)
 	resolvedModel := protocolResolvedUpstreamModel(account, requestedModel, requireCompact)

--- a/backend/internal/service/candidate_eligibility_test.go
+++ b/backend/internal/service/candidate_eligibility_test.go
@@ -155,6 +155,107 @@ func TestCandidateEligibilityUnknownCapabilityIsNotEntitlement(t *testing.T) {
 	require.NotErrorIs(t, err, ErrUniversalNoEntitledGroup)
 }
 
+func TestCandidateEligibilityGeminiUnsupportedModelsWithInvalidPeer(t *testing.T) {
+	for _, model := range []string{"gemini-3-flash-preview", "gemini-3.1-flash-lite"} {
+		t.Run(model, func(t *testing.T) {
+			resolver, gateway, accounts, _ := candidateGoogleFixture(t)
+			invalid := accounts[1]
+			invalid.ID = 61
+			invalid.Schedulable = false
+			attachTestProtocolCapability(&invalid)
+			invalid.ProtocolEndpointCapability.ProbeEvidence = ProtocolProbeEvidence{}
+			chatOnly := *protocolRoutingOpenAIAccount(113, "chat_completions")
+			chatOnly.Platform = PlatformNewAPI
+			chatOnly.GroupIDs = []int64{19}
+			chatOnly.Credentials["model_mapping"] = map[string]any{
+				"gemini-3-flash-preview":        "gemini-3-flash-preview",
+				"gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite-preview",
+			}
+			attachTestProtocolCapability(&chatOnly, protocolrouter.ProtocolChatCompletions)
+			resolver.lister = &stubSpanLister{groups: []Group{
+				grp(16, PlatformNewAPI, 1, false), grp(21, PlatformAntigravity, 2, false), grp(19, PlatformNewAPI, 3, false),
+			}}
+			accounts = append(accounts, invalid, chatOnly)
+			wireCandidateTestResolver(resolver, gateway, accounts)
+			ctx := resolver.WithRequest(context.Background(), ShapeGemini,
+				"/v1beta/models/"+model+":generateContent", model,
+				[]byte(`{"contents":[{"role":"user","parts":[{"text":"OK"}]}]}`))
+			for i := range accounts[:2] {
+				_, governed, err := protocolPlanForAccount(ctx, &accounts[i], model)
+				require.True(t, governed)
+				require.ErrorIs(t, err, protocolrouter.ErrModelNotAllowed)
+			}
+			_, governed, err := protocolPlanForAccount(ctx, &chatOnly, model)
+			require.True(t, governed)
+			require.ErrorIs(t, err, protocolrouter.ErrNoLegalRoute)
+			group, err := resolver.Resolve(ctx, universalKey(334), ShapeGemini, model, "")
+			require.Nil(t, group)
+			require.ErrorIs(t, err, ErrUniversalNoEntitledGroup)
+		})
+	}
+}
+
+func TestCandidateEligibilityInvalidCapabilityIsCandidateRejection(t *testing.T) {
+	for _, invalid := range []struct {
+		name   string
+		mutate func(*ProtocolEndpointCapability)
+	}{
+		{"empty_protocols", func(c *ProtocolEndpointCapability) { c.SupportedProtocols = nil }},
+		{"unverified", func(c *ProtocolEndpointCapability) { c.ProbeEvidence = ProtocolProbeEvidence{} }},
+		{"identity_conflict", func(c *ProtocolEndpointCapability) { c.IdentityConflict = true }},
+		{"evidence_conflict", func(c *ProtocolEndpointCapability) { c.ProbeEvidence.IdentityConflict = true }},
+		{"invalid_revision", func(c *ProtocolEndpointCapability) { c.Revision = 0 }},
+		{"empty_key", func(c *ProtocolEndpointCapability) { c.CapabilityKey = "" }},
+		{"identity_mismatch", func(c *ProtocolEndpointCapability) { c.CapabilityKey = "different-endpoint" }},
+	} {
+		for _, shape := range []UniversalShape{ShapeGemini, ShapeOpenAIChat} {
+			for _, state := range []string{"available", "disabled", "cooling", "unsupported"} {
+				t.Run(fmt.Sprintf("%s/%v/%s", invalid.name, shape, state), func(t *testing.T) {
+					resolver, gateway, accounts, request := candidateGoogleFixture(t)
+					model := request.RequestedModel()
+					invalid.mutate(accounts[1].ProtocolEndpointCapability)
+					switch state {
+					case "disabled":
+						accounts[0].Schedulable = false
+					case "cooling":
+						until := time.Now().Add(time.Hour)
+						accounts[0].RateLimitResetAt = &until
+					case "unsupported":
+						accounts[0].Credentials["model_mapping"] = map[string]any{"other": "other"}
+					}
+					wireCandidateTestResolver(resolver, gateway, accounts)
+					path, body := "/v1/chat/completions", request.Body()
+					if shape == ShapeGemini {
+						path = "/v1beta/models/" + model + ":generateContent"
+						body = []byte(`{"contents":[{"role":"user","parts":[{"text":"OK"}]}]}`)
+					}
+					ctx := resolver.WithRequest(context.Background(), shape, path, model, body)
+					_, governed, err := protocolPlanForAccount(ctx, &accounts[1], model)
+					require.True(t, governed)
+					require.ErrorIs(t, err, protocolrouter.ErrNoLegalRoute)
+					require.ErrorIs(t, err, ErrProtocolRouteUnavailable)
+					require.Empty(t, gateway.gatewayCandidates(ctx, accounts[1:], PlatformAntigravity, false, model, nil))
+					group, err := resolver.Resolve(ctx, universalKey(1), shape, model, "")
+					switch state {
+					case "available":
+						require.NoError(t, err)
+						require.Equal(t, int64(16), group.ID)
+						plan, _, err := protocolPlanForAccount(ctx, &accounts[0], model)
+						require.NoError(t, err)
+						require.Equal(t, protocolrouter.ProtocolGeminiGenerateContent, plan.TargetProtocol())
+					case "unsupported":
+						require.Nil(t, group)
+						require.ErrorIs(t, err, ErrUniversalNoEntitledGroup)
+					default:
+						require.Nil(t, group)
+						require.ErrorIs(t, err, ErrUniversalCapacityUnavailable)
+					}
+				})
+			}
+		}
+	}
+}
+
 func TestCandidateEligibilitySaturationPreservesBillingTier(t *testing.T) {
 	for _, test := range []struct {
 		name              string

--- a/backend/internal/service/protocol_routing_context.go
+++ b/backend/internal/service/protocol_routing_context.go
@@ -155,7 +155,7 @@ func protocolPlanForAccount(
 	}
 	snapshot, err := protocolAccountSnapshotForRequestWithThinking(account, routing.request, thinkingEnabledFromCtx(ctx))
 	if err != nil {
-		return protocolrouter.Plan{}, true, fmt.Errorf("%w: %v", ErrProtocolRouteUnavailable, err)
+		return protocolrouter.Plan{}, true, fmt.Errorf("%w: %w", ErrProtocolRouteUnavailable, err)
 	}
 	key := protocolPlanCacheKey{accountID: snapshot.AccountID()}
 	plan, err := routing.plans.getOrPlan(key, func() (protocolrouter.Plan, error) {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -134,6 +134,30 @@
       "rationale": "Behavior regressions for Candidate Eligibility SSOT."
     },
     {
+      "path": "backend/internal/service/account_supported_protocols.go",
+      "must_contain": [
+        "fmt.Errorf(\"%w: protocol endpoint capability is invalid or conflicted\", protocolrouter.ErrNoLegalRoute)",
+        "fmt.Errorf(\"%w: account endpoint identity does not match linked capability\", protocolrouter.ErrNoLegalRoute)"
+      ],
+      "rationale": "Loaded unusable capability evidence rejects a candidate through the shared Plan error contract, without failing Universal group evaluation."
+    },
+    {
+      "path": "backend/internal/service/protocol_routing_context.go",
+      "must_contain": [
+        "return protocolrouter.Plan{}, true, fmt.Errorf(\"%w: %w\", ErrProtocolRouteUnavailable, err)"
+      ],
+      "rationale": "Preserve typed candidate rejection through the protocol planning boundary."
+    },
+    {
+      "path": "backend/internal/service/candidate_eligibility_test.go",
+      "must_contain": [
+        "TestCandidateEligibilityGeminiUnsupportedModelsWithInvalidPeer",
+        "TestCandidateEligibilityInvalidCapabilityIsCandidateRejection",
+        "TestCandidateEligibilityUnknownCapabilityIsNotEntitlement"
+      ],
+      "rationale": "Pin Gemini and converter candidate rejection, direct scheduler parity, capacity versus unsupported routing, and unknown capability failures."
+    },
+    {
       "path": "backend/internal/server/middleware/universal_routing_tk_test.go",
       "must_contain": [
         "TestMaybeResolveUniversal_CandidatePlanPrecedesBillingAndPreservesBody",


### PR DESCRIPTION
## 摘要

修复 Universal 候选评估将单个账号的无效协议能力升级成整个请求 500 的问题。已加载但为空、未验证、冲突或身份不匹配的能力快照，统一通过现有 `protocolrouter.ErrNoLegalRoute` 拒绝该候选；Plan 边界保留底层错误类型，让共享候选评估继续判断其他账号。

线上只读排查确认：在 1.8.204 发版后至北京时间 2026-09-07 22:57:24 的窗口内，user1 的 universal key 334 对 `gemini-3-flash-preview` 和 `gemini-3.1-flash-lite` 分别出现 202、38 次此类 500，均在选账号和上游转发前失败。

- user1 有 Vertex 分组 16 和 Antigravity 分组 21 的权限，但其正常账号未映射这两个模型。
- 账号 113 映射了 `gemini-3-flash-preview`，但能力仅支持 Chat；现有 Plan 没有 Gemini generateContent 到 Chat 的合法 converter。它声明的是 `gemini-3.1-flash-lite-preview`，也不是本次请求的 lite 名称。
- 停用的 Antigravity 账号 61、85 挂有空协议能力记录，且无有效探测证据。候选评估在没有找到合法路线后，回查包含停用账号的配置成员，将其快照错误最终传成了 500。这里没有证据证明是 identity conflict，原日志将几种情况合用了同一句错误。

修复后的行为：合法且可用的账号继续入选；存在合法路线但账号停用或冷却时仍返回 capacity / 429；全部候选无合法路线时复用现有 no-entitled-group / 403。健康候选原本就能胜出，本次修复的是最终没有合法候选时的错误归类。

遵循 Candidate Eligibility SSOT：模型映射、协议与 converter 合法性仍归现有 Plan；候选资格和可用性仍归共享调度评估；授权选组、计费绑定及饱和状态保留原 owner。没有增加 Gemini 特例、模型别名表或第二套候选筛选逻辑。

## 风险

- 当前线上配置下，这两个模型请求会得到明确的无可服务平台响应；此变更不会新增模型支持或将旧名称映射到其他模型。
- 缺失能力链接、数据读取失败等无法确定候选事实的错误仍保留内部失败语义，避免伪装成用户无权访问。
- no-web-impact：只修复服务端候选错误归类，复用既有响应契约，无 Web UI、数据库、授权范围及计费规则变更。
- 独立于修复 Claude 别名的 #2038；未部署或修改线上配置。

## 验证

- 用线上两个模型名、有效 Vertex/Antigravity、停用空能力账号及 Chat-only 账号组合复现旧错误，修复后回归通过。
- 覆盖空协议、未验证证据、身份冲突、证据冲突、非法 revision、空 key、身份不匹配；验证 Gemini 原生入口及 Chat converter 入口、直接调度与 Universal 一致，以及正常可用、停用、冷却、模型不支持场景。
- 缺失能力链接的既有回归保持通过。
- `go test -tags unit ./internal/service ./internal/server/middleware ./internal/engine/protocolrouter -run 'Test(CandidateEligibility|Protocol|MaybeResolveUniversal)' -count=1` 通过。
- `make test-backend GOLANGCI_LINT_FAST_ARGS='--concurrency=4 --allow-serial-runners'` 通过，全量后端单元测试与 lint 通过。
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh` 通过；新增 sentinel 锚定错误归类、错误传递及行为回归。
- 无真实 UI 变更，未运行 UI e2e；线上证据来自只读排查，未发起付费模型探测。

## 提交

- `79f391003 fix(routing): isolate invalid protocol capability candidates`
- 最新提交：79f391003
